### PR TITLE
docs(changelog): add 1.0.13 section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.0.13] - 2026-05-27
+
+### Fixed
+- **多账号配置下 `octo_management` agent tool 永远报 `Multiple Octo accounts configured; please specify accountId`**（#37）：哪怕 LLM 显式传 `accountId: "default"` 也无效。根因两层：
+  - Layer 1：旧代码无条件把 `"default"` 当作 `DEFAULT_ACCOUNT_ID` 占位符剥掉，但 `"default"` 也可以是用户实际的账号 key，此时被错误丢弃。改成只有当 `"default"` 不在 `listOctoAccountIds(cfg)` 中时才视为占位符
+  - Layer 2：channel `agentTools` 工厂只接收 `{ cfg }`，没有 session 上下文，无法知道当前 session 绑哪个账号。把 `octo_management` 从 channel `agentTools` 迁移到 `api.registerTool()`，后者注入完整 `OpenClawPluginToolContext`，含 framework 自动解析的 `agentAccountId`
+  - accountId 解析优先级：`args.accountId`（LLM 显式）→ `ctx.agentAccountId`（framework 注入）→ `resolveDefaultOctoAccountId(cfg)` → 错误
+- `index.ts`：`api.registerTool(...)` 注册放在 `registrationMode !== 'full'` 守卫**之前**，让 tool-discovery 模式也能看到 tool 注册
+- `openclaw.plugin.json`：声明 `contracts.tools: ["octo_management"]`，对齐 loader 校验
+
+### Internal
+- `src/agent-tools.test.ts` +3 case 覆盖 `agentAccountId` 优先级链
+- `src/channel.ts` / `src/multi-bot-isolation.test.ts`：移除已无意义的 `agentTools` 字段及对应 mock
+
 ## [1.0.12] - 2026-05-26
 
 ### Fixed


### PR DESCRIPTION
## Summary
- 补 1.0.13 section，对应 PR #37 (`octo_management` 迁移到 `api.registerTool`) 的修复内容
- 解锁 v1.0.13 的 ClawHub publish 流程：之前 push v1.0.13 tag 后 workflow 卡在 `assert CHANGELOG section exists`（[failed run](https://github.com/Mininglamp-OSS/openclaw-channel-octo/actions/runs/26504797074)）

## Next steps（merge 之后）
1. 删远端旧 v1.0.13 tag：`git push origin :refs/tags/v1.0.13`
2. 在 main 含此 changelog 的 commit 上重打 v1.0.13 tag 并 push → 自动触发 Publish ClawHub
3. workflow 内 auto-bump 会把 package.json 1.0.12 → 1.0.13 同步回 main

## Test plan
- [ ] CI 全过（含 check-sprint / check (22) / CodeQL）
- [ ] merge 后重打 tag，Publish ClawHub workflow 完整跑通到 ClawHub publish + GitHub Release

🤖 Generated with [Claude Code](https://claude.com/claude-code)