### PR TITLE
chore: remove bin/cli, align with ClawHub plugin conventions

### DIFF
--- a/bin/octo.js
+++ b/bin/octo.js
@@ -1,3 +1,0 @@
-#!/usr/bin/env node
-import { main } from "../dist/cli/index.js";
-main();

--- a/cli/exports.test.ts
+++ b/cli/exports.test.ts
@@ -1,11 +1,7 @@
 /**
- * Smoke test: ensures `import("openclaw-channel-octo/cli")` resolves
- * correctly via the exports["./cli"] subpath.
+ * Smoke test: ensures the package exports are correctly configured.
  *
- * This subpath is public API — external tooling and scripts may import
- * the CLI programmatically. If this test fails, consumers that rely on
- * the ./cli subpath (e.g. `await import("openclaw-channel-octo/cli")`)
- * would get ERR_PACKAGE_PATH_NOT_EXPORTED at runtime.
+ * Tests that the main "." export points to the expected dist output.
  */
 import { describe, it, expect } from "vitest";
 import { readFileSync } from "fs";
@@ -16,15 +12,10 @@ const here = dirname(fileURLToPath(import.meta.url));
 const pkgPath = resolve(here, "../package.json");
 
 describe("package exports", () => {
-  it("exposes ./cli as a subpath export", () => {
+  it("exposes main \".\" export pointing to dist/index.js", () => {
     const pkg = JSON.parse(readFileSync(pkgPath, "utf8"));
     expect(pkg.exports).toBeDefined();
-    expect(pkg.exports["./cli"]).toBeDefined();
-    expect(pkg.exports["./cli"].import).toBe("./dist/cli/index.js");
-  });
-
-  it("cli/index.ts exports a main() function (not auto-parsing on import)", async () => {
-    const cliMod = await import("./index.js");
-    expect(typeof (cliMod as { main?: unknown }).main).toBe("function");
+    expect(pkg.exports["."]).toBeDefined();
+    expect(pkg.exports["."].import).toBe("./dist/index.js");
   });
 });

--- a/package.json
+++ b/package.json
@@ -3,23 +3,15 @@
   "version": "1.0.0",
   "description": "Octo channel plugin for OpenClaw",
   "main": "dist/index.js",
-  "bin": {
-    "openclaw-channel-octo": "bin/octo.js"
-  },
   "types": "dist/index.d.ts",
   "type": "module",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
-    },
-    "./cli": {
-      "types": "./dist/cli/index.d.ts",
-      "import": "./dist/cli/index.js"
     }
   },
   "files": [
-    "bin",
     "dist",
     "index.ts",
     "skills",


### PR DESCRIPTION
Removes the standalone CLI binary — not appropriate for a ClawHub channel plugin (official extensions like feishu/mattermost/discord have no bin/CLI).

## Changes
- Delete `bin/` directory and `"bin"` field from package.json
- Remove `"bin"` from `files` array
- Remove `exports["./cli"]` subpath (no longer needed)
- Update `cli/exports.test.ts` to test main `"."` export only

## What's preserved
`cli/` directory is kept intact — slash commands (`/octo_doctor`, `/octo_install`, `/octo_add_account`, etc.) registered in `index.ts` via `api.registerCommand()` depend on it and are unaffected.