### PR TITLE
chore(ci): pin all action references to SHA for supply chain security

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,8 @@ jobs:
       matrix:
         node-version: [22]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm

--- a/.github/workflows/publish-clawhub.yml
+++ b/.github/workflows/publish-clawhub.yml
@@ -49,12 +49,12 @@ jobs:
       version: ${{ steps.resolve.outputs.version }}
       dry_run: ${{ steps.resolve.outputs.dry_run }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           # Need full history so we can verify the tagged commit is reachable from origin/main.
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
           cache: npm
@@ -134,7 +134,7 @@ jobs:
       - run: npm pack
 
       - name: upload tarball
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: clawpack
           path: octo-*.tgz
@@ -146,14 +146,14 @@ jobs:
     needs: verify
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
 
       - name: download tarball
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: clawpack
 


### PR DESCRIPTION
## Summary

Pin all GitHub Action references from mutable tags (`@v4`) to immutable SHA hashes, matching the org-wide security standard used by all other Mininglamp-OSS repositories.

## Changes

| Action | Before | After |
|--------|--------|-------|
| actions/checkout | `@v4` | `@34e114876b0b11c390a56381ad16ebd13914f8d5` |
| actions/setup-node | `@v4` | `@49933ea5288caeca8642d1e84afbd3f7d6820020` |
| actions/upload-artifact | `@v4` | `@ea165f8d65b6e75b540449e92b4886f43607fa02` |
| actions/download-artifact | `@v4` | `@d3f86a106a0bac45b974a628896c90dbdf5c8093` |

## Why

Tag references are mutable — a compromised upstream action tag can inject malicious code into CI. SHA pinning ensures reproducible, tamper-proof builds.

`openclaw-channel-octo` was the only repo in the org still using tag references.

## Files Changed

- `.github/workflows/ci.yml`
- `.github/workflows/publish-clawhub.yml`

Part of org CI/CD governance hardening (Phase 2).