### PR TITLE
fix(outbound): propagate Octo message_id to OutboundDeliveryResult and toolResult

### DIFF
--- a/src/actions.test.ts
+++ b/src/actions.test.ts
@@ -104,6 +104,65 @@ describe("handleOctoMessageAction", () => {
     });
   });
 
+  // -----------------------------------------------------------------------
+  // #51 — messageId / mediaMessageIds propagation in toolResult.data
+  //   When Octo API returns SendMessageResult, the handler must surface
+  //   message_id back to the LLM via toolResult.data so the agent can
+  //   reference the sent message for downstream edit/pin/delete.
+  // -----------------------------------------------------------------------
+  describe("send — messageId / mediaMessageIds propagation (#51)", () => {
+    it("toolResult.data.messageId comes from Octo API send response", async () => {
+      globalThis.fetch = mockFetch({
+        "/v1/bot/sendMessage": async () =>
+          jsonResponse({ message_id: "2061639302604820480", client_msg_no: "uuid", message_seq: 7 }),
+      });
+
+      const { handleOctoMessageAction } = await import("./actions.js");
+      const result = await handleOctoMessageAction({
+        action: "send",
+        args: { target: "group:chan123", message: "hello" },
+        apiUrl: "http://localhost:8090",
+        botToken: "test-token",
+      });
+
+      expect(result.ok).toBe(true);
+      expect((result.data as any).messageId).toBe("2061639302604820480");
+    });
+
+    it("toolResult.data.mediaMessageIds comes from uploadAndSendMedia results", async () => {
+      const { uploadAndSendMedia } = await import("./inbound.js");
+      vi.mocked(uploadAndSendMedia).mockResolvedValueOnce({
+        message_id: "media-1-id",
+        client_msg_no: "uuid",
+        message_seq: 10,
+      });
+      vi.mocked(uploadAndSendMedia).mockResolvedValueOnce({
+        message_id: "media-2-id",
+        client_msg_no: "uuid",
+        message_seq: 11,
+      });
+
+      const { handleOctoMessageAction } = await import("./actions.js");
+      const result = await handleOctoMessageAction({
+        action: "send",
+        args: {
+          target: "group:chan123",
+          // No text — pure media send so we observe mediaMessageIds in isolation.
+          attachments: [
+            { url: "https://example.com/a.png" },
+            { url: "https://example.com/b.png" },
+          ],
+        },
+        apiUrl: "http://localhost:8090",
+        botToken: "test-token",
+      });
+
+      expect(result.ok).toBe(true);
+      expect((result.data as any).mediaMessageIds).toEqual(["media-1-id", "media-2-id"]);
+      expect((result.data as any).mediaCount).toBe(2);
+    });
+  });
+
   describe("send — bare target defaults to DM", () => {
     it("should default to DM when no prefix", async () => {
       let sentPayload: any = null;

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -368,6 +368,7 @@ async function handleSend(params: {
   }
 
   // Send text message
+  let textMessageId: string | undefined;
   if (message) {
     let mentionUids: string[] = [];
     let mentionEntities: MentionEntity[] = [];
@@ -411,7 +412,7 @@ async function handleSend(params: {
     // Detect @all/@所有人 in final content
     const hasAtAll = /(?:^|(?<=\s))@(?:all|所有人)(?=\s|[^\w]|$)/i.test(finalMessage);
 
-    await sendMessage({
+    const sendResult = await sendMessage({
       apiUrl,
       botToken,
       channelId,
@@ -421,14 +422,19 @@ async function handleSend(params: {
       ...(mentionEntities.length > 0 ? { mentionEntities } : {}),
       mentionAll: hasAtAll || undefined,
     });
+    // Capture message_id so the LLM toolResult can reference this message
+    // (see issue #51). Octo API may rarely return an undefined/empty id
+    // even on 2xx — fall back to undefined and let the caller see no
+    // messageId rather than fabricate one.
+    textMessageId = sendResult?.message_id ? String(sendResult.message_id).trim() : undefined;
   }
 
   // Send media
-  const sentMedia: string[] = [];
+  const sentMedia: Array<{ url: string; messageId?: string }> = [];
   const failedMedia: { url: string; error: string }[] = [];
   for (const mediaUrl of mediaUrls) {
     try {
-      await uploadAndSendMedia({
+      const mediaResult = await uploadAndSendMedia({
         mediaUrl,
         apiUrl,
         botToken,
@@ -436,7 +442,8 @@ async function handleSend(params: {
         channelType,
         log: log as any,
       });
-      sentMedia.push(mediaUrl);
+      const mediaMessageId = mediaResult?.message_id ? String(mediaResult.message_id).trim() : undefined;
+      sentMedia.push({ url: mediaUrl, messageId: mediaMessageId });
     } catch (err) {
       const errMsg = err instanceof Error ? err.message : String(err);
       log?.error?.(`octo: uploadAndSendMedia failed for ${mediaUrl}: ${errMsg}`);
@@ -452,6 +459,10 @@ async function handleSend(params: {
     };
   }
 
+  const mediaMessageIds = sentMedia
+    .map(m => m.messageId)
+    .filter((id): id is string => Boolean(id));
+
   return {
     ok: true,
     data: {
@@ -460,6 +471,10 @@ async function handleSend(params: {
       channelId,
       channelType,
       mediaCount: sentMedia.length,
+      // messageId fields added for issue #51 — let the LLM reference the
+      // sent message(s) for downstream edit/pin/delete operations.
+      ...(textMessageId ? { messageId: textMessageId } : {}),
+      ...(mediaMessageIds.length > 0 ? { mediaMessageIds } : {}),
       ...(failedMedia.length > 0 ? { failedMedia } : {}),
     },
   };

--- a/src/channel.test.ts
+++ b/src/channel.test.ts
@@ -4,10 +4,17 @@ import { DEFAULT_ACCOUNT_ID } from "./sdk-compat.js";
 // Mock api-fetch so outbound adapter wiring tests (below) can observe the
 // final sendMessage / sendMediaMessage arguments without actually hitting
 // Octo. Real implementations still ship in the bundle — this is test-only.
+//
+// Default success result — outbound deliver helper (toDeliveryResult) throws
+// on missing message_id (issue #51), so existing wiring tests that only
+// care about HOW we called sendMessage need a valid result by default.
+// Individual tests can `vi.mocked(sendMessage).mockResolvedValueOnce(...)`
+// to assert failure paths.
 vi.mock("./api-fetch.js", async () => {
+  const okResult = { message_id: "test-msg-id", client_msg_no: "uuid", message_seq: 1 };
   return {
-    sendMessage: vi.fn().mockResolvedValue(undefined),
-    sendMediaMessage: vi.fn().mockResolvedValue(undefined),
+    sendMessage: vi.fn().mockResolvedValue(okResult),
+    sendMediaMessage: vi.fn().mockResolvedValue(okResult),
     getUploadCredentials: vi.fn().mockResolvedValue({
       credentials: { TmpSecretId: "id", TmpSecretKey: "k", Token: "t" },
       startTime: 0,
@@ -711,5 +718,114 @@ describe("outbound sendText/sendMedia — accountId correction threads through t
     expect(sendMessage).toHaveBeenCalledTimes(1);
     const call = (sendMessage as any).mock.calls[0][0];
     expect(call.botToken).toBe("tok-bot-b");
+  });
+});
+
+// ─── #51 outbound deliver — messageId propagation ──────────────────────────
+// Regression tests for the bug where sendText / sendMedia returned
+// `messageId: ""` regardless of what the Octo API returned. After 2026.5.7
+// the host runtime evaluates `deliverySucceeded` strictly and silently
+// drops outbound when the adapter result has an empty messageId.
+
+describe("outbound sendText/sendMedia — messageId propagation (#51)", () => {
+  const cfg = {
+    channels: {
+      octo: {
+        apiUrl: "https://api.example",
+        accounts: {
+          "bot-a": { botToken: "tok-a", apiUrl: "https://api.example" },
+        },
+      },
+    },
+  };
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it("sendText propagates message_id from Octo API result to OutboundDeliveryResult", async () => {
+    const { octoPlugin } = await import("./channel.js");
+    const { sendMessage } = await import("./api-fetch.js");
+    vi.mocked(sendMessage).mockResolvedValueOnce({
+      message_id: "real-id-abc",
+      client_msg_no: "uuid",
+      message_seq: 42,
+    });
+
+    const result = await octoPlugin.outbound!.sendText!({
+      cfg,
+      to: "group:grp1",
+      text: "hello",
+      accountId: "bot-a",
+    } as any);
+
+    expect(result.messageId).toBe("real-id-abc");
+    expect(result.channel).toBe("octo");
+  });
+
+  it("sendText empty text returns messageId='' and does NOT call sendMessage (noop)", async () => {
+    const { octoPlugin } = await import("./channel.js");
+    const { sendMessage } = await import("./api-fetch.js");
+
+    const result = await octoPlugin.outbound!.sendText!({
+      cfg,
+      to: "group:grp1",
+      text: "   ",
+      accountId: "bot-a",
+    } as any);
+
+    expect(result.messageId).toBe("");
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("sendText throws when Octo API returns undefined (fail-fast on anomaly)", async () => {
+    const { octoPlugin } = await import("./channel.js");
+    const { sendMessage } = await import("./api-fetch.js");
+    vi.mocked(sendMessage).mockResolvedValueOnce(undefined);
+
+    await expect(octoPlugin.outbound!.sendText!({
+      cfg,
+      to: "group:grp1",
+      text: "hello",
+      accountId: "bot-a",
+    } as any)).rejects.toThrow(/no message_id/);
+  });
+
+  it("sendText throws when Octo API returns empty message_id", async () => {
+    const { octoPlugin } = await import("./channel.js");
+    const { sendMessage } = await import("./api-fetch.js");
+    vi.mocked(sendMessage).mockResolvedValueOnce({
+      message_id: "",
+      client_msg_no: "uuid",
+      message_seq: 0,
+    });
+
+    await expect(octoPlugin.outbound!.sendText!({
+      cfg,
+      to: "group:grp1",
+      text: "hello",
+      accountId: "bot-a",
+    } as any)).rejects.toThrow(/no message_id/);
+  });
+
+  it("sendMedia propagates message_id from sendMediaMessage result", async () => {
+    const { octoPlugin } = await import("./channel.js");
+    const { sendMediaMessage } = await import("./api-fetch.js");
+    vi.mocked(sendMediaMessage).mockResolvedValueOnce({
+      message_id: "media-xyz",
+      client_msg_no: "uuid",
+      message_seq: 99,
+    });
+
+    const result = await octoPlugin.outbound!.sendMedia!({
+      cfg,
+      to: "group:grp1",
+      text: "",
+      mediaUrl: "data:text/plain;base64,aGVsbG8=",
+      accountId: "bot-a",
+    } as any);
+
+    expect(result.messageId).toBe("media-xyz");
   });
 });

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -27,7 +27,7 @@ function getAgentVersion(): string {
 }
 import { WKSocket } from "./socket.js";
 import { handleInboundMessage, type OctoStatusSink, sanitizeFilename } from "./inbound.js";
-import { ChannelType, MessageType, type BotMessage, type MessagePayload } from "./types.js";
+import { ChannelType, MessageType, type BotMessage, type MessagePayload, type SendMessageResult } from "./types.js";
 import { buildEntitiesFromFallback, parseStructuredMentions, convertStructuredMentions } from "./mention-utils.js";
 import type { MentionEntity } from "./types.js";
 import { handleOctoMessageAction, parseTarget, resolveOutboundOctoTarget, normalizeOutboundChannelPrefix, extractInlineMentionUids } from "./actions.js";
@@ -49,6 +49,27 @@ const DEFAULT_GROUP_HISTORY_LIMIT = 20;
 
 const MAX_UPLOAD_SIZE = 500 * 1024 * 1024; // 500 MB
 const UPLOAD_TEMP_DIR = path.join("/tmp", "octo-upload");
+
+/**
+ * Build OutboundDeliveryResult from Octo's SendMessageResult.
+ *
+ * Fail-fast on missing/empty message_id: when the Octo API returned 2xx but
+ * the body is missing `message_id`, that is an API anomaly — surfacing it as
+ * an error is better than silently returning `messageId: ""`, which OpenClaw
+ * 2026.5.7+ treats as `deliverySucceeded=false` and quietly drops downstream
+ * (see issue #51).
+ *
+ * For early-return noop paths (empty content, no actual API call), do NOT
+ * use this helper — return `{ channel, to, messageId: "" }` directly with an
+ * inline comment.
+ */
+function toDeliveryResult(to: string, result: SendMessageResult | undefined) {
+  const messageId = result?.message_id ? String(result.message_id).trim() : "";
+  if (!messageId) {
+    throw new Error("Octo send API returned no message_id");
+  }
+  return { channel: CHANNEL_ID, to, messageId };
+}
 
 /** Download a URL to a temp file with backpressure, return the temp path. */
 async function downloadToTempFile(url: string, filename: string, signal?: AbortSignal): Promise<{ tempPath: string; contentType: string | undefined }> {
@@ -683,6 +704,11 @@ export const octoPlugin: ChannelPlugin<ResolvedOctoAccount> = {
       }
       const content = ctx.text?.trim();
       if (!content) {
+        // noop early-return: no API call was made, so no real message_id
+        // exists. Runtime will see messageId="" and judge
+        // deliverySucceeded=false — that is the CORRECT semantics for
+        // "we delivered nothing". Do NOT fabricate an ID here. See
+        // toDeliveryResult() helper at the top of this file.
         return { channel: CHANNEL_ID, to: ctx.to, messageId: "" };
       }
 
@@ -732,7 +758,7 @@ export const octoPlugin: ChannelPlugin<ResolvedOctoAccount> = {
       // Detect @all/@所有人 in content
       const hasAtAll = /(?:^|(?<=\s))@(?:all|所有人)(?=\s|[^\w]|$)/i.test(finalContent);
 
-      await sendMessage({
+      const sendResult = await sendMessage({
         apiUrl: account.config.apiUrl,
         botToken: account.config.botToken,
         channelId,
@@ -743,7 +769,7 @@ export const octoPlugin: ChannelPlugin<ResolvedOctoAccount> = {
         mentionAll: hasAtAll || undefined,
       });
 
-      return { channel: CHANNEL_ID, to: ctx.to, messageId: "" };
+      return toDeliveryResult(ctx.to, sendResult);
     },
     sendMedia: async (ctx) => {
       // Resolve correct accountId — framework may pass wrong one for multi-bot setups
@@ -830,6 +856,7 @@ export const octoPlugin: ChannelPlugin<ResolvedOctoAccount> = {
 
       contentType = contentType || "application/octet-stream";
 
+      let sendResult: SendMessageResult | undefined;
       try {
         // 2. Upload to COS via STS credentials (stream mode)
         const creds = await getUploadCredentials({
@@ -867,7 +894,7 @@ export const octoPlugin: ChannelPlugin<ResolvedOctoAccount> = {
             : Buffer.isBuffer(fileBody)
               ? parseImageDimensions(fileBody, contentType)
               : null;
-          await sendMediaMessage({
+          sendResult = await sendMediaMessage({
             apiUrl: account.config.apiUrl,
             botToken: account.config.botToken,
             channelId,
@@ -880,7 +907,7 @@ export const octoPlugin: ChannelPlugin<ResolvedOctoAccount> = {
             size: fileSize,
           });
         } else {
-          await sendMediaMessage({
+          sendResult = await sendMediaMessage({
             apiUrl: account.config.apiUrl,
             botToken: account.config.botToken,
             channelId,
@@ -896,7 +923,7 @@ export const octoPlugin: ChannelPlugin<ResolvedOctoAccount> = {
         if (tempPath) await unlink(tempPath).catch(() => {});
       }
 
-      return { channel: CHANNEL_ID, to: ctx.to, messageId: "" };
+      return toDeliveryResult(ctx.to, sendResult);
     },
   },
   status: {


### PR DESCRIPTION
## Problem

Plugin's outbound deliver path calls `await sendMessage(...)` / `await sendMediaMessage(...)` without capturing the return value, then hardcodes `messageId: ""` on `OutboundDeliveryResult`. After OpenClaw 2026.5.7 tightened `deliverySucceeded` evaluation ([openclaw/openclaw#78532](https://github.com/openclaw/openclaw/pull/78532)), empty messageId is treated as `deliverySucceeded=false`, which silently triggers the rewritten reply fallback and drops the outbound.

User-visible symptom: **agent works on the dashboard but messages never reach the Octo group**, while `@bot` replies still work (they go through plugin's own `dispatchReplyWithBufferedBlockDispatcher` path that bypasses runtime delivery checks). This mismatch is the fingerprint of the bug.

[Failing run example (from a separate validation)](https://github.com/Mininglamp-OSS/openclaw-channel-octo/actions/runs/26505463042) — though most users would just see "bot got disconnected."

## Root cause

3 + 1 call sites in `src/channel.ts` (outbound adapter) and 1 + 1 call sites in `src/actions.ts` (message tool action handler) discarded the `SendMessageResult.message_id` returned by the Octo API:

```ts
// before (channel.ts:735)
await sendMessage({ ... });
return { channel: CHANNEL_ID, to: ctx.to, messageId: "" };  // ← lost the id
```

`src/inbound.ts:2023` already captured the return value correctly. This PR brings outbound + actions up to the same hygiene.

## Fix

### `src/channel.ts`

- New `toDeliveryResult(to, result)` helper that throws on missing/empty `message_id` (fail-fast on API anomaly — same shape as `inbound.ts:2023` and what `OutboundDeliveryResult.messageId: string` non-optional contract expects)
- Capture results at the 3 main call sites (sendText line 735, sendMedia image line 870, sendMedia file line 883)
- Keep the noop early-return at line 686 with `messageId: ""` plus an explanatory comment (no API call was made; fabricating an ID would be wrong — `deliverySucceeded=false` here is the correct semantics)

### `src/actions.ts`

- Capture `sendMessage` / `uploadAndSendMedia` results in the message tool action handler
- Surface `messageId` (text) and `mediaMessageIds` (per-media array) through `MessageActionResult.data` so the LLM can reference sent messages for downstream edit/pin/delete
- Intentional asymmetry vs `channel.ts`: **does NOT throw** on missing id here — actions handler returns LLM-facing toolResult, throwing would falsely tell the model "nothing sent" when in fact the API succeeded just without an id. Silent `undefined` propagation is more honest.

### `src/channel.test.ts`

- top-level api-fetch mock now returns a valid `SendMessageResult` by default (the new throw would otherwise break 11 existing wiring tests that don't care about the result)
- Add 5 new cases: propagation / noop / undefined / empty / sendMedia

### `src/actions.test.ts`

- Add 2 new cases covering `messageId` and `mediaMessageIds` propagation in `toolResult.data` (addresses codex review minor — locks in the actions handler contract)

## Verification

- [x] `npm run type-check` — clean
- [x] `npm test` — 817 pass (was 815, +2 new actions tests; 0 regressions; all 7 new #51 cases pass)
- [x] `npm run build` — clean
- [x] **End-to-end on local OpenClaw 2026.5.28**: deployed to `~/.openclaw/extensions/octo`, restarted gateway, triggered `@main` in an octo group. `trajectory.jsonl` now shows the message tool's `toolResult.data` containing `"messageId": "2061639302604820480"` (a real Octo API message_id) where the pre-fix path had no `messageId` field at all. Before/after diff is unambiguous.

## Risk

Low. Three callsites change behavior to capture the result and propagate it. The new `throw` only fires when the Octo API returns 2xx with missing/empty `message_id` — the correct response is to surface that as a delivery failure rather than masquerade as a success that downstream can't reference.

## Out of scope (intentionally not in this PR)

- session origin metadata being wrongly tagged `webchat` for group inbound (causes `ANNOUNCE_SKIP` on `sessions_send` paths) — independent runtime/host issue
- tool-policy stripping `message` from `webchat` surface profiles — config concern
- `plugin-sdk/channel-message` adapter modernization, `MessageReceipt`, durable send via `prepareSendPayload`, status reactions, reaction approvals — tracked in #52

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)