### PR TITLE
feat: ClawHub compliance - package.json, plugin.json, setup-entry, README, CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [22]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+      - run: npm ci
+      - run: npm run type-check
+      - run: npm test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Thanks for your interest in contributing!
 ## Getting started
 
 ```bash
-git clone https://github.com/Mininglamp-OSS/octo-adapters.git
+git clone https://github.com/Mininglamp-OSS/openclaw-channel-octo.git
 cd openclaw-channel-octo
 npm install
 npm run type-check
@@ -27,4 +27,4 @@ npm test
 
 ## Reporting issues
 
-Open an issue at https://github.com/Mininglamp-OSS/octo-adapters/issues.
+Open an issue at https://github.com/Mininglamp-OSS/openclaw-channel-octo/issues.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,30 @@
+# Contributing to openclaw-channel-octo
+
+Thanks for your interest in contributing!
+
+## Getting started
+
+```bash
+git clone https://github.com/Mininglamp-OSS/octo-adapters.git
+cd openclaw-channel-octo
+npm install
+npm run type-check
+npm test
+```
+
+## Development workflow
+
+1. Create a feature branch from `main`.
+2. Make your changes — keep commits focused and atomic.
+3. Run `npm run type-check && npm test` before pushing.
+4. Open a pull request against `main`.
+
+## Code style
+
+- TypeScript strict mode is enabled.
+- No external linter/formatter is configured yet — match the existing style.
+- Prefer explicit types over `any` where feasible.
+
+## Reporting issues
+
+Open an issue at https://github.com/Mininglamp-OSS/octo-adapters/issues.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![ClawHub](https://img.shields.io/badge/ClawHub-openclaw--channel--octo-blue?logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0Ij48Y2lyY2xlIGN4PSIxMiIgY3k9IjEyIiByPSIxMCIgZmlsbD0id2hpdGUiLz48L3N2Zz4=)](https://clawhub.ai/plugins/openclaw-channel-octo)
 
-OpenClaw channel plugin for **Octo**, a WuKongIM-based team collaboration platform. Connects via WuKongIM WebSocket for real-time messaging.
+OpenClaw channel plugin for **Octo**. Connects via WebSocket for real-time messaging.
 
 ---
 
@@ -113,14 +113,14 @@ Configuration fields per account:
 
 - `botToken` (required): Bot token from BotFather (`bf_` prefix)
 - `apiUrl` (required): Octo server API URL
-- `wsUrl` (optional): WuKongIM WebSocket URL. Auto-detected if omitted.
+- `wsUrl` (optional): WebSocket URL. Auto-detected if omitted.
 - `requireMention` (optional): Only respond when @mentioned in groups
 - `historyLimit` (optional): Group chat history message limit (default: 20)
 
 ## What it does
 
 1. Registers the bot with the Octo server via REST API
-2. Connects to WuKongIM WebSocket for real-time message receiving
+2. Connects to WebSocket for real-time message receiving
 3. Auto-reconnects on disconnection
 4. Sends a greeting to the bot owner on connect
 5. Dispatches incoming messages to OpenClaw's message handler

--- a/README.md
+++ b/README.md
@@ -4,15 +4,6 @@
 
 OpenClaw channel plugin for **Octo**. Connects via WebSocket for real-time messaging.
 
----
-
-> **v1.0.0+**: This package was renamed from `openclaw-channel-dmwork`. Old
-> users still on `openclaw-channel-dmwork@0.6.x` will get an automatic
-> migration path in a follow-up release. New users should use
-> `openclaw-channel-octo` directly.
-
-Repository: https://github.com/Mininglamp-OSS/openclaw-channel-octo
-
 ## Prerequisites
 
 - Node.js >= 22

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Repository: https://github.com/Mininglamp-OSS/octo-adapters
 ## Prerequisites
 
 - Node.js >= 22
+  (OpenClaw >= 2026.4.15 requires Node 22; this is a platform constraint, not a plugin-level requirement.)
 - OpenClaw installed and configured (`npm i -g openclaw`)
 - A bot created via BotFather in Octo (send `/newbot` to BotFather)
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ OpenClaw channel plugin for **Octo**. Connects via WebSocket for real-time messa
 > migration path in a follow-up release. New users should use
 > `openclaw-channel-octo` directly.
 
-Repository: https://github.com/Mininglamp-OSS/octo-adapters
+Repository: https://github.com/Mininglamp-OSS/openclaw-channel-octo
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # openclaw-channel-octo
 
-Octo channel plugin for OpenClaw. Connects via WuKongIM WebSocket for real-time messaging.
+[![ClawHub](https://img.shields.io/badge/ClawHub-openclaw--channel--octo-blue?logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0Ij48Y2lyY2xlIGN4PSIxMiIgY3k9IjEyIiByPSIxMCIgZmlsbD0id2hpdGUiLz48L3N2Zz4=)](https://clawhub.ai/plugins/openclaw-channel-octo)
+
+OpenClaw channel plugin for **Octo**, a WuKongIM-based team collaboration platform. Connects via WuKongIM WebSocket for real-time messaging.
+
+---
 
 > **v1.0.0+**: This package was renamed from `openclaw-channel-dmwork`. Old
 > users still on `openclaw-channel-dmwork@0.6.x` will get an automatic
@@ -11,21 +15,27 @@ Repository: https://github.com/Mininglamp-OSS/octo-adapters
 
 ## Prerequisites
 
-- Node.js >= 18
+- Node.js >= 22
 - OpenClaw installed and configured (`npm i -g openclaw`)
 - A bot created via BotFather in Octo (send `/newbot` to BotFather)
 
 ## Install
 
-`install` only sets up the plugin (no bot account). Use `bind` after install
-to configure a bot account, or `quickstart` for batch creation across all
-your agents.
+Install from ClawHub:
 
 ```bash
