### PR TITLE
ci: add check-sprint workflow for branch protection

### DIFF
--- a/.github/workflows/check-sprint.yml
+++ b/.github/workflows/check-sprint.yml
@@ -1,0 +1,24 @@
+# Calls the org-level reusable workflow to block merge when the PR's
+# Sprint field on the Octo Board is missing or doesn't match the
+# current sprint iteration.
+#
+# Uses pull_request_target so the workflow can access secrets for the
+# Projects API. No code from the PR is checked out or executed.
+
+name: Check Sprint
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+    branches: [main]
+
+permissions: {}
+
+jobs:
+  check-sprint:
+    uses: Mininglamp-OSS/.github/.github/workflows/reusable-check-sprint.yml@main
+    with:
+      pr-number: ${{ github.event.pull_request.number }}
+      repo-name: ${{ github.repository }}
+    secrets:
+      PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}


### PR DESCRIPTION
Branch protection requires `check-sprint / check-sprint` status but the workflow was missing from this repo. Copied from octo-web — calls the org-level reusable workflow.