### PR TITLE
fix(ci): unbreak workflow parsing — escape ${{ in shell comment

### DIFF
--- a/.github/workflows/publish-clawhub.yml
+++ b/.github/workflows/publish-clawhub.yml
@@ -65,7 +65,7 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           INPUT_VERSION: ${{ inputs.version }}
         run: |
-          # Read inputs/event from env (NOT ${{ ... }} interpolation) to avoid shell injection.
+          # Read inputs/event from env (NOT GHA expression interpolation) to avoid shell injection.
           # workflow_dispatch is ALWAYS dry-run (real publish requires tag from main).
           if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
             VERSION="$INPUT_VERSION"


### PR DESCRIPTION
## Summary

After PR #9 was merged, running `workflow_dispatch` failed with:

```
HTTP 422: failed to parse workflow:
(Line: 67, Col: 14): Unexpected symbol: '...'
```

Root cause: the GitHub Actions YAML parser tries to evaluate `${{ ... }}` even inside a shell `#` comment — it treats it as a GHA expression rather than skipping it as comment text. The literal `...` inside the comment is not a valid expression, so parsing aborts.

## Change

A single-line comment edit; the `${{ ... }}` token is rewritten so the parser no longer matches it:

```diff
-          # Read inputs/event from env (NOT ${{ ... }} interpolation) to avoid shell injection.
+          # Read inputs/event from env (NOT GHA expression interpolation) to avoid shell injection.
```

No functional change — just restores the workflow's parseability.

## Test plan

- [x] Local `npx js-yaml` parses cleanly
- [ ] After merge: `gh workflow run publish-clawhub.yml -f version=1.0.7` no longer reports the parse error
- [ ] Dry-run reaches `clawhub package publish --dry-run` (PAT fallback path exercised)

🤖 Generated with [Claude Code](https://claude.com/claude-code)