-# 1. Install the plugin
-npx -y openclaw-channel-octo install
+openclaw plugins install clawhub:openclaw-channel-octo
+```
 
-# 2. Bind a bot to an agent
+Or install via npm:
+
+```bash
+npx -y openclaw-channel-octo install
+```
+
+After installing, bind a bot account:
+
+```bash
 npx -y openclaw-channel-octo bind \
   --bot-token bf_your_token_here \
   --api-url https://your-server.example/api \

--- a/index.ts
+++ b/index.ts
@@ -2,7 +2,7 @@
  * openclaw-channel-octo
  *
  * OpenClaw channel plugin for Octo messaging platform.
- * Connects via WuKongIM WebSocket for real-time messaging.
+ * Connects via WebSocket for real-time messaging.
  *
  * Slash commands are registered under both the new `/octo_*` names and the
  * deprecated `/dmwork_*` aliases (one release cycle for backward compat).
@@ -178,7 +178,7 @@ const plugin: {
 } = {
   id: "openclaw-channel-octo",
   name: "Octo",
-  description: "OpenClaw Octo channel plugin via WuKongIM WebSocket",
+  description: "OpenClaw Octo channel plugin",
   register(api) {
     setDmworkRuntime(api.runtime);
     api.registerChannel({ plugin: dmworkPlugin });

--- a/index.ts
+++ b/index.ts
@@ -6,6 +6,10 @@
  *
  * Slash commands are registered under both the new `/octo_*` names and the
  * deprecated `/dmwork_*` aliases (one release cycle for backward compat).
+ *
+ * TODO: Migrate to defineChannelPluginEntry when the openclaw plugin-sdk
+ * exports it. The current SDK (>=2026.4.15) does not expose this API yet;
+ * the manual plugin-object pattern below remains the supported approach.
  */
 
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "openclaw-channel-octo",
   "name": "Octo",
-  "description": "OpenClaw channel plugin for Octo (WuKongIM-based team collaboration platform)",
+  "description": "OpenClaw channel plugin for Octo",
   "channels": [
     "octo"
   ],

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,11 +1,16 @@
 {
   "id": "openclaw-channel-octo",
+  "name": "Octo",
+  "description": "OpenClaw channel plugin for Octo (WuKongIM-based team collaboration platform)",
   "channels": [
     "octo"
   ],
   "skills": [
     "./skills"
   ],
+  "activation": {
+    "onStartup": true
+  },
   "configSchema": {
     "type": "object",
     "additionalProperties": false,
@@ -19,9 +24,18 @@
         "properties": {
           "name": { "type": "string" },
           "enabled": { "type": "boolean" },
-          "botToken": { "type": "string" },
-          "apiUrl": { "type": "string" },
-          "wsUrl": { "type": "string" },
+          "botToken": {
+            "type": "string",
+            "uiHints": { "sensitive": true }
+          },
+          "apiUrl": {
+            "type": "string",
+            "description": "Octo server REST API base URL (e.g. https://your-server:8090/api)"
+          },
+          "wsUrl": {
+            "type": "string",
+            "description": "WuKongIM WebSocket endpoint. Auto-detected from apiUrl if omitted."
+          },
           "cdnUrl": { "type": "string" },
           "pollIntervalMs": { "type": "number", "minimum": 500 },
           "heartbeatIntervalMs": { "type": "number", "minimum": 5000 },
@@ -37,9 +51,18 @@
               "properties": {
                 "name": { "type": "string" },
                 "enabled": { "type": "boolean" },
-                "botToken": { "type": "string" },
-                "apiUrl": { "type": "string" },
-                "wsUrl": { "type": "string" },
+                "botToken": {
+                  "type": "string",
+                  "uiHints": { "sensitive": true }
+                },
+                "apiUrl": {
+                  "type": "string",
+                  "description": "Octo server REST API base URL (e.g. https://your-server:8090/api)"
+                },
+                "wsUrl": {
+                  "type": "string",
+                  "description": "WuKongIM WebSocket endpoint. Auto-detected from apiUrl if omitted."
+                },
                 "cdnUrl": { "type": "string" },
                 "pollIntervalMs": { "type": "number", "minimum": 500 },
                 "heartbeatIntervalMs": { "type": "number", "minimum": 5000 },

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -34,7 +34,7 @@
           },
           "wsUrl": {
             "type": "string",
-            "description": "WuKongIM WebSocket endpoint. Auto-detected from apiUrl if omitted."
+            "description": "WebSocket endpoint. Auto-detected from apiUrl if omitted."
           },
           "cdnUrl": { "type": "string" },
           "pollIntervalMs": { "type": "number", "minimum": 500 },
@@ -61,7 +61,7 @@
                 },
                 "wsUrl": {
                   "type": "string",
-                  "description": "WuKongIM WebSocket endpoint. Auto-detected from apiUrl if omitted."
+                  "description": "WebSocket endpoint. Auto-detected from apiUrl if omitted."
                 },
                 "cdnUrl": { "type": "string" },
                 "pollIntervalMs": { "type": "number", "minimum": 500 },

--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
   "files": [
     "bin",
     "dist",
+    "index.ts",
     "skills",
+    "setup-entry.ts",
     "openclaw.plugin.json"
   ],
   "scripts": {
@@ -81,7 +83,7 @@
       "pluginApi": ">=2026.4.15"
     },
     "build": {
-      "openclawVersion": "2026.5.16"
+      "openclawVersion": "2026.5.4"
     }
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openclaw-channel-octo",
   "version": "1.0.0",
-  "description": "Octo channel plugin for OpenClaw via WuKongIM WebSocket",
+  "description": "Octo channel plugin for OpenClaw",
   "main": "dist/index.js",
   "bin": {
     "openclaw-channel-octo": "bin/octo.js"
@@ -65,7 +65,7 @@
     "channel": {
       "id": "octo",
       "label": "Octo",
-      "selectionLabel": "Octo (WuKongIM)",
+      "selectionLabel": "Octo",
       "detailLabel": "Octo Bot",
       "docsPath": "/channels/octo",
       "markdownCapable": false,

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
       "detailLabel": "Octo Bot",
       "docsPath": "/channels/octo",
       "markdownCapable": false,
-      "blurb": "Connect OpenClaw to Octo, a WuKongIM-based team collaboration platform."
+      "blurb": "Connect OpenClaw to Octo, an open-source team collaboration platform."
     },
     "install": {
       "npmSpec": "openclaw-channel-octo",

--- a/package.json
+++ b/package.json
@@ -59,8 +59,33 @@
     "id": "openclaw-channel-octo",
     "type": "channel",
     "extensions": [
-      "dist/index.js"
-    ]
+      "./index.ts"
+    ],
+    "setupEntry": "./setup-entry.ts",
+    "channel": {
+      "id": "octo",
+      "label": "Octo",
+      "selectionLabel": "Octo (WuKongIM)",
+      "detailLabel": "Octo Bot",
+      "docsPath": "/channels/octo",
+      "markdownCapable": false,
+      "blurb": "Connect OpenClaw to Octo, a WuKongIM-based team collaboration platform."
+    },
+    "install": {
+      "npmSpec": "openclaw-channel-octo",
+      "defaultChoice": "npm",
+      "publishToClawHub": true,
+      "minHostVersion": ">=2026.4.15"
+    },
+    "compat": {
+      "pluginApi": ">=2026.4.15"
+    },
+    "build": {
+      "openclawVersion": "2026.5.16"
+    }
+  },
+  "engines": {
+    "node": ">=22"
   },
   "bundledDependencies": [
     "cos-nodejs-sdk-v5",

--- a/setup-entry.ts
+++ b/setup-entry.ts
@@ -20,11 +20,16 @@ export default {
   ],
 
   validate(config: Record<string, string>): string | null {
-    if (!config.botToken?.startsWith("bf_")) {
+    if (!config.botToken?.startsWith("bf_") || config.botToken.length <= 13) {
       return "Bot token must start with 'bf_'. Create one via /newbot in Octo BotFather.";
     }
     if (!config.apiUrl) {
       return "API URL is required.";
+    }
+    try {
+      new URL(config.apiUrl);
+    } catch {
+      return "API URL must be a valid URL (e.g. https://your-server/api).";
     }
     return null;
   },

--- a/setup-entry.ts
+++ b/setup-entry.ts
@@ -1,0 +1,31 @@
+/**
+ * ClawHub setup entry for openclaw-channel-octo.
+ *
+ * The openclaw plugin-sdk does not yet export `defineSetupPluginEntry` or
+ * `createOptionalChannelSetupSurface`. This stub satisfies the
+ * `openclaw.setupEntry` contract and will be replaced once the SDK ships
+ * the official setup API.
+ */
+
+// TODO: Replace with `defineSetupPluginEntry` when available in openclaw/plugin-sdk.
+export default {
+  id: "openclaw-channel-octo",
+  name: "Octo",
+  description: "Connect OpenClaw to Octo (WuKongIM-based team collaboration platform)",
+
+  configKeys: [
+    { key: "botToken", label: "Bot Token", required: true, sensitive: true },
+    { key: "apiUrl", label: "API URL", required: true },
+    { key: "wsUrl", label: "WebSocket URL", required: false },
+  ],
+
+  validate(config: Record<string, string>): string | null {
+    if (!config.botToken?.startsWith("bf_")) {
+      return "Bot token must start with 'bf_'. Create one via /newbot in Octo BotFather.";
+    }
+    if (!config.apiUrl) {
+      return "API URL is required.";
+    }
+    return null;
+  },
+};

--- a/setup-entry.ts
+++ b/setup-entry.ts
@@ -11,7 +11,7 @@
 export default {
   id: "openclaw-channel-octo",
   name: "Octo",
-  description: "Connect OpenClaw to Octo (WuKongIM-based team collaboration platform)",
+  description: "Connect OpenClaw to Octo",
 
   configKeys: [
     { key: "botToken", label: "Bot Token", required: true, sensitive: true },

--- a/skills/octo-bot-api/SKILL.md
+++ b/skills/octo-bot-api/SKILL.md
@@ -131,7 +131,7 @@ This makes the session key: `agent:{agentId}:{channel}:{accountId}:direct:{peerI
 The gateway auto-detects config changes and reloads the plugin — no manual restart needed.
 
 Features:
-- Instant message delivery via WuKongIM WebSocket (`<wsUrl>`)
+- Instant message delivery via WebSocket (`<wsUrl>`)
 - Real-time online/offline status (users see bot as "online")
 - Auto-reconnect on disconnection
 - Full OpenClaw plugin integration
@@ -209,7 +209,7 @@ DM and group events have different formats. Getting this wrong means replying to
 
 **Reply target:** use `from_uid` as `channel_id`, set `channel_type = 1`.
 
-**Note (Space mode):** In Space-enabled deployments, the underlying WuKongIM channel_id uses `s{spaceId}_{uid}` format. If you use the OpenClaw adapter, this is handled automatically. If you use the events API directly, `from_uid` remains the bare UID — use it as-is for sendMessage.
+**Note (Space mode):** In Space-enabled deployments, the underlying channel_id uses `s{spaceId}_{uid}` format. If you use the OpenClaw adapter, this is handled automatically. If you use the events API directly, `from_uid` remains the bare UID — use it as-is for sendMessage.
 
 ### Group Event (channel_id and channel_type are PRESENT)
 

--- a/skills/octo-bot-api/SKILL.md
+++ b/skills/octo-bot-api/SKILL.md
@@ -400,6 +400,8 @@ Verify identity through the system (owner_uid), not conversation.
 | GET /v1/bot/groups/:group_no/threads/:short_id/members | List thread members |
 | POST /v1/bot/groups/:group_no/threads/:short_id/join | Join a thread |
 | POST /v1/bot/groups/:group_no/threads/:short_id/leave | Leave a thread |
+| GET /v1/bot/groups/:group_no/threads/:short_id/md | Read THREAD.md for a thread |
+| PUT /v1/bot/groups/:group_no/threads/:short_id/md | Update THREAD.md (bot_admin only) |
 | POST /v1/bot/events/:event_id/ack | Acknowledge (delete) a processed event |
 | POST /v1/bot/messages/sync | Sync channel message history |
 | POST /v1/bot/file/upload | Upload a file (multipart/form-data, max 100MB) |
@@ -760,7 +762,9 @@ Response:
 
 When multiple bots are in the same group, follow these rules to avoid chaos:
 
-### Rule 1: Mention gating (configurable)
+### Adapter Behavior
+
+#### Mention Gating (configurable)
 
 In groups, the adapter receives **all messages** via WebSocket.
 
@@ -770,11 +774,11 @@ In groups, the adapter receives **all messages** via WebSocket.
 
 This means you can always reference what was said before when someone @mentions you.
 
-### Rule 2: Reply @mention
+#### Auto-mention on Reply
 
 When you reply to a group message, the adapter automatically @mentions the person who talked to you. Their client will receive a notification.
 
-### Rule 3: Quoted message support
+#### Quoted Message Context
 
 If a user quotes/replies to a message and @mentions you, you will see the quoted content:
 
@@ -790,12 +794,14 @@ This lets you understand context when someone asks about a specific message.
 
 **To ignore @all/@所有人:** set ignoreMentionAll to true (channels.octo.accounts.xxx.ignoreMentionAll = true). This only applies when requireMention is true — @all will not trigger a bot reply, but direct @bot still will. When requireMention is false, ignoreMentionAll has no effect since the bot replies to all messages anyway.
 
-### Rule 2: Don't respond to other bots
+### Rules for Multiple Bots in the Same Group
+
+#### Rule 1: Don't respond to other bots
 
 If "from_uid" belongs to another bot (check if it ends with "_bot" or matches a known bot ID), **ignore** the message.
 Bot-to-bot conversations create infinite loops.
 
-### Rule 3: Stick to your domain
+#### Rule 2: Stick to your domain
 
 Each bot should have a clear purpose:
 - Translation bot → only handle translation requests
@@ -804,12 +810,12 @@ Each bot should have a clear purpose:
 
 If the request is clearly outside your domain, say so briefly and suggest the right bot.
 
-### Rule 4: Don't pile on
+#### Rule 3: Don't pile on
 
 If you're @mentioned alongside other bots, keep your response focused on **your specialty**.
 Don't try to answer everything — let each bot handle their part.
 
-### Rule 5: Keep group replies short
+#### Rule 4: Keep group replies short
 
 Group messages should be concise — typically 1-3 sentences.
 Save detailed explanations for DM conversations.
@@ -880,6 +886,53 @@ Response:
 - You MUST follow the rules defined in GROUP.md
 - Group creators/managers can also edit GROUP.md from the web UI
 - When GROUP.md is updated/deleted, you receive a notification event in the group
+
+## THREAD.md Management
+
+THREAD.md is a markdown document attached to a specific thread (sub-topic) that defines per-thread rules and context. It works similarly to GROUP.md but is scoped to a single thread. In thread sessions, only THREAD.md is injected into your system prompt — there is no GROUP.md fallback for thread sessions.
+
+### Read THREAD.md (any group member bot)
+
+```bash
+curl -s <apiUrl>/v1/bot/groups/{group_no}/threads/{short_id}/md \
+  -H "Authorization: Bearer YOUR_BOT_TOKEN"
+```
+
+Response:
+```json
+{
+  "content": "# Thread Rules\n- Focus on deployment issues only",
+  "version": 2,
+  "updated_at": "2026-03-18T10:00:00Z",
+  "updated_by": "user_uid"
+}
+```
+
+Returns empty content with version 0 if no THREAD.md exists.
+
+### Update THREAD.md (bot_admin only)
+
+Requires **bot_admin** permission in the parent group.
+
+```bash
+curl -X PUT <apiUrl>/v1/bot/groups/{group_no}/threads/{short_id}/md \
+  -H "Authorization: Bearer YOUR_BOT_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"content": "# Thread Rules\n- Focus on deployment issues only"}'
+```
+
+Response:
+```json
+{"version": 3}
+```
+
+**Constraints:**
+- Max content size: 10,240 bytes
+- **Read**: requires bot to be a group member
+- **Update**: requires bot_admin=1 in the parent group
+- Empty content clears the THREAD.md
+- Version auto-increments on each update
+- Thread sessions only use THREAD.md; GROUP.md is NOT inherited
 
 ## Rate Limiting (Recommended)
 

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -275,10 +275,10 @@ function getAvailableActions(cfg: any): string[] {
 const meta = {
   id: "octo",
   label: "Octo",
-  selectionLabel: "Octo (WuKongIM)",
+  selectionLabel: "Octo",
   docsPath: "/channels/octo",
   docsLabel: "octo",
-  blurb: "WuKongIM gateway for Octo",
+  blurb: "Connect OpenClaw to Octo",
   order: 90,
 };
 
@@ -834,7 +834,7 @@ export const dmworkPlugin: ChannelPlugin<ResolvedDmworkAccount> = {
       let consecutiveHeartbeatFailures = 0;
       const MAX_HEARTBEAT_FAILURES = 3;
 
-      // 6. Connect WebSocket — pure real-time via WuKongIM SDK
+      // 6. Connect WebSocket — pure real-time
       const socket = new WKSocket({
         wsUrl,
         uid: credentials.robot_id,
@@ -858,7 +858,7 @@ export const dmworkPlugin: ChannelPlugin<ResolvedDmworkAccount> = {
 
           // Defense-in-depth DM filter (kept for safety, though v0.2.28+ uses independent
           // WebSocket connections per bot so server-side routing is already correct).
-          // WuKongIM DM channel_id is typically "uid1@uid2", but may also be a plain uid
+          // DM channel_id is typically "uid1@uid2", but may also be a plain uid
           // when channel_type === 1 without '@'. The plain-uid case needs no extra filter
           // since each bot has its own WS connection.
           if (msg.channel_type === ChannelType.DM && msg.channel_id && msg.channel_id.includes("@")) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,6 @@
     "declaration": true,
     "sourceMap": true
   },
-  "include": ["index.ts", "src/**/*.ts", "cli/**/*.ts"],
+  "include": ["index.ts", "setup-entry.ts", "src/**/*.ts", "cli/**/*.ts"],
   "exclude": ["node_modules", "dist", "**/*.test.ts"]
 }


### PR DESCRIPTION
## Summary

This PR brings `openclaw-channel-octo` into compliance with ClawHub publication standards.

## Changes

### package.json
- Added `openclaw.setupEntry` pointing to `./setup-entry.ts`
- Added `openclaw.channel` with full metadata: id/label/selectionLabel/detailLabel/docsPath/markdownCapable/blurb
- Added `openclaw.install` with npmSpec/defaultChoice/publishToClawHub/minHostVersion
- Added `openclaw.compat` with pluginApi version constraint
- Added `openclaw.build` with openclawVersion
- Changed `extensions` entry to `["./index.ts"]` (source entry, not dist)
- Added `engines.node: ">=22"`

### openclaw.plugin.json
- Added `name` and `description` fields
- Added `activation: { onStartup: true }`
- Added `uiHints.sensitive: true` to botToken fields
- Added `description` hints for apiUrl and wsUrl

### setup-entry.ts (new)
- Stub setup entry satisfying the setupEntry contract
- Includes TODO for full `defineSetupPluginEntry` migration when SDK support lands

### index.ts
- Added TODO comment for future `defineChannelPluginEntry` migration

### README.md
- Added ClawHub badge
- Added English introduction section
- Updated install command: `openclaw plugins install clawhub:openclaw-channel-octo`
- Updated Node.js requirement to >=22

### CONTRIBUTING.md (new)
- Basic contribution guide

### .github/workflows/ci.yml (new)
- CI: type-check + test on Node 22

## Next steps after merge
- Publish to npm: `npm publish`
- Register on ClawHub: `clawhub package publish Mininglamp-OSS/openclaw-channel-octo`