### PR TITLE
feat(richtext): bot adapter 支持 RichText=14 图文混排 — enum+inbound+outbound+幂等 (Phase 1)

### DIFF
--- a/src/actions.test.ts
+++ b/src/actions.test.ts
@@ -1113,22 +1113,23 @@ describe("handleOctoMessageAction", () => {
       expect((result.data as any).richText).toBeUndefined();
     });
 
-    it("delivers non-image files alongside images via legacy single-send", async () => {
+    it("delivers non-image files alongside images via sideload send (no re-upload)", async () => {
       const { uploadMedia, uploadAndSendMedia } = await import("./inbound.js");
       const uploadMediaSpy = vi.mocked(uploadMedia);
       const uploadSendSpy = vi.mocked(uploadAndSendMedia);
       uploadMediaSpy.mockClear();
       uploadSendSpy.mockClear();
-      uploadSendSpy.mockResolvedValue(undefined);
       uploadMediaSpy
         .mockResolvedValueOnce({ url: "https://cdn.example.com/i.png", filename: "i.png", size: 1, contentType: "image/png", isImage: true, width: 5, height: 5 })
         .mockResolvedValueOnce({ url: "https://cdn.example.com/d.pdf", filename: "d.pdf", size: 2, contentType: "application/pdf", isImage: false });
 
       let richSends = 0;
+      let fileSends = 0;
       globalThis.fetch = mockFetch({
         "/v1/bot/sendMessage": async (_url, init) => {
           const body = JSON.parse(init?.body as string);
           if (body.payload?.type === 14) richSends += 1;
+          if (body.payload?.type === 8) fileSends += 1;
           return jsonResponse({ message_id: "rt-3", message_seq: 1 });
         },
       });
@@ -1148,7 +1149,50 @@ describe("handleOctoMessageAction", () => {
 
       expect(result.ok).toBe(true);
       expect(richSends).toBe(1); // one RichText send for text+image
-      expect(uploadSendSpy).toHaveBeenCalledOnce(); // the PDF via legacy single-send
+      expect(fileSends).toBe(1); // the PDF delivered via sendMediaMessage (already uploaded)
+      expect(uploadMediaSpy).toHaveBeenCalledTimes(2); // uploaded once each, not re-uploaded
+      expect(uploadSendSpy).not.toHaveBeenCalled();
+      expect((result.data as any).mediaCount).toBe(2);
+    });
+
+    it("routes dimensionless images (e.g. SVG) to sideload, not RichText image block", async () => {
+      const { uploadMedia } = await import("./inbound.js");
+      const uploadMediaSpy = vi.mocked(uploadMedia);
+      uploadMediaSpy.mockClear();
+      uploadMediaSpy
+        .mockResolvedValueOnce({ url: "https://cdn.example.com/ok.png", filename: "ok.png", size: 1, contentType: "image/png", isImage: true, width: 5, height: 5 })
+        // image but dimensions failed to parse → must NOT become an image block
+        .mockResolvedValueOnce({ url: "https://cdn.example.com/vec.svg", filename: "vec.svg", size: 2, contentType: "image/svg+xml", isImage: true });
+
+      let richPayload: any = null;
+      let imageSideloads = 0;
+      globalThis.fetch = mockFetch({
+        "/v1/bot/sendMessage": async (_url, init) => {
+          const body = JSON.parse(init?.body as string);
+          if (body.payload?.type === 14) richPayload = body.payload;
+          if (body.payload?.type === 2) imageSideloads += 1;
+          return jsonResponse({ message_id: "rt-4", message_seq: 1 });
+        },
+      });
+
+      const { handleOctoMessageAction } = await import("./actions.js");
+      const result = await handleOctoMessageAction({
+        action: "send",
+        args: {
+          target: "group:grp1",
+          message: "svg+png",
+          mediaUrls: ["https://example.com/ok.png", "https://example.com/vec.svg"],
+          richText: true,
+        },
+        apiUrl: "http://localhost:8090",
+        botToken: "test-token",
+      });
+
+      expect(result.ok).toBe(true);
+      // RichText has exactly one image block (the dimensioned PNG); the SVG is sideloaded.
+      expect(richPayload.content.filter((b: any) => b.type === "image")).toHaveLength(1);
+      expect(richPayload.content.find((b: any) => b.type === "image").url).toBe("https://cdn.example.com/ok.png");
+      expect(imageSideloads).toBe(1); // SVG via sendMediaMessage type=2
       expect((result.data as any).mediaCount).toBe(2);
     });
   });

--- a/src/actions.test.ts
+++ b/src/actions.test.ts
@@ -4,10 +4,20 @@ import { registerOwnerUid, _clearOwnerRegistry } from "./owner-registry.js";
 import { _clearMemberCache, _setCacheEntry } from "./member-cache.js";
 import { registerBotGroupIds, _testReset as _resetGroupMd } from "./group-md.js";
 
-// Mock uploadAndSendMedia — the streaming COS upload uses its own SDK internals
-// that can't be tested via fetch mocks alone. Upload logic is tested in inbound.test.ts.
+// Mock uploadAndSendMedia / uploadMedia — the streaming COS upload uses its own
+// SDK internals that can't be tested via fetch mocks alone. Upload logic is
+// tested in inbound.test.ts.
 vi.mock("./inbound.js", () => ({
   uploadAndSendMedia: vi.fn().mockResolvedValue(undefined),
+  uploadMedia: vi.fn().mockResolvedValue({
+    url: "https://cdn.example.com/uploaded.png",
+    filename: "uploaded.png",
+    size: 1234,
+    contentType: "image/png",
+    isImage: true,
+    width: 100,
+    height: 80,
+  }),
 }));
 
 /**
@@ -919,6 +929,227 @@ describe("handleOctoMessageAction", () => {
       expect(uploadSpy).toHaveBeenCalledOnce();
       expect(uploadSpy.mock.calls[0][0].mediaUrl).toBe("https://example.com/single.png");
       expect((result as any).data.mediaCount).toBe(1);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // RichText(=14) 图文混排 outbound — single payload assembly (opt-in)
+  // -----------------------------------------------------------------------
+  describe("send — RichText 图文混排 (richText:true)", () => {
+    it("assembles ONE RichText payload for text + image instead of split sends", async () => {
+      const { uploadMedia, uploadAndSendMedia } = await import("./inbound.js");
+      const uploadMediaSpy = vi.mocked(uploadMedia);
+      const uploadSendSpy = vi.mocked(uploadAndSendMedia);
+      uploadMediaSpy.mockClear();
+      uploadSendSpy.mockClear();
+      uploadMediaSpy.mockResolvedValue({
+        url: "https://cdn.example.com/u.png",
+        filename: "u.png",
+        size: 1234,
+        contentType: "image/png",
+        isImage: true,
+        width: 100,
+        height: 80,
+      });
+
+      let sentPayload: any = null;
+      let sendCount = 0;
+      globalThis.fetch = mockFetch({
+        "/v1/bot/sendMessage": async (_url, init) => {
+          sendCount += 1;
+          sentPayload = JSON.parse(init?.body as string);
+          return jsonResponse({ message_id: "rt-1", message_seq: 1 });
+        },
+      });
+
+      const { handleOctoMessageAction } = await import("./actions.js");
+      const result = await handleOctoMessageAction({
+        action: "send",
+        args: {
+          target: "group:grp1",
+          message: "look here",
+          mediaUrl: "https://example.com/pic.png",
+          richText: true,
+        },
+        apiUrl: "http://localhost:8090",
+        botToken: "test-token",
+      });
+
+      expect(result.ok).toBe(true);
+      // ONE HTTP send (RichText), NOT text + media split.
+      expect(sendCount).toBe(1);
+      expect(uploadSendSpy).not.toHaveBeenCalled();
+      expect(uploadMediaSpy).toHaveBeenCalledOnce();
+
+      expect(sentPayload.payload.type).toBe(14);
+      expect(sentPayload.payload.content[0]).toEqual({ type: "text", text: "look here" });
+      expect(sentPayload.payload.content[1].type).toBe("image");
+      expect(sentPayload.payload.content[1].url).toBe("https://cdn.example.com/u.png");
+      expect(sentPayload.payload.content[1].width).toBe(100);
+      expect(sentPayload.client_msg_no).toBeTruthy();
+
+      expect((result.data as any).richText).toBe(true);
+      expect((result.data as any).messageId).toBe("rt-1");
+      expect((result.data as any).mediaCount).toBe(1);
+    });
+
+    it("batch-uploads multiple images into one ordered content array", async () => {
+      const { uploadMedia } = await import("./inbound.js");
+      const uploadMediaSpy = vi.mocked(uploadMedia);
+      uploadMediaSpy.mockClear();
+      uploadMediaSpy
+        .mockResolvedValueOnce({ url: "https://cdn.example.com/1.png", filename: "1.png", size: 1, contentType: "image/png", isImage: true, width: 10, height: 10 })
+        .mockResolvedValueOnce({ url: "https://cdn.example.com/2.png", filename: "2.png", size: 2, contentType: "image/png", isImage: true, width: 20, height: 20 });
+
+      let sentPayload: any = null;
+      globalThis.fetch = mockFetch({
+        "/v1/bot/sendMessage": async (_url, init) => {
+          sentPayload = JSON.parse(init?.body as string);
+          return jsonResponse({ message_id: "rt-2", message_seq: 1 });
+        },
+      });
+
+      const { handleOctoMessageAction } = await import("./actions.js");
+      const result = await handleOctoMessageAction({
+        action: "send",
+        args: {
+          target: "group:grp1",
+          message: "two pics",
+          mediaUrls: ["https://example.com/a.png", "https://example.com/b.png"],
+          richText: true,
+        },
+        apiUrl: "http://localhost:8090",
+        botToken: "test-token",
+      });
+
+      expect(result.ok).toBe(true);
+      expect(uploadMediaSpy).toHaveBeenCalledTimes(2);
+      const content = sentPayload.payload.content;
+      expect(content).toHaveLength(3);
+      expect(content[0]).toEqual({ type: "text", text: "two pics" });
+      expect(content[1].url).toBe("https://cdn.example.com/1.png");
+      expect(content[2].url).toBe("https://cdn.example.com/2.png");
+      expect((result.data as any).mediaCount).toBe(2);
+    });
+
+    it("falls back to legacy split path when no image survives upload", async () => {
+      const { uploadMedia, uploadAndSendMedia } = await import("./inbound.js");
+      const uploadMediaSpy = vi.mocked(uploadMedia);
+      const uploadSendSpy = vi.mocked(uploadAndSendMedia);
+      uploadMediaSpy.mockClear();
+      uploadSendSpy.mockClear();
+      // Non-image (PDF) → no image block → RichText returns null → legacy path.
+      uploadMediaSpy.mockResolvedValue({
+        url: "https://cdn.example.com/doc.pdf",
+        filename: "doc.pdf",
+        size: 10,
+        contentType: "application/pdf",
+        isImage: false,
+      });
+
+      let textSent = false;
+      globalThis.fetch = mockFetch({
+        "/v1/bot/sendMessage": async (_url, init) => {
+          const body = JSON.parse(init?.body as string);
+          if (body.payload?.type === 1 && body.payload?.content) textSent = true;
+          return jsonResponse({ message_id: 1, message_seq: 1 });
+        },
+      });
+
+      const { handleOctoMessageAction } = await import("./actions.js");
+      const result = await handleOctoMessageAction({
+        action: "send",
+        args: {
+          target: "group:grp1",
+          message: "see attached",
+          mediaUrl: "https://example.com/doc.pdf",
+          richText: true,
+        },
+        apiUrl: "http://localhost:8090",
+        botToken: "test-token",
+      });
+
+      expect(result.ok).toBe(true);
+      // Legacy path: plain text send + uploadAndSendMedia for the file.
+      expect(textSent).toBe(true);
+      expect(uploadSendSpy).toHaveBeenCalledOnce();
+      expect((result.data as any).richText).toBeUndefined();
+    });
+
+    it("does NOT use RichText path without opt-in (backward compatible default)", async () => {
+      const { uploadMedia, uploadAndSendMedia } = await import("./inbound.js");
+      const uploadMediaSpy = vi.mocked(uploadMedia);
+      const uploadSendSpy = vi.mocked(uploadAndSendMedia);
+      uploadMediaSpy.mockClear();
+      uploadSendSpy.mockClear();
+      uploadSendSpy.mockResolvedValue(undefined);
+
+      let textSent = false;
+      globalThis.fetch = mockFetch({
+        "/v1/bot/sendMessage": async (_url, init) => {
+          const body = JSON.parse(init?.body as string);
+          if (body.payload?.content) textSent = true;
+          return jsonResponse({ message_id: 1, message_seq: 1 });
+        },
+      });
+
+      const { handleOctoMessageAction } = await import("./actions.js");
+      const result = await handleOctoMessageAction({
+        action: "send",
+        args: {
+          target: "group:grp1",
+          message: "default split",
+          mediaUrl: "https://example.com/pic.png",
+        },
+        apiUrl: "http://localhost:8090",
+        botToken: "test-token",
+      });
+
+      expect(result.ok).toBe(true);
+      // Legacy default: separate text send + uploadAndSendMedia, no RichText.
+      expect(textSent).toBe(true);
+      expect(uploadSendSpy).toHaveBeenCalledOnce();
+      expect(uploadMediaSpy).not.toHaveBeenCalled();
+      expect((result.data as any).richText).toBeUndefined();
+    });
+
+    it("delivers non-image files alongside images via legacy single-send", async () => {
+      const { uploadMedia, uploadAndSendMedia } = await import("./inbound.js");
+      const uploadMediaSpy = vi.mocked(uploadMedia);
+      const uploadSendSpy = vi.mocked(uploadAndSendMedia);
+      uploadMediaSpy.mockClear();
+      uploadSendSpy.mockClear();
+      uploadSendSpy.mockResolvedValue(undefined);
+      uploadMediaSpy
+        .mockResolvedValueOnce({ url: "https://cdn.example.com/i.png", filename: "i.png", size: 1, contentType: "image/png", isImage: true, width: 5, height: 5 })
+        .mockResolvedValueOnce({ url: "https://cdn.example.com/d.pdf", filename: "d.pdf", size: 2, contentType: "application/pdf", isImage: false });
+
+      let richSends = 0;
+      globalThis.fetch = mockFetch({
+        "/v1/bot/sendMessage": async (_url, init) => {
+          const body = JSON.parse(init?.body as string);
+          if (body.payload?.type === 14) richSends += 1;
+          return jsonResponse({ message_id: "rt-3", message_seq: 1 });
+        },
+      });
+
+      const { handleOctoMessageAction } = await import("./actions.js");
+      const result = await handleOctoMessageAction({
+        action: "send",
+        args: {
+          target: "group:grp1",
+          message: "mixed",
+          mediaUrls: ["https://example.com/i.png", "https://example.com/d.pdf"],
+          richText: true,
+        },
+        apiUrl: "http://localhost:8090",
+        botToken: "test-token",
+      });
+
+      expect(result.ok).toBe(true);
+      expect(richSends).toBe(1); // one RichText send for text+image
+      expect(uploadSendSpy).toHaveBeenCalledOnce(); // the PDF via legacy single-send
+      expect((result.data as any).mediaCount).toBe(2);
     });
   });
 

--- a/src/actions.test.ts
+++ b/src/actions.test.ts
@@ -6,19 +6,23 @@ import { registerBotGroupIds, _testReset as _resetGroupMd } from "./group-md.js"
 
 // Mock uploadAndSendMedia / uploadMedia — the streaming COS upload uses its own
 // SDK internals that can't be tested via fetch mocks alone. Upload logic is
-// tested in inbound.test.ts.
-vi.mock("./inbound.js", () => ({
-  uploadAndSendMedia: vi.fn().mockResolvedValue(undefined),
-  uploadMedia: vi.fn().mockResolvedValue({
-    url: "https://cdn.example.com/uploaded.png",
-    filename: "uploaded.png",
-    size: 1234,
-    contentType: "image/png",
-    isImage: true,
-    width: 100,
-    height: 80,
-  }),
-}));
+// tested in inbound.test.ts. resolveRichTextContent is a pure resolver, kept real.
+vi.mock("./inbound.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./inbound.js")>();
+  return {
+    ...actual,
+    uploadAndSendMedia: vi.fn().mockResolvedValue(undefined),
+    uploadMedia: vi.fn().mockResolvedValue({
+      url: "https://cdn.example.com/uploaded.png",
+      filename: "uploaded.png",
+      size: 1234,
+      contentType: "image/png",
+      isImage: true,
+      width: 100,
+      height: 80,
+    }),
+  };
+});
 
 /**
  * Tests for message action handlers.
@@ -1032,13 +1036,13 @@ describe("handleOctoMessageAction", () => {
       expect((result.data as any).mediaCount).toBe(2);
     });
 
-    it("falls back to legacy split path when no image survives upload", async () => {
+    it("file-only richText:true delivers text + sideload without re-upload or orphaned objects", async () => {
       const { uploadMedia, uploadAndSendMedia } = await import("./inbound.js");
       const uploadMediaSpy = vi.mocked(uploadMedia);
       const uploadSendSpy = vi.mocked(uploadAndSendMedia);
       uploadMediaSpy.mockClear();
       uploadSendSpy.mockClear();
-      // Non-image (PDF) → no image block → RichText returns null → legacy path.
+      // Non-image (PDF) → no image block → text + sideload (no re-upload).
       uploadMediaSpy.mockResolvedValue({
         url: "https://cdn.example.com/doc.pdf",
         filename: "doc.pdf",
@@ -1048,10 +1052,12 @@ describe("handleOctoMessageAction", () => {
       });
 
       let textSent = false;
+      let fileSent = false;
       globalThis.fetch = mockFetch({
         "/v1/bot/sendMessage": async (_url, init) => {
           const body = JSON.parse(init?.body as string);
           if (body.payload?.type === 1 && body.payload?.content) textSent = true;
+          if (body.payload?.type === 8) fileSent = true;
           return jsonResponse({ message_id: 1, message_seq: 1 });
         },
       });
@@ -1070,10 +1076,11 @@ describe("handleOctoMessageAction", () => {
       });
 
       expect(result.ok).toBe(true);
-      // Legacy path: plain text send + uploadAndSendMedia for the file.
       expect(textSent).toBe(true);
-      expect(uploadSendSpy).toHaveBeenCalledOnce();
-      expect((result.data as any).richText).toBeUndefined();
+      expect(fileSent).toBe(true); // PDF via sendMediaMessage (reused upload)
+      expect(uploadMediaSpy).toHaveBeenCalledOnce(); // uploaded exactly once
+      expect(uploadSendSpy).not.toHaveBeenCalled(); // no re-upload via legacy path
+      expect((result.data as any).richText).toBeUndefined(); // no type-14 sent
     });
 
     it("does NOT use RichText path without opt-in (backward compatible default)", async () => {
@@ -1481,6 +1488,84 @@ describe("handleOctoMessageAction", () => {
       expect(data.hasMore).toBe(false);
       // Same-channel should NOT have prompt injection wrapper
       expect(data.header).toBeUndefined();
+    });
+  });
+
+  describe("read — RichText(=14) history expansion", () => {
+    it("expands type-14 history into plain text (not empty / [object Object])", async () => {
+      registerBotGroupIds(["grp1"]);
+      const fakeMessages = {
+        messages: [
+          {
+            from_uid: "user1",
+            message_id: "m1",
+            timestamp: 1709654400,
+            // type 14 payload: content is a block array, top-level content "" otherwise
+            payload: Buffer.from(JSON.stringify({
+              type: 14,
+              content: [
+                { type: "text", text: "看图: " },
+                { type: "image", url: "https://cdn.example.com/p.png", width: 5, height: 5 },
+              ],
+              plain: "看图: [图片]",
+            })).toString("base64"),
+          },
+        ],
+      };
+
+      globalThis.fetch = mockFetch({
+        "/v1/bot/messages/sync": async () => jsonResponse(fakeMessages),
+      });
+
+      const { handleOctoMessageAction } = await import("./actions.js");
+      const result = await handleOctoMessageAction({
+        action: "read",
+        args: { target: "group:grp1" },
+        apiUrl: "http://localhost:8090",
+        botToken: "test-token",
+        currentChannelId: "grp1",
+      });
+
+      expect(result.ok).toBe(true);
+      const data = result.data as any;
+      expect(data.messages[0].content).toBe("看图: [图片]");
+    });
+
+    it("builds plain from blocks when top-level plain missing", async () => {
+      registerBotGroupIds(["grp1"]);
+      const fakeMessages = {
+        messages: [
+          {
+            from_uid: "user1",
+            message_id: "m1",
+            timestamp: 1709654400,
+            payload: Buffer.from(JSON.stringify({
+              type: 14,
+              content: [
+                { type: "text", text: "no plain " },
+                { type: "image", url: "https://cdn.example.com/p.png", width: 5, height: 5 },
+              ],
+            })).toString("base64"),
+          },
+        ],
+      };
+
+      globalThis.fetch = mockFetch({
+        "/v1/bot/messages/sync": async () => jsonResponse(fakeMessages),
+      });
+
+      const { handleOctoMessageAction } = await import("./actions.js");
+      const result = await handleOctoMessageAction({
+        action: "read",
+        args: { target: "group:grp1" },
+        apiUrl: "http://localhost:8090",
+        botToken: "test-token",
+        currentChannelId: "grp1",
+      });
+
+      expect(result.ok).toBe(true);
+      const data = result.data as any;
+      expect(data.messages[0].content).toBe("no plain [图片]");
     });
   });
 

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -5,11 +5,12 @@
  * Each handler is stateless — maps and config are passed in via params.
  */
 
-import { ChannelType } from "./types.js";
-import type { MentionEntity, LogSink } from "./types.js";
+import { ChannelType, MessageType, RICH_TEXT_BLOCK_IMAGE, RICH_TEXT_BLOCK_TEXT, RICH_TEXT_IMAGE_PLACEHOLDER } from "./types.js";
+import type { MentionEntity, LogSink, RichTextBlock } from "./types.js";
 import { stripChannelPrefix } from "./constants.js";
 import {
   sendMessage,
+  sendRichTextMessage,
   getChannelMessages,
   getGroupMembers,
   fetchBotGroups,
@@ -17,7 +18,7 @@ import {
   getGroupMd,
   updateGroupMd,
 } from "./api-fetch.js";
-import { uploadAndSendMedia } from "./inbound.js";
+import { uploadAndSendMedia, uploadMedia } from "./inbound.js";
 import { buildEntitiesFromFallback, parseStructuredMentions, convertStructuredMentions } from "./mention-utils.js";
 import { getKnownGroupIds } from "./group-md.js";
 import { checkPermission } from "./permission.js";
@@ -295,6 +296,109 @@ function resolveActionMediaUrls(args: Record<string, unknown>): string[] {
   return [...new Set(urls)];
 }
 
+/**
+ * 组装并发送一条 RichText(=14) 图文混排消息。
+ *
+ * 流程：先批量上传所有 media → 拿到 url/宽高；图片进 image block，非图片（文件等）
+ * 仍走旧的 uploadAndSendMedia 单发（RichText 契约 image block 只接受图片）。文本与
+ * 图片按「先文本后图片」顺序组成单条 content 数组，一次 HTTP 提交（替代 N+1 次）。
+ *
+ * 返回 null 表示「没有任何图片可组装」（全部是非图片文件 / 上传全失败）——调用方应
+ * 回退到旧的拆条路径，保留既有的文件/失败语义。
+ */
+async function sendRichTextCombined(params: {
+  message: string;
+  mediaUrls: string[];
+  apiUrl: string;
+  botToken: string;
+  channelId: string;
+  channelType: ChannelType;
+  resolveMentions: (raw: string) => {
+    finalMessage: string;
+    mentionUids: string[];
+    mentionEntities: MentionEntity[];
+    hasAtAll: boolean;
+  };
+  log?: LogSink;
+}): Promise<{ messageId?: string; imageCount: number; failedMedia: { url: string; error: string }[] } | null> {
+  const { message, mediaUrls, apiUrl, botToken, channelId, channelType, resolveMentions, log } = params;
+
+  // Batch-upload every media asset first.
+  const imageBlocks: RichTextBlock[] = [];
+  const nonImage: Array<{ originalUrl: string }> = [];
+  const failedMedia: { url: string; error: string }[] = [];
+
+  for (const mediaUrl of mediaUrls) {
+    try {
+      const uploaded = await uploadMedia({ mediaUrl, apiUrl, botToken, log: log as any });
+      if (uploaded.isImage) {
+        imageBlocks.push({
+          type: RICH_TEXT_BLOCK_IMAGE,
+          url: uploaded.url,
+          ...(uploaded.width ? { width: uploaded.width } : {}),
+          ...(uploaded.height ? { height: uploaded.height } : {}),
+          ...(uploaded.size != null ? { size: uploaded.size } : {}),
+          ...(uploaded.filename ? { name: uploaded.filename } : {}),
+        });
+      } else {
+        // Non-image (e.g. PDF): RichText image block only accepts images, so
+        // keep the original URL and let the legacy single-send path deliver it.
+        nonImage.push({ originalUrl: mediaUrl });
+      }
+    } catch (err) {
+      const errMsg = err instanceof Error ? err.message : String(err);
+      log?.error?.(`octo: uploadMedia failed for ${mediaUrl}: ${errMsg}`);
+      failedMedia.push({ url: mediaUrl, error: errMsg });
+    }
+  }
+
+  // No image survived → caller should fall back to the legacy split path so the
+  // text + any non-image files keep their established behavior.
+  if (imageBlocks.length === 0) {
+    return null;
+  }
+
+  const { finalMessage, mentionUids, mentionEntities, hasAtAll } = resolveMentions(message);
+
+  // content = [text block, ...image blocks]. Order matches the wire contract
+  // (array order = 图文穿插顺序). plain is best-effort; server reauthors it.
+  const blocks: RichTextBlock[] = [];
+  if (finalMessage.trim() !== "") {
+    blocks.push({ type: RICH_TEXT_BLOCK_TEXT, text: finalMessage });
+  }
+  blocks.push(...imageBlocks);
+  const plain = finalMessage + RICH_TEXT_IMAGE_PLACEHOLDER.repeat(imageBlocks.length);
+
+  const sendResult = await sendRichTextMessage({
+    apiUrl,
+    botToken,
+    channelId,
+    channelType,
+    blocks,
+    plain,
+    ...(mentionUids.length > 0 ? { mentionUids } : {}),
+    ...(mentionEntities.length > 0 ? { mentionEntities } : {}),
+    mentionAll: hasAtAll || undefined,
+  });
+  const messageId = sendResult?.message_id ? String(sendResult.message_id).trim() : undefined;
+
+  // Deliver any non-image files via the legacy single-send path (unchanged
+  // semantics) so file attachments alongside images still work.
+  let extraCount = 0;
+  for (const { originalUrl } of nonImage) {
+    try {
+      await uploadAndSendMedia({ mediaUrl: originalUrl, apiUrl, botToken, channelId, channelType, log: log as any });
+      extraCount += 1;
+    } catch (err) {
+      const errMsg = err instanceof Error ? err.message : String(err);
+      log?.error?.(`octo: uploadAndSendMedia failed for ${originalUrl}: ${errMsg}`);
+      failedMedia.push({ url: originalUrl, error: errMsg });
+    }
+  }
+
+  return { messageId, imageCount: imageBlocks.length + extraCount, failedMedia };
+}
+
 async function handleSend(params: {
   args: Record<string, unknown>;
   apiUrl: string;
@@ -367,12 +471,12 @@ async function handleSend(params: {
     }
   }
 
-  // Send text message
-  let textMessageId: string | undefined;
-  if (message) {
+  // Resolve mentions + @all once; reused by both the legacy text path and the
+  // RichText(=14) 图文混排 path so mention semantics stay identical.
+  const resolveMentions = (raw: string) => {
     let mentionUids: string[] = [];
     let mentionEntities: MentionEntity[] = [];
-    let finalMessage = message;
+    let finalMessage = raw;
 
     if (channelType === ChannelType.Group || channelType === ChannelType.CommunityTopic) {
       // v2 path: convert @[uid:name] → @name + entities
@@ -411,6 +515,53 @@ async function handleSend(params: {
 
     // Detect @all/@所有人 in final content
     const hasAtAll = /(?:^|(?<=\s))@(?:all|所有人)(?=\s|[^\w]|$)/i.test(finalMessage);
+
+    return { finalMessage, mentionUids, mentionEntities, hasAtAll };
+  };
+
+  // ── RichText(=14) 图文混排 path ──────────────────────────────────────────
+  // When the agent sends text PLUS at least one image, assemble a SINGLE
+  // RichText payload (one HTTP send) instead of "sendMessage + loop uploadMedia"
+  // (text + N media = N+1 sends). Opt-in via `richText: true` so the legacy
+  // split path (type 1/2/8/11) stays byte-for-byte the default; callers that
+  // want 图文混排 single-payload semantics ask for it explicitly. Triggers only
+  // when there IS a text message AND at least one media URL.
+  const richTextOptIn = args.richText === true;
+  if (message && mediaUrls.length > 0 && richTextOptIn) {
+    const richResult = await sendRichTextCombined({
+      message,
+      mediaUrls,
+      apiUrl,
+      botToken,
+      channelId,
+      channelType,
+      resolveMentions,
+      log,
+    });
+    if (richResult) {
+      return {
+        ok: true,
+        data: {
+          sent: true,
+          target,
+          channelId,
+          channelType,
+          richText: true,
+          mediaCount: richResult.imageCount,
+          ...(richResult.messageId ? { messageId: richResult.messageId } : {}),
+          ...(richResult.failedMedia.length > 0 ? { failedMedia: richResult.failedMedia } : {}),
+        },
+      };
+    }
+    // richResult === null → no images survived upload (e.g. all were non-image
+    // files or all uploads failed). Fall through to the legacy split path which
+    // sends the text and handles files/failures with the established semantics.
+  }
+
+  // Send text message
+  let textMessageId: string | undefined;
+  if (message) {
+    const { finalMessage, mentionUids, mentionEntities, hasAtAll } = resolveMentions(message);
 
     const sendResult = await sendMessage({
       apiUrl,

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -10,6 +10,7 @@ import type { MentionEntity, LogSink, RichTextBlock } from "./types.js";
 import { stripChannelPrefix } from "./constants.js";
 import {
   sendMessage,
+  sendMediaMessage,
   sendRichTextMessage,
   getChannelMessages,
   getGroupMembers,
@@ -18,7 +19,7 @@ import {
   getGroupMd,
   updateGroupMd,
 } from "./api-fetch.js";
-import { uploadAndSendMedia, uploadMedia } from "./inbound.js";
+import { uploadAndSendMedia, uploadMedia, type UploadedMedia } from "./inbound.js";
 import { buildEntitiesFromFallback, parseStructuredMentions, convertStructuredMentions } from "./mention-utils.js";
 import { getKnownGroupIds } from "./group-md.js";
 import { checkPermission } from "./permission.js";
@@ -299,9 +300,10 @@ function resolveActionMediaUrls(args: Record<string, unknown>): string[] {
 /**
  * 组装并发送一条 RichText(=14) 图文混排消息。
  *
- * 流程：先批量上传所有 media → 拿到 url/宽高；图片进 image block，非图片（文件等）
- * 仍走旧的 uploadAndSendMedia 单发（RichText 契约 image block 只接受图片）。文本与
- * 图片按「先文本后图片」顺序组成单条 content 数组，一次 HTTP 提交（替代 N+1 次）。
+ * 流程：先批量上传所有 media → 拿到 url/宽高；带正宽高的图片进 image block，其余
+ * （非图片文件、或宽高解析失败的图片如 SVG）走 sendMediaMessage 单发复用已上传 url
+ * （RichText 契约 image block 只接受带正宽高的图片）。文本与图片按「先文本后图片」
+ * 顺序组成单条 content 数组，一次 HTTP 提交（替代 N+1 次）。
  *
  * 返回 null 表示「没有任何图片可组装」（全部是非图片文件 / 上传全失败）——调用方应
  * 回退到旧的拆条路径，保留既有的文件/失败语义。
@@ -324,26 +326,32 @@ async function sendRichTextCombined(params: {
   const { message, mediaUrls, apiUrl, botToken, channelId, channelType, resolveMentions, log } = params;
 
   // Batch-upload every media asset first.
+  // - Images WITH positive width/height → RichText image blocks (single payload).
+  // - Everything else (non-image files, or images whose dimensions couldn't be
+  //   parsed — SVG, corrupt headers) → legacy single-send. The type-14 contract
+  //   requires image blocks to carry width/height > 0, so a dimensionless image
+  //   would make the WHOLE RichText payload invalid; route it out instead.
   const imageBlocks: RichTextBlock[] = [];
-  const nonImage: Array<{ originalUrl: string }> = [];
+  const sideloads: Array<{ uploaded: UploadedMedia }> = [];
   const failedMedia: { url: string; error: string }[] = [];
 
   for (const mediaUrl of mediaUrls) {
     try {
       const uploaded = await uploadMedia({ mediaUrl, apiUrl, botToken, log: log as any });
-      if (uploaded.isImage) {
+      const hasDims = !!(uploaded.width && uploaded.width > 0 && uploaded.height && uploaded.height > 0);
+      if (uploaded.isImage && hasDims) {
         imageBlocks.push({
           type: RICH_TEXT_BLOCK_IMAGE,
           url: uploaded.url,
-          ...(uploaded.width ? { width: uploaded.width } : {}),
-          ...(uploaded.height ? { height: uploaded.height } : {}),
+          width: uploaded.width!,
+          height: uploaded.height!,
           ...(uploaded.size != null ? { size: uploaded.size } : {}),
           ...(uploaded.filename ? { name: uploaded.filename } : {}),
         });
       } else {
-        // Non-image (e.g. PDF): RichText image block only accepts images, so
-        // keep the original URL and let the legacy single-send path deliver it.
-        nonImage.push({ originalUrl: mediaUrl });
+        // Non-image OR dimensionless image: deliver via the legacy single-send
+        // path using the already-uploaded URL (no re-upload needed).
+        sideloads.push({ uploaded });
       }
     } catch (err) {
       const errMsg = err instanceof Error ? err.message : String(err);
@@ -382,17 +390,29 @@ async function sendRichTextCombined(params: {
   });
   const messageId = sendResult?.message_id ? String(sendResult.message_id).trim() : undefined;
 
-  // Deliver any non-image files via the legacy single-send path (unchanged
-  // semantics) so file attachments alongside images still work.
+  // Deliver any sideloaded assets (non-image files, or dimensionless images)
+  // via a single-send each, reusing the already-uploaded URL — no re-upload.
+  // Unchanged delivery semantics vs the legacy path.
   let extraCount = 0;
-  for (const { originalUrl } of nonImage) {
+  for (const { uploaded } of sideloads) {
     try {
-      await uploadAndSendMedia({ mediaUrl: originalUrl, apiUrl, botToken, channelId, channelType, log: log as any });
+      await sendMediaMessage({
+        apiUrl,
+        botToken,
+        channelId,
+        channelType,
+        type: uploaded.isImage ? MessageType.Image : MessageType.File,
+        url: uploaded.url,
+        name: uploaded.filename,
+        size: uploaded.size,
+        ...(uploaded.width ? { width: uploaded.width } : {}),
+        ...(uploaded.height ? { height: uploaded.height } : {}),
+      });
       extraCount += 1;
     } catch (err) {
       const errMsg = err instanceof Error ? err.message : String(err);
-      log?.error?.(`octo: uploadAndSendMedia failed for ${originalUrl}: ${errMsg}`);
-      failedMedia.push({ url: originalUrl, error: errMsg });
+      log?.error?.(`octo: sendMediaMessage failed for ${uploaded.url}: ${errMsg}`);
+      failedMedia.push({ url: uploaded.url, error: errMsg });
     }
   }
 

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -19,7 +19,7 @@ import {
   getGroupMd,
   updateGroupMd,
 } from "./api-fetch.js";
-import { uploadAndSendMedia, uploadMedia, type UploadedMedia } from "./inbound.js";
+import { uploadAndSendMedia, uploadMedia, resolveRichTextContent, type UploadedMedia } from "./inbound.js";
 import { buildEntitiesFromFallback, parseStructuredMentions, convertStructuredMentions } from "./mention-utils.js";
 import { getKnownGroupIds } from "./group-md.js";
 import { checkPermission } from "./permission.js";
@@ -305,8 +305,9 @@ function resolveActionMediaUrls(args: Record<string, unknown>): string[] {
  * （RichText 契约 image block 只接受带正宽高的图片）。文本与图片按「先文本后图片」
  * 顺序组成单条 content 数组，一次 HTTP 提交（替代 N+1 次）。
  *
- * 返回 null 表示「没有任何图片可组装」（全部是非图片文件 / 上传全失败）——调用方应
- * 回退到旧的拆条路径，保留既有的文件/失败语义。
+ * 当没有任何带正宽高的图片可组装（全部是非图片文件 / 宽高解析失败 / 上传全失败）时，
+ * 不返回 null（那会让调用方重新上传、孤儿化已上传的 COS 对象）：直接在此发送文本 +
+ * 复用已上传 url 的 sideload 媒体，返回 `richText:false`。
  */
 async function sendRichTextCombined(params: {
   message: string;
@@ -322,7 +323,7 @@ async function sendRichTextCombined(params: {
     hasAtAll: boolean;
   };
   log?: LogSink;
-}): Promise<{ messageId?: string; imageCount: number; failedMedia: { url: string; error: string }[] } | null> {
+}): Promise<{ messageId?: string; imageCount: number; failedMedia: { url: string; error: string }[]; richText: boolean }> {
   const { message, mediaUrls, apiUrl, botToken, channelId, channelType, resolveMentions, log } = params;
 
   // Batch-upload every media asset first.
@@ -360,13 +361,61 @@ async function sendRichTextCombined(params: {
     }
   }
 
-  // No image survived → caller should fall back to the legacy split path so the
-  // text + any non-image files keep their established behavior.
-  if (imageBlocks.length === 0) {
-    return null;
-  }
-
   const { finalMessage, mentionUids, mentionEntities, hasAtAll } = resolveMentions(message);
+
+  // Deliver any sideloaded assets (non-image files, or dimensionless images)
+  // via a single-send each, reusing the already-uploaded URL — no re-upload.
+  // Defined before the no-image early path so both branches share it (avoids
+  // returning null after uploads, which would orphan COS objects + re-upload).
+  const deliverSideloads = async (): Promise<number> => {
+    let delivered = 0;
+    for (const { uploaded } of sideloads) {
+      try {
+        await sendMediaMessage({
+          apiUrl,
+          botToken,
+          channelId,
+          channelType,
+          type: uploaded.isImage ? MessageType.Image : MessageType.File,
+          url: uploaded.url,
+          name: uploaded.filename,
+          size: uploaded.size,
+          ...(uploaded.width ? { width: uploaded.width } : {}),
+          ...(uploaded.height ? { height: uploaded.height } : {}),
+        });
+        delivered += 1;
+      } catch (err) {
+        const errMsg = err instanceof Error ? err.message : String(err);
+        log?.error?.(`octo: sendMediaMessage failed for ${uploaded.url}: ${errMsg}`);
+        failedMedia.push({ url: uploaded.url, error: errMsg });
+      }
+    }
+    return delivered;
+  };
+
+  // No image block survived (all non-image files / dimensionless images / all
+  // uploads failed). We already uploaded the sideloads, so deliver them here
+  // (reusing the uploaded URLs) plus the text — do NOT return null, which would
+  // make the caller re-upload via the legacy path and orphan the COS objects.
+  if (imageBlocks.length === 0) {
+    let textMessageId: string | undefined;
+    if (finalMessage.trim() !== "") {
+      const textResult = await sendMessage({
+        apiUrl,
+        botToken,
+        channelId,
+        channelType,
+        content: finalMessage,
+        ...(mentionUids.length > 0 ? { mentionUids } : {}),
+        ...(mentionEntities.length > 0 ? { mentionEntities } : {}),
+        mentionAll: hasAtAll || undefined,
+      });
+      textMessageId = textResult?.message_id ? String(textResult.message_id).trim() : undefined;
+    }
+    const delivered = await deliverSideloads();
+    // No RichText payload was sent (no images), so this is NOT a richText result.
+    return { messageId: textMessageId, imageCount: delivered, failedMedia, richText: false };
+  }
 
   // content = [text block, ...image blocks]. Order matches the wire contract
   // (array order = 图文穿插顺序). plain is best-effort; server reauthors it.
@@ -390,33 +439,9 @@ async function sendRichTextCombined(params: {
   });
   const messageId = sendResult?.message_id ? String(sendResult.message_id).trim() : undefined;
 
-  // Deliver any sideloaded assets (non-image files, or dimensionless images)
-  // via a single-send each, reusing the already-uploaded URL — no re-upload.
-  // Unchanged delivery semantics vs the legacy path.
-  let extraCount = 0;
-  for (const { uploaded } of sideloads) {
-    try {
-      await sendMediaMessage({
-        apiUrl,
-        botToken,
-        channelId,
-        channelType,
-        type: uploaded.isImage ? MessageType.Image : MessageType.File,
-        url: uploaded.url,
-        name: uploaded.filename,
-        size: uploaded.size,
-        ...(uploaded.width ? { width: uploaded.width } : {}),
-        ...(uploaded.height ? { height: uploaded.height } : {}),
-      });
-      extraCount += 1;
-    } catch (err) {
-      const errMsg = err instanceof Error ? err.message : String(err);
-      log?.error?.(`octo: sendMediaMessage failed for ${uploaded.url}: ${errMsg}`);
-      failedMedia.push({ url: uploaded.url, error: errMsg });
-    }
-  }
+  const extraCount = await deliverSideloads();
 
-  return { messageId, imageCount: imageBlocks.length + extraCount, failedMedia };
+  return { messageId, imageCount: imageBlocks.length + extraCount, failedMedia, richText: true };
 }
 
 async function handleSend(params: {
@@ -558,24 +583,21 @@ async function handleSend(params: {
       resolveMentions,
       log,
     });
-    if (richResult) {
-      return {
-        ok: true,
-        data: {
-          sent: true,
-          target,
-          channelId,
-          channelType,
-          richText: true,
-          mediaCount: richResult.imageCount,
-          ...(richResult.messageId ? { messageId: richResult.messageId } : {}),
-          ...(richResult.failedMedia.length > 0 ? { failedMedia: richResult.failedMedia } : {}),
-        },
-      };
-    }
-    // richResult === null → no images survived upload (e.g. all were non-image
-    // files or all uploads failed). Fall through to the legacy split path which
-    // sends the text and handles files/failures with the established semantics.
+    return {
+      ok: true,
+      data: {
+        sent: true,
+        target,
+        channelId,
+        channelType,
+        // richText is true only when a type-14 payload was actually sent (≥1
+        // image block); a text-only / file-only send reports richText:false.
+        ...(richResult.richText ? { richText: true } : {}),
+        mediaCount: richResult.imageCount,
+        ...(richResult.messageId ? { messageId: richResult.messageId } : {}),
+        ...(richResult.failedMedia.length > 0 ? { failedMedia: richResult.failedMedia } : {}),
+      },
+    };
   }
 
   // Send text message
@@ -751,6 +773,13 @@ async function handleRead(params: {
     else if (msgType === 5) content = "[视频]";
     else if (msgType === 9 || msgType === 8) content = `[文件: ${m.name ?? "unknown"}]`;
     else if (msgType === 11 || msgType === 12) content = "[合并转发]";
+    else if (msgType === MessageType.RichText) {
+      // RichText(=14): m.content is "" (payload.content is a block array), so
+      // expand the full payload — prefer plain, fall back to building from blocks.
+      const rt = resolveRichTextContent((m.payload ?? {}) as any);
+      const text = rt.text || "[图文消息]";
+      content = text.length > 500 ? text.slice(0, 500) + "…" : text;
+    }
     else content = rawContent.length > 500 ? rawContent.slice(0, 500) + "…" : rawContent;
 
     return {

--- a/src/api-fetch.test.ts
+++ b/src/api-fetch.test.ts
@@ -1201,3 +1201,205 @@ describe("sendMessage — mentionAll serialization", () => {
     expect(sentBody.payload.mention).toBeUndefined();
   });
 });
+
+// ---------------------------------------------------------------------------
+// client_msg_no idempotency — outbound sends carry a dedup key
+// ---------------------------------------------------------------------------
+describe("client_msg_no idempotency", () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  const captureBody = () => {
+    const bodies: any[] = [];
+    global.fetch = vi.fn().mockImplementation(async (_url: string, init?: RequestInit) => {
+      bodies.push(JSON.parse(init?.body as string));
+      return new Response(JSON.stringify({ message_id: 1, message_seq: 1 }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as unknown as typeof fetch;
+    return bodies;
+  };
+
+  it("sendMessage auto-generates a client_msg_no", async () => {
+    const bodies = captureBody();
+    const { sendMessage } = await import("./api-fetch.js");
+    await sendMessage({
+      apiUrl: "http://localhost:8090",
+      botToken: "t",
+      channelId: "c",
+      channelType: ChannelType.Group,
+      content: "hi",
+    });
+    expect(typeof bodies[0].client_msg_no).toBe("string");
+    expect(bodies[0].client_msg_no.length).toBeGreaterThan(0);
+  });
+
+  it("sendMessage honors an explicit clientMsgNo (caller reuse on retry)", async () => {
+    const bodies = captureBody();
+    const { sendMessage } = await import("./api-fetch.js");
+    await sendMessage({
+      apiUrl: "http://localhost:8090",
+      botToken: "t",
+      channelId: "c",
+      channelType: ChannelType.Group,
+      content: "hi",
+      clientMsgNo: "fixed-uuid-123",
+    });
+    expect(bodies[0].client_msg_no).toBe("fixed-uuid-123");
+  });
+
+  it("two sendMessage calls get distinct client_msg_no values", async () => {
+    const bodies = captureBody();
+    const { sendMessage } = await import("./api-fetch.js");
+    const base = { apiUrl: "http://localhost:8090", botToken: "t", channelId: "c", channelType: ChannelType.Group };
+    await sendMessage({ ...base, content: "one" });
+    await sendMessage({ ...base, content: "two" });
+    expect(bodies[0].client_msg_no).not.toBe(bodies[1].client_msg_no);
+  });
+
+  it("sendMediaMessage auto-generates a client_msg_no", async () => {
+    const bodies = captureBody();
+    const { sendMediaMessage } = await import("./api-fetch.js");
+    await sendMediaMessage({
+      apiUrl: "http://localhost:8090",
+      botToken: "t",
+      channelId: "c",
+      channelType: ChannelType.Group,
+      type: MessageType.Image,
+      url: "https://cdn.example.com/a.png",
+      width: 10,
+      height: 10,
+    });
+    expect(typeof bodies[0].client_msg_no).toBe("string");
+    expect(bodies[0].client_msg_no.length).toBeGreaterThan(0);
+  });
+
+  it("generateClientMsgNo returns unique values", async () => {
+    const { generateClientMsgNo } = await import("./api-fetch.js");
+    const a = generateClientMsgNo();
+    const b = generateClientMsgNo();
+    expect(a).not.toBe(b);
+    expect(a.length).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sendRichTextMessage — single RichText(=14) payload assembly
+// ---------------------------------------------------------------------------
+describe("sendRichTextMessage — payload assembly", () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  const captureBody = () => {
+    const bodies: any[] = [];
+    global.fetch = vi.fn().mockImplementation(async (_url: string, init?: RequestInit) => {
+      bodies.push(JSON.parse(init?.body as string));
+      return new Response(JSON.stringify({ message_id: 7, message_seq: 1 }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as unknown as typeof fetch;
+    return bodies;
+  };
+
+  it("assembles a single type=14 payload with content blocks in order", async () => {
+    const bodies = captureBody();
+    const { sendRichTextMessage } = await import("./api-fetch.js");
+    await sendRichTextMessage({
+      apiUrl: "http://localhost:8090",
+      botToken: "t",
+      channelId: "c",
+      channelType: ChannelType.Group,
+      blocks: [
+        { type: "text", text: "look:" },
+        { type: "image", url: "https://cdn.example.com/a.png", width: 100, height: 80, size: 1234, name: "a.png" },
+      ],
+      plain: "look:[图片]",
+    });
+
+    expect(bodies).toHaveLength(1); // ONE HTTP send, not text + media split
+    const payload = bodies[0].payload;
+    expect(payload.type).toBe(MessageType.RichText);
+    expect(payload.content).toHaveLength(2);
+    expect(payload.content[0]).toEqual({ type: "text", text: "look:" });
+    expect(payload.content[1].type).toBe("image");
+    expect(payload.content[1].url).toBe("https://cdn.example.com/a.png");
+    expect(payload.content[1].width).toBe(100);
+    expect(payload.plain).toBe("look:[图片]");
+  });
+
+  it("carries client_msg_no for idempotency", async () => {
+    const bodies = captureBody();
+    const { sendRichTextMessage } = await import("./api-fetch.js");
+    await sendRichTextMessage({
+      apiUrl: "http://localhost:8090",
+      botToken: "t",
+      channelId: "c",
+      channelType: ChannelType.Group,
+      blocks: [{ type: "text", text: "x" }],
+    });
+    expect(typeof bodies[0].client_msg_no).toBe("string");
+    expect(bodies[0].client_msg_no.length).toBeGreaterThan(0);
+  });
+
+  it("serializes mention.all as number 1", async () => {
+    const bodies = captureBody();
+    const { sendRichTextMessage } = await import("./api-fetch.js");
+    await sendRichTextMessage({
+      apiUrl: "http://localhost:8090",
+      botToken: "t",
+      channelId: "c",
+      channelType: ChannelType.Group,
+      blocks: [{ type: "text", text: "hey @all" }],
+      mentionAll: true,
+    });
+    expect(bodies[0].payload.mention.all).toBe(1);
+  });
+
+  it("includes mention uids/entities and reply when provided", async () => {
+    const bodies = captureBody();
+    const { sendRichTextMessage } = await import("./api-fetch.js");
+    await sendRichTextMessage({
+      apiUrl: "http://localhost:8090",
+      botToken: "t",
+      channelId: "c",
+      channelType: ChannelType.Group,
+      blocks: [{ type: "text", text: "hi" }],
+      mentionUids: ["u1"],
+      mentionEntities: [{ uid: "u1", offset: 0, length: 3 }],
+      replyMsgId: "999",
+    });
+    const payload = bodies[0].payload;
+    expect(payload.mention.uids).toEqual(["u1"]);
+    expect(payload.mention.entities).toHaveLength(1);
+    expect(payload.reply).toEqual({ message_id: "999" });
+  });
+
+  it("omits plain when not provided", async () => {
+    const bodies = captureBody();
+    const { sendRichTextMessage } = await import("./api-fetch.js");
+    await sendRichTextMessage({
+      apiUrl: "http://localhost:8090",
+      botToken: "t",
+      channelId: "c",
+      channelType: ChannelType.Group,
+      blocks: [{ type: "text", text: "x" }],
+    });
+    expect("plain" in bodies[0].payload).toBe(false);
+  });
+});

--- a/src/api-fetch.ts
+++ b/src/api-fetch.ts
@@ -3,13 +3,25 @@
  * These are used by inbound/outbound where the full OctoAPI class is not available.
  */
 
-import { ChannelType, MessageType, type MentionEntity, type SendMessageResult } from "./types.js";
+import { ChannelType, MessageType, type MentionEntity, type RichTextBlock, type SendMessageResult } from "./types.js";
 import path from "path";
 import { open } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
 // @ts-ignore — cos-nodejs-sdk-v5 has incomplete TypeScript definitions
 import COS from "cos-nodejs-sdk-v5";
 
 const DEFAULT_TIMEOUT_MS = 30_000;
+
+/**
+ * 生成出站消息的客户端幂等编号 client_msg_no（UUID）。
+ *
+ * WuKongIM 以 client_msg_no 做服务端去重（见 pkg/wkdb/message.go：相同
+ * client_msg_no 只落库一条）。图文混排 payload 体积大、链路长、更易触发重试，
+ * 故出站统一附带 client_msg_no，保证重试不会产生重复消息。
+ */
+export function generateClientMsgNo(): string {
+  return randomUUID();
+}
 
 const DEFAULT_HEADERS = {
   "Content-Type": "application/json",
@@ -78,6 +90,7 @@ export async function sendMediaMessage(params: {
   mentionUids?: string[];
   mentionEntities?: MentionEntity[];
   onBehalfOf?: string;
+  clientMsgNo?: string;
   signal?: AbortSignal;
 }): Promise<SendMessageResult | undefined> {
   const payload: Record<string, unknown> = {
@@ -113,6 +126,7 @@ export async function sendMediaMessage(params: {
     channel_id: params.channelId,
     channel_type: params.channelType,
     payload,
+    client_msg_no: params.clientMsgNo ?? generateClientMsgNo(),
     ...(params.onBehalfOf ? { on_behalf_of: params.onBehalfOf } : {}),
   }, params.signal);
 }
@@ -218,6 +232,7 @@ export async function sendMessage(params: {
   mentionAll?: boolean;
   replyMsgId?: string;
   onBehalfOf?: string;
+  clientMsgNo?: string;
   signal?: AbortSignal;
 }): Promise<SendMessageResult | undefined> {
   const payload: Record<string, unknown> = {
@@ -250,6 +265,71 @@ export async function sendMessage(params: {
     channel_id: params.channelId,
     channel_type: params.channelType,
     payload,
+    client_msg_no: params.clientMsgNo ?? generateClientMsgNo(),
+    ...(params.onBehalfOf ? { on_behalf_of: params.onBehalfOf } : {}),
+  }, params.signal);
+}
+
+/**
+ * 发送一条 RichText(=14) 图文混排消息。
+ *
+ * 替代「sendMessage 文本 + 循环 uploadMedia」的多次 HTTP：调用方先批量上传图片
+ * 拿到 url（含 width/height），再把文本与图片按顺序组成一条 `content` block 数组
+ * 提交。一条 payload = 一次 HTTP，server 端图文不再拆条。
+ *
+ * 契约（见 octo-lib richtext.go）：
+ *   - `content` 必填且非空；text block 的 text 非空、image block 的 url 为
+ *     http/https 且 width/height >0 —— 校验由调用方/ server 负责，本函数只组装。
+ *   - `plain` 出站可附带（供老客户端/降级），server 会用 content 权威重算覆盖。
+ *   - `client_msg_no` 默认自动生成（幂等去重），调用方可显式传入复用。
+ */
+export async function sendRichTextMessage(params: {
+  apiUrl: string;
+  botToken: string;
+  channelId: string;
+  channelType: ChannelType;
+  blocks: RichTextBlock[];
+  plain?: string;
+  mentionUids?: string[];
+  mentionEntities?: MentionEntity[];
+  mentionAll?: boolean;
+  replyMsgId?: string;
+  onBehalfOf?: string;
+  clientMsgNo?: string;
+  signal?: AbortSignal;
+}): Promise<SendMessageResult | undefined> {
+  const payload: Record<string, unknown> = {
+    type: MessageType.RichText,
+    content: params.blocks,
+  };
+  if (typeof params.plain === "string") {
+    payload.plain = params.plain;
+  }
+  if (
+    (params.mentionUids && params.mentionUids.length > 0) ||
+    (params.mentionEntities && params.mentionEntities.length > 0) ||
+    params.mentionAll
+  ) {
+    const mention: Record<string, unknown> = {};
+    if (params.mentionUids && params.mentionUids.length > 0) {
+      mention.uids = params.mentionUids;
+    }
+    if (params.mentionEntities && params.mentionEntities.length > 0) {
+      mention.entities = params.mentionEntities;
+    }
+    if (params.mentionAll) {
+      mention.all = 1;
+    }
+    payload.mention = mention;
+  }
+  if (params.replyMsgId) {
+    payload.reply = { message_id: params.replyMsgId };
+  }
+  return await postJson<SendMessageResult>(params.apiUrl, params.botToken, "/v1/bot/sendMessage", {
+    channel_id: params.channelId,
+    channel_type: params.channelType,
+    payload,
+    client_msg_no: params.clientMsgNo ?? generateClientMsgNo(),
     ...(params.onBehalfOf ? { on_behalf_of: params.onBehalfOf } : {}),
   }, params.signal);
 }

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1175,7 +1175,7 @@ export const octoPlugin: ChannelPlugin<ResolvedOctoAccount> = {
           // Also allow event messages (e.g. group_md_updated) from any source.
           if (_knownBotUids.has(msg.from_uid) && msg.channel_type === ChannelType.DM && !isEvent) return;
           // Skip unsupported message types (Location, Card), but allow event messages through
-          const supportedTypes = [MessageType.Text, MessageType.Image, MessageType.GIF, MessageType.Voice, MessageType.Video, MessageType.File, MessageType.MultipleForward];
+          const supportedTypes = [MessageType.Text, MessageType.Image, MessageType.GIF, MessageType.Voice, MessageType.Video, MessageType.File, MessageType.MultipleForward, MessageType.RichText];
           if (!msg.payload || (!supportedTypes.includes(msg.payload.type) && !isEvent)) return;
 
           // Defense-in-depth DM filter (kept for safety, though v0.2.28+ uses independent

--- a/src/inbound.test.ts
+++ b/src/inbound.test.ts
@@ -1,10 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { ChannelType, MessageType, type MentionPayload } from "./types.js";
+import { ChannelType, MessageType, RICH_TEXT_BLOCK_IMAGE, RICH_TEXT_BLOCK_TEXT, type MentionPayload } from "./types.js";
 import { DEFAULT_HISTORY_PROMPT_TEMPLATE } from "./config-schema.js";
 import {
   resolveInnerMessageText,
   resolveApiMessagePlaceholder,
   resolveMultipleForwardText,
+  resolveRichTextContent,
   buildMediaUrl,
   calcDownloadTimeout,
   formatSize,
@@ -475,6 +476,129 @@ describe("MultipleForward handling", () => {
     expect(resolveInnerMessageText({ type: MessageType.MultipleForward })).toBe("[合并转发]");
     expect(resolveInnerMessageText({ type: 99 })).toBe("[消息]");
     expect(resolveInnerMessageText({ type: 99, content: "fallback" })).toBe("fallback");
+  });
+});
+
+/**
+ * Tests for RichText(=14) 图文混排 inbound resolution.
+ *
+ * Contract (octo-lib common/richtext.go):
+ *   - content = ordered block array ([{type:'text',text}, {type:'image',url,...}]);
+ *   - plain = redundant flat text, server-authored;
+ *   - inbound maps RichText into a single semantic message { text, mediaUrls[] }.
+ */
+describe("RichText(=14) inbound resolution", () => {
+  it("prefers top-level plain when present", () => {
+    const result = resolveRichTextContent({
+      content: [
+        { type: RICH_TEXT_BLOCK_TEXT, text: "hello" },
+        { type: RICH_TEXT_BLOCK_IMAGE, url: "https://cdn.example.com/a.png", width: 10, height: 10 },
+      ],
+      plain: "server authored plain",
+    });
+    expect(result.text).toBe("server authored plain");
+    expect(result.mediaUrls).toEqual(["https://cdn.example.com/a.png"]);
+  });
+
+  it("falls back to building plain from blocks when plain missing", () => {
+    const result = resolveRichTextContent({
+      content: [
+        { type: RICH_TEXT_BLOCK_TEXT, text: "before " },
+        { type: RICH_TEXT_BLOCK_IMAGE, url: "https://cdn.example.com/a.png", width: 1, height: 1 },
+        { type: RICH_TEXT_BLOCK_TEXT, text: " after" },
+      ],
+    });
+    // text block + [图片] placeholder + text block, in array order
+    expect(result.text).toBe("before [图片] after");
+    expect(result.mediaUrls).toEqual(["https://cdn.example.com/a.png"]);
+  });
+
+  it("falls back to building plain when plain is whitespace-only", () => {
+    const result = resolveRichTextContent({
+      content: [{ type: RICH_TEXT_BLOCK_TEXT, text: "real text" }],
+      plain: "   ",
+    });
+    expect(result.text).toBe("real text");
+    expect(result.mediaUrls).toEqual([]);
+  });
+
+  it("collects every image url in array order", () => {
+    const result = resolveRichTextContent({
+      content: [
+        { type: RICH_TEXT_BLOCK_IMAGE, url: "https://cdn.example.com/1.png", width: 1, height: 1 },
+        { type: RICH_TEXT_BLOCK_TEXT, text: "mid" },
+        { type: RICH_TEXT_BLOCK_IMAGE, url: "https://cdn.example.com/2.png", width: 1, height: 1 },
+      ],
+    });
+    expect(result.mediaUrls).toEqual([
+      "https://cdn.example.com/1.png",
+      "https://cdn.example.com/2.png",
+    ]);
+    expect(result.text).toBe("[图片]mid[图片]");
+  });
+
+  it("normalizes relative image urls via buildUrl", () => {
+    const result = resolveRichTextContent(
+      {
+        content: [
+          { type: RICH_TEXT_BLOCK_IMAGE, url: "file/preview/abc.png", width: 1, height: 1 },
+        ],
+      },
+      (u) => buildMediaUrl(u, "http://api.example.com", "https://cdn.example.com"),
+    );
+    expect(result.mediaUrls).toEqual(["https://cdn.example.com/abc.png"]);
+  });
+
+  it("handles legacy string content (single text block) — backward compat", () => {
+    const result = resolveRichTextContent({ content: "legacy plain string" as any });
+    expect(result.text).toBe("legacy plain string");
+    expect(result.mediaUrls).toEqual([]);
+  });
+
+  it("degrades unknown block types: keeps text, skips noise (Postel)", () => {
+    const result = resolveRichTextContent({
+      content: [
+        { type: "future-thing", text: "kept" },
+        { type: "noise" },
+      ] as any,
+    });
+    expect(result.text).toBe("kept");
+    expect(result.mediaUrls).toEqual([]);
+  });
+
+  it("returns empty for empty/missing content", () => {
+    expect(resolveRichTextContent({ content: [] }).text).toBe("");
+    expect(resolveRichTextContent({ content: [] }).mediaUrls).toEqual([]);
+    expect(resolveRichTextContent({} as any).mediaUrls).toEqual([]);
+  });
+
+  it("resolveInnerMessageText expands nested RichText (引用/转发预览)", () => {
+    // Nested type-14 inside a quote/forward: prefer plain, fall back to blocks.
+    expect(
+      resolveInnerMessageText({
+        type: MessageType.RichText,
+        plain: "nested plain",
+        content: [{ type: RICH_TEXT_BLOCK_TEXT, text: "ignored when plain present" }],
+      } as any),
+    ).toBe("nested plain");
+
+    expect(
+      resolveInnerMessageText({
+        type: MessageType.RichText,
+        content: [
+          { type: RICH_TEXT_BLOCK_TEXT, text: "图: " },
+          { type: RICH_TEXT_BLOCK_IMAGE, url: "https://cdn.example.com/x.png", width: 1, height: 1 },
+        ],
+      } as any),
+    ).toBe("图: [图片]");
+  });
+
+  it("resolveInnerMessageText falls back to label for empty RichText", () => {
+    expect(resolveInnerMessageText({ type: MessageType.RichText, content: [] } as any)).toBe("[图文消息]");
+  });
+
+  it("resolveApiMessagePlaceholder labels RichText", () => {
+    expect(resolveApiMessagePlaceholder(MessageType.RichText)).toBe("[图文消息]");
   });
 });
 

--- a/src/inbound.test.ts
+++ b/src/inbound.test.ts
@@ -572,6 +572,21 @@ describe("RichText(=14) inbound resolution", () => {
     expect(resolveRichTextContent({} as any).mediaUrls).toEqual([]);
   });
 
+  it("hardens against malformed block field shapes (no throw, no [object Object])", () => {
+    const result = resolveRichTextContent({
+      content: [
+        { type: RICH_TEXT_BLOCK_IMAGE, url: {} },          // non-string url → placeholder kept, url skipped
+        { type: RICH_TEXT_BLOCK_TEXT, text: { x: 1 } },     // non-string text → skipped
+        { type: RICH_TEXT_BLOCK_TEXT, text: "ok" },
+        { type: RICH_TEXT_BLOCK_IMAGE, url: "https://cdn.example.com/good.png", width: 1, height: 1 },
+      ] as any,
+    });
+    // image blocks always contribute a placeholder; malformed text is skipped;
+    // only the string url is collected into mediaUrls.
+    expect(result.text).toBe("[图片]ok[图片]");
+    expect(result.mediaUrls).toEqual(["https://cdn.example.com/good.png"]);
+  });
+
   it("resolveInnerMessageText expands nested RichText (引用/转发预览)", () => {
     // Nested type-14 inside a quote/forward: prefer plain, fall back to blocks.
     expect(

--- a/src/inbound.ts
+++ b/src/inbound.ts
@@ -1402,7 +1402,11 @@ export async function handleInboundMessage(params: {
   const replyData = message.payload?.reply;
   if (replyData) {
     const replyPayload = replyData.payload;
-    const replyContent = replyPayload?.content ?? (replyPayload ? resolveContentText(replyPayload, account.config.apiUrl) : "");
+    // RichText(=14) carries `content` as a block array, not a string — using the
+    // raw `content` would interpolate `[object Object]`. Only trust a string
+    // `content`; otherwise (RichText, or missing) resolve via the type-aware path.
+    const rawReplyContent = typeof replyPayload?.content === "string" ? replyPayload.content : undefined;
+    const replyContent = rawReplyContent ?? (replyPayload ? resolveContentText(replyPayload, account.config.apiUrl) : "");
     const replyFrom = replyData.from_uid ?? replyData.from_name ?? "unknown";
     if (replyContent) {
       quotePrefix = `[Quoted message from ${replyFrom}]: ${replyContent}\n---\n`;

--- a/src/inbound.ts
+++ b/src/inbound.ts
@@ -1346,15 +1346,17 @@ export async function handleInboundMessage(params: {
     inboundMediaUrl = localPath; // undefined on failure — graceful degradation
   }
   // RichText(=14): download every embedded image to a local temp file (same
-  // rationale as single-media types above). Each failure degrades gracefully:
-  // a failed download is dropped from the list rather than passing a remote URL.
+  // rationale as single-media types above). On a per-image download failure,
+  // fall back to the REMOTE url so the agent keeps a usable reference — unlike
+  // single-media types where the url survives inside rawBody, the RichText body
+  // is only plain text with [图片] placeholders, so dropping the url loses it.
   if (message.payload?.type === MessageType.RichText && resolved.mediaUrls?.length) {
-    const localPaths: string[] = [];
+    const resolvedImageUrls: string[] = [];
     for (const remoteUrl of resolved.mediaUrls) {
       const localPath = await downloadMediaToLocal(remoteUrl, guessMime(remoteUrl, "image/jpeg"), log);
-      if (localPath) localPaths.push(localPath);
+      resolvedImageUrls.push(localPath ?? remoteUrl);
     }
-    inboundMediaUrls = localPaths.length > 0 ? localPaths : undefined;
+    inboundMediaUrls = resolvedImageUrls.length > 0 ? resolvedImageUrls : undefined;
     inboundMediaUrl = inboundMediaUrls?.[0];
   }
   // Inline text file content if possible, or stream large files to temp

--- a/src/inbound.ts
+++ b/src/inbound.ts
@@ -4,7 +4,8 @@ import { DEFAULT_GROUP_HISTORY_LIMIT } from "openclaw/plugin-sdk/reply-history";
 import { sendMessage, sendReadReceipt, sendTyping, getChannelMessages, getGroupMembers, getGroupMd, postJson, sendMediaMessage, inferContentType, ensureTextCharset, parseImageDimensions, parseImageDimensionsFromFile, getUploadCredentials, uploadFileToCOS, fetchUserInfo } from "./api-fetch.js";
 import type { ResolvedOctoAccount } from "./accounts.js";
 import type { BotMessage } from "./types.js";
-import { ChannelType, MessageType } from "./types.js";
+import { ChannelType, MessageType, RICH_TEXT_BLOCK_IMAGE, RICH_TEXT_BLOCK_TEXT, RICH_TEXT_IMAGE_PLACEHOLDER } from "./types.js";
+import type { RichTextBlock } from "./types.js";
 import { getOctoRuntime } from "./runtime.js";
 import { CHANNEL_ID } from "./constants.js";
 import {
@@ -116,17 +117,41 @@ export function extractFilename(url: string): string {
   }
 }
 
-/** Upload media to MinIO and send as image/file message */
-export async function uploadAndSendMedia(params: {
+/**
+ * Result of uploading a single media asset to COS (without sending).
+ */
+export interface UploadedMedia {
+  /** Public CDN/object URL of the uploaded asset. */
+  url: string;
+  /** Sanitized filename used for the upload. */
+  filename: string;
+  /** Byte size of the uploaded asset. */
+  size: number;
+  /** Resolved content type (charset normalized for text/*). */
+  contentType: string;
+  /** True when the asset is an image (contentType starts with image/). */
+  isImage: boolean;
+  /** Image width in px (images only, when parseable). */
+  width?: number;
+  /** Image height in px (images only, when parseable). */
+  height?: number;
+}
+
+/**
+ * Upload a single media asset (remote URL or local path) to COS and return its
+ * public URL plus metadata — WITHOUT sending a message.
+ *
+ * Extracted from {@link uploadAndSendMedia} so the outbound RichText(=14) path
+ * can batch-upload images first, collect their URLs/dimensions, then assemble a
+ * single RichText payload (one HTTP send) instead of one send per asset.
+ */
+export async function uploadMedia(params: {
   mediaUrl: string;
   apiUrl: string;
   botToken: string;
-  channelId: string;
-  channelType: ChannelType;
-  onBehalfOf?: string;
   log?: ChannelLogSink;
-}): Promise<SendMessageResult | undefined> {
-  const { mediaUrl, apiUrl, botToken, channelId, channelType, onBehalfOf, log } = params;
+}): Promise<UploadedMedia> {
+  const { mediaUrl, apiUrl, botToken, log } = params;
 
   const { createReadStream: fsCreateReadStream, statSync: fsStatSync, createWriteStream: fsCreateWriteStream } = await import("node:fs");
   const { basename, join: pathJoin } = await import("node:path");
@@ -203,9 +228,8 @@ export async function uploadAndSendMedia(params: {
       filename,
     });
 
-    // Determine message type from MIME
+    // Determine media kind from MIME
     const isImage = contentType.startsWith("image/");
-    const msgType = isImage ? MessageType.Image : MessageType.File;
 
     // For images, parse dimensions from file (not full buffer)
     let width: number | undefined;
@@ -219,24 +243,43 @@ export async function uploadAndSendMedia(params: {
 
     log?.info?.(`octo: uploaded media as ${isImage ? "image" : "file"}: ${filename}${width ? ` (${width}x${height})` : ""}`);
 
-    // Send via sendMessage
-    const result = await sendMediaMessage({
-      apiUrl,
-      botToken,
-      channelId,
-      channelType,
-      type: msgType,
-      url: uploadedUrl,
-      name: filename,
-      size: fileSize,
-      width,
-      height,
-      ...(onBehalfOf ? { onBehalfOf } : {}),
-    });
-    return result;
+    return { url: uploadedUrl, filename, size: fileSize, contentType, isImage, width, height };
   } finally {
     if (tempPath) await fsUnlink(tempPath).catch(() => {});
   }
+}
+
+/** Upload media to MinIO and send as image/file message */
+export async function uploadAndSendMedia(params: {
+  mediaUrl: string;
+  apiUrl: string;
+  botToken: string;
+  channelId: string;
+  channelType: ChannelType;
+  onBehalfOf?: string;
+  log?: ChannelLogSink;
+}): Promise<SendMessageResult | undefined> {
+  const { mediaUrl, apiUrl, botToken, channelId, channelType, onBehalfOf, log } = params;
+
+  const uploaded = await uploadMedia({ mediaUrl, apiUrl, botToken, log });
+
+  const msgType = uploaded.isImage ? MessageType.Image : MessageType.File;
+
+  // Send via sendMessage
+  const result = await sendMediaMessage({
+    apiUrl,
+    botToken,
+    channelId,
+    channelType,
+    type: msgType,
+    url: uploaded.url,
+    name: uploaded.filename,
+    size: uploaded.size,
+    width: uploaded.width,
+    height: uploaded.height,
+    ...(onBehalfOf ? { onBehalfOf } : {}),
+  });
+  return result;
 }
 
 /** Guess MIME type from file extension */
@@ -262,6 +305,11 @@ export interface ResolvedContent {
   text: string;
   mediaUrl?: string;
   mediaType?: string;
+  /**
+   * RichText(=14) 图文混排展开后的全部图片 URL（有序，按 block 顺序）。
+   * 单图/纯媒体类型仍走 `mediaUrl`；此字段仅在一条消息可携带多张图时填充。
+   */
+  mediaUrls?: string[];
 }
 
 export interface ForwardUser {
@@ -329,9 +377,80 @@ export function resolveInnerMessageText(
     }
     case MessageType.MultipleForward:
       return "[合并转发]";
+    case MessageType.RichText: {
+      // 嵌套 RichText（引用/转发预览）：优先顶层 plain，缺则遍历 content blocks。
+      const rt = resolveRichTextContent(payload as any, buildUrl);
+      return rt.text || "[图文消息]";
+    }
     default:
       return payload.content ?? "[消息]";
   }
+}
+
+/**
+ * 将 RichText(=14) payload 展开成单条语义消息 `{ text, mediaUrls[] }`。
+ *
+ * 复刻 MultipleForward(=11) 的展开范式：
+ *   - 文本：优先读顶层 `plain`（server 权威生成的冗余纯文本）；
+ *     缺失时遍历 `content` block 数组现场拼接（text 取 text、image 注入占位符）。
+ *   - 图片：遍历 image block 收集 `url`（经 buildUrl 归一化为完整地址）。
+ *
+ * 向后兼容老 payload：`content` 为字符串时按单个 text block 处理。
+ */
+export function resolveRichTextContent(
+  payload: { content?: unknown; plain?: unknown; url?: string },
+  buildUrl?: (url?: string) => string | undefined,
+): { text: string; mediaUrls: string[] } {
+  const blocks = normalizeRichTextBlocks(payload?.content);
+  const mediaUrls: string[] = [];
+  for (const blk of blocks) {
+    if (blk.type === RICH_TEXT_BLOCK_IMAGE && blk.url) {
+      const full = buildUrl ? buildUrl(blk.url) : blk.url;
+      if (full) mediaUrls.push(full);
+    }
+  }
+  // 顶层 plain 优先（server 权威）。注意 plain 仅供展示，图片仍从 blocks 收集。
+  const topPlain = typeof payload?.plain === "string" ? payload.plain : "";
+  const text = topPlain.trim() !== ""
+    ? topPlain
+    : buildRichTextPlain(blocks);
+  return { text, mediaUrls };
+}
+
+/**
+ * 归一化 RichText `content`：
+ *   - 数组 → 原样（过滤非对象元素）；
+ *   - 字符串 → 视为单个 text block（向后兼容老的字符串 content）；
+ *   - 其它 → 空数组。
+ */
+function normalizeRichTextBlocks(content: unknown): RichTextBlock[] {
+  if (Array.isArray(content)) {
+    return content.filter((b): b is RichTextBlock => !!b && typeof b === "object");
+  }
+  if (typeof content === "string" && content) {
+    return [{ type: RICH_TEXT_BLOCK_TEXT, text: content }];
+  }
+  return [];
+}
+
+/**
+ * 遍历 content blocks 生成纯文本（对齐 octo-lib BuildRichTextPlain）：
+ *   - text block 取 text；
+ *   - image block 注入 RICH_TEXT_IMAGE_PLACEHOLDER；
+ *   - 未知 type 降级：有 text 写 text，否则跳过（Postel，展示端宽容）。
+ */
+function buildRichTextPlain(blocks: RichTextBlock[]): string {
+  let out = "";
+  for (const blk of blocks) {
+    if (blk.type === RICH_TEXT_BLOCK_IMAGE) {
+      out += RICH_TEXT_IMAGE_PLACEHOLDER;
+    } else if (blk.type === RICH_TEXT_BLOCK_TEXT) {
+      out += blk.text ?? "";
+    } else if (blk.text) {
+      out += blk.text;
+    }
+  }
+  return out;
 }
 
 /** Resolve MultipleForward payload into readable text */
@@ -408,6 +527,18 @@ function resolveContent(payload: BotMessage["payload"], apiUrl?: string, log?: C
     }
     case MessageType.MultipleForward: {
       return { text: resolveMultipleForwardText(payload, apiUrl, cdnUrl) };
+    }
+    case MessageType.RichText: {
+      // 图文混排：展开成单条语义 { text, mediaUrls[] }。优先顶层 plain，
+      // 缺则遍历 content blocks（复刻 MultipleForward 的展开范式）。
+      const buildUrl = (url?: string) => buildMediaUrl(url, apiUrl, cdnUrl);
+      const rt = resolveRichTextContent(payload as any, buildUrl);
+      const mediaUrls = rt.mediaUrls;
+      return {
+        text: rt.text,
+        ...(mediaUrls.length > 0 ? { mediaUrl: mediaUrls[0], mediaUrls } : {}),
+        ...(mediaUrls.length > 0 ? { mediaType: guessMime(mediaUrls[0], "image/jpeg") } : {}),
+      };
     }
     default:
       return { text: payload.content ?? payload.url ?? "" };
@@ -848,6 +979,7 @@ export function resolveApiMessagePlaceholder(type?: number, name?: string): stri
     case MessageType.Location: return "[位置信息]";
     case MessageType.Card: return "[名片]";
     case MessageType.MultipleForward: return "[合并转发]";
+    case MessageType.RichText: return "[图文消息]";
     default: return "[消息]";
   }
 }
@@ -1196,6 +1328,8 @@ export async function handleInboundMessage(params: {
   const resolved = resolveContent(message.payload, account.config.apiUrl, log, account.config.cdnUrl);
   let rawBody = resolved.text;
   let inboundMediaUrl = resolved.mediaUrl;
+  // RichText(=14) 图文混排可携带多张图：在此累积本地化后的图片路径。
+  let inboundMediaUrls: string[] | undefined;
 
   // Opportunistic uid→name cache fill from MultipleForward payloads
   if (message.payload?.type === MessageType.MultipleForward && Array.isArray(message.payload.users)) {
@@ -1210,6 +1344,18 @@ export async function handleInboundMessage(params: {
   if (inboundMediaUrl && message.payload?.type != null && mediaDownloadTypes.includes(message.payload.type)) {
     const localPath = await downloadMediaToLocal(inboundMediaUrl, resolved.mediaType, log);
     inboundMediaUrl = localPath; // undefined on failure — graceful degradation
+  }
+  // RichText(=14): download every embedded image to a local temp file (same
+  // rationale as single-media types above). Each failure degrades gracefully:
+  // a failed download is dropped from the list rather than passing a remote URL.
+  if (message.payload?.type === MessageType.RichText && resolved.mediaUrls?.length) {
+    const localPaths: string[] = [];
+    for (const remoteUrl of resolved.mediaUrls) {
+      const localPath = await downloadMediaToLocal(remoteUrl, guessMime(remoteUrl, "image/jpeg"), log);
+      if (localPath) localPaths.push(localPath);
+    }
+    inboundMediaUrls = localPaths.length > 0 ? localPaths : undefined;
+    inboundMediaUrl = inboundMediaUrls?.[0];
   }
   // Inline text file content if possible, or stream large files to temp
   const isFileMessage = message.payload?.type === MessageType.File;
@@ -1439,6 +1585,12 @@ export async function handleInboundMessage(params: {
           // For MultipleForward, expand the nested messages from full payload
           if (m.type === MessageType.MultipleForward && m.payload) {
             body = resolveMultipleForwardText(m.payload, account.config.apiUrl, account.config.cdnUrl);
+          }
+          // For RichText(=14), expand the 图文混排 payload into a single-line
+          // semantic body (plain text with [图片] placeholders), same as inbound.
+          if (m.type === MessageType.RichText && m.payload) {
+            const apiResolved = resolveContent(m.payload, account.config.apiUrl, log, account.config.cdnUrl);
+            if (apiResolved.text) body = apiResolved.text;
           }
           const entry: any = {
             sender: m.from_uid,
@@ -1795,11 +1947,19 @@ export async function handleInboundMessage(params: {
     CommandAuthorized: commandAuthorized,
     MediaUrl: isFileMessage ? undefined : inboundMediaUrl,
     MediaUrls: (() => {
-      // Only pass current message's local media path (no remote history URLs)
-      const current = isFileMessage ? undefined : inboundMediaUrl;
-      return current ? [current] : undefined;
+      if (isFileMessage) return undefined;
+      // RichText(=14): pass every locally-downloaded image (図文混排 multi-image).
+      if (inboundMediaUrls?.length) return inboundMediaUrls;
+      // Other types: only pass current message's local media path (no remote history URLs)
+      return inboundMediaUrl ? [inboundMediaUrl] : undefined;
     })(),
-    MediaTypes: resolved.mediaType ? [resolved.mediaType] : undefined,
+    MediaTypes: (() => {
+      if (isFileMessage) return undefined;
+      if (inboundMediaUrls?.length) {
+        return inboundMediaUrls.map((u) => guessMime(u, "image/jpeg"));
+      }
+      return resolved.mediaType ? [resolved.mediaType] : undefined;
+    })(),
     From: `${CHANNEL_ID}:${message.from_uid}`,
     To: `${CHANNEL_ID}:${sessionId}`,
     SessionKey: route.sessionKey,

--- a/src/inbound.ts
+++ b/src/inbound.ts
@@ -404,7 +404,9 @@ export function resolveRichTextContent(
   const blocks = normalizeRichTextBlocks(payload?.content);
   const mediaUrls: string[] = [];
   for (const blk of blocks) {
-    if (blk.type === RICH_TEXT_BLOCK_IMAGE && blk.url) {
+    // Defensive: server-originated data — only collect string urls so a
+    // malformed `{type:'image', url:{}}` never reaches buildUrl and throws.
+    if (blk.type === RICH_TEXT_BLOCK_IMAGE && typeof blk.url === "string" && blk.url) {
       const full = buildUrl ? buildUrl(blk.url) : blk.url;
       if (full) mediaUrls.push(full);
     }
@@ -445,8 +447,10 @@ function buildRichTextPlain(blocks: RichTextBlock[]): string {
     if (blk.type === RICH_TEXT_BLOCK_IMAGE) {
       out += RICH_TEXT_IMAGE_PLACEHOLDER;
     } else if (blk.type === RICH_TEXT_BLOCK_TEXT) {
-      out += blk.text ?? "";
-    } else if (blk.text) {
+      // Only string text — guards against a malformed non-string `text`
+      // rendering as "[object Object]".
+      out += typeof blk.text === "string" ? blk.text : "";
+    } else if (typeof blk.text === "string" && blk.text) {
       out += blk.text;
     }
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -144,6 +144,50 @@ export enum MessageType {
   Card = 7,
   File = 8,
   MultipleForward = 11,
+  /**
+   * 图文混排（rich text）。复用 octo-lib Phase 0 已定的 ContentType=14（见
+   * octo-lib common/richtext.go）。正文以有序 `content` block 数组承载，数组
+   * 顺序即图文穿插顺序；顶层 `plain` 为冗余纯文本，契约上由 server 权威生成。
+   */
+  RichText = 14,
+}
+
+/** RichText(=14) 单个 block 类型常量（与 octo-lib RichTextBlockText/Image 对齐）。 */
+export const RICH_TEXT_BLOCK_TEXT = "text";
+export const RICH_TEXT_BLOCK_IMAGE = "image";
+
+/** 生成 plain 时 image block 注入的占位符（与 octo-lib RichTextImagePlaceholder 对齐）。 */
+export const RICH_TEXT_IMAGE_PLACEHOLDER = "[图片]";
+
+/**
+ * RichText(=14) `content` 数组中的单个 block。
+ *   - type=text  使用 `text`（纯文本，MVP 不渲染 markdown）；
+ *   - type=image 使用 `url`/`width`/`height`（`size`、`name` 可选）。
+ *
+ * ⚠️ 命名锁定（见 octo-lib richtext.go）：禁止使用 entities + offset/length。
+ */
+export interface RichTextBlock {
+  type: typeof RICH_TEXT_BLOCK_TEXT | typeof RICH_TEXT_BLOCK_IMAGE | string;
+  /** text block 文本内容（type=text 必填且非空）。 */
+  text?: string;
+  /** image block 图片地址（type=image 必填，scheme 仅 http/https）。 */
+  url?: string;
+  /** image block 宽度（像素，契约必填且 >0，供端上占位排版避免抖动）。 */
+  width?: number;
+  /** image block 高度（像素，契约必填且 >0）。 */
+  height?: number;
+  /** image block 字节大小（可选）。 */
+  size?: number;
+  /** image block 原始文件名（可选）。 */
+  name?: string;
+}
+
+/** RichText(=14) 消息的 payload。 */
+export interface RichTextPayload {
+  /** 有序 block 数组，顺序即图文穿插顺序（契约必填且非空）。 */
+  content: RichTextBlock[];
+  /** 冗余纯文本，契约上由 server 生成；adapter 出站可附带，server 会覆盖。 */
+  plain?: string;
 }
 
 /** Minimal logger interface used across modules. */


### PR DESCRIPTION
## 概述

图文混排 Phase 1：bot adapter 支持 **RichText=14**（复用 octo-lib Phase 0 已定的 ContentType=14）。解决图文双向各拆两条的问题：inbound 每帧单 BotMessage 无聚合；outbound 先 sendMessage 文本再循环 uploadMedia = 两次 HTTP。

Fixes #54

## 改动

### 1. enum + 类型（`src/types.ts`）
- `MessageType` 补 `RichText = 14`。
- 新增 `RichTextBlock` / `RichTextPayload` 类型 + `RICH_TEXT_BLOCK_TEXT/IMAGE`、`RICH_TEXT_IMAGE_PLACEHOLDER` 常量，与 octo-lib `common/richtext.go` 命名对齐（content block 数组 + plain，禁用 entities/offset/length）。

### 2. inbound（`src/inbound.ts`）
- `resolveContent` 加 14 case → 单条语义 `{ text, mediaUrls[] }`：优先读顶层 `plain`（server 权威），缺则遍历 `content` blocks 现场拼接（text 取 text、image 注入 `[图片]`），复刻 MultipleForward(11) 展开范式。
- 新增导出 `resolveRichTextContent`（含老字符串 content 向后兼容 + 未知 block 类型 Postel 降级）。
- `resolveInnerMessageText` 对嵌套 14 补 case（引用/转发预览）。
- 多图本地化下载；**download 失败回退 remote url**（body 仅含 `[图片]` 占位，丢 url 会失去引用）；`MediaUrls`/`MediaTypes` 多图透传。
- history 回填（messages/sync）对 14 展开；`resolveApiMessagePlaceholder` 加 `[图文消息]`。

### 3. outbound（`src/api-fetch.ts` + `src/actions.ts`）
- 新增 `sendRichTextMessage`：组装**单条** RichText payload（type=14, content blocks + plain），一次 HTTP 替代「sendMessage + 循环 uploadMedia」。
- `actions.ts handleSend` 新增 `richText: true` opt-in 图文混排路径：先批量上传图片拿 url/宽高 → 带正宽高的图片进 image block → 组一条 payload 提交。
  - 宽高解析失败的图片（如 SVG）/ 非图片文件 → sideload 走 `sendMediaMessage` 复用已上传 url（不重复上传），避免无效 type-14 block。
  - 无图片可组装时回退旧拆条路径，保留既有文件/失败语义。
- 抽出 `uploadMedia`（仅上传返回 url+元数据）供出站复用，`uploadAndSendMedia` 改为薄封装。

### 4. 幂等（`src/api-fetch.ts`）
- 出站 `sendMessage` / `sendMediaMessage` / `sendRichTextMessage` 统一补 `client_msg_no`（UUID，可显式传入复用）。WuKongIM 以 client_msg_no 服务端去重，图文体积大链路长更易重试重复。

### 5. enum 完整性（`src/channel.ts`）
- 入站 `supportedTypes` 允许 RichText 通过（否则 14 会被 onMessage 过滤丢弃）。

## 向后兼容
- type 1/2/11 路径不变；出站 RichText 为显式 opt-in，默认仍走原拆条路径。
- 老字符串 content / 缺 plain / 未知 block 类型均有降级。

## 测试
- build / type-check / test 全绿：**844 tests passed**（新增 +27）。
- 覆盖：inbound14（plain 优先 / blocks 回退 / 多图有序 / url 归一化 / 老字符串 / 未知 block / 嵌套引用）、outbound 组装（单 payload / 多图有序 / SVG sideload / 非图片 sideload / opt-in 边界 / 回退）、幂等（自动生成 / 显式复用 / 唯一性）。

## /review 自审

走 codex 独立 review 两轮：

**第一轮**发现 2 个真实问题，已修复：
1. `actions.ts` — `uploaded.isImage` 为真即出 image block，但 width/height 可选；SVG/解析失败图片会产生违约 type-14 payload 使整条发送失败。→ 改为仅带正宽高的图片进 block，其余 sideload。
2. `inbound.ts` — RichText 图片本地下载失败时丢弃 url；不同于 type 2/3/4/5 在 body 保留 remote url，14 的 body 仅占位符，丢 url 会失去引用。→ 下载失败回退 remote url。

**第二轮**：`No real issues found` — 确认两处修复生效，enum 完整性 / 幂等 / 向后兼容均完好。

review-tier: high-risk（跨端 bot 收发协议 + 幂等）→ 另派 ReviewBot 独立 codex-review。
