### PR TITLE
feat(octo/mention): 群级免@偏好 gate + pull-TTL 缓存

### DIFF
--- a/src/api-fetch.test.ts
+++ b/src/api-fetch.test.ts
@@ -1403,3 +1403,67 @@ describe("sendRichTextMessage — payload assembly", () => {
     expect("plain" in bodies[0].payload).toBe(false);
   });
 });
+
+describe("getMentionPref", () => {
+  const originalFetch = global.fetch;
+  afterEach(() => {
+    global.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it("hits GET /v1/bot/groups/:group_no/mention_pref with Bearer token", async () => {
+    let seenUrl = "";
+    let seenAuth = "";
+    global.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      seenUrl = typeof input === "string" ? input : input.toString();
+      seenAuth = (init?.headers as Record<string, string>)?.Authorization ?? "";
+      return new Response(JSON.stringify({ no_mention: true }), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const { getMentionPref } = await import("./api-fetch.js");
+    const pref = await getMentionPref({
+      apiUrl: "http://localhost:8090",
+      botToken: "tok",
+      groupNo: "g1",
+    });
+
+    expect(seenUrl).toBe("http://localhost:8090/v1/bot/groups/g1/mention_pref");
+    expect(seenAuth).toBe("Bearer tok");
+    expect(pref).toEqual({ no_mention: true });
+  });
+
+  it("coerces numeric no_mention=1 to true", async () => {
+    global.fetch = vi.fn(async () =>
+      new Response(JSON.stringify({ no_mention: 1 }), { status: 200 }),
+    ) as unknown as typeof fetch;
+    const { getMentionPref } = await import("./api-fetch.js");
+    const pref = await getMentionPref({ apiUrl: "http://x", botToken: "t", groupNo: "g" });
+    expect(pref).toEqual({ no_mention: true });
+  });
+
+  it("coerces missing/other no_mention to false", async () => {
+    global.fetch = vi.fn(async () =>
+      new Response(JSON.stringify({}), { status: 200 }),
+    ) as unknown as typeof fetch;
+    const { getMentionPref } = await import("./api-fetch.js");
+    const pref = await getMentionPref({ apiUrl: "http://x", botToken: "t", groupNo: "g" });
+    expect(pref).toEqual({ no_mention: false });
+  });
+
+  it("returns {no_mention:false} on non-2xx", async () => {
+    global.fetch = vi.fn(async () => new Response("err", { status: 404 })) as unknown as typeof fetch;
+    const { getMentionPref } = await import("./api-fetch.js");
+    const pref = await getMentionPref({ apiUrl: "http://x", botToken: "t", groupNo: "g" });
+    expect(pref).toEqual({ no_mention: false });
+  });
+
+  it("returns {no_mention:false} on network error (no throw)", async () => {
+    global.fetch = vi.fn(async () => {
+      throw new Error("network down");
+    }) as unknown as typeof fetch;
+    const { getMentionPref } = await import("./api-fetch.js");
+    await expect(
+      getMentionPref({ apiUrl: "http://x", botToken: "t", groupNo: "g" }),
+    ).resolves.toEqual({ no_mention: false });
+  });
+});

--- a/src/api-fetch.test.ts
+++ b/src/api-fetch.test.ts
@@ -1466,4 +1466,24 @@ describe("getMentionPref", () => {
       getMentionPref({ apiUrl: "http://x", botToken: "t", groupNo: "g" }),
     ).resolves.toEqual({ no_mention: false });
   });
+
+  it("uses a short (≤5s) hot-path timeout, not the 30s default", async () => {
+    // This is the per-message hot-path lookup: on a cache miss it fires on the
+    // first message of every group every TTL window and, before the backend
+    // ships, 404s. It must not stall inbound for the full 30s DEFAULT_TIMEOUT_MS.
+    let seenSignal: AbortSignal | undefined;
+    global.fetch = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      seenSignal = init?.signal ?? undefined;
+      return new Response(JSON.stringify({ no_mention: false }), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const { getMentionPref } = await import("./api-fetch.js");
+    await getMentionPref({ apiUrl: "http://x", botToken: "t", groupNo: "g" });
+
+    expect(seenSignal).toBeInstanceOf(AbortSignal);
+    // The short timeout aborts well before the 30s default. Wait past the
+    // expected 3s window and confirm the signal has fired.
+    await new Promise((r) => setTimeout(r, 3200));
+    expect(seenSignal!.aborted).toBe(true);
+  }, 10_000);
 });

--- a/src/api-fetch.ts
+++ b/src/api-fetch.ts
@@ -11,6 +11,11 @@ import { randomUUID } from "node:crypto";
 import COS from "cos-nodejs-sdk-v5";
 
 const DEFAULT_TIMEOUT_MS = 30_000;
+// Short timeout for the per-message mention_pref hot-path lookup. On a cache
+// miss this fires on the first message of every group every TTL window; before
+// the backend ships it 404s, and we must not stall the inbound pipeline for the
+// full 30s. A failed/slow lookup just falls back to the account-level config.
+const MENTION_PREF_TIMEOUT_MS = 3_000;
 
 /**
  * 生成出站消息的客户端幂等编号 client_msg_no（UUID）。
@@ -529,7 +534,7 @@ export async function getMentionPref(params: {
       headers: {
         Authorization: `Bearer ${params.botToken}`,
       },
-      signal: AbortSignal.timeout(DEFAULT_TIMEOUT_MS),
+      signal: AbortSignal.timeout(MENTION_PREF_TIMEOUT_MS),
     });
     if (!resp.ok) {
       params.log?.error?.(`octo: getMentionPref(${params.groupNo}) failed: ${resp.status}`);

--- a/src/api-fetch.ts
+++ b/src/api-fetch.ts
@@ -499,6 +499,52 @@ export async function getGroupInfo(params: {
   }
 }
 
+/**
+ * 群级免@偏好（per-group mention preference）。
+ *
+ * 后端 octo-server#237 暴露 GET /v1/bot/groups/:group_no/mention_pref，
+ * 返回 `{ no_mention: boolean }`。`no_mention=true` 表示该群对当前 bot
+ * 免@即可触发回复。
+ */
+export interface MentionPref {
+  no_mention: boolean;
+}
+
+/**
+ * 获取某群对当前 bot 的免@偏好。
+ *
+ * 失败（网络错误 / 非 2xx / 解析失败）一律回退到账号级行为
+ * （`{ no_mention: false }`，即保持需@），绝不抛错，避免 gate 崩溃。
+ */
+export async function getMentionPref(params: {
+  apiUrl: string;
+  botToken: string;
+  groupNo: string;  // 父群 group_no（thread 复合 channel_id 须先取父群）
+  log?: { info?: (msg: string) => void; error?: (msg: string) => void };
+}): Promise<MentionPref> {
+  const url = `${params.apiUrl.replace(/\/+$/, "")}/v1/bot/groups/${params.groupNo}/mention_pref`;
+  try {
+    const resp = await fetch(url, {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${params.botToken}`,
+      },
+      signal: AbortSignal.timeout(DEFAULT_TIMEOUT_MS),
+    });
+    if (!resp.ok) {
+      params.log?.error?.(`octo: getMentionPref(${params.groupNo}) failed: ${resp.status}`);
+      return { no_mention: false };
+    }
+    const data = await resp.json();
+    // Accept boolean `true` or numeric `1` (DB/JSON may serialize either),
+    // mirroring the mention.{all,ais,humans} coercion in inbound.ts.
+    return { no_mention: data?.no_mention === true || data?.no_mention === 1 };
+  } catch (err) {
+    params.log?.error?.(`octo: getMentionPref(${params.groupNo}) error: ${err}`);
+    return { no_mention: false };
+  }
+}
+
 // Fetch GROUP.md content for a group
 export async function getGroupMd(params: {
   apiUrl: string;

--- a/src/api-fetch.ts
+++ b/src/api-fetch.ts
@@ -443,7 +443,9 @@ export interface GroupMember {
   uid: string;
   name: string;
   role?: string;    // admin/member
-  robot?: boolean;  // 是否是机器人
+  // 是否是机器人。后端把该 flag 序列化成数字（1/0），但历史上也出现过 boolean，
+  // 故类型放宽为 boolean | number；消费端须同时认 `=== true` 和 `=== 1`。
+  robot?: boolean | number;
 }
 
 export async function getGroupMembers(params: {
@@ -527,7 +529,7 @@ export async function getMentionPref(params: {
   groupNo: string;  // 父群 group_no（thread 复合 channel_id 须先取父群）
   log?: { info?: (msg: string) => void; error?: (msg: string) => void };
 }): Promise<MentionPref> {
-  const url = `${params.apiUrl.replace(/\/+$/, "")}/v1/bot/groups/${params.groupNo}/mention_pref`;
+  const url = `${params.apiUrl.replace(/\/+$/, "")}/v1/bot/groups/${encodeURIComponent(params.groupNo)}/mention_pref`;
   try {
     const resp = await fetch(url, {
       method: "GET",

--- a/src/api-fetch.ts
+++ b/src/api-fetch.ts
@@ -539,7 +539,17 @@ export async function getMentionPref(params: {
       signal: AbortSignal.timeout(MENTION_PREF_TIMEOUT_MS),
     });
     if (!resp.ok) {
-      params.log?.error?.(`octo: getMentionPref(${params.groupNo}) failed: ${resp.status}`);
+      // 404 = the mention_pref endpoint isn't deployed yet (expected during
+      // rollout before octo-server#237 ships); 401 = empty/short-lived Bearer.
+      // Both are benign — we fall back to no_mention=false below — and recur on
+      // every inbound message, so logging them at error level (compounded by
+      // the 30s negative-cache TTL) makes a healthy rollout look broken. Log
+      // expected statuses at info and reserve error for genuinely unexpected
+      // responses (5xx, etc.).
+      const expected = resp.status === 404 || resp.status === 401;
+      const msg = `octo: getMentionPref(${params.groupNo}) failed: ${resp.status}`;
+      if (expected) params.log?.info?.(msg);
+      else params.log?.error?.(msg);
       return { no_mention: false };
     }
     const data = await resp.json();

--- a/src/bot-registry.ts
+++ b/src/bot-registry.ts
@@ -1,0 +1,34 @@
+/**
+ * Known-bot identity registry — tracks the robot_ids of every bot started by
+ * this plugin instance, for bot-to-bot loop prevention.
+ *
+ * channel.ts registers each bot's uid during startAccount(); both the DM
+ * loop-guard (channel.ts) and the group 免@ relaxation gate (inbound.ts)
+ * consult isKnownBot() so the two paths stay in sync.
+ *
+ * Lives in its own module (rather than channel.ts) to avoid a circular import:
+ * channel.ts imports handleInboundMessage from inbound.ts, so inbound.ts must
+ * not import back from channel.ts.
+ */
+
+const _knownBotUids = new Set<string>();
+
+/** Register a bot's robot_id so it can be recognised as a non-human sender. */
+export function registerKnownBot(uid: string): void {
+  if (uid) _knownBotUids.add(uid);
+}
+
+/** True when `uid` belongs to a bot started by this plugin instance. */
+export function isKnownBot(uid: string): boolean {
+  return _knownBotUids.has(uid);
+}
+
+/** Visible for testing — clears all registered bot uids. */
+export function _clearKnownBots(): void {
+  _knownBotUids.clear();
+}
+
+/** Visible for testing — current count of known bots. */
+export function _knownBotCount(): number {
+  return _knownBotUids.size;
+}

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -239,6 +239,20 @@ function getOrCreateGroupCacheTimestamps(accountId: string): Map<string, number>
   return m;
 }
 
+// Module-level robot flags: uid -> robot (server-authoritative GroupMember.robot)
+// Consulted by the 免@ mention gate to keep requireMention for ANY bot sender,
+// including cross-process / external bots not registered via registerKnownBot().
+// Flat uid→robot map (not keyed by groupId), like uidToNameMap.
+const _memberRobotMaps = new Map<string, Map<string, boolean>>();
+function getOrCreateMemberRobotMap(accountId: string): Map<string, boolean> {
+  let m = _memberRobotMaps.get(accountId);
+  if (!m) {
+    m = new Map<string, boolean>();
+    _memberRobotMaps.set(accountId, m);
+  }
+  return m;
+}
+
 
 // --- Group → Account mapping: tracks which accounts are active in each group ---
 // Used by handleAction to resolve the correct account when framework passes wrong accountId
@@ -1162,6 +1176,9 @@ export const octoPlugin: ChannelPlugin<ResolvedOctoAccount> = {
       // 4d. Group cache timestamps — track when each group's members were last fetched
       const groupCacheTimestamps = getOrCreateGroupCacheTimestamps(account.accountId);
 
+      // 4e. Robot flags map — server-authoritative sender classification for the 免@ gate
+      const memberRobotMap = getOrCreateMemberRobotMap(account.accountId);
+
       // 5. Token refresh state — time-based cooldown to prevent refresh storms
       let lastTokenRefreshAt = 0;
       const TOKEN_REFRESH_COOLDOWN_MS = 60_000; // 60 seconds
@@ -1240,6 +1257,7 @@ export const octoPlugin: ChannelPlugin<ResolvedOctoAccount> = {
                 memberMap,
                 uidToNameMap,
                 groupCacheTimestamps,
+                memberRobotMap,
                 groupMdCache,
                 log,
                 statusSink,

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -34,6 +34,7 @@ import { handleOctoMessageAction, parseTarget, resolveOutboundOctoTarget, normal
 import { getOrCreateGroupMdCache, registerBotGroupIds, getKnownGroupIds, writeGroupMdToDisk } from "./group-md.js";
 import { registerOwnerUid } from "./owner-registry.js";
 import { preloadGroupMemberCache, getGroupMembersFromCache } from "./member-cache.js";
+import { preloadMentionPrefs } from "./mention-prefs.js";
 import { initPersonaPromptCache, stopPersonaPromptCache } from "./persona-prompt.js";
 import { registerOctoThreadBindingAdapter } from "./thread-binding-adapter.js";
 import path from "node:path";
@@ -1002,6 +1003,15 @@ export const octoPlugin: ChannelPlugin<ResolvedOctoAccount> = {
 
       // Preload member cache for cross-session permission checks (fire-and-forget)
       preloadGroupMemberCache({
+        apiUrl: account.config.apiUrl,
+        botToken: account.config.botToken!,
+        log,
+      }).catch(() => {});
+
+      // Preload group-level 免@偏好 for this bot (fire-and-forget). Optional
+      // warm-up; the inbound mention gate works lazily without it.
+      preloadMentionPrefs({
+        accountId: account.accountId,
         apiUrl: account.config.apiUrl,
         botToken: account.config.botToken!,
         log,

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -33,6 +33,7 @@ import type { MentionEntity } from "./types.js";
 import { handleOctoMessageAction, parseTarget, resolveOutboundOctoTarget, normalizeOutboundChannelPrefix, extractInlineMentionUids } from "./actions.js";
 import { getOrCreateGroupMdCache, registerBotGroupIds, getKnownGroupIds, writeGroupMdToDisk } from "./group-md.js";
 import { registerOwnerUid } from "./owner-registry.js";
+import { registerKnownBot, isKnownBot } from "./bot-registry.js";
 import { preloadGroupMemberCache, getGroupMembersFromCache } from "./member-cache.js";
 import { preloadMentionPrefs } from "./mention-prefs.js";
 import { initPersonaPromptCache, stopPersonaPromptCache } from "./persona-prompt.js";
@@ -296,8 +297,15 @@ function cleanupStaleCaches(): void {
   }
 }
 
-// Known bot robot_ids across all accounts — for bot-to-bot loop prevention
-const _knownBotUids = new Set<string>();
+// Known bot robot_ids across all accounts — for bot-to-bot loop prevention.
+// Backed by the shared bot-registry so inbound.ts can consult the same set
+// without importing channel.ts (channel.ts → inbound.ts is one-way; importing
+// back would create a cycle). The thin wrapper keeps existing call sites
+// (_knownBotUids.add / .has) unchanged.
+const _knownBotUids = {
+  add: (uid: string) => registerKnownBot(uid),
+  has: (uid: string) => isKnownBot(uid),
+};
 
 // Singleton timer to prevent accumulation during hot reload (#54)
 let _cleanupTimer: NodeJS.Timeout | null = null;

--- a/src/inbound-mention-gate.test.ts
+++ b/src/inbound-mention-gate.test.ts
@@ -10,9 +10,13 @@ import type { ResolvedOctoAccount } from "./accounts.js";
  * Integration test for the inbound mention-gate 免@ relaxation (PR#57 review P1).
  *
  * The 免@ (no_mention=true) group preference relaxes requireMention so the bot
- * replies to non-@ messages. The fix scopes that relaxation to HUMAN senders:
- * messages from a known bot must still require an explicit @mention, otherwise
- * two 免@ bots in the same group reply to each other forever (bot-to-bot loop).
+ * replies to non-@ messages. The fix scopes that relaxation to HUMAN senders,
+ * and does so FAIL-CLOSED (round-4): the gate relaxes requireMention ONLY for a
+ * sender the server-authoritative member list positively confirms is human
+ * (memberRobotMap.get(uid) === false). Unknown senders, ANY robot, and the case
+ * where the member refresh fails/returns empty (so the robot flag is undefined)
+ * all keep requireMention — otherwise two 免@ bots in the same group, or any
+ * mis-classified sender, reply to each other forever (bot-to-bot loop).
  *
  * These tests drive the real handleInboundMessage with a stubbed OpenClaw
  * runtime + stubbed network so we exercise the actual gate (not a re-impl).
@@ -132,6 +136,38 @@ function installFetchStub() {
       return json({ message_id: "reply1", message_seq: 0 });
     }
     // Default benign 200
+    return json({});
+  }) as unknown as typeof fetch;
+  return { sends };
+}
+
+/**
+ * Network stub variant where the group-members endpoint FAILS (or returns
+ * empty), so refreshGroupMemberCache can't populate memberRobotMap. Every other
+ * endpoint behaves like installFetchStub. Used to prove the fail-closed gate:
+ * with no server robot flag, even a real human sender stays gated because the
+ * member list never confirmed them as human.
+ */
+function installFetchStubMembersDown(mode: "error" | "empty" = "error") {
+  const sends: any[] = [];
+  globalThis.fetch = vi.fn(async (input: any, init?: any) => {
+    const url = typeof input === "string" ? input : input.toString();
+    const json = (data: unknown, status = 200) =>
+      new Response(JSON.stringify(data), { status, headers: { "Content-Type": "application/json" } });
+
+    if (url.includes("/members")) {
+      if (mode === "error") return json({ error: "boom" }, 500);
+      return json({ members: [] });
+    }
+    if (url.includes("/mention_pref")) return json({ no_mention: true });
+    if (url.includes("/md")) return json({ content: "", version: 0, updated_at: null, updated_by: "" });
+    if (url.includes("/messages/sync")) return json({ messages: [] });
+    if (url.includes("/readReceipt")) return json({});
+    if (url.includes("/typing")) return json({});
+    if (url.includes("/sendMessage")) {
+      sends.push(init?.body ? JSON.parse(init.body) : {});
+      return json({ message_id: "reply1", message_seq: 0 });
+    }
     return json({});
   }) as unknown as typeof fetch;
   return { sends };
@@ -350,5 +386,90 @@ describe("inbound mention-gate 免@ relaxation (P1: human-only)", () => {
 
     expect(dispatch).toHaveBeenCalledTimes(1);
     expect(sends.length).toBeGreaterThan(0);
+  });
+
+  it("does NOT reply to a HUMAN non-@ message when member refresh FAILS (fail-closed)", async () => {
+    // round-4 P1: the loop guard inverts to a whitelist. A sender is relaxed
+    // ONLY when the member list positively confirms them human. When the
+    // members endpoint errors out, refreshGroupMemberCache leaves memberRobotMap
+    // unpopulated → robot flag is undefined → classification unknown → keep
+    // requireMention. The blacklist version failed OPEN here (undefined !== true
+    // → treated as human → relax → reply → loop for ANY sender on refresh fail).
+    const { dispatch } = installRuntimeStub();
+    const { sends } = installFetchStubMembersDown("error");
+    const memberRobotMap = new Map<string, boolean>();
+
+    await handleInboundMessage({
+      account: makeAccount(),
+      message: makeTextMessage(HUMAN_UID, "hello bot"),
+      botUid: BOT_UID,
+      groupHistories: new Map(),
+      lastBotReplySeqMap: new Map(),
+      memberMap: new Map(),
+      uidToNameMap: new Map(),
+      groupCacheTimestamps: new Map(),
+      memberRobotMap,
+    });
+
+    // Refresh failed → no robot flag recorded → fail-closed: gate kept
+    // requireMention, the non-@ message was cached only, no dispatch/send.
+    expect(memberRobotMap.has(HUMAN_UID)).toBe(false);
+    expect(dispatch).not.toHaveBeenCalled();
+    expect(sends.length).toBe(0);
+  });
+
+  it("does NOT reply to a HUMAN non-@ message when member list is EMPTY (fail-closed)", async () => {
+    // Sibling of the refresh-error case: an empty member list is the other way
+    // refreshGroupMemberCache returns without populating memberRobotMap. Same
+    // fail-closed outcome — unknown classification keeps requireMention.
+    const { dispatch } = installRuntimeStub();
+    const { sends } = installFetchStubMembersDown("empty");
+    const memberRobotMap = new Map<string, boolean>();
+
+    await handleInboundMessage({
+      account: makeAccount(),
+      message: makeTextMessage(HUMAN_UID, "hello bot"),
+      botUid: BOT_UID,
+      groupHistories: new Map(),
+      lastBotReplySeqMap: new Map(),
+      memberMap: new Map(),
+      uidToNameMap: new Map(),
+      groupCacheTimestamps: new Map(),
+      memberRobotMap,
+    });
+
+    expect(memberRobotMap.has(HUMAN_UID)).toBe(false);
+    expect(dispatch).not.toHaveBeenCalled();
+    expect(sends.length).toBe(0);
+  });
+
+  it("does NOT reply to an UNKNOWN non-@ sender absent from the member list (fail-closed)", async () => {
+    // The member list loads fine but does NOT contain this sender (e.g. a uid
+    // that joined after the cache warmed, or a cross-process sender the server
+    // omits). memberRobotMap.get(uid) === undefined → not confirmed human →
+    // keep requireMention. The blacklist version relaxed here (undefined !==
+    // true), reopening the loop for any sender the member list happened to miss.
+    const UNKNOWN_UID = "user_ghost_99999999999999999999999999";
+    const { dispatch } = installRuntimeStub();
+    const { sends } = installFetchStub(); // members endpoint OK, just no UNKNOWN_UID row
+    const memberRobotMap = new Map<string, boolean>();
+
+    await handleInboundMessage({
+      account: makeAccount(),
+      message: makeTextMessage(UNKNOWN_UID, "hello bot"),
+      botUid: BOT_UID,
+      groupHistories: new Map(),
+      lastBotReplySeqMap: new Map(),
+      memberMap: new Map(),
+      uidToNameMap: new Map(),
+      groupCacheTimestamps: new Map(),
+      memberRobotMap,
+    });
+
+    // Member list loaded but had no row for UNKNOWN_UID → flag undefined →
+    // fail-closed: gate kept requireMention.
+    expect(memberRobotMap.has(UNKNOWN_UID)).toBe(false);
+    expect(dispatch).not.toHaveBeenCalled();
+    expect(sends.length).toBe(0);
   });
 });

--- a/src/inbound-mention-gate.test.ts
+++ b/src/inbound-mention-gate.test.ts
@@ -25,6 +25,9 @@ const API = "http://octo.test";
 const BOT_UID = "bot_self_0000000000000000000000000000";
 const HUMAN_UID = "human_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
 const OTHER_BOT_UID = "bot_other_111111111111111111111111111";
+// A bot from another OpenClaw process / external integration: present in the
+// server member list with robot:true but NEVER passed to registerKnownBot().
+const EXTERNAL_BOT_UID = "bot_extern_22222222222222222222222222";
 const GROUP_ID = "g_room_1";
 
 const originalFetch = globalThis.fetch;
@@ -106,6 +109,9 @@ function installFetchStub() {
           { uid: HUMAN_UID, name: "Alice", robot: false },
           { uid: BOT_UID, name: "SelfBot", robot: true },
           { uid: OTHER_BOT_UID, name: "OtherBot", robot: true },
+          // Cross-process / external bot: server marks it robot:true, but this
+          // plugin never registered it via registerKnownBot().
+          { uid: EXTERNAL_BOT_UID, name: "ExternalBot", robot: true },
         ],
       });
     }
@@ -225,5 +231,60 @@ describe("inbound mention-gate 免@ relaxation (P1: human-only)", () => {
     const calledUrls = (globalThis.fetch as any).mock.calls.map((c: any[]) => String(c[0]));
     expect(calledUrls.some((u: string) => u.includes("/mention_pref"))).toBe(false);
     expect(sends.length).toBe(0);
+  });
+
+  it("does NOT reply to a CROSS-PROCESS bot (robot:true in member list, NOT registerKnownBot'd)", async () => {
+    // Regression for PR#57 round-2 P1: the loop guard must use the
+    // server-authoritative GroupMember.robot signal, not just the local
+    // registerKnownBot() set. EXTERNAL_BOT_UID is robot:true in the group
+    // member list but was never registered, so isKnownBot() returns false for
+    // it. Before the fix it was treated as human → 免@ relaxed → reply → loop.
+    const { dispatch } = installRuntimeStub();
+    const { sends } = installFetchStub();
+    // Force a member-cache fetch so the robot flag is loaded from the server.
+    const memberRobotMap = new Map<string, boolean>();
+
+    await handleInboundMessage({
+      account: makeAccount(),
+      message: makeTextMessage(EXTERNAL_BOT_UID, "hello from a bot in another process"),
+      botUid: BOT_UID,
+      groupHistories: new Map(),
+      lastBotReplySeqMap: new Map(),
+      memberMap: new Map(),
+      uidToNameMap: new Map(),
+      groupCacheTimestamps: new Map(),
+      memberRobotMap,
+    });
+
+    // Gate kept requireMention for the server-flagged robot sender: no dispatch,
+    // no send. The robot flag was sourced from the member list.
+    expect(memberRobotMap.get(EXTERNAL_BOT_UID)).toBe(true);
+    expect(dispatch).not.toHaveBeenCalled();
+    expect(sends.length).toBe(0);
+  });
+
+  it("DOES reply to a CROSS-PROCESS bot that explicitly @mentions this bot", async () => {
+    // Explicit @mention always triggers, even from a server-flagged robot that
+    // is not locally registered — symmetric with the known-bot @mention case.
+    const { dispatch } = installRuntimeStub();
+    const { sends } = installFetchStub();
+
+    const msg = makeTextMessage(EXTERNAL_BOT_UID, "@SelfBot ping");
+    (msg.payload as any).mention = { uids: [BOT_UID] };
+
+    await handleInboundMessage({
+      account: makeAccount(),
+      message: msg,
+      botUid: BOT_UID,
+      groupHistories: new Map(),
+      lastBotReplySeqMap: new Map(),
+      memberMap: new Map(),
+      uidToNameMap: new Map(),
+      groupCacheTimestamps: new Map(),
+      memberRobotMap: new Map(),
+    });
+
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    expect(sends.length).toBeGreaterThan(0);
   });
 });

--- a/src/inbound-mention-gate.test.ts
+++ b/src/inbound-mention-gate.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { ChannelType, MessageType } from "./types.js";
+import { handleInboundMessage } from "./inbound.js";
+import { setOctoRuntime } from "./runtime.js";
+import { registerKnownBot, _clearKnownBots } from "./bot-registry.js";
+import { _clearMentionPrefCache, _setMentionPrefEntry } from "./mention-prefs.js";
+import type { ResolvedOctoAccount } from "./accounts.js";
+
+/**
+ * Integration test for the inbound mention-gate 免@ relaxation (PR#57 review P1).
+ *
+ * The 免@ (no_mention=true) group preference relaxes requireMention so the bot
+ * replies to non-@ messages. The fix scopes that relaxation to HUMAN senders:
+ * messages from a known bot must still require an explicit @mention, otherwise
+ * two 免@ bots in the same group reply to each other forever (bot-to-bot loop).
+ *
+ * These tests drive the real handleInboundMessage with a stubbed OpenClaw
+ * runtime + stubbed network so we exercise the actual gate (not a re-impl).
+ * "Replied" is observed via the dispatcher being invoked AND a text message
+ * being POSTed to the send endpoint; "suppressed" is observed via the history-
+ * only short-circuit (no dispatch, no send).
+ */
+
+const API = "http://octo.test";
+const BOT_UID = "bot_self_0000000000000000000000000000";
+const HUMAN_UID = "human_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const OTHER_BOT_UID = "bot_other_111111111111111111111111111";
+const GROUP_ID = "g_room_1";
+
+const originalFetch = globalThis.fetch;
+
+function makeAccount(): ResolvedOctoAccount {
+  return {
+    accountId: "acct1",
+    enabled: true,
+    configured: true,
+    config: {
+      botToken: "tok",
+      apiUrl: API,
+      pollIntervalMs: 1000,
+      heartbeatIntervalMs: 1000,
+      requireMention: true, // account requires @ by default; 免@ pref relaxes it
+    },
+  };
+}
+
+function makeTextMessage(fromUid: string, content: string) {
+  return {
+    message_id: "m1",
+    message_seq: 100,
+    from_uid: fromUid,
+    channel_id: GROUP_ID,
+    channel_type: ChannelType.Group,
+    timestamp: Math.floor(Date.now() / 1000),
+    payload: { type: MessageType.Text, content },
+  };
+}
+
+/**
+ * Stub OpenClaw runtime. The dispatcher immediately emits one final text block
+ * so the buffered-text path runs and POSTs a reply — letting us assert "replied"
+ * by observing the send endpoint.
+ */
+function installRuntimeStub(): { dispatch: ReturnType<typeof vi.fn> } {
+  const dispatch = vi.fn(async (args: any) => {
+    await args.dispatcherOptions.deliver({ text: "hi there" }, { kind: "final" });
+  });
+  setOctoRuntime({
+    config: { loadConfig: () => ({}) },
+    channel: {
+      reply: {
+        dispatchReplyWithBufferedBlockDispatcher: dispatch,
+        resolveEnvelopeFormatOptions: () => ({}),
+        formatAgentEnvelope: ({ body }: any) => body,
+        finalizeInboundContext: (ctx: any) => ctx,
+      },
+      routing: {
+        resolveAgentRoute: () => ({ agentId: "agent1", sessionKey: "sk1", accountId: "acct1" }),
+      },
+      session: {
+        resolveStorePath: () => "/tmp/store",
+        readSessionUpdatedAt: () => undefined,
+        recordInboundSession: async () => {},
+      },
+    },
+  } as any);
+  return { dispatch };
+}
+
+/**
+ * Network stub. Members endpoint returns the human + both bots (with robot
+ * flags); the bot's own GROUP.md / mention_pref are answered benignly; the send
+ * + typing + read-receipt endpoints record calls. Returns the list of POSTed
+ * send-message bodies so we can assert a reply went out.
+ */
+function installFetchStub() {
+  const sends: any[] = [];
+  globalThis.fetch = vi.fn(async (input: any, init?: any) => {
+    const url = typeof input === "string" ? input : input.toString();
+    const json = (data: unknown, status = 200) =>
+      new Response(JSON.stringify(data), { status, headers: { "Content-Type": "application/json" } });
+
+    if (url.includes("/members")) {
+      return json({
+        members: [
+          { uid: HUMAN_UID, name: "Alice", robot: false },
+          { uid: BOT_UID, name: "SelfBot", robot: true },
+          { uid: OTHER_BOT_UID, name: "OtherBot", robot: true },
+        ],
+      });
+    }
+    if (url.includes("/mention_pref")) return json({ no_mention: true });
+    if (url.includes("/md")) return json({ content: "", version: 0, updated_at: null, updated_by: "" });
+    if (url.includes("/messages/sync")) return json({ messages: [] });
+    if (url.includes("/readReceipt")) return json({});
+    if (url.includes("/typing")) return json({});
+    // sendMessage POST → record the outbound reply
+    if (url.includes("/sendMessage")) {
+      sends.push(init?.body ? JSON.parse(init.body) : {});
+      return json({ message_id: "reply1", message_seq: 0 });
+    }
+    // Default benign 200
+    return json({});
+  }) as unknown as typeof fetch;
+  return { sends };
+}
+
+describe("inbound mention-gate 免@ relaxation (P1: human-only)", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    _clearKnownBots();
+    _clearMentionPrefCache();
+    // Register both this bot and the other bot as known bots.
+    registerKnownBot(BOT_UID);
+    registerKnownBot(OTHER_BOT_UID);
+    // Pre-seed the 免@ pref so no network round-trip is needed for the lookup.
+    _setMentionPrefEntry("acct1", GROUP_ID, { no_mention: true });
+  });
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    _clearKnownBots();
+    _clearMentionPrefCache();
+  });
+
+  it("replies to a HUMAN non-@ message in a 免@ group", async () => {
+    const { dispatch } = installRuntimeStub();
+    const { sends } = installFetchStub();
+
+    await handleInboundMessage({
+      account: makeAccount(),
+      message: makeTextMessage(HUMAN_UID, "hello bot"),
+      botUid: BOT_UID,
+      groupHistories: new Map(),
+      lastBotReplySeqMap: new Map(),
+      memberMap: new Map(),
+      uidToNameMap: new Map(),
+      groupCacheTimestamps: new Map(),
+    });
+
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    expect(sends.length).toBeGreaterThan(0);
+  });
+
+  it("does NOT reply to a KNOWN-BOT non-@ message in a 免@ group (loop guard)", async () => {
+    const { dispatch } = installRuntimeStub();
+    const { sends } = installFetchStub();
+
+    await handleInboundMessage({
+      account: makeAccount(),
+      message: makeTextMessage(OTHER_BOT_UID, "hello from other bot"),
+      botUid: BOT_UID,
+      groupHistories: new Map(),
+      lastBotReplySeqMap: new Map(),
+      memberMap: new Map(),
+      uidToNameMap: new Map(),
+      groupCacheTimestamps: new Map(),
+    });
+
+    // History-only short-circuit: gate kept requireMention for the bot sender,
+    // the non-@ message was cached as context and the bot never dispatched.
+    expect(dispatch).not.toHaveBeenCalled();
+    expect(sends.length).toBe(0);
+  });
+
+  it("DOES reply to a KNOWN-BOT message that explicitly @mentions this bot", async () => {
+    const { dispatch } = installRuntimeStub();
+    const { sends } = installFetchStub();
+
+    const msg = makeTextMessage(OTHER_BOT_UID, "@SelfBot ping");
+    (msg.payload as any).mention = { uids: [BOT_UID] };
+
+    await handleInboundMessage({
+      account: makeAccount(),
+      message: msg,
+      botUid: BOT_UID,
+      groupHistories: new Map(),
+      lastBotReplySeqMap: new Map(),
+      memberMap: new Map(),
+      uidToNameMap: new Map(),
+      groupCacheTimestamps: new Map(),
+    });
+
+    // Explicit @mention always triggers, even from a known bot.
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    expect(sends.length).toBeGreaterThan(0);
+  });
+
+  it("suppresses the group-pref lookup for known-bot senders (no mention_pref fetch)", async () => {
+    installRuntimeStub();
+    const { sends } = installFetchStub();
+    // Force a cache miss so a lookup WOULD hit the network if attempted.
+    _clearMentionPrefCache();
+
+    await handleInboundMessage({
+      account: makeAccount(),
+      message: makeTextMessage(OTHER_BOT_UID, "noise"),
+      botUid: BOT_UID,
+      groupHistories: new Map(),
+      lastBotReplySeqMap: new Map(),
+      memberMap: new Map(),
+      uidToNameMap: new Map(),
+      groupCacheTimestamps: new Map(),
+    });
+
+    const calledUrls = (globalThis.fetch as any).mock.calls.map((c: any[]) => String(c[0]));
+    expect(calledUrls.some((u: string) => u.includes("/mention_pref"))).toBe(false);
+    expect(sends.length).toBe(0);
+  });
+});

--- a/src/inbound-mention-gate.test.ts
+++ b/src/inbound-mention-gate.test.ts
@@ -28,6 +28,10 @@ const OTHER_BOT_UID = "bot_other_111111111111111111111111111";
 // A bot from another OpenClaw process / external integration: present in the
 // server member list with robot:true but NEVER passed to registerKnownBot().
 const EXTERNAL_BOT_UID = "bot_extern_22222222222222222222222222";
+// A cross-process bot whose server robot flag is the NUMERIC shape (robot:1)
+// rather than boolean true — the backend serializes it as a number. The gate
+// must treat 1 the same as true, else this bot is misclassified as human.
+const NUMERIC_BOT_UID = "bot_numeric_3333333333333333333333333";
 const GROUP_ID = "g_room_1";
 
 const originalFetch = globalThis.fetch;
@@ -112,6 +116,8 @@ function installFetchStub() {
           // Cross-process / external bot: server marks it robot:true, but this
           // plugin never registered it via registerKnownBot().
           { uid: EXTERNAL_BOT_UID, name: "ExternalBot", robot: true },
+          // Cross-process bot whose robot flag arrives as the numeric shape (1).
+          { uid: NUMERIC_BOT_UID, name: "NumericBot", robot: 1 },
         ],
       });
     }
@@ -233,6 +239,37 @@ describe("inbound mention-gate 免@ relaxation (P1: human-only)", () => {
     expect(sends.length).toBe(0);
   });
 
+  it("suppresses the group-pref lookup for an explicit @bot message (no needless latency)", async () => {
+    // round-3 non-blocking #1: an explicit @bot message already passes the gate,
+    // so the 免@ pref can't change the outcome. The lookup must be short-
+    // circuited (computed AFTER mention flags, only when !isMentioned) so a
+    // cold/slow pref backend never adds latency to normal @bot replies.
+    const { dispatch } = installRuntimeStub();
+    const { sends } = installFetchStub();
+    // Force a cache miss so a lookup WOULD hit the network if attempted.
+    _clearMentionPrefCache();
+
+    const msg = makeTextMessage(HUMAN_UID, "@SelfBot please answer");
+    (msg.payload as any).mention = { uids: [BOT_UID] };
+
+    await handleInboundMessage({
+      account: makeAccount(),
+      message: msg,
+      botUid: BOT_UID,
+      groupHistories: new Map(),
+      lastBotReplySeqMap: new Map(),
+      memberMap: new Map(),
+      uidToNameMap: new Map(),
+      groupCacheTimestamps: new Map(),
+    });
+
+    const calledUrls = (globalThis.fetch as any).mock.calls.map((c: any[]) => String(c[0]));
+    expect(calledUrls.some((u: string) => u.includes("/mention_pref"))).toBe(false);
+    // The @bot message still triggers a normal reply.
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    expect(sends.length).toBeGreaterThan(0);
+  });
+
   it("does NOT reply to a CROSS-PROCESS bot (robot:true in member list, NOT registerKnownBot'd)", async () => {
     // Regression for PR#57 round-2 P1: the loop guard must use the
     // server-authoritative GroupMember.robot signal, not just the local
@@ -259,6 +296,33 @@ describe("inbound mention-gate 免@ relaxation (P1: human-only)", () => {
     // Gate kept requireMention for the server-flagged robot sender: no dispatch,
     // no send. The robot flag was sourced from the member list.
     expect(memberRobotMap.get(EXTERNAL_BOT_UID)).toBe(true);
+    expect(dispatch).not.toHaveBeenCalled();
+    expect(sends.length).toBe(0);
+  });
+
+  it("does NOT reply to a CROSS-PROCESS bot whose robot flag is NUMERIC (robot:1)", async () => {
+    // Regression for PR#57 round-3 P1: the backend serializes GroupMember.robot
+    // as a number, so a strict `=== true` would treat robot:1 as human → relax
+    // requireMention → reply to the non-@ bot message → bot-to-bot loop. The
+    // gate must coerce robot:1 to a bot exactly like robot:true.
+    const { dispatch } = installRuntimeStub();
+    const { sends } = installFetchStub();
+    const memberRobotMap = new Map<string, boolean>();
+
+    await handleInboundMessage({
+      account: makeAccount(),
+      message: makeTextMessage(NUMERIC_BOT_UID, "hello from a numeric-flagged bot"),
+      botUid: BOT_UID,
+      groupHistories: new Map(),
+      lastBotReplySeqMap: new Map(),
+      memberMap: new Map(),
+      uidToNameMap: new Map(),
+      groupCacheTimestamps: new Map(),
+      memberRobotMap,
+    });
+
+    // robot:1 coerced to true → gate kept requireMention → no dispatch, no send.
+    expect(memberRobotMap.get(NUMERIC_BOT_UID)).toBe(true);
     expect(dispatch).not.toHaveBeenCalled();
     expect(sends.length).toBe(0);
   });

--- a/src/inbound.ts
+++ b/src/inbound.ts
@@ -1039,12 +1039,16 @@ async function refreshGroupMemberCache(opts: {
   memberMap: Map<string, string>;
   uidToNameMap: Map<string, string>;
   groupCacheTimestamps: Map<string, number>;
+  // uid -> robot flag (server-authoritative GroupMember.robot). Used by the 免@
+  // gate to suppress relaxation for ANY bot sender — including cross-process /
+  // external bots this plugin never registered via registerKnownBot().
+  memberRobotMap?: Map<string, boolean>;
   apiUrl: string;
   botToken: string;
   forceRefresh?: boolean;
   log?: ChannelLogSink;
 }): Promise<boolean> {
-  const { sessionId, memberMap, uidToNameMap, groupCacheTimestamps, apiUrl, botToken, log } = opts;
+  const { sessionId, memberMap, uidToNameMap, groupCacheTimestamps, memberRobotMap, apiUrl, botToken, log } = opts;
   const forceRefresh = opts.forceRefresh ?? false;
 
   const lastFetched = groupCacheTimestamps.get(sessionId) ?? 0;
@@ -1076,6 +1080,12 @@ async function refreshGroupMemberCache(opts: {
             memberMap.set(nameWithoutEmoji, m.uid);
             log?.debug?.(`octo: [CACHE] Added emoji alias: "${nameWithoutEmoji}" -> "${m.uid}"`);
           }
+        }
+        // Preserve the server-authoritative robot flag for the 免@ gate. Keyed
+        // by uid (not name) so sender classification survives display-name
+        // collisions. `=== true` normalizes any truthy/legacy shape to boolean.
+        if (m.uid && memberRobotMap) {
+          memberRobotMap.set(m.uid, m.robot === true);
         }
       }
       groupCacheTimestamps.set(sessionId, now);
@@ -1180,11 +1190,16 @@ export async function handleInboundMessage(params: {
   memberMap: Map<string, string>;  // displayName -> uid mapping
   uidToNameMap: Map<string, string>;  // uid -> displayName mapping (reverse)
   groupCacheTimestamps: Map<string, number>;  // groupId -> lastFetchedAt
+  memberRobotMap?: Map<string, boolean>;  // uid -> robot flag (server-authoritative)
   groupMdCache?: Map<string, { content: string; version: number }>;
   log?: ChannelLogSink;
   statusSink?: OctoStatusSink;
 }) {
   const { account, message, botUid, groupHistories, lastBotReplySeqMap, memberMap, uidToNameMap, groupCacheTimestamps, groupMdCache, log, statusSink } = params;
+  // Server-authoritative robot map. Default to a throwaway Map when the caller
+  // omits it so the gate logic below can read it unconditionally; the real
+  // channel call site passes a persistent per-account map.
+  const memberRobotMap = params.memberRobotMap ?? new Map<string, boolean>();
 
   // Detect GROUP.md update/delete notification — refresh both memory + disk cache, do NOT pass to LLM
   const earlyEventType = (message.payload as any)?.event?.type;
@@ -1424,6 +1439,18 @@ export async function handleInboundMessage(params: {
     }
   }
 
+  // Refresh group member cache BEFORE the mention gate.
+  // The gate's bot-sender classification relies on the server-authoritative
+  // GroupMember.robot flag (populated into memberRobotMap by this refresh), so
+  // the cache must be warm before we decide whether to relax requireMention.
+  // Use parent groupNo for member cache API calls (thread channelIds are compound)
+  const memberCacheGroupNo = isGroup
+    ? extractParentGroupNo(message.channel_id!)
+    : sessionId;
+  if (isGroup) {
+    await refreshGroupMemberCache({ sessionId: memberCacheGroupNo, memberMap, uidToNameMap, groupCacheTimestamps, memberRobotMap, apiUrl: account.config.apiUrl, botToken: account.config.botToken ?? "", log });
+  }
+
   // --- Mention gating for group messages ---
   // Group-aware requireMention: a group admin can mark a group as 免@
   // (no_mention=true) for this specific bot, in which case the bot replies to
@@ -1435,19 +1462,28 @@ export async function handleInboundMessage(params: {
   //
   // The 免@ relaxation is HUMAN-ONLY. channel.ts forwards other bots' group
   // messages into here on purpose, relying on this mention gate to drop the
-  // non-@ ones. If we relaxed requireMention for a known-bot sender, two 免@
-  // bots in the same group would reply to each other with no @ to break the
-  // chain — an unbounded bot-to-bot loop (group spam + token burn). So known
-  // bots always keep requireMention regardless of the group 免@ preference.
+  // non-@ ones. If we relaxed requireMention for a bot sender, two 免@ bots in
+  // the same group would reply to each other with no @ to break the chain — an
+  // unbounded bot-to-bot loop (group spam + token burn). So bots always keep
+  // requireMention regardless of the group 免@ preference.
+  //
+  // Bot classification uses TWO signals, combined so either one suffices:
+  //   1. isKnownBot(from_uid) — bots registered by THIS plugin process.
+  //   2. memberRobotMap.get(from_uid) === true — the server-authoritative
+  //      GroupMember.robot flag from the member list. This catches bots from
+  //      ANOTHER OpenClaw process, another integration, or any bot not started
+  //      by this instance — exactly the cross-process loop case (1) misses.
   const isFromKnownBot = isKnownBot(message.from_uid);
+  const isFromServerRobot = memberRobotMap.get(message.from_uid) === true;
+  const isFromBot = isFromKnownBot || isFromServerRobot;
   // account-level requireMention: false means the account is already 免@.
   const accountRequiresMention = account.config.requireMention !== false;
   // Only consult the group 免@ preference when it can actually change the
   // outcome: the account must otherwise require @ (else the pref can only
   // return no_mention=false, with no effect) AND the sender must be human (the
-  // relaxation never applies to known bots). This also avoids a pointless hot-
-  // path network round-trip (cache miss → up to DEFAULT_TIMEOUT_MS).
-  const shouldCheckGroupPref = isGroup && accountRequiresMention && !isFromKnownBot;
+  // relaxation never applies to bots). This also avoids a pointless hot-path
+  // network round-trip (cache miss → up to MENTION_PREF_TIMEOUT_MS).
+  const shouldCheckGroupPref = isGroup && accountRequiresMention && !isFromBot;
   const mentionPref = shouldCheckGroupPref
     ? await getMentionPrefFromCache({
         accountId: account.accountId,
@@ -1467,15 +1503,6 @@ export async function handleInboundMessage(params: {
 
   // Save original mention uids for reply (exclude bot itself)
   const originalMentionUids: string[] = (message.payload?.mention?.uids ?? []).filter((uid: string) => uid !== botUid);
-
-    // Refresh group member cache if needed (on first message or after expiry)
-  // Use parent groupNo for member cache API calls (thread channelIds are compound)
-  const memberCacheGroupNo = isGroup
-    ? extractParentGroupNo(message.channel_id!)
-    : sessionId;
-  if (isGroup) {
-    await refreshGroupMemberCache({ sessionId: memberCacheGroupNo, memberMap, uidToNameMap, groupCacheTimestamps, apiUrl: account.config.apiUrl, botToken: account.config.botToken ?? "", log });
-  }
 
   // Compute mention flags — separate "reply gating" from "command gating"
   let isMentioned = false;
@@ -2199,7 +2226,7 @@ export async function handleInboundMessage(params: {
 
         if (unresolvedNames.length > 0) {
           log?.info?.(`octo: [REPLY] ${unresolvedNames.length} unresolved names, force refreshing cache...`);
-          const refreshed = await refreshGroupMemberCache({ sessionId: memberCacheGroupNo, memberMap, uidToNameMap, groupCacheTimestamps, apiUrl: account.config.apiUrl, botToken: account.config.botToken ?? "", forceRefresh: true, log });
+          const refreshed = await refreshGroupMemberCache({ sessionId: memberCacheGroupNo, memberMap, uidToNameMap, groupCacheTimestamps, memberRobotMap, apiUrl: account.config.apiUrl, botToken: account.config.botToken ?? "", forceRefresh: true, log });
           if (refreshed) {
             for (const { name, index } of unresolvedNames) {
               const uid = findUidByName(name, memberMap);

--- a/src/inbound.ts
+++ b/src/inbound.ts
@@ -1083,9 +1083,13 @@ async function refreshGroupMemberCache(opts: {
         }
         // Preserve the server-authoritative robot flag for the 免@ gate. Keyed
         // by uid (not name) so sender classification survives display-name
-        // collisions. `=== true` normalizes any truthy/legacy shape to boolean.
+        // collisions. Accept BOTH boolean `true` and numeric `1`: the backend
+        // serializes GroupMember.robot as a number, so a strict `=== true`
+        // would misclassify a bot (robot:1) as human → relax requireMention →
+        // reply to non-@ bot messages → bot-to-bot loop. This matches the
+        // no_mention true/1 coercion used elsewhere in the gate.
         if (m.uid && memberRobotMap) {
-          memberRobotMap.set(m.uid, m.robot === true);
+          memberRobotMap.set(m.uid, m.robot === true || m.robot === 1);
         }
       }
       groupCacheTimestamps.set(sessionId, now);
@@ -1478,27 +1482,6 @@ export async function handleInboundMessage(params: {
   const isFromBot = isFromKnownBot || isFromServerRobot;
   // account-level requireMention: false means the account is already 免@.
   const accountRequiresMention = account.config.requireMention !== false;
-  // Only consult the group 免@ preference when it can actually change the
-  // outcome: the account must otherwise require @ (else the pref can only
-  // return no_mention=false, with no effect) AND the sender must be human (the
-  // relaxation never applies to bots). This also avoids a pointless hot-path
-  // network round-trip (cache miss → up to MENTION_PREF_TIMEOUT_MS).
-  const shouldCheckGroupPref = isGroup && accountRequiresMention && !isFromBot;
-  const mentionPref = shouldCheckGroupPref
-    ? await getMentionPrefFromCache({
-        accountId: account.accountId,
-        parentGroupNo: extractParentGroupNo(message.channel_id!),
-        apiUrl: account.config.apiUrl,
-        // botToken ?? "" can yield an empty `Bearer` header; getMentionPref
-        // treats any non-2xx (incl. the resulting 401) as no_mention=false, so
-        // the gate safely falls back to the account-level config.
-        botToken: account.config.botToken ?? "",
-        log,
-      })
-    : undefined;
-  const requireMention = mentionPref?.no_mention === true
-    ? false
-    : accountRequiresMention;
   let historyPrefix = "";
 
   // Save original mention uids for reply (exclude bot itself)
@@ -1574,6 +1557,33 @@ export async function handleInboundMessage(params: {
       }
     }
   }
+
+  // Group 免@ preference lookup — deferred until AFTER mention flags are known.
+  // Only consult the group pref when it can actually change the outcome:
+  //   1. isGroup && accountRequiresMention — else the pref can only return
+  //      no_mention=false, with no effect.
+  //   2. !isFromBot — the 免@ relaxation never applies to bot senders.
+  //   3. !isMentioned — an explicit @bot message already passes the gate, so
+  //      the pref can't change anything. Short-circuiting here keeps explicit
+  //      @bot replies off the (cold/slow) pref network path entirely, avoiding
+  //      up to MENTION_PREF_TIMEOUT_MS of needless latency on the hot path.
+  const shouldCheckGroupPref =
+    isGroup && accountRequiresMention && !isFromBot && !isMentioned;
+  const mentionPref = shouldCheckGroupPref
+    ? await getMentionPrefFromCache({
+        accountId: account.accountId,
+        parentGroupNo: extractParentGroupNo(message.channel_id!),
+        apiUrl: account.config.apiUrl,
+        // botToken ?? "" can yield an empty `Bearer` header; getMentionPref
+        // treats any non-2xx (incl. the resulting 401) as no_mention=false, so
+        // the gate safely falls back to the account-level config.
+        botToken: account.config.botToken ?? "",
+        log,
+      })
+    : undefined;
+  const requireMention = mentionPref?.no_mention === true
+    ? false
+    : accountRequiresMention;
 
   if (isGroup && requireMention) {
     // Debug: log received mention info

--- a/src/inbound.ts
+++ b/src/inbound.ts
@@ -22,6 +22,7 @@ import {
 import type { MentionPayload, MentionEntity, SendMessageResult } from "./types.js";
 import { registerGroupAccount, ensureGroupMd, handleGroupMdEvent, broadcastGroupMdUpdate, extractParentGroupNo, extractThreadShortId, ensureThreadMd, handleThreadMdEvent } from "./group-md.js";
 import { isOwner } from "./owner-registry.js";
+import { isKnownBot } from "./bot-registry.js";
 import { getPersonaPromptForSession } from "./persona-prompt.js";
 import { createWriteStream } from "node:fs";
 import { mkdir, unlink, readdir, stat } from "node:fs/promises";
@@ -1431,19 +1432,37 @@ export async function handleInboundMessage(params: {
   // preference, so we resolve the parent group_no first. On miss/expiry the
   // cache pulls GET /v1/bot/groups/:group_no/mention_pref (TTL 5min); any
   // failure falls back to the account-level config, so the gate never crashes.
-  const parentGroupNo = isGroup ? extractParentGroupNo(message.channel_id!) : '';
-  const mentionPref = isGroup
+  //
+  // The 免@ relaxation is HUMAN-ONLY. channel.ts forwards other bots' group
+  // messages into here on purpose, relying on this mention gate to drop the
+  // non-@ ones. If we relaxed requireMention for a known-bot sender, two 免@
+  // bots in the same group would reply to each other with no @ to break the
+  // chain — an unbounded bot-to-bot loop (group spam + token burn). So known
+  // bots always keep requireMention regardless of the group 免@ preference.
+  const isFromKnownBot = isKnownBot(message.from_uid);
+  // account-level requireMention: false means the account is already 免@.
+  const accountRequiresMention = account.config.requireMention !== false;
+  // Only consult the group 免@ preference when it can actually change the
+  // outcome: the account must otherwise require @ (else the pref can only
+  // return no_mention=false, with no effect) AND the sender must be human (the
+  // relaxation never applies to known bots). This also avoids a pointless hot-
+  // path network round-trip (cache miss → up to DEFAULT_TIMEOUT_MS).
+  const shouldCheckGroupPref = isGroup && accountRequiresMention && !isFromKnownBot;
+  const mentionPref = shouldCheckGroupPref
     ? await getMentionPrefFromCache({
         accountId: account.accountId,
-        parentGroupNo,
+        parentGroupNo: extractParentGroupNo(message.channel_id!),
         apiUrl: account.config.apiUrl,
+        // botToken ?? "" can yield an empty `Bearer` header; getMentionPref
+        // treats any non-2xx (incl. the resulting 401) as no_mention=false, so
+        // the gate safely falls back to the account-level config.
         botToken: account.config.botToken ?? "",
         log,
       })
     : undefined;
   const requireMention = mentionPref?.no_mention === true
     ? false
-    : (account.config.requireMention !== false);
+    : accountRequiresMention;
   let historyPrefix = "";
 
   // Save original mention uids for reply (exclude bot itself)

--- a/src/inbound.ts
+++ b/src/inbound.ts
@@ -1464,22 +1464,40 @@ export async function handleInboundMessage(params: {
   // cache pulls GET /v1/bot/groups/:group_no/mention_pref (TTL 5min); any
   // failure falls back to the account-level config, so the gate never crashes.
   //
-  // The 免@ relaxation is HUMAN-ONLY. channel.ts forwards other bots' group
-  // messages into here on purpose, relying on this mention gate to drop the
-  // non-@ ones. If we relaxed requireMention for a bot sender, two 免@ bots in
-  // the same group would reply to each other with no @ to break the chain — an
-  // unbounded bot-to-bot loop (group spam + token burn). So bots always keep
-  // requireMention regardless of the group 免@ preference.
+  // The 免@ relaxation is HUMAN-ONLY and FAIL-CLOSED (PR#57 round-4 P1).
+  // channel.ts forwards other bots' group messages into here on purpose,
+  // relying on this mention gate to drop the non-@ ones. If we relaxed
+  // requireMention for a non-human sender, two 免@ bots in the same group would
+  // reply to each other with no @ to break the chain — an unbounded bot-to-bot
+  // loop (group spam + token burn).
   //
-  // Bot classification uses TWO signals, combined so either one suffices:
-  //   1. isKnownBot(from_uid) — bots registered by THIS plugin process.
-  //   2. memberRobotMap.get(from_uid) === true — the server-authoritative
-  //      GroupMember.robot flag from the member list. This catches bots from
-  //      ANOTHER OpenClaw process, another integration, or any bot not started
-  //      by this instance — exactly the cross-process loop case (1) misses.
+  // Earlier rounds used a BLACKLIST ("relax UNLESS the sender is a proven
+  // bot"), which fails OPEN: any sender we could not positively prove was a bot
+  // defaulted to "human" and had requireMention relaxed. That left loop paths
+  // open whenever classification was uncertain — an unknown/cross-process
+  // sender absent from isKnownBot, or ANY sender when refreshGroupMemberCache
+  // failed/returned empty so memberRobotMap was never populated (robot flag →
+  // undefined → treated as human → reply → loop).
+  //
+  // We invert to a WHITELIST: relax requireMention ONLY for a sender the
+  // server-authoritative member list positively confirms as human. This closes
+  // every loop path at once, independent of where the sender came from, how its
+  // robot flag was serialized, or whether the member refresh succeeded:
+  //   memberRobotMap.get(uid) === false → confirmed human          → may relax
+  //   memberRobotMap.get(uid) === true  → confirmed bot             → keep @
+  //   memberRobotMap.get(uid) === undefined (unknown sender, OR the
+  //       member refresh failed/empty so the map is unpopulated)
+  //                                      → classification unknown   → keep @
+  //   isKnownBot(uid)                   → bot from this process     → keep @
+  //
+  // memberRobotMap is populated by the refreshGroupMemberCache() call above;
+  // a failed/empty refresh simply leaves the sender's uid absent → undefined →
+  // fail-closed. We key on this per-sender map entry rather than the refresh()
+  // boolean on purpose: that boolean is ambiguous (it also returns false on a
+  // warm-cache hit, and the maps are shared across groups), so gating on it
+  // would wrongly suppress replies to humans on every cached message.
   const isFromKnownBot = isKnownBot(message.from_uid);
-  const isFromServerRobot = memberRobotMap.get(message.from_uid) === true;
-  const isFromBot = isFromKnownBot || isFromServerRobot;
+  const isConfirmedHuman = !isFromKnownBot && memberRobotMap.get(message.from_uid) === false;
   // account-level requireMention: false means the account is already 免@.
   const accountRequiresMention = account.config.requireMention !== false;
   let historyPrefix = "";
@@ -1562,13 +1580,16 @@ export async function handleInboundMessage(params: {
   // Only consult the group pref when it can actually change the outcome:
   //   1. isGroup && accountRequiresMention — else the pref can only return
   //      no_mention=false, with no effect.
-  //   2. !isFromBot — the 免@ relaxation never applies to bot senders.
+  //   2. isConfirmedHuman — the 免@ relaxation is whitelist/fail-closed: it
+  //      applies ONLY to a sender the member list positively confirms is human.
+  //      Unknown senders, refresh failures, and any bot keep requireMention, so
+  //      there is no point paying for the pref lookup for them either.
   //   3. !isMentioned — an explicit @bot message already passes the gate, so
   //      the pref can't change anything. Short-circuiting here keeps explicit
   //      @bot replies off the (cold/slow) pref network path entirely, avoiding
   //      up to MENTION_PREF_TIMEOUT_MS of needless latency on the hot path.
   const shouldCheckGroupPref =
-    isGroup && accountRequiresMention && !isFromBot && !isMentioned;
+    isGroup && accountRequiresMention && isConfirmedHuman && !isMentioned;
   const mentionPref = shouldCheckGroupPref
     ? await getMentionPrefFromCache({
         accountId: account.accountId,

--- a/src/inbound.ts
+++ b/src/inbound.ts
@@ -2,6 +2,7 @@ import type { OpenClawConfig } from "openclaw/plugin-sdk";
 import type { ChannelLogSink } from "openclaw/plugin-sdk/channel-contract";
 import { DEFAULT_GROUP_HISTORY_LIMIT } from "openclaw/plugin-sdk/reply-history";
 import { sendMessage, sendReadReceipt, sendTyping, getChannelMessages, getGroupMembers, getGroupMd, postJson, sendMediaMessage, inferContentType, ensureTextCharset, parseImageDimensions, parseImageDimensionsFromFile, getUploadCredentials, uploadFileToCOS, fetchUserInfo } from "./api-fetch.js";
+import { getMentionPrefFromCache } from "./mention-prefs.js";
 import type { ResolvedOctoAccount } from "./accounts.js";
 import type { BotMessage } from "./types.js";
 import { ChannelType, MessageType, RICH_TEXT_BLOCK_IMAGE, RICH_TEXT_BLOCK_TEXT, RICH_TEXT_IMAGE_PLACEHOLDER } from "./types.js";
@@ -1423,7 +1424,26 @@ export async function handleInboundMessage(params: {
   }
 
   // --- Mention gating for group messages ---
-  const requireMention = account.config.requireMention !== false;
+  // Group-aware requireMention: a group admin can mark a group as 免@
+  // (no_mention=true) for this specific bot, in which case the bot replies to
+  // every message without an explicit @mention. The preference is per-(bot,
+  // group); thread (compound channel_id) messages inherit their PARENT group's
+  // preference, so we resolve the parent group_no first. On miss/expiry the
+  // cache pulls GET /v1/bot/groups/:group_no/mention_pref (TTL 5min); any
+  // failure falls back to the account-level config, so the gate never crashes.
+  const parentGroupNo = isGroup ? extractParentGroupNo(message.channel_id!) : '';
+  const mentionPref = isGroup
+    ? await getMentionPrefFromCache({
+        accountId: account.accountId,
+        parentGroupNo,
+        apiUrl: account.config.apiUrl,
+        botToken: account.config.botToken ?? "",
+        log,
+      })
+    : undefined;
+  const requireMention = mentionPref?.no_mention === true
+    ? false
+    : (account.config.requireMention !== false);
   let historyPrefix = "";
 
   // Save original mention uids for reply (exclude bot itself)

--- a/src/mention-prefs.test.ts
+++ b/src/mention-prefs.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  getMentionPrefFromCache,
+  invalidateMentionPref,
+  preloadMentionPrefs,
+  _clearMentionPrefCache,
+  _setMentionPrefEntry,
+  _hasMentionPrefEntry,
+} from "./mention-prefs.js";
+
+const originalFetch = globalThis.fetch;
+
+function mockFetch(handler: (url: string, init?: RequestInit) => Promise<Response>) {
+  return vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    return handler(url, init);
+  }) as unknown as typeof fetch;
+}
+
+function jsonResponse(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+const API = "http://localhost:8090";
+const TOKEN = "tok";
+
+describe("mention-prefs", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    _clearMentionPrefCache();
+  });
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    _clearMentionPrefCache();
+  });
+
+  describe("getMentionPrefFromCache", () => {
+    it("returns cached pref without hitting the network", async () => {
+      _setMentionPrefEntry("acct1", "g100", { no_mention: true });
+      const spy = vi.fn();
+      globalThis.fetch = spy as unknown as typeof fetch;
+
+      const pref = await getMentionPrefFromCache({
+        accountId: "acct1",
+        parentGroupNo: "g100",
+        apiUrl: API,
+        botToken: TOKEN,
+      });
+
+      expect(pref).toEqual({ no_mention: true });
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    it("pulls and caches on miss, hitting the mention_pref endpoint", async () => {
+      const fetchMock = mockFetch(async (url) => {
+        expect(url).toBe(`${API}/v1/bot/groups/g200/mention_pref`);
+        return jsonResponse({ no_mention: true });
+      });
+      globalThis.fetch = fetchMock;
+
+      const pref = await getMentionPrefFromCache({
+        accountId: "acct1",
+        parentGroupNo: "g200",
+        apiUrl: API,
+        botToken: TOKEN,
+      });
+
+      expect(pref).toEqual({ no_mention: true });
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(_hasMentionPrefEntry("acct1", "g200")).toBe(true);
+
+      // Second call served from cache.
+      await getMentionPrefFromCache({
+        accountId: "acct1",
+        parentGroupNo: "g200",
+        apiUrl: API,
+        botToken: TOKEN,
+      });
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("isolates prefs per-bot in the same group (composite key)", async () => {
+      const fetchMock = mockFetch(async (url, init) => {
+        const auth = (init?.headers as Record<string, string>)?.Authorization;
+        // Bot A → no_mention, Bot B → needs @
+        return jsonResponse({ no_mention: auth === "Bearer tokA" });
+      });
+      globalThis.fetch = fetchMock;
+
+      const a = await getMentionPrefFromCache({
+        accountId: "botA",
+        parentGroupNo: "shared",
+        apiUrl: API,
+        botToken: "tokA",
+      });
+      const b = await getMentionPrefFromCache({
+        accountId: "botB",
+        parentGroupNo: "shared",
+        apiUrl: API,
+        botToken: "tokB",
+      });
+
+      expect(a).toEqual({ no_mention: true });
+      expect(b).toEqual({ no_mention: false });
+      expect(_hasMentionPrefEntry("botA", "shared")).toBe(true);
+      expect(_hasMentionPrefEntry("botB", "shared")).toBe(true);
+    });
+
+    it("refreshes after TTL expiry", async () => {
+      _setMentionPrefEntry("acct1", "g300", { no_mention: true }, -1); // already expired
+      const fetchMock = mockFetch(async () => jsonResponse({ no_mention: false }));
+      globalThis.fetch = fetchMock;
+
+      const pref = await getMentionPrefFromCache({
+        accountId: "acct1",
+        parentGroupNo: "g300",
+        apiUrl: API,
+        botToken: TOKEN,
+      });
+
+      expect(pref).toEqual({ no_mention: false });
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("falls back to account-level (no_mention:false) on API failure", async () => {
+      const fetchMock = mockFetch(async () => new Response("boom", { status: 500 }));
+      globalThis.fetch = fetchMock;
+
+      const pref = await getMentionPrefFromCache({
+        accountId: "acct1",
+        parentGroupNo: "g400",
+        apiUrl: API,
+        botToken: TOKEN,
+      });
+
+      expect(pref).toEqual({ no_mention: false });
+    });
+  });
+
+  describe("invalidateMentionPref", () => {
+    it("removes only the targeted (bot, group) entry", () => {
+      _setMentionPrefEntry("acct1", "g1", { no_mention: true });
+      _setMentionPrefEntry("acct1", "g2", { no_mention: true });
+      invalidateMentionPref("acct1", "g1");
+      expect(_hasMentionPrefEntry("acct1", "g1")).toBe(false);
+      expect(_hasMentionPrefEntry("acct1", "g2")).toBe(true);
+    });
+  });
+
+  describe("preloadMentionPrefs", () => {
+    it("warms the cache for all bot groups", async () => {
+      const fetchMock = mockFetch(async (url) => {
+        if (url.endsWith("/v1/bot/groups")) {
+          return jsonResponse([{ group_no: "g1", name: "G1" }, { group_no: "g2", name: "G2" }]);
+        }
+        return jsonResponse({ no_mention: true });
+      });
+      globalThis.fetch = fetchMock;
+
+      await preloadMentionPrefs({ accountId: "acct1", apiUrl: API, botToken: TOKEN });
+
+      expect(_hasMentionPrefEntry("acct1", "g1")).toBe(true);
+      expect(_hasMentionPrefEntry("acct1", "g2")).toBe(true);
+    });
+
+    it("degrades silently when group list fetch fails", async () => {
+      const fetchMock = mockFetch(async (url) => {
+        if (url.endsWith("/v1/bot/groups")) return new Response("nope", { status: 500 });
+        return jsonResponse({ no_mention: true });
+      });
+      globalThis.fetch = fetchMock;
+
+      await expect(
+        preloadMentionPrefs({ accountId: "acct1", apiUrl: API, botToken: TOKEN }),
+      ).resolves.toBeUndefined();
+    });
+  });
+});

--- a/src/mention-prefs.test.ts
+++ b/src/mention-prefs.test.ts
@@ -138,6 +138,86 @@ describe("mention-prefs", () => {
 
       expect(pref).toEqual({ no_mention: false });
     });
+
+    it("caches a negative (no_mention=false) result with a short TTL so it re-pulls soon", async () => {
+      // Negative results (genuine "needs @" OR failure fallback) must not be
+      // pinned for the full 5min positive TTL — a freshly-enabled 免@ should
+      // surface within the short negative window. We assert the entry expires
+      // well before 5min by advancing the clock past the 30s negative TTL.
+      vi.useFakeTimers();
+      try {
+        let calls = 0;
+        const fetchMock = mockFetch(async () => {
+          calls++;
+          // First pull: needs @ (negative). Second pull (after short TTL): 免@.
+          return jsonResponse({ no_mention: calls >= 2 });
+        });
+        globalThis.fetch = fetchMock;
+
+        const first = await getMentionPrefFromCache({
+          accountId: "acct1",
+          parentGroupNo: "gneg",
+          apiUrl: API,
+          botToken: TOKEN,
+        });
+        expect(first).toEqual({ no_mention: false });
+        expect(calls).toBe(1);
+
+        // Just before the negative TTL elapses → still served from cache.
+        vi.advanceTimersByTime(29 * 1000);
+        const cached = await getMentionPrefFromCache({
+          accountId: "acct1",
+          parentGroupNo: "gneg",
+          apiUrl: API,
+          botToken: TOKEN,
+        });
+        expect(cached).toEqual({ no_mention: false });
+        expect(calls).toBe(1);
+
+        // Past the 30s negative TTL → re-pulls and now sees 免@.
+        vi.advanceTimersByTime(2 * 1000);
+        const refreshed = await getMentionPrefFromCache({
+          accountId: "acct1",
+          parentGroupNo: "gneg",
+          apiUrl: API,
+          botToken: TOKEN,
+        });
+        expect(refreshed).toEqual({ no_mention: true });
+        expect(calls).toBe(2);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("caches a positive (no_mention=true) result for the full 5min TTL", async () => {
+      vi.useFakeTimers();
+      try {
+        const fetchMock = mockFetch(async () => jsonResponse({ no_mention: true }));
+        globalThis.fetch = fetchMock;
+
+        const first = await getMentionPrefFromCache({
+          accountId: "acct1",
+          parentGroupNo: "gpos",
+          apiUrl: API,
+          botToken: TOKEN,
+        });
+        expect(first).toEqual({ no_mention: true });
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+
+        // Past the 30s negative window but within 5min → still cached (positive TTL).
+        vi.advanceTimersByTime(60 * 1000);
+        const cached = await getMentionPrefFromCache({
+          accountId: "acct1",
+          parentGroupNo: "gpos",
+          apiUrl: API,
+          botToken: TOKEN,
+        });
+        expect(cached).toEqual({ no_mention: true });
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
   });
 
   describe("invalidateMentionPref", () => {

--- a/src/mention-prefs.ts
+++ b/src/mention-prefs.ts
@@ -25,7 +25,14 @@
 import { getMentionPref, fetchBotGroups, type MentionPref } from "./api-fetch.js";
 import type { LogSink } from "./types.js";
 
-const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes (positive: no_mention=true)
+// Negative results (no_mention=false) get a shorter TTL. getMentionPref returns
+// no_mention=false BOTH for a genuine "needs @" group AND as its failure
+// fallback, so a transient backend blip would otherwise pin no_mention=false
+// for a full 5min — delaying a freshly-enabled 免@ from taking effect. A short
+// negative TTL bounds that staleness while positive (免@) results, which are
+// the stable steady state, still cache for the full window.
+const NEGATIVE_CACHE_TTL_MS = 30 * 1000; // 30 seconds
 
 interface CacheEntry {
   pref: MentionPref;
@@ -43,8 +50,10 @@ function cacheKey(accountId: string, parentGroupNo: string): string {
  * Get the 免@偏好 for a (bot, group) pair, refreshing lazily on miss/expiry.
  *
  * On a fetch failure getMentionPref already returns `{ no_mention: false }`
- * (account-level fallback), which we cache like any other result so a flaky
- * backend doesn't hammer the API on every inbound message.
+ * (account-level fallback). We still cache that, but with a shorter
+ * NEGATIVE_CACHE_TTL_MS so a flaky backend doesn't hammer the API on every
+ * inbound message yet a freshly-enabled 免@ surfaces within ~30s rather than
+ * being masked for the full positive TTL.
  */
 export async function getMentionPrefFromCache(params: {
   accountId: string;
@@ -68,7 +77,8 @@ export async function getMentionPrefFromCache(params: {
         }
       : undefined,
   });
-  _prefCache.set(key, { pref, expiry: Date.now() + CACHE_TTL_MS });
+  const ttl = pref.no_mention ? CACHE_TTL_MS : NEGATIVE_CACHE_TTL_MS;
+  _prefCache.set(key, { pref, expiry: Date.now() + ttl });
   return pref;
 }
 

--- a/src/mention-prefs.ts
+++ b/src/mention-prefs.ts
@@ -1,0 +1,148 @@
+/**
+ * Per-(bot, group) "免@偏好" cache.
+ *
+ * A group admin can mark a group as `no_mention=true` for a specific bot,
+ * meaning that bot replies to *every* message in the group without needing
+ * an explicit @mention. The mention gate in inbound.ts consults this cache
+ * to decide, per message, whether `requireMention` should be relaxed.
+ *
+ * Design mirrors member-cache.ts: a plain Map with per-entry TTL, lazy
+ * (pull-on-miss) refresh, and an explicit invalidate hook. There is NO
+ * push/event branch — the backend (octo-server#237) exposes only the
+ * GET /v1/bot/groups/:group_no/mention_pref pull endpoint; there is no
+ * config push bus. Edits propagate within at most one TTL window.
+ *
+ * IMPORTANT: the cache key is the COMPOSITE `${accountId}:${parentGroupNo}`,
+ * never the bare groupNo. The preference is per-bot — two bots in the same
+ * group can have independent 免@ settings, and keying on groupNo alone would
+ * cross-contaminate them.
+ *
+ * Thread (compound channel_id) messages must resolve their PARENT group_no
+ * (via extractParentGroupNo) before calling in, so a thread inherits its
+ * parent group's preference.
+ */
+
+import { getMentionPref, fetchBotGroups, type MentionPref } from "./api-fetch.js";
+import type { LogSink } from "./types.js";
+
+const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+interface CacheEntry {
+  pref: MentionPref;
+  expiry: number;
+}
+
+const _prefCache = new Map<string, CacheEntry>();
+
+/** Build the composite per-bot cache key. */
+function cacheKey(accountId: string, parentGroupNo: string): string {
+  return `${accountId}:${parentGroupNo}`;
+}
+
+/**
+ * Get the 免@偏好 for a (bot, group) pair, refreshing lazily on miss/expiry.
+ *
+ * On a fetch failure getMentionPref already returns `{ no_mention: false }`
+ * (account-level fallback), which we cache like any other result so a flaky
+ * backend doesn't hammer the API on every inbound message.
+ */
+export async function getMentionPrefFromCache(params: {
+  accountId: string;
+  parentGroupNo: string;
+  apiUrl: string;
+  botToken: string;
+  log?: LogSink;
+}): Promise<MentionPref> {
+  const key = cacheKey(params.accountId, params.parentGroupNo);
+  const cached = _prefCache.get(key);
+  if (cached && cached.expiry > Date.now()) return cached.pref;
+
+  const pref = await getMentionPref({
+    apiUrl: params.apiUrl,
+    botToken: params.botToken,
+    groupNo: params.parentGroupNo,
+    log: params.log
+      ? {
+          info: (...a: unknown[]) => params.log!.info?.(String(a[0])),
+          error: (...a: unknown[]) => params.log!.error?.(String(a[0])),
+        }
+      : undefined,
+  });
+  _prefCache.set(key, { pref, expiry: Date.now() + CACHE_TTL_MS });
+  return pref;
+}
+
+/** Invalidate a single (bot, group) entry. */
+export function invalidateMentionPref(accountId: string, parentGroupNo: string): void {
+  _prefCache.delete(cacheKey(accountId, parentGroupNo));
+}
+
+/**
+ * Preload 免@偏好 for all of a bot's groups (fire-and-forget at startup).
+ *
+ * Optional warm-up — the gate works purely lazily without it; this just
+ * avoids a first-message latency bump and a thundering pull when a busy
+ * group wakes up. Per-group failures are swallowed (getMentionPref already
+ * falls back to no_mention=false), so a flaky backend degrades to lazy load.
+ */
+export async function preloadMentionPrefs(params: {
+  accountId: string;
+  apiUrl: string;
+  botToken: string;
+  log?: LogSink;
+}): Promise<void> {
+  const apiLog = params.log
+    ? {
+        info: (...a: unknown[]) => params.log!.info?.(String(a[0])),
+        error: (...a: unknown[]) => params.log!.error?.(String(a[0])),
+      }
+    : undefined;
+  let groups: { group_no: string }[];
+  try {
+    groups = await fetchBotGroups({ apiUrl: params.apiUrl, botToken: params.botToken, log: apiLog });
+  } catch {
+    return; // degrade to lazy load
+  }
+  let count = 0;
+  for (const g of groups) {
+    if (!g?.group_no) continue;
+    try {
+      await getMentionPrefFromCache({
+        accountId: params.accountId,
+        parentGroupNo: g.group_no,
+        apiUrl: params.apiUrl,
+        botToken: params.botToken,
+        log: params.log,
+      });
+      count++;
+    } catch {
+      // Ignore per-group failures
+    }
+  }
+  if (count > 0) {
+    params.log?.info?.(`octo: mention-pref preloaded ${count} groups`);
+  }
+}
+
+/** Visible for testing — clears all cached preferences. */
+export function _clearMentionPrefCache(): void {
+  _prefCache.clear();
+}
+
+/** Visible for testing — directly set a cache entry. */
+export function _setMentionPrefEntry(
+  accountId: string,
+  parentGroupNo: string,
+  pref: MentionPref,
+  ttlMs?: number,
+): void {
+  _prefCache.set(cacheKey(accountId, parentGroupNo), {
+    pref,
+    expiry: Date.now() + (ttlMs ?? CACHE_TTL_MS),
+  });
+}
+
+/** Visible for testing — check whether an entry exists (ignoring expiry). */
+export function _hasMentionPrefEntry(accountId: string, parentGroupNo: string): boolean {
+  return _prefCache.has(cacheKey(accountId, parentGroupNo));
+}


### PR DESCRIPTION
## What

群级免@偏好（per-(bot, group) `no_mention`）：群管理员可让某个 bot 在本群免@即可触发回复，其它无偏好的群仍维持需@。多 bot 同群互相隔离。

Implements #56. Depends on octo-server#237 (`GET /v1/bot/groups/:group_no/mention_pref`) — code can merge ahead of backend; until the endpoint ships every group safely falls back to account-level behavior.

## Changes

- **`src/inbound.ts`** — group-aware `requireMention` gate placed above the persona-clone block. Resolves the parent `group_no` via `extractParentGroupNo` (thread compound channel_ids inherit the parent group's preference), then relaxes `requireMention` only when `no_mention=true`; otherwise falls back to `account.config.requireMention !== false`. The non-@ history-push path is intentionally left unchanged (免@ does not cache history).
- **`src/mention-prefs.ts`** *(new)* — cache mirroring `member-cache.ts`: `Map` + 5min TTL + lazy pull-on-miss + `invalidate`. Cache key is the **composite `${accountId}:${parentGroupNo}`** (per-bot isolation; never bare groupNo). Pull + TTL only — no push/event branch (backend has no config push bus). Includes optional `preloadMentionPrefs`.
- **`src/api-fetch.ts`** — `getMentionPref({apiUrl, botToken, groupNo})` → `GET /v1/bot/groups/:group_no/mention_pref` with `Bearer botToken`. Accepts `true`/`1`; any failure (non-2xx / network / parse) returns `{ no_mention: false }` without throwing.
- **`src/channel.ts`** — optional fire-and-forget preload at bot startup, next to the existing member-cache preload.

Untouched per scope: `config-schema.ts`, persona-prompt / thread-binding (orthogonal), and the 1512+ history-push behavior.

## Tests

- `src/mention-prefs.test.ts` *(new)* — composite-key per-bot isolation, lazy pull + cache hit, TTL refresh, failure fallback, preload.
- `src/api-fetch.test.ts` — endpoint/URL/Bearer, `no_mention=1`→true, non-2xx and network-error fallback.
- Full suite green: 860 tests, `type-check` + `build` clean.

## Verification (acceptance)

- 某群 `no_mention=1` → 该群非@触发回复；无偏好群维持需@ ✅
- 多 bot 同群 A 免@ / B 需@ 隔离正确（composite key）✅
- TTL 刷新 ✅
- 拉取失败回退账号级、不崩 ✅

End-to-end verification pending octo-server#237 deploy.

Fixes #56

<!-- re-trigger check-sprint W23 1780475566 -->

<!-- sprint W23 retrigger2 1780475636 -->