### PR TITLE
fix: register SessionBindingAdapter for ACP thread binding (#23)

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -36,6 +36,7 @@ import { getOrCreateGroupMdCache, registerBotGroupIds, getKnownGroupIds, writeGr
 import { registerOwnerUid } from "./owner-registry.js";
 import { preloadGroupMemberCache, getGroupMembersFromCache } from "./member-cache.js";
 import { initPersonaPromptCache, stopPersonaPromptCache } from "./persona-prompt.js";
+import { registerOctoThreadBindingAdapter } from "./thread-binding-adapter.js";
 import path from "node:path";
 import os from "node:os";
 import { mkdir, readFile, writeFile, unlink } from "node:fs/promises";
@@ -918,6 +919,15 @@ export const octoPlugin: ChannelPlugin<ResolvedOctoAccount> = {
         log,
       );
 
+      // Register ACP thread-binding adapter (fixes #23). Without this, OpenClaw's
+      // ACP runtime aborts session+thread spawns with `thread_binding_invalid`.
+      const unregisterThreadBinding = registerOctoThreadBindingAdapter({
+        accountId: account.accountId,
+        apiUrl: account.config.apiUrl,
+        botToken: account.config.botToken!,
+        log,
+      });
+
       // Prefetch GROUP.md and group members for all groups (fire-and-forget)
       const groupMdCache = getOrCreateGroupMdCache(account.accountId);
       (async () => {
@@ -1208,6 +1218,7 @@ export const octoPlugin: ChannelPlugin<ResolvedOctoAccount> = {
           if (heartbeatTimer) { clearInterval(heartbeatTimer); heartbeatTimer = null; }
           if (cooldownReconnectTimer) { clearTimeout(cooldownReconnectTimer); cooldownReconnectTimer = null; }
           stopPersonaPromptCache(account.accountId);
+          unregisterThreadBinding();
           ctx.setStatus({
             accountId: account.accountId,
             running: false,

--- a/src/thread-binding-adapter.test.ts
+++ b/src/thread-binding-adapter.test.ts
@@ -1,0 +1,305 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  registerOctoThreadBindingAdapter,
+  __resetOctoThreadBindingsForTests,
+} from "./thread-binding-adapter.js";
+
+// Mock createThread (used only by the `child` placement path).
+vi.mock("./api-fetch.js", () => ({
+  createThread: vi.fn(),
+}));
+
+import { createThread } from "./api-fetch.js";
+
+const ACCOUNT_ID = "27pBwzf2F6bfa5cd142_bot";
+const API_URL = "https://im.example.com/api";
+const BOT_TOKEN = "bf_test123";
+
+function makeAdapterContext() {
+  // capture log output for assertion
+  const logs: { level: string; msg: string }[] = [];
+  const log = {
+    info: (msg: string) => logs.push({ level: "info", msg }),
+    warn: (msg: string) => logs.push({ level: "warn", msg }),
+    debug: (msg: string) => logs.push({ level: "debug", msg }),
+  };
+  const unregister = registerOctoThreadBindingAdapter({
+    accountId: ACCOUNT_ID,
+    apiUrl: API_URL,
+    botToken: BOT_TOKEN,
+    log,
+  });
+  return { unregister, logs };
+}
+
+// We need a way to call the adapter's bind/listBySession/etc. methods.
+// The adapter is registered into the SDK's internal registry; the SDK
+// doesn't publicly expose getCapabilities. So we re-register a fresh
+// adapter for each test and capture a reference to its method surface
+// via a small spy.
+//
+// Instead, we test the OBSERVABLE side-effects through the SDK's
+// register/unregister API and through createThread mock calls.
+//
+// For per-method assertions, expose a "test handle" by reading the
+// adapter we're about to register. Easiest: import the SessionBindingAdapter
+// shape from the SDK and construct a fresh bind input ourselves using
+// the same registry the SDK uses.
+
+import {
+  registerSessionBindingAdapter,
+  unregisterSessionBindingAdapter,
+  type SessionBindingAdapter,
+} from "openclaw/plugin-sdk/thread-bindings-runtime";
+
+// Helper: capture the registered adapter so tests can call its methods.
+// We replace the SDK's register fn via vi.mock for the duration of the test.
+let _capturedAdapter: SessionBindingAdapter | null = null;
+
+vi.mock("openclaw/plugin-sdk/thread-bindings-runtime", async (importActual) => {
+  const actual = (await importActual()) as Record<string, unknown>;
+  return {
+    ...actual,
+    registerSessionBindingAdapter: (adapter: SessionBindingAdapter) => {
+      _capturedAdapter = adapter;
+      // Also register with the real SDK so unregister round-trips work.
+      (actual.registerSessionBindingAdapter as typeof registerSessionBindingAdapter)(adapter);
+    },
+    unregisterSessionBindingAdapter: (params: Parameters<typeof unregisterSessionBindingAdapter>[0]) => {
+      _capturedAdapter = null;
+      (actual.unregisterSessionBindingAdapter as typeof unregisterSessionBindingAdapter)(params);
+    },
+  };
+});
+
+describe("registerOctoThreadBindingAdapter", () => {
+  beforeEach(() => {
+    __resetOctoThreadBindingsForTests();
+    _capturedAdapter = null;
+    vi.mocked(createThread).mockReset();
+  });
+
+  afterEach(() => {
+    if (_capturedAdapter) {
+      // Best-effort cleanup
+      _capturedAdapter = null;
+    }
+    __resetOctoThreadBindingsForTests();
+  });
+
+  it("registers an adapter with placements=[current,child] and bindSupported=true", () => {
+    const { unregister } = makeAdapterContext();
+    expect(_capturedAdapter).not.toBeNull();
+    expect(_capturedAdapter!.channel).toBe("octo");
+    expect(_capturedAdapter!.accountId).toBe(ACCOUNT_ID);
+    expect(_capturedAdapter!.capabilities).toEqual({
+      placements: ["current", "child"],
+      bindSupported: true,
+      unbindSupported: true,
+    });
+    unregister();
+  });
+
+  it("bind(placement=current) records a binding using the existing conversationId without calling createThread", async () => {
+    const { unregister } = makeAdapterContext();
+    const conversationId = "groupNo_abc";
+    const targetSessionKey = "agent:cc:acp:9da61851";
+
+    const record = await _capturedAdapter!.bind!({
+      targetSessionKey,
+      targetKind: "session",
+      conversation: { channel: "octo", accountId: ACCOUNT_ID, conversationId },
+      placement: "current",
+    });
+
+    expect(record).not.toBeNull();
+    expect(record!.bindingId).toBe(`${ACCOUNT_ID}:${conversationId}`);
+    expect(record!.targetSessionKey).toBe(targetSessionKey);
+    expect(record!.conversation.conversationId).toBe(conversationId);
+    expect(record!.status).toBe("active");
+    expect(vi.mocked(createThread)).not.toHaveBeenCalled();
+
+    // Adapter should be able to look the binding up by conversation.
+    const found = _capturedAdapter!.resolveByConversation({
+      channel: "octo",
+      accountId: ACCOUNT_ID,
+      conversationId,
+    });
+    expect(found?.bindingId).toBe(record!.bindingId);
+
+    // …and by session key.
+    const bySession = _capturedAdapter!.listBySession(targetSessionKey);
+    expect(bySession).toHaveLength(1);
+    expect(bySession[0]!.bindingId).toBe(record!.bindingId);
+
+    unregister();
+  });
+
+  it("bind(placement=child) calls createThread and uses groupNo____shortId as conversationId", async () => {
+    vi.mocked(createThread).mockResolvedValueOnce({
+      short_id: "thrxyz",
+      name: "Agent: 9da61851",
+      creator_uid: "bot-uid",
+    });
+    const { unregister } = makeAdapterContext();
+
+    const record = await _capturedAdapter!.bind!({
+      targetSessionKey: "agent:cc:acp:9da61851",
+      targetKind: "session",
+      conversation: {
+        channel: "octo",
+        accountId: ACCOUNT_ID,
+        conversationId: "parentGroup",
+      },
+      placement: "child",
+    });
+
+    expect(vi.mocked(createThread)).toHaveBeenCalledOnce();
+    expect(vi.mocked(createThread)).toHaveBeenCalledWith({
+      apiUrl: API_URL,
+      botToken: BOT_TOKEN,
+      groupNo: "parentGroup",
+      name: "Agent: 9da61851",
+    });
+    expect(record).not.toBeNull();
+    expect(record!.conversation.conversationId).toBe("parentGroup____thrxyz");
+    expect(record!.conversation.parentConversationId).toBe("parentGroup");
+
+    unregister();
+  });
+
+  it("bind(placement=child) returns null when createThread fails (does not throw)", async () => {
+    vi.mocked(createThread).mockRejectedValueOnce(new Error("network down"));
+    const { unregister, logs } = makeAdapterContext();
+
+    const record = await _capturedAdapter!.bind!({
+      targetSessionKey: "agent:cc:acp:abc",
+      targetKind: "session",
+      conversation: {
+        channel: "octo",
+        accountId: ACCOUNT_ID,
+        conversationId: "parentGroup",
+      },
+      placement: "child",
+    });
+
+    expect(record).toBeNull();
+    expect(logs.some((l) => l.level === "warn" && l.msg.includes("createThread failed"))).toBe(true);
+
+    unregister();
+  });
+
+  it("bind(placement=child) extracts parent group_no from a thread-shaped parentConversationId", async () => {
+    vi.mocked(createThread).mockResolvedValueOnce({
+      short_id: "newshort",
+      name: "x",
+      creator_uid: "bot-uid",
+    });
+    const { unregister } = makeAdapterContext();
+
+    await _capturedAdapter!.bind!({
+      targetSessionKey: "agent:cc:acp:abc",
+      targetKind: "session",
+      conversation: {
+        channel: "octo",
+        accountId: ACCOUNT_ID,
+        // Caller is already in a thread; child should still be created under the parent group.
+        conversationId: "parentGroup____oldshort",
+      },
+      placement: "child",
+    });
+
+    expect(vi.mocked(createThread)).toHaveBeenCalledWith(
+      expect.objectContaining({ groupNo: "parentGroup" }),
+    );
+    unregister();
+  });
+
+  it("unbind by bindingId removes the record and returns it with status=ended", async () => {
+    const { unregister } = makeAdapterContext();
+    const conv = "groupX";
+    const rec = await _capturedAdapter!.bind!({
+      targetSessionKey: "s1",
+      targetKind: "session",
+      conversation: { channel: "octo", accountId: ACCOUNT_ID, conversationId: conv },
+      placement: "current",
+    });
+
+    const removed = await _capturedAdapter!.unbind!({
+      bindingId: rec!.bindingId,
+      reason: "user-requested",
+    });
+
+    expect(removed).toHaveLength(1);
+    expect(removed[0]!.status).toBe("ended");
+    expect(_capturedAdapter!.resolveByConversation({ channel: "octo", accountId: ACCOUNT_ID, conversationId: conv })).toBeNull();
+
+    unregister();
+  });
+
+  it("unbind by targetSessionKey removes all matching bindings", async () => {
+    const { unregister } = makeAdapterContext();
+    await _capturedAdapter!.bind!({
+      targetSessionKey: "shared",
+      targetKind: "session",
+      conversation: { channel: "octo", accountId: ACCOUNT_ID, conversationId: "g1" },
+      placement: "current",
+    });
+    await _capturedAdapter!.bind!({
+      targetSessionKey: "shared",
+      targetKind: "session",
+      conversation: { channel: "octo", accountId: ACCOUNT_ID, conversationId: "g2" },
+      placement: "current",
+    });
+    await _capturedAdapter!.bind!({
+      targetSessionKey: "other",
+      targetKind: "session",
+      conversation: { channel: "octo", accountId: ACCOUNT_ID, conversationId: "g3" },
+      placement: "current",
+    });
+
+    const removed = await _capturedAdapter!.unbind!({
+      targetSessionKey: "shared",
+      reason: "session-ended",
+    });
+    expect(removed).toHaveLength(2);
+    expect(_capturedAdapter!.listBySession("shared")).toHaveLength(0);
+    expect(_capturedAdapter!.listBySession("other")).toHaveLength(1);
+
+    unregister();
+  });
+
+  it("the unregister function clears bindings and is idempotent", async () => {
+    const { unregister } = makeAdapterContext();
+    await _capturedAdapter!.bind!({
+      targetSessionKey: "s",
+      targetKind: "session",
+      conversation: { channel: "octo", accountId: ACCOUNT_ID, conversationId: "c" },
+      placement: "current",
+    });
+    expect(_capturedAdapter!.listBySession("s")).toHaveLength(1);
+
+    unregister();
+    // Calling unregister again must not throw.
+    unregister();
+    // The captured adapter reference is from BEFORE unregister; its listBySession
+    // reads from the module-level map. After unregister, that map is cleared.
+    expect(_capturedAdapter).toBeNull();
+  });
+
+  it("bind(placement=current) ignores conversations from other channels", async () => {
+    const { unregister } = makeAdapterContext();
+    const record = await _capturedAdapter!.bind!({
+      targetSessionKey: "s",
+      targetKind: "session",
+      conversation: {
+        channel: "telegram", // not octo
+        accountId: ACCOUNT_ID,
+        conversationId: "tg-chat",
+      },
+      placement: "current",
+    });
+    expect(record).toBeNull();
+    unregister();
+  });
+});

--- a/src/thread-binding-adapter.ts
+++ b/src/thread-binding-adapter.ts
@@ -1,0 +1,287 @@
+/**
+ * Octo SessionBindingAdapter — fixes octo-adapters#23 (thread_binding_invalid).
+ *
+ * OpenClaw's ACP runtime queries `getSessionBindingService().getCapabilities({channel,accountId})`
+ * before spawning a thread-bound ACP session. If no SessionBindingAdapter is
+ * registered for the channel+account, the service returns
+ * `{ adapterAvailable: false, bindSupported: false }` and the runtime aborts
+ * the spawn with `errorCode: "thread_binding_invalid"`.
+ *
+ * Reference impl: see Telegram's bundled adapter at
+ * `node_modules/openclaw/dist/thread-bindings-BnqTb64l.js`.
+ *
+ * This adapter:
+ *   - placement="current": records a binding against the current Octo
+ *     conversationId without creating any new server-side resource. This is
+ *     the most common path (binding a session to the active group / thread
+ *     the user is talking in).
+ *   - placement="child":  calls Octo `POST /v1/bot/groups/{groupNo}/threads`
+ *     to create a new sub-thread, then records a binding against the
+ *     resulting `groupNo____shortId` conversationId. This is the path used
+ *     when an ACP session needs a fresh isolated sub-topic.
+ *
+ * Persistence is in-memory and per-account. Bindings are wiped when
+ * `stopAccount` runs (e.g. on gateway restart). For first-iteration
+ * correctness this is acceptable — ACP sessions themselves are not
+ * persisted across restarts either, so a stale binding pointing to a dead
+ * session would be useless. Future iterations can adopt the SDK's
+ * `createAccountScopedConversationBindingManager` for disk-backed records.
+ */
+import {
+  registerSessionBindingAdapter,
+  unregisterSessionBindingAdapter,
+  type SessionBindingAdapter,
+  type SessionBindingRecord,
+} from "openclaw/plugin-sdk/thread-bindings-runtime";
+import { CHANNEL_ID } from "./constants.js";
+import { createThread } from "./api-fetch.js";
+
+// SDK's `thread-bindings-runtime` only re-exports the adapter + record types.
+// Derive the input types from the adapter signature itself to stay loosely
+// coupled and avoid reaching into internal SDK subpaths.
+type SessionBindingBindInput = Parameters<NonNullable<SessionBindingAdapter["bind"]>>[0];
+type SessionBindingUnbindInput = Parameters<NonNullable<SessionBindingAdapter["unbind"]>>[0];
+type ConversationRef = Parameters<SessionBindingAdapter["resolveByConversation"]>[0];
+
+type Logger = {
+  info?: (msg: string) => void;
+  warn?: (msg: string) => void;
+  debug?: (msg: string) => void;
+} | undefined;
+
+/**
+ * Module-level binding registry, keyed by accountId. Each entry maps
+ * bindingId → record. bindingId format is `${accountId}:${conversationId}`,
+ * matching the Telegram adapter's convention.
+ */
+const _bindingsByAccount = new Map<string, Map<string, SessionBindingRecord>>();
+
+function getOrCreateBindingMap(
+  accountId: string,
+): Map<string, SessionBindingRecord> {
+  let m = _bindingsByAccount.get(accountId);
+  if (!m) {
+    m = new Map();
+    _bindingsByAccount.set(accountId, m);
+  }
+  return m;
+}
+
+function buildBindingId(accountId: string, conversationId: string): string {
+  return `${accountId}:${conversationId}`;
+}
+
+function deriveThreadName(
+  metadata: Record<string, unknown> | undefined,
+  targetSessionKey: string,
+): string {
+  const md = metadata ?? {};
+  const fromMd =
+    (typeof md.threadName === "string" && md.threadName.trim()) ||
+    (typeof md.label === "string" && md.label.trim()) ||
+    "";
+  if (fromMd) return fromMd as string;
+  const tail = targetSessionKey.split(":").pop() ?? "session";
+  return `Agent: ${tail}`;
+}
+
+/**
+ * Resolve the parent group_no from a child conversationId. Octo encodes
+ * threads as `groupNo____shortId` (4 underscores). When the caller passes
+ * a parent conversationId that is itself a thread ref, strip the suffix.
+ */
+function resolveParentGroupNo(
+  conversation: SessionBindingBindInput["conversation"],
+): string | null {
+  const raw =
+    conversation.parentConversationId?.trim() ||
+    conversation.conversationId?.trim() ||
+    "";
+  if (!raw) return null;
+  return raw.includes("____") ? raw.split("____")[0]! : raw;
+}
+
+export interface RegisterOctoThreadBindingAdapterParams {
+  accountId: string;
+  apiUrl: string;
+  /** Bot token (bf_...). Used by the `child` placement to create new threads. */
+  botToken: string;
+  log?: Logger;
+}
+
+/**
+ * Register a SessionBindingAdapter for one Octo account. Call once per
+ * account during `startAccount`. Returns an unregister function that the
+ * caller MUST invoke during `stopAccount` (or the abortSignal cleanup
+ * path) to keep the SDK registry in sync across hot reloads.
+ */
+export function registerOctoThreadBindingAdapter(
+  params: RegisterOctoThreadBindingAdapterParams,
+): () => void {
+  const { accountId, apiUrl, botToken, log } = params;
+
+  const adapter: SessionBindingAdapter = {
+    channel: CHANNEL_ID,
+    accountId,
+    capabilities: {
+      placements: ["current", "child"],
+      bindSupported: true,
+      unbindSupported: true,
+    },
+
+    bind: async (
+      input: SessionBindingBindInput,
+    ): Promise<SessionBindingRecord | null> => {
+      // Defensive: SDK should already filter by channel/accountId, but the
+      // adapter contract permits us to no-op on mismatched input.
+      if (input.conversation.channel !== CHANNEL_ID) return null;
+
+      const targetSessionKey = input.targetSessionKey.trim();
+      if (!targetSessionKey) return null;
+
+      const placement: "current" | "child" =
+        input.placement === "child" ? "child" : "current";
+
+      let conversationId: string;
+      let parentConversationId: string | undefined;
+
+      if (placement === "child") {
+        const parentGroupNo = resolveParentGroupNo(input.conversation);
+        if (!parentGroupNo) {
+          log?.warn?.(
+            `octo: [${accountId}] child bind failed — could not resolve parent group_no from conversation=${JSON.stringify(input.conversation)}`,
+          );
+          return null;
+        }
+        const threadName = deriveThreadName(input.metadata, targetSessionKey);
+        try {
+          const thread = await createThread({
+            apiUrl,
+            botToken,
+            groupNo: parentGroupNo,
+            name: threadName,
+          });
+          conversationId = `${parentGroupNo}____${thread.short_id}`;
+          parentConversationId = parentGroupNo;
+          log?.info?.(
+            `octo: [${accountId}] child thread created group=${parentGroupNo} short_id=${thread.short_id} (name="${threadName}")`,
+          );
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          log?.warn?.(
+            `octo: [${accountId}] createThread failed for group=${parentGroupNo}: ${message}`,
+          );
+          return null;
+        }
+      } else {
+        // placement === "current": bind to the conversationId the caller is
+        // already in. No new server-side resource is created.
+        const raw = input.conversation.conversationId?.trim();
+        if (!raw) return null;
+        conversationId = raw;
+        parentConversationId = input.conversation.parentConversationId;
+      }
+
+      const now = Date.now();
+      const record: SessionBindingRecord = {
+        bindingId: buildBindingId(accountId, conversationId),
+        targetSessionKey,
+        targetKind: input.targetKind,
+        conversation: {
+          channel: CHANNEL_ID,
+          accountId,
+          conversationId,
+          ...(parentConversationId ? { parentConversationId } : {}),
+        },
+        status: "active",
+        boundAt: now,
+        ...(input.ttlMs ? { expiresAt: now + input.ttlMs } : {}),
+        ...(input.metadata ? { metadata: input.metadata } : {}),
+      };
+
+      getOrCreateBindingMap(accountId).set(record.bindingId, record);
+      log?.info?.(
+        `octo: [${accountId}] bound conversation=${conversationId} → session=${targetSessionKey} (placement=${placement}, kind=${input.targetKind})`,
+      );
+      return record;
+    },
+
+    listBySession: (targetSessionKey: string): SessionBindingRecord[] => {
+      const m = _bindingsByAccount.get(accountId);
+      if (!m) return [];
+      const out: SessionBindingRecord[] = [];
+      for (const rec of m.values()) {
+        if (rec.targetSessionKey === targetSessionKey) out.push(rec);
+      }
+      return out;
+    },
+
+    resolveByConversation: (ref: ConversationRef): SessionBindingRecord | null => {
+      if (ref.channel !== CHANNEL_ID || ref.accountId !== accountId) return null;
+      const m = _bindingsByAccount.get(accountId);
+      if (!m) return null;
+      return m.get(buildBindingId(accountId, ref.conversationId)) ?? null;
+    },
+
+    touch: (bindingId: string, _at?: number): void => {
+      // In-memory adapter has no idle-expiry sweeper, so touch is a no-op.
+      // Kept for SDK contract compliance; record's boundAt is the source of
+      // truth for callers that care about activity.
+      const m = _bindingsByAccount.get(accountId);
+      if (!m || !m.has(bindingId)) return;
+      // Future: if we add a sweeper, mutate a lastTouchedAt field here.
+    },
+
+    unbind: async (
+      input: SessionBindingUnbindInput,
+    ): Promise<SessionBindingRecord[]> => {
+      const m = _bindingsByAccount.get(accountId);
+      if (!m) return [];
+      const removed: SessionBindingRecord[] = [];
+      if (input.bindingId) {
+        const rec = m.get(input.bindingId);
+        if (rec) {
+          m.delete(input.bindingId);
+          removed.push({ ...rec, status: "ended" });
+        }
+      } else if (input.targetSessionKey) {
+        const target = input.targetSessionKey;
+        for (const [key, rec] of Array.from(m.entries())) {
+          if (rec.targetSessionKey === target) {
+            m.delete(key);
+            removed.push({ ...rec, status: "ended" });
+          }
+        }
+      }
+      if (removed.length > 0) {
+        log?.info?.(
+          `octo: [${accountId}] unbound ${removed.length} binding(s) (reason: ${input.reason})`,
+        );
+      }
+      return removed;
+    },
+  };
+
+  registerSessionBindingAdapter(adapter);
+  log?.info?.(
+    `octo: [${accountId}] registered SessionBindingAdapter (placements=current,child)`,
+  );
+
+  let unregistered = false;
+  return function unregister() {
+    if (unregistered) return;
+    unregistered = true;
+    unregisterSessionBindingAdapter({
+      channel: CHANNEL_ID,
+      accountId,
+      adapter,
+    });
+    _bindingsByAccount.delete(accountId);
+    log?.info?.(`octo: [${accountId}] unregistered SessionBindingAdapter`);
+  };
+}
+
+/** Test-only: clear the in-memory binding registry across all accounts. */
+export function __resetOctoThreadBindingsForTests(): void {
+  _bindingsByAccount.clear();
+}


### PR DESCRIPTION
Closes #23.

## Problem

OpenClaw ACP runtime 在 Octo channel 上抛 `thread_binding_invalid`：

```json
{ "status": "error", "errorCode": "thread_binding_invalid",
  "error": "Thread bindings are unavailable for octo." }
```

所有 ACP harness（Claude Code / Codex / Cursor / Gemini）在 Octo 群里**无法跑 `mode: "session"` + `thread: true` 的持久会话**，只能 `mode: "run"` 一次性，丢失对话上下文。

## Root cause

Issue 作者最初指向 `describeMessageTool` 的 `capabilities` 数组，但 SDK 的 `ChannelMessageCapability` 类型只有 `\"presentation\" | \"delivery-pin\"` —— 跟 thread 无关。

真正的检查在 `node_modules/openclaw/dist/lifecycle-BMWHsKQZ.js:206`：

```js
const capabilities = bindingService.getCapabilities({ channel, accountId });
if (!capabilities.adapterAvailable) abort with thread_binding_invalid
if (!capabilities.bindSupported)    abort with thread_binding_invalid
```

`getSessionBindingService` 维护独立的 `SessionBindingAdapter` 注册表，通过 `registerSessionBindingAdapter()`（从 `openclaw/plugin-sdk/thread-bindings-runtime` 导出）填充。**Telegram 的 bundled channel 调了；Octo 从来没调过**：

- `grep -rn registerSessionBindingAdapter src/` → 0 hits
- bundled telegram 调用 placements `[\"current\", \"child\"]`

## Fix

新文件 `src/thread-binding-adapter.ts`：

- `registerOctoThreadBindingAdapter({accountId, apiUrl, botToken, log})` 注册 adapter，返回 unregister 函数
- `placement: \"current\"`：对当前 conversationId 建 binding（不创建任何 server-side 资源）
- `placement: \"child\"`：调 `POST /v1/bot/groups/{groupNo}/threads`（已有的 `createThread` API）创建新 sub-thread，binding 用 `groupNo____shortId` 作为 conversationId
- `listBySession` / `resolveByConversation` / `unbind` / `touch` 补齐 adapter contract
- 内存存储，按 account 分桶；unregister 时清空（在 `startAccount` 的 abort-signal cleanup 里调用）

`channel.ts` `startAccount` 紧挨 `initPersonaPromptCache` 调注册，返回的 unregister fn 跟 `stopPersonaPromptCache` 一起在 cleanup 闭包里执行。

## Tests

`src/thread-binding-adapter.test.ts` — 9 个单元测试：

- adapter 注册时声明 `placements: [\"current\", \"child\"]` + `bindSupported/unbindSupported: true`
- `bind(current)` 记录 binding，不调 createThread
- `bind(child)` 调 createThread，conversationId 用 `groupNo____shortId`
- `bind(child)` 在 createThread 失败时返回 null（不抛）
- `bind(child)` 从已是 thread 的 parentConversationId 中正确剥出 group_no（`group____short` → `group`）
- `unbind(bindingId)` 移除 1 条，status = `\"ended\"`
- `unbind(targetSessionKey)` 移除所有匹配
- `unregister` 幂等 + 清空内存
- 外 channel（如 telegram）的 conversation 被 `bind` 拒绝

**全部 807 个原有测试仍通过**。

## Out of scope (未来工作)

- 磁盘持久化（当前内存存储，gateway 重启后丢；ACP session 本身也不跨重启，所以一致）
- 空闲/过期 sweeper（telegram 那种）—— 等持久化加上再考虑

## Test plan

- [x] `npm run type-check` 通过
- [x] `npm test` 全过（807/807）
- [x] `npm run build` 干净
- [ ] 本地真机回归：在 OpenClaw 启用 ACP + 群里 @main 调 `sessions_spawn({runtime:\"acp\", mode:\"session\", thread:true})`，期望返回 `\"ok\"` 不再是 `\"thread_binding_invalid\"`（这步等 PR 合并 + 发版后做）