### PR TITLE
fix(ci): add pull-requests:write to welcome workflow

### DIFF
--- a/.github/workflows/pr-contributor-welcome.yml
+++ b/.github/workflows/pr-contributor-welcome.yml
@@ -11,3 +11,4 @@ jobs:
     uses: Mininglamp-OSS/.github/.github/workflows/reusable-pr-contributor-welcome.yml@main
     permissions:
       issues: write
+      pull-requests: write


### PR DESCRIPTION
## Summary

PR Contributor Welcome workflow 在每个新 PR 上稳定 403 失败：

```
'x-accepted-github-permissions': 'issues=write; pull_requests=write'
data: { message: 'Resource not accessible by integration', status: '403' }
```

报错日志: https://github.com/Mininglamp-OSS/openclaw-channel-octo/actions/runs/26386511533/job/77666095283

## Root cause

复用的 org-level workflow 底层 API 同时需要 `issues: write` 和 `pull-requests: write`，但 job 只声明了 `issues: write`。

git history 显示：
```
f4bafa2 fix: change pr-contributor-welcome permission to issues: write
```
那次为了解决另一个问题，把权限从 `pull-requests: write` 单边改成了 `issues: write`，结果这边又 regress 了。两个权限都加上即可。

## Test plan

- [ ] 这个 PR 自己开 → 看 welcome workflow 是否成功（首发评论）
- [ ] 后续新 PR 不再有 403