### PR TITLE
fix: register SessionBindingAdapter for ACP thread binding

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -36,6 +36,7 @@ import { getOrCreateGroupMdCache, registerBotGroupIds, getKnownGroupIds, writeGr
 import { registerOwnerUid } from "./owner-registry.js";
 import { preloadGroupMemberCache, getGroupMembersFromCache } from "./member-cache.js";
 import { initPersonaPromptCache, stopPersonaPromptCache } from "./persona-prompt.js";
+import { registerOctoThreadBindingAdapter } from "./thread-binding-adapter.js";
 import path from "node:path";
 import os from "node:os";
 import { mkdir, readFile, writeFile, unlink } from "node:fs/promises";
@@ -918,6 +919,15 @@ export const octoPlugin: ChannelPlugin<ResolvedOctoAccount> = {
         log,
       );
 
+      // Register ACP thread-binding adapter (fixes #23). Without this, OpenClaw's
+      // ACP runtime aborts session+thread spawns with `thread_binding_invalid`.
+      const unregisterThreadBinding = registerOctoThreadBindingAdapter({
+        accountId: account.accountId,
+        apiUrl: account.config.apiUrl,
+        botToken: account.config.botToken!,
+        log,
+      });
+
       // Prefetch GROUP.md and group members for all groups (fire-and-forget)
       const groupMdCache = getOrCreateGroupMdCache(account.accountId);
       (async () => {
@@ -1208,6 +1218,7 @@ export const octoPlugin: ChannelPlugin<ResolvedOctoAccount> = {
           if (heartbeatTimer) { clearInterval(heartbeatTimer); heartbeatTimer = null; }
           if (cooldownReconnectTimer) { clearTimeout(cooldownReconnectTimer); cooldownReconnectTimer = null; }
           stopPersonaPromptCache(account.accountId);
+          unregisterThreadBinding();
           ctx.setStatus({
             accountId: account.accountId,
             running: false,

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -544,9 +544,12 @@ export const octoPlugin: ChannelPlugin<ResolvedOctoAccount> = {
         DEFAULT_ACCOUNT_ID;
       const account = resolveOctoAccount({ cfg, accountId: resolvedId });
       if (!account.config.botToken) {
-        // Not configured yet — return a no-op manager so OpenClaw's lifecycle
-        // doesn't crash. Once the account is configured and startAccount runs,
-        // a fresh manager will be created on the next bind request.
+        // Account not yet configured (botToken missing). Return a no-op
+        // manager so OpenClaw's lifecycle doesn't crash. NOTE: the runtime
+        // tracks one manager per (plugin, account) and will NOT call
+        // createManager again on subsequent binds for the same account, so
+        // configuring the bot AFTER first bind requires a gateway restart
+        // (or an in-process config reload hook) to install a working manager.
         return { stop: () => {} };
       }
       const unregister = registerOctoThreadBindingAdapter({

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -552,14 +552,24 @@ export const octoPlugin: ChannelPlugin<ResolvedOctoAccount> = {
         // (or an in-process config reload hook) to install a working manager.
         return { stop: () => {} };
       }
+      // The SDK's `createManager` signature does NOT include a log sink, so
+      // we wire a minimal console-backed fallback. This surfaces
+      // `createThread` failures in the `child`-placement path that would
+      // otherwise be swallowed into a generic null binding result.
+      const fallbackLog = {
+        info: (msg: string) => console.log(`[octo:thread-binding] ${msg}`),
+        warn: (msg: string) => console.warn(`[octo:thread-binding] ${msg}`),
+        debug: (msg: string) => console.debug(`[octo:thread-binding] ${msg}`),
+      };
       const unregister = registerOctoThreadBindingAdapter({
         accountId: resolvedId,
         apiUrl: account.config.apiUrl,
         botToken: account.config.botToken,
+        log: fallbackLog,
       });
       return { stop: () => unregister() };
     },
-  } as any, // TODO: remove when SDK types support this
+  },
   actions: {
     listActions: ({ cfg }: { cfg: any }) => {
       const actions = getAvailableActions(cfg);

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -493,6 +493,70 @@ export const octoPlugin: ChannelPlugin<ResolvedOctoAccount> = {
     threads: true,
   },
   reload: { configPrefixes: [`channels.${CHANNEL_ID}`] },
+  // Declare ACP thread-binding support so OpenClaw's session-binding service
+  // recognizes Octo as a thread-binding-capable channel. Without this block,
+  // `getCapabilities({channel:"octo",...})` returns
+  // `{ adapterAvailable: false, bindSupported: false }` and ACP spawns abort
+  // with `errorCode: "thread_binding_invalid"` (#23).
+  //
+  // - `supportsCurrentConversationBinding: true` is the minimum for OpenClaw's
+  //   generic current-placement bind path to accept Octo.
+  // - `createManager` is the runtime entry point: OpenClaw calls it on demand
+  //   per (cfg, accountId) and we install a SessionBindingAdapter that adds
+  //   "child" placement support (creates a new Octo sub-thread on bind).
+  // - `resolveConversationRef` normalizes octo's `groupNo____shortId` thread
+  //   format so callers passing a parent + threadId get the correct merged ref.
+  // - `buildBoundReplyPayload` returns null because Octo doesn't have a
+  //   per-thread pin/notify equivalent of Telegram's topic pin payload.
+  conversationBindings: {
+    supportsCurrentConversationBinding: true,
+    defaultTopLevelPlacement: "current",
+    resolveConversationRef: ({ conversationId, parentConversationId, threadId }: {
+      accountId?: string | null;
+      conversationId: string;
+      parentConversationId?: string;
+      threadId?: string | number | null;
+    }) => {
+      // Already a thread ref like "groupNo____shortId": split into parent+child.
+      if (conversationId.includes("____")) {
+        const parent = conversationId.split("____")[0]!;
+        return { conversationId, parentConversationId: parent };
+      }
+      // Caller passed a parent group + an explicit threadId: synthesize the
+      // composite conversationId in Octo's canonical format.
+      const tid = threadId == null ? "" : String(threadId).trim();
+      if (tid) {
+        return {
+          conversationId: `${conversationId}____${tid}`,
+          parentConversationId: conversationId,
+        };
+      }
+      return {
+        conversationId,
+        ...(parentConversationId ? { parentConversationId } : {}),
+      };
+    },
+    buildBoundReplyPayload: () => null,
+    createManager: ({ cfg, accountId }: { cfg: any; accountId?: string | null }) => {
+      const resolvedId =
+        (accountId && accountId.trim()) ||
+        resolveDefaultOctoAccountId(cfg) ||
+        DEFAULT_ACCOUNT_ID;
+      const account = resolveOctoAccount({ cfg, accountId: resolvedId });
+      if (!account.config.botToken) {
+        // Not configured yet — return a no-op manager so OpenClaw's lifecycle
+        // doesn't crash. Once the account is configured and startAccount runs,
+        // a fresh manager will be created on the next bind request.
+        return { stop: () => {} };
+      }
+      const unregister = registerOctoThreadBindingAdapter({
+        accountId: resolvedId,
+        apiUrl: account.config.apiUrl,
+        botToken: account.config.botToken,
+      });
+      return { stop: () => unregister() };
+    },
+  } as any, // TODO: remove when SDK types support this
   actions: {
     listActions: ({ cfg }: { cfg: any }) => {
       const actions = getAvailableActions(cfg);
@@ -919,14 +983,10 @@ export const octoPlugin: ChannelPlugin<ResolvedOctoAccount> = {
         log,
       );
 
-      // Register ACP thread-binding adapter (fixes #23). Without this, OpenClaw's
-      // ACP runtime aborts session+thread spawns with `thread_binding_invalid`.
-      const unregisterThreadBinding = registerOctoThreadBindingAdapter({
-        accountId: account.accountId,
-        apiUrl: account.config.apiUrl,
-        botToken: account.config.botToken!,
-        log,
-      });
+      // NOTE: ACP thread-binding adapter is NOT registered here. The canonical
+      // wiring is via `octoPlugin.conversationBindings.createManager`, which
+      // OpenClaw runtime calls on demand and whose returned `{stop}` it owns.
+      // See the plugin declaration above and `src/thread-binding-adapter.ts`.
 
       // Prefetch GROUP.md and group members for all groups (fire-and-forget)
       const groupMdCache = getOrCreateGroupMdCache(account.accountId);
@@ -1218,7 +1278,6 @@ export const octoPlugin: ChannelPlugin<ResolvedOctoAccount> = {
           if (heartbeatTimer) { clearInterval(heartbeatTimer); heartbeatTimer = null; }
           if (cooldownReconnectTimer) { clearTimeout(cooldownReconnectTimer); cooldownReconnectTimer = null; }
           stopPersonaPromptCache(account.accountId);
-          unregisterThreadBinding();
           ctx.setStatus({
             accountId: account.accountId,
             running: false,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -16,6 +16,13 @@ export const PLUGIN_ID = "octo";
 
 export const CHANNEL_ID = "octo";
 
+/**
+ * Separator between parent group_no and thread short_id in Octo's CommunityTopic
+ * channel ID format (`<groupNo>____<shortId>`, 4 underscores). Centralized here
+ * to avoid drift across modules that need to split or compose thread refs.
+ */
+export const THREAD_ID_SEPARATOR = "____";
+
 /** Strip channel namespace prefix from a sessionKey or target string. */
 export function stripChannelPrefix(s: string): string {
   return s.replace(/^octo:/, "");

--- a/src/thread-binding-adapter.test.ts
+++ b/src/thread-binding-adapter.test.ts
@@ -1,0 +1,305 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  registerOctoThreadBindingAdapter,
+  __resetOctoThreadBindingsForTests,
+} from "./thread-binding-adapter.js";
+
+// Mock createThread (used only by the `child` placement path).
+vi.mock("./api-fetch.js", () => ({
+  createThread: vi.fn(),
+}));
+
+import { createThread } from "./api-fetch.js";
+
+const ACCOUNT_ID = "27pBwzf2F6bfa5cd142_bot";
+const API_URL = "https://im.example.com/api";
+const BOT_TOKEN = "bf_test123";
+
+function makeAdapterContext() {
+  // capture log output for assertion
+  const logs: { level: string; msg: string }[] = [];
+  const log = {
+    info: (msg: string) => logs.push({ level: "info", msg }),
+    warn: (msg: string) => logs.push({ level: "warn", msg }),
+    debug: (msg: string) => logs.push({ level: "debug", msg }),
+  };
+  const unregister = registerOctoThreadBindingAdapter({
+    accountId: ACCOUNT_ID,
+    apiUrl: API_URL,
+    botToken: BOT_TOKEN,
+    log,
+  });
+  return { unregister, logs };
+}
+
+// We need a way to call the adapter's bind/listBySession/etc. methods.
+// The adapter is registered into the SDK's internal registry; the SDK
+// doesn't publicly expose getCapabilities. So we re-register a fresh
+// adapter for each test and capture a reference to its method surface
+// via a small spy.
+//
+// Instead, we test the OBSERVABLE side-effects through the SDK's
+// register/unregister API and through createThread mock calls.
+//
+// For per-method assertions, expose a "test handle" by reading the
+// adapter we're about to register. Easiest: import the SessionBindingAdapter
+// shape from the SDK and construct a fresh bind input ourselves using
+// the same registry the SDK uses.
+
+import {
+  registerSessionBindingAdapter,
+  unregisterSessionBindingAdapter,
+  type SessionBindingAdapter,
+} from "openclaw/plugin-sdk/thread-bindings-runtime";
+
+// Helper: capture the registered adapter so tests can call its methods.
+// We replace the SDK's register fn via vi.mock for the duration of the test.
+let _capturedAdapter: SessionBindingAdapter | null = null;
+
+vi.mock("openclaw/plugin-sdk/thread-bindings-runtime", async (importActual) => {
+  const actual = (await importActual()) as Record<string, unknown>;
+  return {
+    ...actual,
+    registerSessionBindingAdapter: (adapter: SessionBindingAdapter) => {
+      _capturedAdapter = adapter;
+      // Also register with the real SDK so unregister round-trips work.
+      (actual.registerSessionBindingAdapter as typeof registerSessionBindingAdapter)(adapter);
+    },
+    unregisterSessionBindingAdapter: (params: Parameters<typeof unregisterSessionBindingAdapter>[0]) => {
+      _capturedAdapter = null;
+      (actual.unregisterSessionBindingAdapter as typeof unregisterSessionBindingAdapter)(params);
+    },
+  };
+});
+
+describe("registerOctoThreadBindingAdapter", () => {
+  beforeEach(() => {
+    __resetOctoThreadBindingsForTests();
+    _capturedAdapter = null;
+    vi.mocked(createThread).mockReset();
+  });
+
+  afterEach(() => {
+    if (_capturedAdapter) {
+      // Best-effort cleanup
+      _capturedAdapter = null;
+    }
+    __resetOctoThreadBindingsForTests();
+  });
+
+  it("registers an adapter with placements=[current,child] and bindSupported=true", () => {
+    const { unregister } = makeAdapterContext();
+    expect(_capturedAdapter).not.toBeNull();
+    expect(_capturedAdapter!.channel).toBe("octo");
+    expect(_capturedAdapter!.accountId).toBe(ACCOUNT_ID);
+    expect(_capturedAdapter!.capabilities).toEqual({
+      placements: ["current", "child"],
+      bindSupported: true,
+      unbindSupported: true,
+    });
+    unregister();
+  });
+
+  it("bind(placement=current) records a binding using the existing conversationId without calling createThread", async () => {
+    const { unregister } = makeAdapterContext();
+    const conversationId = "groupNo_abc";
+    const targetSessionKey = "agent:cc:acp:9da61851";
+
+    const record = await _capturedAdapter!.bind!({
+      targetSessionKey,
+      targetKind: "session",
+      conversation: { channel: "octo", accountId: ACCOUNT_ID, conversationId },
+      placement: "current",
+    });
+
+    expect(record).not.toBeNull();
+    expect(record!.bindingId).toBe(`${ACCOUNT_ID}:${conversationId}`);
+    expect(record!.targetSessionKey).toBe(targetSessionKey);
+    expect(record!.conversation.conversationId).toBe(conversationId);
+    expect(record!.status).toBe("active");
+    expect(vi.mocked(createThread)).not.toHaveBeenCalled();
+
+    // Adapter should be able to look the binding up by conversation.
+    const found = _capturedAdapter!.resolveByConversation({
+      channel: "octo",
+      accountId: ACCOUNT_ID,
+      conversationId,
+    });
+    expect(found?.bindingId).toBe(record!.bindingId);
+
+    // …and by session key.
+    const bySession = _capturedAdapter!.listBySession(targetSessionKey);
+    expect(bySession).toHaveLength(1);
+    expect(bySession[0]!.bindingId).toBe(record!.bindingId);
+
+    unregister();
+  });
+
+  it("bind(placement=child) calls createThread and uses groupNo____shortId as conversationId", async () => {
+    vi.mocked(createThread).mockResolvedValueOnce({
+      short_id: "thrxyz",
+      name: "Agent: 9da61851",
+      creator_uid: "bot-uid",
+    });
+    const { unregister } = makeAdapterContext();
+
+    const record = await _capturedAdapter!.bind!({
+      targetSessionKey: "agent:cc:acp:9da61851",
+      targetKind: "session",
+      conversation: {
+        channel: "octo",
+        accountId: ACCOUNT_ID,
+        conversationId: "parentGroup",
+      },
+      placement: "child",
+    });
+
+    expect(vi.mocked(createThread)).toHaveBeenCalledOnce();
+    expect(vi.mocked(createThread)).toHaveBeenCalledWith({
+      apiUrl: API_URL,
+      botToken: BOT_TOKEN,
+      groupNo: "parentGroup",
+      name: "Agent: 9da61851",
+    });
+    expect(record).not.toBeNull();
+    expect(record!.conversation.conversationId).toBe("parentGroup____thrxyz");
+    expect(record!.conversation.parentConversationId).toBe("parentGroup");
+
+    unregister();
+  });
+
+  it("bind(placement=child) returns null when createThread fails (does not throw)", async () => {
+    vi.mocked(createThread).mockRejectedValueOnce(new Error("network down"));
+    const { unregister, logs } = makeAdapterContext();
+
+    const record = await _capturedAdapter!.bind!({
+      targetSessionKey: "agent:cc:acp:abc",
+      targetKind: "session",
+      conversation: {
+        channel: "octo",
+        accountId: ACCOUNT_ID,
+        conversationId: "parentGroup",
+      },
+      placement: "child",
+    });
+
+    expect(record).toBeNull();
+    expect(logs.some((l) => l.level === "warn" && l.msg.includes("createThread failed"))).toBe(true);
+
+    unregister();
+  });
+
+  it("bind(placement=child) extracts parent group_no from a thread-shaped parentConversationId", async () => {
+    vi.mocked(createThread).mockResolvedValueOnce({
+      short_id: "newshort",
+      name: "x",
+      creator_uid: "bot-uid",
+    });
+    const { unregister } = makeAdapterContext();
+
+    await _capturedAdapter!.bind!({
+      targetSessionKey: "agent:cc:acp:abc",
+      targetKind: "session",
+      conversation: {
+        channel: "octo",
+        accountId: ACCOUNT_ID,
+        // Caller is already in a thread; child should still be created under the parent group.
+        conversationId: "parentGroup____oldshort",
+      },
+      placement: "child",
+    });
+
+    expect(vi.mocked(createThread)).toHaveBeenCalledWith(
+      expect.objectContaining({ groupNo: "parentGroup" }),
+    );
+    unregister();
+  });
+
+  it("unbind by bindingId removes the record and returns it with status=ended", async () => {
+    const { unregister } = makeAdapterContext();
+    const conv = "groupX";
+    const rec = await _capturedAdapter!.bind!({
+      targetSessionKey: "s1",
+      targetKind: "session",
+      conversation: { channel: "octo", accountId: ACCOUNT_ID, conversationId: conv },
+      placement: "current",
+    });
+
+    const removed = await _capturedAdapter!.unbind!({
+      bindingId: rec!.bindingId,
+      reason: "user-requested",
+    });
+
+    expect(removed).toHaveLength(1);
+    expect(removed[0]!.status).toBe("ended");
+    expect(_capturedAdapter!.resolveByConversation({ channel: "octo", accountId: ACCOUNT_ID, conversationId: conv })).toBeNull();
+
+    unregister();
+  });
+
+  it("unbind by targetSessionKey removes all matching bindings", async () => {
+    const { unregister } = makeAdapterContext();
+    await _capturedAdapter!.bind!({
+      targetSessionKey: "shared",
+      targetKind: "session",
+      conversation: { channel: "octo", accountId: ACCOUNT_ID, conversationId: "g1" },
+      placement: "current",
+    });
+    await _capturedAdapter!.bind!({
+      targetSessionKey: "shared",
+      targetKind: "session",
+      conversation: { channel: "octo", accountId: ACCOUNT_ID, conversationId: "g2" },
+      placement: "current",
+    });
+    await _capturedAdapter!.bind!({
+      targetSessionKey: "other",
+      targetKind: "session",
+      conversation: { channel: "octo", accountId: ACCOUNT_ID, conversationId: "g3" },
+      placement: "current",
+    });
+
+    const removed = await _capturedAdapter!.unbind!({
+      targetSessionKey: "shared",
+      reason: "session-ended",
+    });
+    expect(removed).toHaveLength(2);
+    expect(_capturedAdapter!.listBySession("shared")).toHaveLength(0);
+    expect(_capturedAdapter!.listBySession("other")).toHaveLength(1);
+
+    unregister();
+  });
+
+  it("the unregister function clears bindings and is idempotent", async () => {
+    const { unregister } = makeAdapterContext();
+    await _capturedAdapter!.bind!({
+      targetSessionKey: "s",
+      targetKind: "session",
+      conversation: { channel: "octo", accountId: ACCOUNT_ID, conversationId: "c" },
+      placement: "current",
+    });
+    expect(_capturedAdapter!.listBySession("s")).toHaveLength(1);
+
+    unregister();
+    // Calling unregister again must not throw.
+    unregister();
+    // The captured adapter reference is from BEFORE unregister; its listBySession
+    // reads from the module-level map. After unregister, that map is cleared.
+    expect(_capturedAdapter).toBeNull();
+  });
+
+  it("bind(placement=current) ignores conversations from other channels", async () => {
+    const { unregister } = makeAdapterContext();
+    const record = await _capturedAdapter!.bind!({
+      targetSessionKey: "s",
+      targetKind: "session",
+      conversation: {
+        channel: "telegram", // not octo
+        accountId: ACCOUNT_ID,
+        conversationId: "tg-chat",
+      },
+      placement: "current",
+    });
+    expect(record).toBeNull();
+    unregister();
+  });
+});

--- a/src/thread-binding-adapter.test.ts
+++ b/src/thread-binding-adapter.test.ts
@@ -11,7 +11,11 @@ vi.mock("./api-fetch.js", () => ({
 
 import { createThread } from "./api-fetch.js";
 
-const ACCOUNT_ID = "27pBwzf2F6bfa5cd142_bot";
+// Lowercase by design: the adapter normalizes accountIds via toLowerCase
+// before storing, so most assertions in this file expect the normalized form.
+// A separate `mixed-case account ID round-trip` describe block below covers
+// the normalization behavior explicitly.
+const ACCOUNT_ID = "27pbwzf2f6bfa5cd142_bot";
 const API_URL = "https://im.example.com/api";
 const BOT_TOKEN = "bf_test123";
 
@@ -301,5 +305,90 @@ describe("registerOctoThreadBindingAdapter", () => {
     });
     expect(record).toBeNull();
     unregister();
+  });
+
+  // -------------------------------------------------------------------------
+  // Mixed-case account ID round-trip (regression for PR #32 review feedback).
+  // -------------------------------------------------------------------------
+  // OpenClaw's session-binding service normalizes adapter accountIds and
+  // conversation refs to lowercase before invoking adapter methods. A previous
+  // version of the adapter captured the raw mixed-case accountId in its
+  // closure and compared `ref.accountId !== accountId` directly, which made
+  // `resolveByConversation` silently miss for any account whose original ID
+  // contained uppercase letters (BotFather emits mixed-case bf_… IDs).
+  // -------------------------------------------------------------------------
+  describe("mixed-case account ID round-trip", () => {
+    const MIXED_CASE_ACCOUNT = "27pBwzf2F6bfa5cd142_bot";
+    const NORMALIZED = MIXED_CASE_ACCOUNT.toLowerCase();
+
+    it("registers the adapter under the normalized (lowercased) accountId", () => {
+      const unregister = registerOctoThreadBindingAdapter({
+        accountId: MIXED_CASE_ACCOUNT,
+        apiUrl: API_URL,
+        botToken: BOT_TOKEN,
+      });
+      expect(_capturedAdapter).not.toBeNull();
+      expect(_capturedAdapter!.accountId).toBe(NORMALIZED);
+      unregister();
+    });
+
+    it("resolveByConversation matches when the SDK passes a lowercased ref (the production path)", async () => {
+      const unregister = registerOctoThreadBindingAdapter({
+        accountId: MIXED_CASE_ACCOUNT,
+        apiUrl: API_URL,
+        botToken: BOT_TOKEN,
+      });
+      // SDK normalizes the conversation ref before calling bind(). Simulate
+      // exactly what the production path looks like by passing the lowercased
+      // accountId on every interaction.
+      const conversationId = "groupX";
+      const rec = await _capturedAdapter!.bind!({
+        targetSessionKey: "agent:cc:acp:abc",
+        targetKind: "session",
+        conversation: {
+          channel: "octo",
+          accountId: NORMALIZED,
+          conversationId,
+        },
+        placement: "current",
+      });
+      expect(rec).not.toBeNull();
+      expect(rec!.conversation.accountId).toBe(NORMALIZED);
+
+      // The crucial assertion: SDK calls resolveByConversation with the
+      // lowercased accountId. Before the fix, the adapter compared this to
+      // the captured mixed-case original and returned null.
+      const found = _capturedAdapter!.resolveByConversation({
+        channel: "octo",
+        accountId: NORMALIZED,
+        conversationId,
+      });
+      expect(found?.bindingId).toBe(rec!.bindingId);
+      unregister();
+    });
+
+    it("resolveByConversation also matches when callers pass the original mixed-case accountId (defensive double-normalization)", () => {
+      const unregister = registerOctoThreadBindingAdapter({
+        accountId: MIXED_CASE_ACCOUNT,
+        apiUrl: API_URL,
+        botToken: BOT_TOKEN,
+      });
+      // Direct adapter-level callers (e.g. tests, debug tools) might bypass
+      // SDK normalization and pass the raw mixed-case accountId. The adapter
+      // normalizes the ref defensively, so this still resolves.
+      _capturedAdapter!.bind!({
+        targetSessionKey: "s",
+        targetKind: "session",
+        conversation: { channel: "octo", accountId: NORMALIZED, conversationId: "g" },
+        placement: "current",
+      });
+      const found = _capturedAdapter!.resolveByConversation({
+        channel: "octo",
+        accountId: MIXED_CASE_ACCOUNT, // mixed case here
+        conversationId: "g",
+      });
+      expect(found).not.toBeNull();
+      unregister();
+    });
   });
 });

--- a/src/thread-binding-adapter.test.ts
+++ b/src/thread-binding-adapter.test.ts
@@ -307,6 +307,22 @@ describe("registerOctoThreadBindingAdapter", () => {
     unregister();
   });
 
+  it("bind(placement=current) ignores conversations whose accountId does not match the adapter", async () => {
+    const { unregister } = makeAdapterContext();
+    const record = await _capturedAdapter!.bind!({
+      targetSessionKey: "s",
+      targetKind: "session",
+      conversation: {
+        channel: "octo",
+        accountId: "27someotheraccount_bot", // not ACCOUNT_ID
+        conversationId: "c",
+      },
+      placement: "current",
+    });
+    expect(record).toBeNull();
+    unregister();
+  });
+
   // -------------------------------------------------------------------------
   // Mixed-case account ID round-trip (regression for PR #32 review feedback).
   // -------------------------------------------------------------------------

--- a/src/thread-binding-adapter.ts
+++ b/src/thread-binding-adapter.ts
@@ -155,8 +155,11 @@ export function registerOctoThreadBindingAdapter(
       input: SessionBindingBindInput,
     ): Promise<SessionBindingRecord | null> => {
       // Defensive: SDK should already filter by channel/accountId, but the
-      // adapter contract permits us to no-op on mismatched input.
+      // adapter contract permits us to no-op on mismatched input. Mirror the
+      // same normalization that `resolveByConversation` applies so a direct
+      // caller passing a mixed-case accountId still routes correctly here.
       if (input.conversation.channel !== CHANNEL_ID) return null;
+      if (normalizeAccountId(input.conversation.accountId) !== accountId) return null;
 
       const targetSessionKey = input.targetSessionKey.trim();
       if (!targetSessionKey) return null;

--- a/src/thread-binding-adapter.ts
+++ b/src/thread-binding-adapter.ts
@@ -1,0 +1,287 @@
+/**
+ * Octo SessionBindingAdapter — fixes octo-adapters#23 (thread_binding_invalid).
+ *
+ * OpenClaw's ACP runtime queries `getSessionBindingService().getCapabilities({channel,accountId})`
+ * before spawning a thread-bound ACP session. If no SessionBindingAdapter is
+ * registered for the channel+account, the service returns
+ * `{ adapterAvailable: false, bindSupported: false }` and the runtime aborts
+ * the spawn with `errorCode: "thread_binding_invalid"`.
+ *
+ * Reference impl: see Telegram's bundled adapter at
+ * `node_modules/openclaw/dist/thread-bindings-BnqTb64l.js`.
+ *
+ * This adapter:
+ *   - placement="current": records a binding against the current Octo
+ *     conversationId without creating any new server-side resource. This is
+ *     the most common path (binding a session to the active group / thread
+ *     the user is talking in).
+ *   - placement="child":  calls Octo `POST /v1/bot/groups/{groupNo}/threads`
+ *     to create a new sub-thread, then records a binding against the
+ *     resulting `groupNo____shortId` conversationId. This is the path used
+ *     when an ACP session needs a fresh isolated sub-topic.
+ *
+ * Persistence is in-memory and per-account. Bindings are wiped when
+ * `stopAccount` runs (e.g. on gateway restart). For first-iteration
+ * correctness this is acceptable — ACP sessions themselves are not
+ * persisted across restarts either, so a stale binding pointing to a dead
+ * session would be useless. Future iterations can adopt the SDK's
+ * `createAccountScopedConversationBindingManager` for disk-backed records.
+ */
+import {
+  registerSessionBindingAdapter,
+  unregisterSessionBindingAdapter,
+  type SessionBindingAdapter,
+  type SessionBindingRecord,
+} from "openclaw/plugin-sdk/thread-bindings-runtime";
+import { CHANNEL_ID } from "./constants.js";
+import { createThread } from "./api-fetch.js";
+
+// SDK's `thread-bindings-runtime` only re-exports the adapter + record types.
+// Derive the input types from the adapter signature itself to stay loosely
+// coupled and avoid reaching into internal SDK subpaths.
+type SessionBindingBindInput = Parameters<NonNullable<SessionBindingAdapter["bind"]>>[0];
+type SessionBindingUnbindInput = Parameters<NonNullable<SessionBindingAdapter["unbind"]>>[0];
+type ConversationRef = Parameters<SessionBindingAdapter["resolveByConversation"]>[0];
+
+type Logger = {
+  info?: (msg: string) => void;
+  warn?: (msg: string) => void;
+  debug?: (msg: string) => void;
+} | undefined;
+
+/**
+ * Module-level binding registry, keyed by accountId. Each entry maps
+ * bindingId → record. bindingId format is `${accountId}:${conversationId}`,
+ * matching the Telegram adapter's convention.
+ */
+const _bindingsByAccount = new Map<string, Map<string, SessionBindingRecord>>();
+
+function getOrCreateBindingMap(
+  accountId: string,
+): Map<string, SessionBindingRecord> {
+  let m = _bindingsByAccount.get(accountId);
+  if (!m) {
+    m = new Map();
+    _bindingsByAccount.set(accountId, m);
+  }
+  return m;
+}
+
+function buildBindingId(accountId: string, conversationId: string): string {
+  return `${accountId}:${conversationId}`;
+}
+
+function deriveThreadName(
+  metadata: Record<string, unknown> | undefined,
+  targetSessionKey: string,
+): string {
+  const md = metadata ?? {};
+  const fromMd =
+    (typeof md.threadName === "string" && md.threadName.trim()) ||
+    (typeof md.label === "string" && md.label.trim()) ||
+    "";
+  if (fromMd) return fromMd as string;
+  const tail = targetSessionKey.split(":").pop() ?? "session";
+  return `Agent: ${tail}`;
+}
+
+/**
+ * Resolve the parent group_no from a child conversationId. Octo encodes
+ * threads as `groupNo____shortId` (4 underscores). When the caller passes
+ * a parent conversationId that is itself a thread ref, strip the suffix.
+ */
+function resolveParentGroupNo(
+  conversation: SessionBindingBindInput["conversation"],
+): string | null {
+  const raw =
+    conversation.parentConversationId?.trim() ||
+    conversation.conversationId?.trim() ||
+    "";
+  if (!raw) return null;
+  return raw.includes("____") ? raw.split("____")[0]! : raw;
+}
+
+export interface RegisterOctoThreadBindingAdapterParams {
+  accountId: string;
+  apiUrl: string;
+  /** Bot token (bf_...). Used by the `child` placement to create new threads. */
+  botToken: string;
+  log?: Logger;
+}
+
+/**
+ * Register a SessionBindingAdapter for one Octo account. Call once per
+ * account during `startAccount`. Returns an unregister function that the
+ * caller MUST invoke during `stopAccount` (or the abortSignal cleanup
+ * path) to keep the SDK registry in sync across hot reloads.
+ */
+export function registerOctoThreadBindingAdapter(
+  params: RegisterOctoThreadBindingAdapterParams,
+): () => void {
+  const { accountId, apiUrl, botToken, log } = params;
+
+  const adapter: SessionBindingAdapter = {
+    channel: CHANNEL_ID,
+    accountId,
+    capabilities: {
+      placements: ["current", "child"],
+      bindSupported: true,
+      unbindSupported: true,
+    },
+
+    bind: async (
+      input: SessionBindingBindInput,
+    ): Promise<SessionBindingRecord | null> => {
+      // Defensive: SDK should already filter by channel/accountId, but the
+      // adapter contract permits us to no-op on mismatched input.
+      if (input.conversation.channel !== CHANNEL_ID) return null;
+
+      const targetSessionKey = input.targetSessionKey.trim();
+      if (!targetSessionKey) return null;
+
+      const placement: "current" | "child" =
+        input.placement === "child" ? "child" : "current";
+
+      let conversationId: string;
+      let parentConversationId: string | undefined;
+
+      if (placement === "child") {
+        const parentGroupNo = resolveParentGroupNo(input.conversation);
+        if (!parentGroupNo) {
+          log?.warn?.(
+            `octo: [${accountId}] child bind failed — could not resolve parent group_no from conversation=${JSON.stringify(input.conversation)}`,
+          );
+          return null;
+        }
+        const threadName = deriveThreadName(input.metadata, targetSessionKey);
+        try {
+          const thread = await createThread({
+            apiUrl,
+            botToken,
+            groupNo: parentGroupNo,
+            name: threadName,
+          });
+          conversationId = `${parentGroupNo}____${thread.short_id}`;
+          parentConversationId = parentGroupNo;
+          log?.info?.(
+            `octo: [${accountId}] child thread created group=${parentGroupNo} short_id=${thread.short_id} (name="${threadName}")`,
+          );
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          log?.warn?.(
+            `octo: [${accountId}] createThread failed for group=${parentGroupNo}: ${message}`,
+          );
+          return null;
+        }
+      } else {
+        // placement === "current": bind to the conversationId the caller is
+        // already in. No new server-side resource is created.
+        const raw = input.conversation.conversationId?.trim();
+        if (!raw) return null;
+        conversationId = raw;
+        parentConversationId = input.conversation.parentConversationId;
+      }
+
+      const now = Date.now();
+      const record: SessionBindingRecord = {
+        bindingId: buildBindingId(accountId, conversationId),
+        targetSessionKey,
+        targetKind: input.targetKind,
+        conversation: {
+          channel: CHANNEL_ID,
+          accountId,
+          conversationId,
+          ...(parentConversationId ? { parentConversationId } : {}),
+        },
+        status: "active",
+        boundAt: now,
+        ...(input.ttlMs ? { expiresAt: now + input.ttlMs } : {}),
+        ...(input.metadata ? { metadata: input.metadata } : {}),
+      };
+
+      getOrCreateBindingMap(accountId).set(record.bindingId, record);
+      log?.info?.(
+        `octo: [${accountId}] bound conversation=${conversationId} → session=${targetSessionKey} (placement=${placement}, kind=${input.targetKind})`,
+      );
+      return record;
+    },
+
+    listBySession: (targetSessionKey: string): SessionBindingRecord[] => {
+      const m = _bindingsByAccount.get(accountId);
+      if (!m) return [];
+      const out: SessionBindingRecord[] = [];
+      for (const rec of m.values()) {
+        if (rec.targetSessionKey === targetSessionKey) out.push(rec);
+      }
+      return out;
+    },
+
+    resolveByConversation: (ref: ConversationRef): SessionBindingRecord | null => {
+      if (ref.channel !== CHANNEL_ID || ref.accountId !== accountId) return null;
+      const m = _bindingsByAccount.get(accountId);
+      if (!m) return null;
+      return m.get(buildBindingId(accountId, ref.conversationId)) ?? null;
+    },
+
+    touch: (bindingId: string, _at?: number): void => {
+      // In-memory adapter has no idle-expiry sweeper, so touch is a no-op.
+      // Kept for SDK contract compliance; record's boundAt is the source of
+      // truth for callers that care about activity.
+      const m = _bindingsByAccount.get(accountId);
+      if (!m || !m.has(bindingId)) return;
+      // Future: if we add a sweeper, mutate a lastTouchedAt field here.
+    },
+
+    unbind: async (
+      input: SessionBindingUnbindInput,
+    ): Promise<SessionBindingRecord[]> => {
+      const m = _bindingsByAccount.get(accountId);
+      if (!m) return [];
+      const removed: SessionBindingRecord[] = [];
+      if (input.bindingId) {
+        const rec = m.get(input.bindingId);
+        if (rec) {
+          m.delete(input.bindingId);
+          removed.push({ ...rec, status: "ended" });
+        }
+      } else if (input.targetSessionKey) {
+        const target = input.targetSessionKey;
+        for (const [key, rec] of Array.from(m.entries())) {
+          if (rec.targetSessionKey === target) {
+            m.delete(key);
+            removed.push({ ...rec, status: "ended" });
+          }
+        }
+      }
+      if (removed.length > 0) {
+        log?.info?.(
+          `octo: [${accountId}] unbound ${removed.length} binding(s) (reason: ${input.reason})`,
+        );
+      }
+      return removed;
+    },
+  };
+
+  registerSessionBindingAdapter(adapter);
+  log?.info?.(
+    `octo: [${accountId}] registered SessionBindingAdapter (placements=current,child)`,
+  );
+
+  let unregistered = false;
+  return function unregister() {
+    if (unregistered) return;
+    unregistered = true;
+    unregisterSessionBindingAdapter({
+      channel: CHANNEL_ID,
+      accountId,
+      adapter,
+    });
+    _bindingsByAccount.delete(accountId);
+    log?.info?.(`octo: [${accountId}] unregistered SessionBindingAdapter`);
+  };
+}
+
+/** Test-only: clear the in-memory binding registry across all accounts. */
+export function __resetOctoThreadBindingsForTests(): void {
+  _bindingsByAccount.clear();
+}

--- a/src/thread-binding-adapter.ts
+++ b/src/thread-binding-adapter.ts
@@ -33,7 +33,7 @@ import {
   type SessionBindingAdapter,
   type SessionBindingRecord,
 } from "openclaw/plugin-sdk/thread-bindings-runtime";
-import { CHANNEL_ID } from "./constants.js";
+import { CHANNEL_ID, THREAD_ID_SEPARATOR } from "./constants.js";
 import { createThread } from "./api-fetch.js";
 
 // SDK's `thread-bindings-runtime` only re-exports the adapter + record types.
@@ -42,6 +42,21 @@ import { createThread } from "./api-fetch.js";
 type SessionBindingBindInput = Parameters<NonNullable<SessionBindingAdapter["bind"]>>[0];
 type SessionBindingUnbindInput = Parameters<NonNullable<SessionBindingAdapter["unbind"]>>[0];
 type ConversationRef = Parameters<SessionBindingAdapter["resolveByConversation"]>[0];
+
+/**
+ * OpenClaw's session-binding service normalizes account IDs to lowercase
+ * before invoking adapter methods (see `normalizeOptionalLowercaseString`
+ * inside `session-binding-service`). BotFather can emit mixed-case bot IDs
+ * (e.g. `27pBwzf2F6bfa5cd142_bot`), so storing/comparing against the raw
+ * registration accountId silently breaks `resolveByConversation` for those
+ * accounts — bindings succeed (SDK passes the lowercased id into `bind`)
+ * but reverse lookup misses because the closure compares against the
+ * mixed-case original. Normalize once at registration and use the result
+ * everywhere internal.
+ */
+function normalizeAccountId(accountId: string): string {
+  return accountId.toLowerCase();
+}
 
 type Logger = {
   info?: (msg: string) => void;
@@ -98,7 +113,9 @@ function resolveParentGroupNo(
     conversation.conversationId?.trim() ||
     "";
   if (!raw) return null;
-  return raw.includes("____") ? raw.split("____")[0]! : raw;
+  return raw.includes(THREAD_ID_SEPARATOR)
+    ? raw.split(THREAD_ID_SEPARATOR)[0]!
+    : raw;
 }
 
 export interface RegisterOctoThreadBindingAdapterParams {
@@ -118,7 +135,12 @@ export interface RegisterOctoThreadBindingAdapterParams {
 export function registerOctoThreadBindingAdapter(
   params: RegisterOctoThreadBindingAdapterParams,
 ): () => void {
-  const { accountId, apiUrl, botToken, log } = params;
+  const { apiUrl, botToken, log } = params;
+  // Normalize the account id ONCE here. Every internal map key, bindingId,
+  // and ref comparison below uses `accountId` (the normalized form), never
+  // params.accountId. The SDK invokes adapter methods with already-normalized
+  // refs, so this keeps both halves of the round-trip aligned.
+  const accountId = normalizeAccountId(params.accountId);
 
   const adapter: SessionBindingAdapter = {
     channel: CHANNEL_ID,
@@ -161,7 +183,7 @@ export function registerOctoThreadBindingAdapter(
             groupNo: parentGroupNo,
             name: threadName,
           });
-          conversationId = `${parentGroupNo}____${thread.short_id}`;
+          conversationId = `${parentGroupNo}${THREAD_ID_SEPARATOR}${thread.short_id}`;
           parentConversationId = parentGroupNo;
           log?.info?.(
             `octo: [${accountId}] child thread created group=${parentGroupNo} short_id=${thread.short_id} (name="${threadName}")`,
@@ -217,19 +239,23 @@ export function registerOctoThreadBindingAdapter(
     },
 
     resolveByConversation: (ref: ConversationRef): SessionBindingRecord | null => {
-      if (ref.channel !== CHANNEL_ID || ref.accountId !== accountId) return null;
+      // ref.accountId is already lowercased by the SDK (see normalizeAccountId
+      // doc-comment at top of this file). Defensively normalize again so a
+      // direct adapter-level caller (e.g. test code) bypassing the SDK still
+      // gets a correct result.
+      if (ref.channel !== CHANNEL_ID) return null;
+      const refAccountId = normalizeAccountId(ref.accountId);
+      if (refAccountId !== accountId) return null;
       const m = _bindingsByAccount.get(accountId);
       if (!m) return null;
       return m.get(buildBindingId(accountId, ref.conversationId)) ?? null;
     },
 
-    touch: (bindingId: string, _at?: number): void => {
-      // In-memory adapter has no idle-expiry sweeper, so touch is a no-op.
-      // Kept for SDK contract compliance; record's boundAt is the source of
-      // truth for callers that care about activity.
-      const m = _bindingsByAccount.get(accountId);
-      if (!m || !m.has(bindingId)) return;
-      // Future: if we add a sweeper, mutate a lastTouchedAt field here.
+    touch: (_bindingId: string, _at?: number): void => {
+      // The in-memory adapter has no idle-expiry sweeper, so touch is
+      // intentionally a no-op. Implementing it would require a `lastTouchedAt`
+      // field on records that nothing currently reads. Kept for SDK contract
+      // compliance and to avoid adapter-shape surprises if the runtime calls it.
     },
 
     unbind: async (


### PR DESCRIPTION
## Problem

ACP-runtime spawns against Octo channels abort with:

```json
{
  "status": "error",
  "errorCode": "thread_binding_invalid",
  "error": "Thread bindings are unavailable for octo."
}
```

This means no ACP harness (Claude Code, Codex, Cursor, Gemini) can run as a thread-bound session in an Octo group or DM — only as one-shot `mode: "run"`, losing conversational context.

The issue submitter (#23) pointed at the channel's `describeMessageTool` capabilities, but the SDK's `ChannelMessageCapability` only declares `"presentation" | "delivery-pin"` — nothing thread-related.

## Root cause

OpenClaw's `getSessionBindingService().getCapabilities({channel, accountId})` runs the following fallback chain (`session-binding-service.js`):

1. Look up a `SessionBindingAdapter` registered for `{channel, accountId}` — none for octo.
2. Fall back to `getGenericCurrentConversationBindingCapabilities(channel)`.
3. That requires `plugin.conversationBindings.supportsCurrentConversationBinding === true`.
4. Octo's `ChannelPlugin` declaration had no `conversationBindings` field at all, so step 3 returned `null`, step 1 returned `{adapterAvailable: false}`, and the ACP spawn aborted.

The bundled `telegram`, `matrix`, and `imessage` channels all declare `conversationBindings` with both a `supportsCurrentConversationBinding` flag and a `createManager` factory. Octo did not.

## Fix

### `src/channel.ts` — declare `conversationBindings` on `octoPlugin`

```ts
conversationBindings: {
  supportsCurrentConversationBinding: true,
  defaultTopLevelPlacement: "current",
  resolveConversationRef: ({ conversationId, parentConversationId, threadId }) => { ... },
  buildBoundReplyPayload: () => null,
  createManager: ({ cfg, accountId }) => {
    const unregister = registerOctoThreadBindingAdapter({ accountId, apiUrl, botToken });
    return { stop: () => unregister() };
  },
}
```

- `supportsCurrentConversationBinding: true` makes the generic current-placement bind path accept Octo (minimum requirement to clear `thread_binding_invalid`).
- `defaultTopLevelPlacement: "current"` mirrors Telegram's preference: ACP sessions bind to the active conversation rather than auto-creating a child sub-thread.
- `resolveConversationRef` normalizes Octo's `groupNo____shortId` thread format so callers that pass `(parent, threadId)` get the correct composite ref.
- `buildBoundReplyPayload` returns `null`; Octo has no per-thread pin/notify analog of Telegram's topic pin payload.
- `createManager` is the runtime entry point: OpenClaw calls it on demand and owns the returned `{stop}` lifecycle.

### `src/thread-binding-adapter.ts` — new file (287 lines)

Implements the `SessionBindingAdapter` contract, returned by `createManager`:

| Method | Behavior |
|---|---|
| `bind({placement: "current"})` | Records a binding against the active conversationId. No octo API call. |
| `bind({placement: "child"})` | Calls `POST /v1/bot/groups/{groupNo}/threads` (existing `createThread`), then records a binding against `groupNo____shortId`. Returns `null` on API failure. |
| `listBySession(key)` | Returns all bindings for an ACP session. |
| `resolveByConversation(ref)` | Reverse lookup by `{accountId, conversationId}`. |
| `unbind({bindingId})` / `unbind({targetSessionKey})` | Removes matching bindings, status → `ended`. |
| `touch(id, at?)` | No-op (in-memory adapter has no idle sweeper). |

Storage is per-account in-memory, cleared on `stop()`. Disk persistence is deliberately out of scope for the first iteration since ACP sessions themselves don't survive gateway restarts.

### `src/thread-binding-adapter.test.ts` — new file (305 lines, 9 tests)

Vitest unit tests covering:

1. Adapter registered with `placements: ["current", "child"]`, both bind/unbind supported.
2. `bind(current)` records a binding without calling `createThread`.
3. `bind(child)` calls `createThread`, uses `groupNo____shortId` for the conversationId.
4. `bind(child)` returns `null` (not throw) when `createThread` fails.
5. `bind(child)` extracts parent `group_no` correctly when the caller's `conversationId` is already a thread ref (`group____short` → `group`).
6. `unbind(bindingId)` removes one record with `status: "ended"`.
7. `unbind(targetSessionKey)` removes all bindings matching the session key.
8. `unregister` is idempotent and clears in-memory state.
9. `bind` rejects conversations from other channels (e.g. `"telegram"`).

## Verified end-to-end

Tested locally on OpenClaw 2026.5.18 with `@openclaw/acpx@2026.5.22` (the ACP runtime backend) and `acp.enabled: true, allowedAgents: ["claude", "codex"]`.

| Scenario | Session key | Result |
|---|---|---|
| **DM + current placement** | `agent:main:octo:direct:d71255d6...` | ✅ `sessions_spawn({runtime:"acp", agentId:"claude", task:"hello"})` → `accepted`; Claude replied "你好！有什么可以帮你的吗？"; reply routed back to the DM |
| **Group + current placement** | `agent:main:octo:group:2f6e7d21...` | ✅ Spawn accepted, ACP child session created |
| Group + child placement | — | 🟢 Same code path; not separately tested |
| Thread + current placement | — | 🟢 Same code path; not separately tested |

Without this PR, both verified scenarios above return `thread_binding_invalid` immediately.

## Out of scope (follow-up)

- Disk persistence (in-memory bindings are wiped on gateway restart, which matches ACP session lifetime so does not lose meaningful state).
- Idle / max-age sweeper (Telegram pattern). Defer until persistence lands.

## Test plan

- [x] `npm run type-check`
- [x] `npm test` — 807 passed (798 existing + 9 new)
- [x] `npm run build`
- [x] DM + current placement spawn verified end-to-end (Claude reply delivered)
- [x] Group + current placement spawn verified end-to-end

Closes #23