### PR TITLE
fix(inbound): set MediaPaths + download under Core-allowed root (Fixes #58)

### DIFF
--- a/src/inbound.test.ts
+++ b/src/inbound.test.ts
@@ -22,6 +22,8 @@ import {
   buildSessionAccountKey,
   segmentHistoryEntries,
   resolveInboundMediaList,
+  resolveInboundMediaPaths,
+  isRemoteMediaUrl,
   type ResolveFileResult,
 } from "./inbound.js";
 import { extractMentionUids } from "./mention-utils.js";
@@ -1149,7 +1151,7 @@ describe("resolveInboundMediaList (Fixes #58)", () => {
     expect(resolveInboundMediaList({ isFileMessage: false })).toBeUndefined();
   });
 
-  it("MediaPaths and MediaUrls derive identical values (compat)", () => {
+  it("all-local: MediaPaths and MediaUrls derive identical values (compat)", () => {
     const args = {
       isFileMessage: false,
       inboundMediaUrl: "/tmp/openclaw/octo-media/a.jpg",
@@ -1158,7 +1160,90 @@ describe("resolveInboundMediaList (Fixes #58)", () => {
         "/tmp/openclaw/octo-media/b.jpg",
       ],
     };
-    expect(resolveInboundMediaList(args)).toEqual(resolveInboundMediaList(args));
+    // When every entry is a local path, paths and urls are the same list.
+    expect(resolveInboundMediaPaths(args)).toEqual(resolveInboundMediaList(args));
+  });
+});
+
+/**
+ * resolveInboundMediaPaths is the local-only counterpart of resolveInboundMediaList.
+ * Core treats MediaPaths as local fs inputs (normalizeAttachments prefers them and
+ * reads via fs), so a RichText image whose download FAILED and fell back to its
+ * remote URL must never enter MediaPaths — otherwise Core fs-reads a remote URL
+ * string and rejects it as blocked/unreadable (the LIVE bug fixed here, Jerry-Xin
+ * P1 on #59). Failed-fallback remote URLs stay only in MediaUrls.
+ */
+describe("resolveInboundMediaPaths (#59 — exclude failed remote fallbacks)", () => {
+  it("File messages carry no inline media → undefined", () => {
+    expect(
+      resolveInboundMediaPaths({
+        isFileMessage: true,
+        inboundMediaUrl: "/tmp/openclaw/octo-media/a.jpg",
+        inboundMediaUrls: ["/tmp/openclaw/octo-media/a.jpg"],
+      }),
+    ).toBeUndefined();
+  });
+
+  it("single local media path → one-element list", () => {
+    expect(
+      resolveInboundMediaPaths({
+        isFileMessage: false,
+        inboundMediaUrl: "/tmp/openclaw/octo-media/a.jpg",
+      }),
+    ).toEqual(["/tmp/openclaw/octo-media/a.jpg"]);
+  });
+
+  it("mixed local + failed remote fallback → only local paths reach MediaPaths", () => {
+    // RichText with two images: first downloaded OK (local path), second failed
+    // and fell back to its remote https URL.
+    const local = "/tmp/openclaw/octo-media/a.jpg";
+    const remote = "https://cdn.example.com/b.png";
+    const args = {
+      isFileMessage: false,
+      inboundMediaUrl: local,
+      inboundMediaUrls: [local, remote],
+    };
+    // The failed remote URL is EXCLUDED from MediaPaths…
+    expect(resolveInboundMediaPaths(args)).toEqual([local]);
+    // …but is still carried as a reference via MediaUrls.
+    expect(resolveInboundMediaList(args)).toEqual([local, remote]);
+    expect(resolveInboundMediaPaths(args)).not.toContain(remote);
+  });
+
+  it("all images failed (every entry remote) → MediaPaths undefined", () => {
+    const args = {
+      isFileMessage: false,
+      inboundMediaUrl: "https://cdn.example.com/a.png",
+      inboundMediaUrls: [
+        "https://cdn.example.com/a.png",
+        "http://cdn.example.com/b.png",
+      ],
+    };
+    // Nothing local to fs-read → no MediaPaths; references survive via MediaUrls.
+    expect(resolveInboundMediaPaths(args)).toBeUndefined();
+    expect(resolveInboundMediaList(args)).toEqual([
+      "https://cdn.example.com/a.png",
+      "http://cdn.example.com/b.png",
+    ]);
+  });
+
+  it("no media at all → undefined", () => {
+    expect(resolveInboundMediaPaths({ isFileMessage: false })).toBeUndefined();
+  });
+});
+
+describe("isRemoteMediaUrl", () => {
+  it("detects http/https URLs as remote", () => {
+    expect(isRemoteMediaUrl("https://cdn.example.com/a.png")).toBe(true);
+    expect(isRemoteMediaUrl("http://cdn.example.com/a.png")).toBe(true);
+    expect(isRemoteMediaUrl("HTTPS://CDN.EXAMPLE.COM/A.PNG")).toBe(true);
+  });
+
+  it("treats local fs paths as not remote", () => {
+    expect(isRemoteMediaUrl("/tmp/openclaw/octo-media/a.jpg")).toBe(false);
+    expect(isRemoteMediaUrl("octo-media/a.jpg")).toBe(false);
+    expect(isRemoteMediaUrl(undefined)).toBe(false);
+    expect(isRemoteMediaUrl("")).toBe(false);
   });
 });
 

--- a/src/inbound.test.ts
+++ b/src/inbound.test.ts
@@ -21,6 +21,7 @@ import {
   sessionAccountMap,
   buildSessionAccountKey,
   segmentHistoryEntries,
+  resolveInboundMediaList,
   type ResolveFileResult,
 } from "./inbound.js";
 import { extractMentionUids } from "./mention-utils.js";
@@ -982,7 +983,7 @@ describe("downloadMediaToLocal", () => {
 
     expect(result).toBeDefined();
     expect(result).not.toContain("http");
-    expect(result!.startsWith("/tmp/octo-media/")).toBe(true);
+    expect(result!.startsWith("/tmp/openclaw/octo-media/")).toBe(true);
     expect(result!.endsWith(".jpeg")).toBe(true);
     expect(existsSync(result!)).toBe(true);
     expect(readFileSync(result!)).toEqual(Buffer.from(imageData));
@@ -1101,6 +1102,63 @@ describe("downloadMediaToLocal", () => {
     expect(result).toBeDefined();
     expect(result!.endsWith(".mp4")).toBe(true);
     tempFiles.push(result!);
+  });
+});
+
+/**
+ * resolveInboundMediaList drives both MediaPaths (primary, fs-read by Core's
+ * normalizeAttachments) and MediaUrls (backward compat). This is the field that
+ * fixes #58: inbound images now travel as local fs paths under Core's allowed
+ * root, so media-understanding no longer falls back to http fetch + MediaFetchError.
+ */
+describe("resolveInboundMediaList (Fixes #58)", () => {
+  it("File messages carry no inline media → undefined", () => {
+    expect(
+      resolveInboundMediaList({
+        isFileMessage: true,
+        inboundMediaUrl: "/tmp/openclaw/octo-media/a.jpg",
+        inboundMediaUrls: ["/tmp/openclaw/octo-media/a.jpg"],
+      }),
+    ).toBeUndefined();
+  });
+
+  it("single local media path → one-element list", () => {
+    expect(
+      resolveInboundMediaList({
+        isFileMessage: false,
+        inboundMediaUrl: "/tmp/openclaw/octo-media/a.jpg",
+      }),
+    ).toEqual(["/tmp/openclaw/octo-media/a.jpg"]);
+  });
+
+  it("RichText(=14) multi-image → every local path", () => {
+    const paths = [
+      "/tmp/openclaw/octo-media/a.jpg",
+      "/tmp/openclaw/octo-media/b.png",
+    ];
+    expect(
+      resolveInboundMediaList({
+        isFileMessage: false,
+        inboundMediaUrl: paths[0],
+        inboundMediaUrls: paths,
+      }),
+    ).toEqual(paths);
+  });
+
+  it("no media at all → undefined", () => {
+    expect(resolveInboundMediaList({ isFileMessage: false })).toBeUndefined();
+  });
+
+  it("MediaPaths and MediaUrls derive identical values (compat)", () => {
+    const args = {
+      isFileMessage: false,
+      inboundMediaUrl: "/tmp/openclaw/octo-media/a.jpg",
+      inboundMediaUrls: [
+        "/tmp/openclaw/octo-media/a.jpg",
+        "/tmp/openclaw/octo-media/b.jpg",
+      ],
+    };
+    expect(resolveInboundMediaList(args)).toEqual(resolveInboundMediaList(args));
   });
 });
 

--- a/src/inbound.test.ts
+++ b/src/inbound.test.ts
@@ -1109,149 +1109,133 @@ describe("downloadMediaToLocal", () => {
 });
 
 /**
- * resolveInboundMediaList drives both MediaPaths (primary, fs-read by Core's
- * normalizeAttachments) and MediaUrls (backward compat). This is the field that
- * fixes #58: inbound images now travel as local fs paths under Core's allowed
- * root, so media-understanding no longer falls back to http fetch + MediaFetchError.
+ * resolveInboundMediaList drives MediaUrls and resolveInboundMediaPaths drives
+ * MediaPaths. The fix for #58 is ALL-OR-NOTHING: when every inbound image
+ * downloaded to a local path under Core's allowed root, both arrays carry the
+ * compact local paths and Core fs-reads them (no http MediaFetchError). If ANY
+ * image failed, MediaPaths is undefined and MediaUrls carries every image's
+ * original remote http(s) URL, so Core falls back to the URL (http fetch) branch
+ * for the whole message — never a sparse array, never a bare local path in the
+ * http path.
  */
 describe("resolveInboundMediaList (Fixes #58)", () => {
-  it("File messages carry no inline media → undefined", () => {
-    expect(
-      resolveInboundMediaList({
-        isFileMessage: true,
-        inboundMediaUrl: "/tmp/openclaw/octo-media/a.jpg",
-        inboundMediaUrls: ["/tmp/openclaw/octo-media/a.jpg"],
-      }),
-    ).toBeUndefined();
+  it("no items → undefined", () => {
+    expect(resolveInboundMediaList(undefined)).toBeUndefined();
+    expect(resolveInboundMediaList([])).toBeUndefined();
   });
 
   it("single local media path → one-element list", () => {
     expect(
-      resolveInboundMediaList({
-        isFileMessage: false,
-        inboundMediaUrl: "/tmp/openclaw/octo-media/a.jpg",
-      }),
+      resolveInboundMediaList([
+        { localPath: "/tmp/openclaw/octo-media/a.jpg", remoteUrl: "https://cdn.example.com/a.jpg" },
+      ]),
     ).toEqual(["/tmp/openclaw/octo-media/a.jpg"]);
   });
 
-  it("RichText(=14) multi-image → every local path", () => {
-    const paths = [
+  it("all-local multi-image → every local path", () => {
+    const items = [
+      { localPath: "/tmp/openclaw/octo-media/a.jpg", remoteUrl: "https://cdn.example.com/a.jpg" },
+      { localPath: "/tmp/openclaw/octo-media/b.png", remoteUrl: "https://cdn.example.com/b.png" },
+    ];
+    expect(resolveInboundMediaList(items)).toEqual([
       "/tmp/openclaw/octo-media/a.jpg",
       "/tmp/openclaw/octo-media/b.png",
-    ];
-    expect(
-      resolveInboundMediaList({
-        isFileMessage: false,
-        inboundMediaUrl: paths[0],
-        inboundMediaUrls: paths,
-      }),
-    ).toEqual(paths);
+    ]);
   });
 
-  it("no media at all → undefined", () => {
-    expect(resolveInboundMediaList({ isFileMessage: false })).toBeUndefined();
+  it("any download failed → MediaUrls is every image's remote URL (no local paths)", () => {
+    const items = [
+      { localPath: "/tmp/openclaw/octo-media/a.jpg", remoteUrl: "https://cdn.example.com/a.jpg" },
+      { localPath: undefined, remoteUrl: "https://cdn.example.com/b.png" },
+    ];
+    // Mixed-fail falls back to remote http URLs for the WHOLE message — including
+    // the image that did download — so Core never fs-reads while MediaPaths is unset.
+    expect(resolveInboundMediaList(items)).toEqual([
+      "https://cdn.example.com/a.jpg",
+      "https://cdn.example.com/b.png",
+    ]);
   });
 
   it("all-local: MediaPaths and MediaUrls derive identical values (compat)", () => {
-    const args = {
-      isFileMessage: false,
-      inboundMediaUrl: "/tmp/openclaw/octo-media/a.jpg",
-      inboundMediaUrls: [
-        "/tmp/openclaw/octo-media/a.jpg",
-        "/tmp/openclaw/octo-media/b.jpg",
-      ],
-    };
-    // When every entry is a local path, paths and urls are the same list.
-    expect(resolveInboundMediaPaths(args)).toEqual(resolveInboundMediaList(args));
+    const items = [
+      { localPath: "/tmp/openclaw/octo-media/a.jpg", remoteUrl: "https://cdn.example.com/a.jpg" },
+      { localPath: "/tmp/openclaw/octo-media/b.jpg", remoteUrl: "https://cdn.example.com/b.jpg" },
+    ];
+    expect(resolveInboundMediaPaths(items)).toEqual(resolveInboundMediaList(items));
   });
 });
 
 /**
- * resolveInboundMediaPaths is the index-aligned counterpart of
- * resolveInboundMediaList. Core's normalizeAttachments path-branch pairs
- * MediaPaths[i] with MediaUrls[i] for the SAME image i, so the two arrays must
- * stay equal-length and index-aligned. A RichText image whose download FAILED
- * and fell back to its remote URL must never be handed to Core as a local fs
- * path — Core would fs-read a remote URL string and reject it as
- * blocked/unreadable (#58). But it must NOT be dropped either (Jerry-Xin P1 on
- * #59): dropping shifts later indices and mis-pairs a local path with another
- * image's remote URL. Instead, failed (remote) slots become `undefined`
- * placeholders, which Core keeps as URL-only attachments via
- * `.filter((e) => Boolean(e.path ?? e.url))`, sourcing the URL from MediaUrls[i].
+ * resolveInboundMediaPaths emits Core's fs-read MediaPaths array ONLY when every
+ * image downloaded locally (compact string[], no holes). If any image failed it
+ * returns undefined so the whole message falls back to the MediaUrls (remote
+ * http) branch. This deliberately avoids sparse MediaPaths: Core's sandbox media
+ * staging treats MediaPaths as a plain string[] (resolveRawPaths → raw.trim())
+ * and would crash on an undefined slot (Jerry-Xin round-3 P1). The return type
+ * is string[] — no non-string element ever reaches MediaPaths.
  */
-describe("resolveInboundMediaPaths (#59 — placeholder, not exclude, for failed remote fallbacks)", () => {
-  it("File messages carry no inline media → undefined", () => {
-    expect(
-      resolveInboundMediaPaths({
-        isFileMessage: true,
-        inboundMediaUrl: "/tmp/openclaw/octo-media/a.jpg",
-        inboundMediaUrls: ["/tmp/openclaw/octo-media/a.jpg"],
-      }),
-    ).toBeUndefined();
+describe("resolveInboundMediaPaths (#59 — all-or-nothing, never sparse)", () => {
+  it("no items → undefined", () => {
+    expect(resolveInboundMediaPaths(undefined)).toBeUndefined();
+    expect(resolveInboundMediaPaths([])).toBeUndefined();
   });
 
   it("single local media path → one-element list", () => {
     expect(
-      resolveInboundMediaPaths({
-        isFileMessage: false,
-        inboundMediaUrl: "/tmp/openclaw/octo-media/a.jpg",
-      }),
+      resolveInboundMediaPaths([
+        { localPath: "/tmp/openclaw/octo-media/a.jpg", remoteUrl: "https://cdn.example.com/a.jpg" },
+      ]),
     ).toEqual(["/tmp/openclaw/octo-media/a.jpg"]);
   });
 
-  it("mixed [local, failed-remote] → remote slot is an undefined placeholder, length preserved", () => {
-    // RichText with two images: first downloaded OK (local path), second failed
-    // and fell back to its remote https URL.
-    const local = "/tmp/openclaw/octo-media/a.jpg";
-    const remote = "https://cdn.example.com/b.png";
-    const args = {
-      isFileMessage: false,
-      inboundMediaUrl: local,
-      inboundMediaUrls: [local, remote],
-    };
-    // MediaPaths stays the SAME LENGTH as MediaUrls, index-aligned: the failed
-    // remote slot is an `undefined` placeholder, not dropped.
-    expect(resolveInboundMediaPaths(args)).toEqual([local, undefined]);
-    // The remote URL survives only via MediaUrls at the SAME index.
-    expect(resolveInboundMediaList(args)).toEqual([local, remote]);
-    // Same cardinality is the load-bearing invariant for Core's path-branch.
-    expect(resolveInboundMediaPaths(args)?.length).toBe(
-      resolveInboundMediaList(args)?.length,
-    );
+  it("all-local multi-image → compact local-path array", () => {
+    const items = [
+      { localPath: "/tmp/openclaw/octo-media/a.jpg", remoteUrl: "https://cdn.example.com/a.jpg" },
+      { localPath: "/tmp/openclaw/octo-media/b.png", remoteUrl: "https://cdn.example.com/b.png" },
+    ];
+    const paths = resolveInboundMediaPaths(items);
+    expect(paths).toEqual([
+      "/tmp/openclaw/octo-media/a.jpg",
+      "/tmp/openclaw/octo-media/b.png",
+    ]);
+    // Load-bearing: no undefined/null element ever reaches MediaPaths.
+    expect(paths!.every((p) => typeof p === "string")).toBe(true);
   });
 
-  it("mixed [failed-remote, local] → leading remote slot is placeholder, local keeps its index", () => {
-    const remote = "https://cdn.example.com/a.png";
-    const local = "/tmp/openclaw/octo-media/b.jpg";
-    const args = {
-      isFileMessage: false,
-      inboundMediaUrl: remote,
-      inboundMediaUrls: [remote, local],
-    };
-    expect(resolveInboundMediaPaths(args)).toEqual([undefined, local]);
-    expect(resolveInboundMediaList(args)).toEqual([remote, local]);
-  });
-
-  it("all images failed (every entry remote) → MediaPaths undefined", () => {
-    const args = {
-      isFileMessage: false,
-      inboundMediaUrl: "https://cdn.example.com/a.png",
-      inboundMediaUrls: [
-        "https://cdn.example.com/a.png",
-        "http://cdn.example.com/b.png",
-      ],
-    };
-    // Nothing local to fs-read → no MediaPaths; references survive via MediaUrls,
-    // where Core takes the URL branch instead.
-    expect(resolveInboundMediaPaths(args)).toBeUndefined();
-    expect(resolveInboundMediaList(args)).toEqual([
-      "https://cdn.example.com/a.png",
-      "http://cdn.example.com/b.png",
+  it("mixed [local, failed] → MediaPaths undefined (whole message falls back to URLs)", () => {
+    const items = [
+      { localPath: "/tmp/openclaw/octo-media/a.jpg", remoteUrl: "https://cdn.example.com/a.jpg" },
+      { localPath: undefined, remoteUrl: "https://cdn.example.com/b.png" },
+    ];
+    expect(resolveInboundMediaPaths(items)).toBeUndefined();
+    expect(resolveInboundMediaList(items)).toEqual([
+      "https://cdn.example.com/a.jpg",
+      "https://cdn.example.com/b.png",
     ]);
   });
 
-  it("no media at all → undefined", () => {
-    expect(resolveInboundMediaPaths({ isFileMessage: false })).toBeUndefined();
+  it("mixed [failed, local] → MediaPaths undefined regardless of order", () => {
+    const items = [
+      { localPath: undefined, remoteUrl: "https://cdn.example.com/a.png" },
+      { localPath: "/tmp/openclaw/octo-media/b.jpg", remoteUrl: "https://cdn.example.com/b.jpg" },
+    ];
+    expect(resolveInboundMediaPaths(items)).toBeUndefined();
+    expect(resolveInboundMediaList(items)).toEqual([
+      "https://cdn.example.com/a.png",
+      "https://cdn.example.com/b.jpg",
+    ]);
+  });
+
+  it("all images failed → MediaPaths undefined, MediaUrls keeps remote refs", () => {
+    const items = [
+      { localPath: undefined, remoteUrl: "https://cdn.example.com/a.png" },
+      { localPath: undefined, remoteUrl: "http://cdn.example.com/b.png" },
+    ];
+    expect(resolveInboundMediaPaths(items)).toBeUndefined();
+    expect(resolveInboundMediaList(items)).toEqual([
+      "https://cdn.example.com/a.png",
+      "http://cdn.example.com/b.png",
+    ]);
   });
 });
 
@@ -1271,98 +1255,125 @@ describe("isRemoteMediaUrl", () => {
 });
 
 /**
- * Integration-style test (#59 P1): assert the inbound media payload built by
- * inbound.ts (MediaPaths / MediaUrls / MediaTypes) flows correctly through
- * Core's REAL normalizeMediaAttachments (= normalizeAttachments). This guards
- * the load-bearing cardinality + index-alignment invariant directly against
- * Core, so a future change to resolveInboundMediaPaths that re-breaks alignment
- * fails here, not silently in production.
- *
- * Core's path-branch pairs MediaPaths[i] ↔ MediaUrls[i] for the SAME image i:
- *   pathsFromArray.map((value, index) => ({ path: value, url: urls?.[index] ?? ctx.MediaUrl }))
- * and keeps entries where `path ?? url` is truthy. A failed (remote) image is a
- * MediaPaths placeholder (undefined) whose URL survives at the same index.
+ * Integration-style test (#59 round-3 P1): assert the inbound media payload built
+ * by inbound.ts (MediaPaths / MediaUrls / MediaTypes) flows correctly through
+ * Core's REAL normalizeMediaAttachments (= normalizeAttachments). This guards the
+ * all-or-nothing contract directly against Core: all-local goes through the fs
+ * (path) branch; any mixed-fail emits NO MediaPaths and every attachment is a
+ * remote-URL attachment via the URL branch — so neither Core consumer ever sees
+ * a sparse array or a bare local path in the http path.
  */
-describe("inbound media payload × Core normalizeMediaAttachments (#59 alignment)", () => {
-  // Mirror the exact MediaPaths/MediaUrls/MediaTypes the inbound payload builds.
-  const buildPayload = (inboundMediaUrls: string[]) => {
-    const inboundMediaUrl = inboundMediaUrls[0];
-    const args = { isFileMessage: false, inboundMediaUrl, inboundMediaUrls };
-    const list = resolveInboundMediaList(args);
+describe("inbound media payload × Core normalizeMediaAttachments (#59 all-or-nothing)", () => {
+  // Mirror the exact MediaPaths/MediaUrls/MediaTypes the inbound payload builds
+  // from the per-image download outcome (localPath set ⇒ success, undefined ⇒ fail).
+  const buildPayload = (items: { localPath?: string; remoteUrl: string }[]) => {
+    const list = resolveInboundMediaList(items);
     return {
-      MediaPaths: resolveInboundMediaPaths(args),
+      MediaPaths: resolveInboundMediaPaths(items),
       MediaUrls: list,
       MediaTypes: list?.map((u) => guessImageMime(u)),
     };
   };
-  // Local mime helper mirroring inbound.ts's guessMime fallback for images.
   const guessImageMime = (u: string) =>
     /\.png$/i.test(u) ? "image/png" : "image/jpeg";
 
-  it("[local, failed-remote]: Core keeps 2 attachments, correct path/url per index", () => {
-    const local = "/tmp/openclaw/octo-media/a.jpg";
-    const remote = "https://cdn.example.com/b.png";
-    const payload = buildPayload([local, remote]);
-
-    // The inbound payload itself keeps both arrays equal-length + index-aligned.
-    expect(payload.MediaPaths).toEqual([local, undefined]);
-    expect(payload.MediaUrls).toEqual([local, remote]);
-
-    const attachments = normalizeMediaAttachments(payload as never);
-    expect(attachments).toHaveLength(2);
-    // Image 0: local download → fs path; url mirrors the same local entry.
-    expect(attachments[0].path).toBe(local);
-    expect(attachments[0].index).toBe(0);
-    expect(attachments[0].mime).toBe("image/jpeg");
-    // Image 1: download failed → URL-only attachment at the SAME index,
-    // carrying ITS OWN remote URL (not image 0's), with no local path.
-    expect(attachments[1].path).toBeUndefined();
-    expect(attachments[1].url).toBe(remote);
-    expect(attachments[1].index).toBe(1);
-    expect(attachments[1].mime).toBe("image/png");
-  });
-
-  it("[failed-remote, local]: order preserved, no cross-index mis-pairing", () => {
-    const remote = "https://cdn.example.com/a.png";
-    const local = "/tmp/openclaw/octo-media/b.jpg";
-    const payload = buildPayload([remote, local]);
-
-    expect(payload.MediaPaths).toEqual([undefined, local]);
-    expect(payload.MediaUrls).toEqual([remote, local]);
-
-    const attachments = normalizeMediaAttachments(payload as never);
-    expect(attachments).toHaveLength(2);
-    // Image 0: failed remote → URL-only, keeps its remote URL and index 0.
-    expect(attachments[0].path).toBeUndefined();
-    expect(attachments[0].url).toBe(remote);
-    expect(attachments[0].mime).toBe("image/png");
-    // Image 1: local → fs path, NOT paired with image 0's remote URL.
-    expect(attachments[1].path).toBe(local);
-    expect(attachments[1].url).toBe(local);
-    expect(attachments[1].mime).toBe("image/jpeg");
-  });
-
   it("all-local: every attachment is an fs path read locally", () => {
-    const a = "/tmp/openclaw/octo-media/a.jpg";
-    const b = "/tmp/openclaw/octo-media/b.png";
-    const payload = buildPayload([a, b]);
+    const items = [
+      { localPath: "/tmp/openclaw/octo-media/a.jpg", remoteUrl: "https://cdn.example.com/a.jpg" },
+      { localPath: "/tmp/openclaw/octo-media/b.png", remoteUrl: "https://cdn.example.com/b.png" },
+    ];
+    const payload = buildPayload(items);
+    expect(payload.MediaPaths).toEqual([
+      "/tmp/openclaw/octo-media/a.jpg",
+      "/tmp/openclaw/octo-media/b.png",
+    ]);
 
     const attachments = normalizeMediaAttachments(payload as never);
     expect(attachments).toHaveLength(2);
-    expect(attachments.map((x) => x.path)).toEqual([a, b]);
+    expect(attachments.map((x) => x.path)).toEqual([
+      "/tmp/openclaw/octo-media/a.jpg",
+      "/tmp/openclaw/octo-media/b.png",
+    ]);
+  });
+
+  it("[local, remote-fail]: MediaPaths undefined, both flow as remote-URL attachments", () => {
+    const items = [
+      { localPath: "/tmp/openclaw/octo-media/a.jpg", remoteUrl: "https://cdn.example.com/a.jpg" },
+      { localPath: undefined, remoteUrl: "https://cdn.example.com/b.png" },
+    ];
+    const payload = buildPayload(items);
+    // Mixed-fail: NO MediaPaths (never sparse) — the round-3 P1 guarantee.
+    expect(payload.MediaPaths).toBeUndefined();
+    expect(payload.MediaUrls).toEqual([
+      "https://cdn.example.com/a.jpg",
+      "https://cdn.example.com/b.png",
+    ]);
+
+    const attachments = normalizeMediaAttachments(payload as never);
+    expect(attachments).toHaveLength(2);
+    expect(attachments.every((x) => x.path === undefined)).toBe(true);
+    expect(attachments.map((x) => x.url)).toEqual([
+      "https://cdn.example.com/a.jpg",
+      "https://cdn.example.com/b.png",
+    ]);
+    expect(attachments.map((x) => x.index)).toEqual([0, 1]);
+  });
+
+  it("[remote-fail, local]: order preserved, MediaPaths still undefined", () => {
+    const items = [
+      { localPath: undefined, remoteUrl: "https://cdn.example.com/a.png" },
+      { localPath: "/tmp/openclaw/octo-media/b.jpg", remoteUrl: "https://cdn.example.com/b.jpg" },
+    ];
+    const payload = buildPayload(items);
+    expect(payload.MediaPaths).toBeUndefined();
+    expect(payload.MediaUrls).toEqual([
+      "https://cdn.example.com/a.png",
+      "https://cdn.example.com/b.jpg",
+    ]);
+
+    const attachments = normalizeMediaAttachments(payload as never);
+    expect(attachments).toHaveLength(2);
+    expect(attachments.every((x) => x.path === undefined)).toBe(true);
+    expect(attachments.map((x) => x.url)).toEqual([
+      "https://cdn.example.com/a.png",
+      "https://cdn.example.com/b.jpg",
+    ]);
   });
 
   it("all-failed (every remote): Core takes the URL branch, references survive", () => {
-    const a = "https://cdn.example.com/a.png";
-    const b = "http://cdn.example.com/b.png";
-    const payload = buildPayload([a, b]);
-
-    // No local path anywhere → MediaPaths undefined → Core uses MediaUrls branch.
+    const items = [
+      { localPath: undefined, remoteUrl: "https://cdn.example.com/a.png" },
+      { localPath: undefined, remoteUrl: "http://cdn.example.com/b.png" },
+    ];
+    const payload = buildPayload(items);
     expect(payload.MediaPaths).toBeUndefined();
     const attachments = normalizeMediaAttachments(payload as never);
     expect(attachments).toHaveLength(2);
     expect(attachments.every((x) => x.path === undefined)).toBe(true);
-    expect(attachments.map((x) => x.url)).toEqual([a, b]);
+    expect(attachments.map((x) => x.url)).toEqual([
+      "https://cdn.example.com/a.png",
+      "http://cdn.example.com/b.png",
+    ]);
+  });
+
+  it("MediaPaths never contains a non-string element in any download outcome", () => {
+    const cases = [
+      [{ localPath: "/tmp/openclaw/octo-media/a.jpg", remoteUrl: "https://cdn.example.com/a.jpg" }],
+      [
+        { localPath: "/tmp/openclaw/octo-media/a.jpg", remoteUrl: "https://cdn.example.com/a.jpg" },
+        { localPath: undefined, remoteUrl: "https://cdn.example.com/b.png" },
+      ],
+      [
+        { localPath: undefined, remoteUrl: "https://cdn.example.com/a.png" },
+        { localPath: undefined, remoteUrl: "http://cdn.example.com/b.png" },
+      ],
+    ];
+    for (const items of cases) {
+      const paths = resolveInboundMediaPaths(items);
+      if (paths !== undefined) {
+        expect(paths.every((p) => typeof p === "string")).toBe(true);
+      }
+    }
   });
 });
 

--- a/src/inbound.test.ts
+++ b/src/inbound.test.ts
@@ -27,6 +27,7 @@ import {
   type ResolveFileResult,
 } from "./inbound.js";
 import { extractMentionUids } from "./mention-utils.js";
+import { normalizeMediaAttachments } from "openclaw/plugin-sdk/media-runtime";
 import { existsSync, unlinkSync, readFileSync } from "node:fs";
 
 /**
@@ -1166,14 +1167,19 @@ describe("resolveInboundMediaList (Fixes #58)", () => {
 });
 
 /**
- * resolveInboundMediaPaths is the local-only counterpart of resolveInboundMediaList.
- * Core treats MediaPaths as local fs inputs (normalizeAttachments prefers them and
- * reads via fs), so a RichText image whose download FAILED and fell back to its
- * remote URL must never enter MediaPaths — otherwise Core fs-reads a remote URL
- * string and rejects it as blocked/unreadable (the LIVE bug fixed here, Jerry-Xin
- * P1 on #59). Failed-fallback remote URLs stay only in MediaUrls.
+ * resolveInboundMediaPaths is the index-aligned counterpart of
+ * resolveInboundMediaList. Core's normalizeAttachments path-branch pairs
+ * MediaPaths[i] with MediaUrls[i] for the SAME image i, so the two arrays must
+ * stay equal-length and index-aligned. A RichText image whose download FAILED
+ * and fell back to its remote URL must never be handed to Core as a local fs
+ * path — Core would fs-read a remote URL string and reject it as
+ * blocked/unreadable (#58). But it must NOT be dropped either (Jerry-Xin P1 on
+ * #59): dropping shifts later indices and mis-pairs a local path with another
+ * image's remote URL. Instead, failed (remote) slots become `undefined`
+ * placeholders, which Core keeps as URL-only attachments via
+ * `.filter((e) => Boolean(e.path ?? e.url))`, sourcing the URL from MediaUrls[i].
  */
-describe("resolveInboundMediaPaths (#59 — exclude failed remote fallbacks)", () => {
+describe("resolveInboundMediaPaths (#59 — placeholder, not exclude, for failed remote fallbacks)", () => {
   it("File messages carry no inline media → undefined", () => {
     expect(
       resolveInboundMediaPaths({
@@ -1193,7 +1199,7 @@ describe("resolveInboundMediaPaths (#59 — exclude failed remote fallbacks)", (
     ).toEqual(["/tmp/openclaw/octo-media/a.jpg"]);
   });
 
-  it("mixed local + failed remote fallback → only local paths reach MediaPaths", () => {
+  it("mixed [local, failed-remote] → remote slot is an undefined placeholder, length preserved", () => {
     // RichText with two images: first downloaded OK (local path), second failed
     // and fell back to its remote https URL.
     const local = "/tmp/openclaw/octo-media/a.jpg";
@@ -1203,11 +1209,27 @@ describe("resolveInboundMediaPaths (#59 — exclude failed remote fallbacks)", (
       inboundMediaUrl: local,
       inboundMediaUrls: [local, remote],
     };
-    // The failed remote URL is EXCLUDED from MediaPaths…
-    expect(resolveInboundMediaPaths(args)).toEqual([local]);
-    // …but is still carried as a reference via MediaUrls.
+    // MediaPaths stays the SAME LENGTH as MediaUrls, index-aligned: the failed
+    // remote slot is an `undefined` placeholder, not dropped.
+    expect(resolveInboundMediaPaths(args)).toEqual([local, undefined]);
+    // The remote URL survives only via MediaUrls at the SAME index.
     expect(resolveInboundMediaList(args)).toEqual([local, remote]);
-    expect(resolveInboundMediaPaths(args)).not.toContain(remote);
+    // Same cardinality is the load-bearing invariant for Core's path-branch.
+    expect(resolveInboundMediaPaths(args)?.length).toBe(
+      resolveInboundMediaList(args)?.length,
+    );
+  });
+
+  it("mixed [failed-remote, local] → leading remote slot is placeholder, local keeps its index", () => {
+    const remote = "https://cdn.example.com/a.png";
+    const local = "/tmp/openclaw/octo-media/b.jpg";
+    const args = {
+      isFileMessage: false,
+      inboundMediaUrl: remote,
+      inboundMediaUrls: [remote, local],
+    };
+    expect(resolveInboundMediaPaths(args)).toEqual([undefined, local]);
+    expect(resolveInboundMediaList(args)).toEqual([remote, local]);
   });
 
   it("all images failed (every entry remote) → MediaPaths undefined", () => {
@@ -1219,7 +1241,8 @@ describe("resolveInboundMediaPaths (#59 — exclude failed remote fallbacks)", (
         "http://cdn.example.com/b.png",
       ],
     };
-    // Nothing local to fs-read → no MediaPaths; references survive via MediaUrls.
+    // Nothing local to fs-read → no MediaPaths; references survive via MediaUrls,
+    // where Core takes the URL branch instead.
     expect(resolveInboundMediaPaths(args)).toBeUndefined();
     expect(resolveInboundMediaList(args)).toEqual([
       "https://cdn.example.com/a.png",
@@ -1244,6 +1267,102 @@ describe("isRemoteMediaUrl", () => {
     expect(isRemoteMediaUrl("octo-media/a.jpg")).toBe(false);
     expect(isRemoteMediaUrl(undefined)).toBe(false);
     expect(isRemoteMediaUrl("")).toBe(false);
+  });
+});
+
+/**
+ * Integration-style test (#59 P1): assert the inbound media payload built by
+ * inbound.ts (MediaPaths / MediaUrls / MediaTypes) flows correctly through
+ * Core's REAL normalizeMediaAttachments (= normalizeAttachments). This guards
+ * the load-bearing cardinality + index-alignment invariant directly against
+ * Core, so a future change to resolveInboundMediaPaths that re-breaks alignment
+ * fails here, not silently in production.
+ *
+ * Core's path-branch pairs MediaPaths[i] ↔ MediaUrls[i] for the SAME image i:
+ *   pathsFromArray.map((value, index) => ({ path: value, url: urls?.[index] ?? ctx.MediaUrl }))
+ * and keeps entries where `path ?? url` is truthy. A failed (remote) image is a
+ * MediaPaths placeholder (undefined) whose URL survives at the same index.
+ */
+describe("inbound media payload × Core normalizeMediaAttachments (#59 alignment)", () => {
+  // Mirror the exact MediaPaths/MediaUrls/MediaTypes the inbound payload builds.
+  const buildPayload = (inboundMediaUrls: string[]) => {
+    const inboundMediaUrl = inboundMediaUrls[0];
+    const args = { isFileMessage: false, inboundMediaUrl, inboundMediaUrls };
+    const list = resolveInboundMediaList(args);
+    return {
+      MediaPaths: resolveInboundMediaPaths(args),
+      MediaUrls: list,
+      MediaTypes: list?.map((u) => guessImageMime(u)),
+    };
+  };
+  // Local mime helper mirroring inbound.ts's guessMime fallback for images.
+  const guessImageMime = (u: string) =>
+    /\.png$/i.test(u) ? "image/png" : "image/jpeg";
+
+  it("[local, failed-remote]: Core keeps 2 attachments, correct path/url per index", () => {
+    const local = "/tmp/openclaw/octo-media/a.jpg";
+    const remote = "https://cdn.example.com/b.png";
+    const payload = buildPayload([local, remote]);
+
+    // The inbound payload itself keeps both arrays equal-length + index-aligned.
+    expect(payload.MediaPaths).toEqual([local, undefined]);
+    expect(payload.MediaUrls).toEqual([local, remote]);
+
+    const attachments = normalizeMediaAttachments(payload as never);
+    expect(attachments).toHaveLength(2);
+    // Image 0: local download → fs path; url mirrors the same local entry.
+    expect(attachments[0].path).toBe(local);
+    expect(attachments[0].index).toBe(0);
+    expect(attachments[0].mime).toBe("image/jpeg");
+    // Image 1: download failed → URL-only attachment at the SAME index,
+    // carrying ITS OWN remote URL (not image 0's), with no local path.
+    expect(attachments[1].path).toBeUndefined();
+    expect(attachments[1].url).toBe(remote);
+    expect(attachments[1].index).toBe(1);
+    expect(attachments[1].mime).toBe("image/png");
+  });
+
+  it("[failed-remote, local]: order preserved, no cross-index mis-pairing", () => {
+    const remote = "https://cdn.example.com/a.png";
+    const local = "/tmp/openclaw/octo-media/b.jpg";
+    const payload = buildPayload([remote, local]);
+
+    expect(payload.MediaPaths).toEqual([undefined, local]);
+    expect(payload.MediaUrls).toEqual([remote, local]);
+
+    const attachments = normalizeMediaAttachments(payload as never);
+    expect(attachments).toHaveLength(2);
+    // Image 0: failed remote → URL-only, keeps its remote URL and index 0.
+    expect(attachments[0].path).toBeUndefined();
+    expect(attachments[0].url).toBe(remote);
+    expect(attachments[0].mime).toBe("image/png");
+    // Image 1: local → fs path, NOT paired with image 0's remote URL.
+    expect(attachments[1].path).toBe(local);
+    expect(attachments[1].url).toBe(local);
+    expect(attachments[1].mime).toBe("image/jpeg");
+  });
+
+  it("all-local: every attachment is an fs path read locally", () => {
+    const a = "/tmp/openclaw/octo-media/a.jpg";
+    const b = "/tmp/openclaw/octo-media/b.png";
+    const payload = buildPayload([a, b]);
+
+    const attachments = normalizeMediaAttachments(payload as never);
+    expect(attachments).toHaveLength(2);
+    expect(attachments.map((x) => x.path)).toEqual([a, b]);
+  });
+
+  it("all-failed (every remote): Core takes the URL branch, references survive", () => {
+    const a = "https://cdn.example.com/a.png";
+    const b = "http://cdn.example.com/b.png";
+    const payload = buildPayload([a, b]);
+
+    // No local path anywhere → MediaPaths undefined → Core uses MediaUrls branch.
+    expect(payload.MediaPaths).toBeUndefined();
+    const attachments = normalizeMediaAttachments(payload as never);
+    expect(attachments).toHaveLength(2);
+    expect(attachments.every((x) => x.path === undefined)).toBe(true);
+    expect(attachments.map((x) => x.url)).toEqual([a, b]);
   });
 });
 

--- a/src/inbound.ts
+++ b/src/inbound.ts
@@ -635,25 +635,41 @@ export function resolveInboundMediaList(args: {
 }
 
 /**
- * Derive the inbound MediaPaths list: ONLY local fs paths under Core's allowed
- * media root. Core treats MediaPaths as local fs inputs (normalizeAttachments
- * prefers them and reads via fs), so a RichText image whose download failed and
- * fell back to its remote URL must NOT enter MediaPaths — otherwise Core would
- * try to fs-read a remote URL string and reject it as `blocked`/unreadable.
- * Failed-fallback remote URLs are excluded here and instead travel via MediaUrls
- * (Core does not treat MediaUrls as a local fs input), preserving the reference
- * without violating the "remote media must not be passed as a local path"
- * convention.
+ * Derive the inbound MediaPaths list, kept the SAME LENGTH and INDEX-ALIGNED
+ * with resolveInboundMediaList (the MediaUrls list). This alignment is load-
+ * bearing: Core's normalizeAttachments path-branch pairs the two arrays
+ * positionally — MediaPaths[i] supplies the local fs path and MediaUrls[i] the
+ * URL for the SAME image i:
+ *   pathsFromArray.map((value, index) => ({ path: value, url: urls?.[index] ?? ctx.MediaUrl, ... }))
+ * If the arrays drift in length or index, Core pairs a local path with another
+ * image's URL (e.g. local image B inherits failed image A's remote URL), so a
+ * later blocked/deleted local file would fall back to the WRONG remote image.
+ *
+ * A RichText image whose download FAILED falls back to its remote URL. A remote
+ * URL must never be handed to Core as a local fs path — Core would fs-read the
+ * URL string and reject it as `blocked`/unreadable (the #58 bug). So rather than
+ * DROPPING failed entries (which shifts every later index and breaks alignment),
+ * we keep the slot and place an `undefined` placeholder at each failed (remote)
+ * index. Core's normalizeOptionalString turns the placeholder into no path, and
+ * its `.filter((e) => Boolean(e.path ?? normalizeOptionalString(e.url)))` keeps
+ * that index as a URL-only attachment carrying the remote URL (from MediaUrls[i]).
+ * Downloaded entries keep their local path and are read via fs.
+ *
+ * Returns undefined only when there is no local path at all (every image
+ * failed); Core then takes the MediaUrls (URL) branch with the same entries.
  */
 export function resolveInboundMediaPaths(args: {
   isFileMessage: boolean;
   inboundMediaUrl?: string;
   inboundMediaUrls?: string[];
-}): string[] | undefined {
+}): (string | undefined)[] | undefined {
   const list = resolveInboundMediaList(args);
   if (!list) return undefined;
-  const localOnly = list.filter((entry) => !isRemoteMediaUrl(entry));
-  return localOnly.length > 0 ? localOnly : undefined;
+  const hasLocal = list.some((entry) => !isRemoteMediaUrl(entry));
+  if (!hasLocal) return undefined;
+  // Equal length + index-aligned with MediaUrls; remote (failed) slots become
+  // undefined placeholders so they survive as URL-only attachments in Core.
+  return list.map((entry) => (isRemoteMediaUrl(entry) ? undefined : entry));
 }
 
 /** Best-effort cleanup of inbound media temp files older than 1 hour */
@@ -2103,16 +2119,17 @@ export async function handleInboundMessage(params: {
     CommandAuthorized: commandAuthorized,
     MediaUrl: isFileMessage ? undefined : inboundMediaUrl,
     // MediaPath(s): inbound media is downloaded to a Core-allowed local root, so
-    // pass ONLY local fs path(s) here. normalizeAttachments prefers MediaPaths
-    // and reads them via fs — avoiding the readRemoteMediaBuffer http path that
-    // throws MediaFetchError on bare local paths. A RichText image whose
-    // download FAILED falls back to its remote URL (see inboundMediaUrls build
-    // above); that remote URL must NOT enter MediaPaths/MediaPath, or Core would
-    // try to fs-read a remote URL string and reject it as blocked/unreadable.
-    // resolveInboundMediaPaths filters out those remote fallbacks; they instead
-    // travel via MediaUrls (Core does not treat MediaUrls as a local fs input),
-    // preserving the reference without violating "remote media must not be passed
-    // as a local path".
+    // pass local fs path(s) here. normalizeAttachments prefers MediaPaths and
+    // reads them via fs — avoiding the readRemoteMediaBuffer http path that
+    // throws MediaFetchError on bare local paths. MediaPaths is kept the SAME
+    // LENGTH and INDEX-ALIGNED with MediaUrls below: Core's path-branch pairs
+    // the two arrays positionally (path[i] ↔ url[i] = same image i). A RichText
+    // image whose download FAILED falls back to its remote URL; that slot gets
+    // an `undefined` placeholder in MediaPaths (not dropped — dropping would
+    // shift later indices and mis-pair a local path with another image's remote
+    // URL). Core keeps the placeholder index as a URL-only attachment via
+    // `.filter((e) => Boolean(e.path ?? e.url))`, so the remote reference
+    // survives without Core fs-reading a remote URL string (the #58 bug).
     MediaPath: (() => {
       if (isFileMessage) return undefined;
       return isRemoteMediaUrl(inboundMediaUrl) ? undefined : inboundMediaUrl;
@@ -2121,15 +2138,14 @@ export async function handleInboundMessage(params: {
     MediaUrls: resolveInboundMediaList({ isFileMessage, inboundMediaUrl, inboundMediaUrls }),
     MediaTypes: (() => {
       if (isFileMessage) return undefined;
-      // Align MediaTypes with whichever list Core iterates: MediaPaths when any
-      // local path is present (Core's preferred branch), else the MediaUrls
-      // list. Keeping mime indices aligned with the driving list avoids pairing
-      // a local path with the wrong (failed remote sibling's) mime.
-      const localPaths = resolveInboundMediaPaths({ isFileMessage, inboundMediaUrl, inboundMediaUrls });
-      const driving = localPaths ?? resolveInboundMediaList({ isFileMessage, inboundMediaUrl, inboundMediaUrls });
-      if (driving?.length) {
-        if (inboundMediaUrls?.length) return driving.map((u) => guessMime(u, "image/jpeg"));
-        return resolved.mediaType ? [resolved.mediaType] : driving.map((u) => guessMime(u, "image/jpeg"));
+      // Align MediaTypes index-for-index with the MediaUrls/MediaPaths arrays.
+      // The MediaUrls list has a real entry (local path or remote URL) at every
+      // index, so deriving mime from it keeps each attachment's mime correct
+      // even when that index is a remote (failed) placeholder in MediaPaths.
+      const aligned = resolveInboundMediaList({ isFileMessage, inboundMediaUrl, inboundMediaUrls });
+      if (aligned?.length) {
+        if (inboundMediaUrls?.length) return aligned.map((u) => guessMime(u, "image/jpeg"));
+        return resolved.mediaType ? [resolved.mediaType] : aligned.map((u) => guessMime(u, "image/jpeg"));
       }
       return resolved.mediaType ? [resolved.mediaType] : undefined;
     })(),

--- a/src/inbound.ts
+++ b/src/inbound.ts
@@ -617,59 +617,60 @@ export function isRemoteMediaUrl(entry: string | undefined): boolean {
 }
 
 /**
- * Derive the inbound media list passed to Core as MediaUrls (backward-compatible
- * reference list). File messages carry no inline media here. RichText(=14)
- * yields every image entry (locally-downloaded path, or — on a per-image
- * download failure — the remote fallback URL so the reference survives); other
- * types yield the single current local media path (no remote history URLs).
+ * One inbound media image: its locally-downloaded fs path (if the download
+ * succeeded) paired with the original remote http(s) URL fallback (always
+ * fetchable). The remote URL lets Core re-fetch the image whenever the local
+ * path is unavailable, without ever fs-reading a remote URL string.
  */
-export function resolveInboundMediaList(args: {
-  isFileMessage: boolean;
-  inboundMediaUrl?: string;
-  inboundMediaUrls?: string[];
-}): string[] | undefined {
-  const { isFileMessage, inboundMediaUrl, inboundMediaUrls } = args;
-  if (isFileMessage) return undefined;
-  if (inboundMediaUrls?.length) return inboundMediaUrls;
-  return inboundMediaUrl ? [inboundMediaUrl] : undefined;
+export interface InboundMediaItem {
+  /** Local fs path under Core's allowed root; undefined when the download failed. */
+  localPath?: string;
+  /** Original remote http(s) URL — the always-reachable fallback for this image. */
+  remoteUrl: string;
 }
 
 /**
- * Derive the inbound MediaPaths list, kept the SAME LENGTH and INDEX-ALIGNED
- * with resolveInboundMediaList (the MediaUrls list). This alignment is load-
- * bearing: Core's normalizeAttachments path-branch pairs the two arrays
- * positionally — MediaPaths[i] supplies the local fs path and MediaUrls[i] the
- * URL for the SAME image i:
- *   pathsFromArray.map((value, index) => ({ path: value, url: urls?.[index] ?? ctx.MediaUrl, ... }))
- * If the arrays drift in length or index, Core pairs a local path with another
- * image's URL (e.g. local image B inherits failed image A's remote URL), so a
- * later blocked/deleted local file would fall back to the WRONG remote image.
+ * Derive the inbound MediaPaths list (Core's preferred, fs-read branch).
  *
- * A RichText image whose download FAILED falls back to its remote URL. A remote
- * URL must never be handed to Core as a local fs path — Core would fs-read the
- * URL string and reject it as `blocked`/unreadable (the #58 bug). So rather than
- * DROPPING failed entries (which shifts every later index and breaks alignment),
- * we keep the slot and place an `undefined` placeholder at each failed (remote)
- * index. Core's normalizeOptionalString turns the placeholder into no path, and
- * its `.filter((e) => Boolean(e.path ?? normalizeOptionalString(e.url)))` keeps
- * that index as a URL-only attachment carrying the remote URL (from MediaUrls[i]).
- * Downloaded entries keep their local path and are read via fs.
+ * ALL-OR-NOTHING: emit MediaPaths only when EVERY image downloaded to a local
+ * path. The returned array is then compact (string[], no holes) and same-order
+ * with MediaUrls. If ANY image failed, return undefined so the whole message
+ * falls back to the MediaUrls (remote http) branch instead.
  *
- * Returns undefined only when there is no local path at all (every image
- * failed); Core then takes the MediaUrls (URL) branch with the same entries.
+ * This sidesteps the sparse-array trap: Core consumes MediaPaths through two
+ * paths with different contracts — normalizeAttachments pairs MediaPaths[i] with
+ * MediaUrls[i] positionally, while sandbox staging (resolveRawPaths → trim each
+ * raw) treats MediaPaths as a plain string[] and CRASHES on an undefined slot.
+ * Never emitting a non-string MediaPaths element keeps both consumers safe.
  */
-export function resolveInboundMediaPaths(args: {
-  isFileMessage: boolean;
-  inboundMediaUrl?: string;
-  inboundMediaUrls?: string[];
-}): (string | undefined)[] | undefined {
-  const list = resolveInboundMediaList(args);
-  if (!list) return undefined;
-  const hasLocal = list.some((entry) => !isRemoteMediaUrl(entry));
-  if (!hasLocal) return undefined;
-  // Equal length + index-aligned with MediaUrls; remote (failed) slots become
-  // undefined placeholders so they survive as URL-only attachments in Core.
-  return list.map((entry) => (isRemoteMediaUrl(entry) ? undefined : entry));
+export function resolveInboundMediaPaths(
+  items: InboundMediaItem[] | undefined,
+): string[] | undefined {
+  if (!items?.length) return undefined;
+  if (!items.every((it) => it.localPath)) return undefined;
+  return items.map((it) => it.localPath!);
+}
+
+/**
+ * Derive the inbound media list passed to Core as MediaUrls.
+ *
+ * Mirrors the MediaPaths all-or-nothing decision so the two arrays never drift:
+ * - All images downloaded → local fs paths (same values as MediaPaths; Core
+ *   fs-reads them via the MediaPaths branch).
+ * - Any download failed → every image's ORIGINAL remote http(s) URL. MediaPaths
+ *   is undefined in this case, so Core takes the URL branch and http-fetches all
+ *   of them — including the ones that did download locally (the local-path
+ *   optimisation is sacrificed for this message to guarantee correctness and to
+ *   avoid handing a bare local path to the http fetch, which was the #58 bug).
+ */
+export function resolveInboundMediaList(
+  items: InboundMediaItem[] | undefined,
+): string[] | undefined {
+  if (!items?.length) return undefined;
+  const allLocal = items.every((it) => it.localPath);
+  return allLocal
+    ? items.map((it) => it.localPath!)
+    : items.map((it) => it.remoteUrl);
 }
 
 /** Best-effort cleanup of inbound media temp files older than 1 hour */
@@ -1418,8 +1419,10 @@ export async function handleInboundMessage(params: {
   const resolved = resolveContent(message.payload, account.config.apiUrl, log, account.config.cdnUrl);
   let rawBody = resolved.text;
   let inboundMediaUrl = resolved.mediaUrl;
-  // RichText(=14) 图文混排可携带多张图：在此累积本地化后的图片路径。
-  let inboundMediaUrls: string[] | undefined;
+  // Inbound inline media images, each carrying its local download path (if the
+  // download succeeded) and its original remote http(s) URL fallback. Drives the
+  // MediaPaths/MediaUrls payload below. RichText(=14) 图文混排 may carry several.
+  let inboundMediaItems: InboundMediaItem[] | undefined;
 
   // Opportunistic uid→name cache fill from MultipleForward payloads
   if (message.payload?.type === MessageType.MultipleForward && Array.isArray(message.payload.users)) {
@@ -1432,22 +1435,26 @@ export async function handleInboundMessage(params: {
   // local files instead of remote URLs (avoids hang on large/slow downloads in Core)
   const mediaDownloadTypes = [MessageType.Image, MessageType.GIF, MessageType.Voice, MessageType.Video];
   if (inboundMediaUrl && message.payload?.type != null && mediaDownloadTypes.includes(message.payload.type)) {
-    const localPath = await downloadMediaToLocal(inboundMediaUrl, resolved.mediaType, log);
+    const remoteUrl = inboundMediaUrl; // original http(s) URL (always fetchable)
+    const localPath = await downloadMediaToLocal(remoteUrl, resolved.mediaType, log);
     inboundMediaUrl = localPath; // undefined on failure — graceful degradation
+    inboundMediaItems = [{ localPath, remoteUrl }];
   }
   // RichText(=14): download every embedded image to a local temp file (same
-  // rationale as single-media types above). On a per-image download failure,
-  // fall back to the REMOTE url so the agent keeps a usable reference — unlike
-  // single-media types where the url survives inside rawBody, the RichText body
-  // is only plain text with [图片] placeholders, so dropping the url loses it.
+  // rationale as single-media types above). Each image keeps its original remote
+  // http(s) URL so Core can re-fetch it whenever the local download failed —
+  // unlike single-media types where the url survives inside rawBody, the RichText
+  // body is only plain text with [图片] placeholders, so the url must travel as
+  // structured media or it is lost.
   if (message.payload?.type === MessageType.RichText && resolved.mediaUrls?.length) {
-    const resolvedImageUrls: string[] = [];
+    const items: InboundMediaItem[] = [];
     for (const remoteUrl of resolved.mediaUrls) {
       const localPath = await downloadMediaToLocal(remoteUrl, guessMime(remoteUrl, "image/jpeg"), log);
-      resolvedImageUrls.push(localPath ?? remoteUrl);
+      items.push({ localPath, remoteUrl });
     }
-    inboundMediaUrls = resolvedImageUrls.length > 0 ? resolvedImageUrls : undefined;
-    inboundMediaUrl = inboundMediaUrls?.[0];
+    inboundMediaItems = items.length > 0 ? items : undefined;
+    // History reference: prefer the first image's local path, else its remote URL.
+    inboundMediaUrl = items[0]?.localPath ?? items[0]?.remoteUrl;
   }
   // Inline text file content if possible, or stream large files to temp
   const isFileMessage = message.payload?.type === MessageType.File;
@@ -2117,35 +2124,39 @@ export async function handleInboundMessage(params: {
     CommandBody: commandBody,
     BodyForCommands: commandBody,
     CommandAuthorized: commandAuthorized,
-    MediaUrl: isFileMessage ? undefined : inboundMediaUrl,
-    // MediaPath(s): inbound media is downloaded to a Core-allowed local root, so
-    // pass local fs path(s) here. normalizeAttachments prefers MediaPaths and
-    // reads them via fs — avoiding the readRemoteMediaBuffer http path that
-    // throws MediaFetchError on bare local paths. MediaPaths is kept the SAME
-    // LENGTH and INDEX-ALIGNED with MediaUrls below: Core's path-branch pairs
-    // the two arrays positionally (path[i] ↔ url[i] = same image i). A RichText
-    // image whose download FAILED falls back to its remote URL; that slot gets
-    // an `undefined` placeholder in MediaPaths (not dropped — dropping would
-    // shift later indices and mis-pair a local path with another image's remote
-    // URL). Core keeps the placeholder index as a URL-only attachment via
-    // `.filter((e) => Boolean(e.path ?? e.url))`, so the remote reference
-    // survives without Core fs-reading a remote URL string (the #58 bug).
+    // Scalar MediaUrl/MediaPath mirror the array all-or-nothing decision so a
+    // single-media consumer never sees a local path while the arrays fell back
+    // to remote URLs (and vice versa). All-local → first local path; mixed-fail
+    // → first remote URL (matching MediaUrls[0], never an unstaged local path).
+    MediaUrl: isFileMessage ? undefined : (resolveInboundMediaList(inboundMediaItems)?.[0] ?? inboundMediaUrl),
+    // MediaPath(s) / MediaUrls — ALL-OR-NOTHING (see resolveInboundMediaPaths):
+    // inbound media is downloaded to a Core-allowed local root, so when EVERY
+    // image succeeds we pass the compact local fs paths via MediaPath(s). Core's
+    // normalizeAttachments prefers MediaPaths and fs-reads them, avoiding the
+    // readRemoteMediaBuffer http path that throws MediaFetchError on bare local
+    // paths (the #58 bug). If ANY image download failed we emit NO MediaPaths
+    // (undefined) and put every image's original remote http(s) URL in MediaUrls;
+    // Core then takes the URL branch and http-fetches them. This never produces a
+    // sparse MediaPaths array, so the sandbox staging path (resolveRawPaths →
+    // raw.trim()) cannot crash on an undefined slot.
     MediaPath: (() => {
       if (isFileMessage) return undefined;
-      return isRemoteMediaUrl(inboundMediaUrl) ? undefined : inboundMediaUrl;
+      const paths = resolveInboundMediaPaths(inboundMediaItems);
+      return paths?.[0];
     })(),
-    MediaPaths: resolveInboundMediaPaths({ isFileMessage, inboundMediaUrl, inboundMediaUrls }),
-    MediaUrls: resolveInboundMediaList({ isFileMessage, inboundMediaUrl, inboundMediaUrls }),
+    MediaPaths: isFileMessage ? undefined : resolveInboundMediaPaths(inboundMediaItems),
+    MediaUrls: isFileMessage ? undefined : resolveInboundMediaList(inboundMediaItems),
     MediaTypes: (() => {
       if (isFileMessage) return undefined;
       // Align MediaTypes index-for-index with the MediaUrls/MediaPaths arrays.
-      // The MediaUrls list has a real entry (local path or remote URL) at every
-      // index, so deriving mime from it keeps each attachment's mime correct
-      // even when that index is a remote (failed) placeholder in MediaPaths.
-      const aligned = resolveInboundMediaList({ isFileMessage, inboundMediaUrl, inboundMediaUrls });
-      if (aligned?.length) {
-        if (inboundMediaUrls?.length) return aligned.map((u) => guessMime(u, "image/jpeg"));
-        return resolved.mediaType ? [resolved.mediaType] : aligned.map((u) => guessMime(u, "image/jpeg"));
+      // Both helpers return same-length, same-order lists, so deriving mime from
+      // the MediaUrls list keeps each attachment's mime correct.
+      const list = resolveInboundMediaList(inboundMediaItems);
+      if (list?.length) {
+        if (inboundMediaItems && inboundMediaItems.length > 1) {
+          return list.map((u) => guessMime(u, "image/jpeg"));
+        }
+        return resolved.mediaType ? [resolved.mediaType] : list.map((u) => guessMime(u, "image/jpeg"));
       }
       return resolved.mediaType ? [resolved.mediaType] : undefined;
     })(),

--- a/src/inbound.ts
+++ b/src/inbound.ts
@@ -603,9 +603,30 @@ export function calcDownloadTimeout(fileSize?: number): number {
   return Math.min(MAX_TIMEOUT, Math.max(MIN_TIMEOUT, computed));
 }
 
-const MEDIA_TEMP_DIR = join("/tmp", "octo-media");
+// Download inbound media under Core's allowed media root (/tmp/openclaw) so
+// that isInboundPathAllowed accepts the local path passed via MediaPaths.
+// A bare /tmp/octo-media dir is outside buildMediaLocalRoots and would be
+// rejected as `blocked`.
+const MEDIA_TEMP_DIR = join("/tmp", "openclaw", "octo-media");
 const MAX_MEDIA_DOWNLOAD_SIZE = 20 * 1024 * 1024; // 20MB cap for inbound media
 const MEDIA_DOWNLOAD_TIMEOUT = 120_000; // 120 seconds
+
+/**
+ * Derive the inbound media list passed to Core as both MediaPaths (primary,
+ * fs-read) and MediaUrls (backward-compatible). File messages carry no inline
+ * media here. RichText(=14) yields every locally-downloaded image; other types
+ * yield the single current local media path (no remote history URLs).
+ */
+export function resolveInboundMediaList(args: {
+  isFileMessage: boolean;
+  inboundMediaUrl?: string;
+  inboundMediaUrls?: string[];
+}): string[] | undefined {
+  const { isFileMessage, inboundMediaUrl, inboundMediaUrls } = args;
+  if (isFileMessage) return undefined;
+  if (inboundMediaUrls?.length) return inboundMediaUrls;
+  return inboundMediaUrl ? [inboundMediaUrl] : undefined;
+}
 
 /** Best-effort cleanup of inbound media temp files older than 1 hour */
 async function cleanupMediaTempFiles(): Promise<void> {
@@ -2053,13 +2074,14 @@ export async function handleInboundMessage(params: {
     BodyForCommands: commandBody,
     CommandAuthorized: commandAuthorized,
     MediaUrl: isFileMessage ? undefined : inboundMediaUrl,
-    MediaUrls: (() => {
-      if (isFileMessage) return undefined;
-      // RichText(=14): pass every locally-downloaded image (図文混排 multi-image).
-      if (inboundMediaUrls?.length) return inboundMediaUrls;
-      // Other types: only pass current message's local media path (no remote history URLs)
-      return inboundMediaUrl ? [inboundMediaUrl] : undefined;
-    })(),
+    // MediaPath(s): inbound media is downloaded to a Core-allowed local root,
+    // so pass the local fs path(s). normalizeAttachments prefers MediaPaths and
+    // reads via fs — avoiding the readRemoteMediaBuffer http path that throws
+    // MediaFetchError on bare local paths. MediaUrls below is kept at the same
+    // value for backward-compatible consumers.
+    MediaPath: isFileMessage ? undefined : inboundMediaUrl,
+    MediaPaths: resolveInboundMediaList({ isFileMessage, inboundMediaUrl, inboundMediaUrls }),
+    MediaUrls: resolveInboundMediaList({ isFileMessage, inboundMediaUrl, inboundMediaUrls }),
     MediaTypes: (() => {
       if (isFileMessage) return undefined;
       if (inboundMediaUrls?.length) {

--- a/src/inbound.ts
+++ b/src/inbound.ts
@@ -611,11 +611,17 @@ const MEDIA_TEMP_DIR = join("/tmp", "openclaw", "octo-media");
 const MAX_MEDIA_DOWNLOAD_SIZE = 20 * 1024 * 1024; // 20MB cap for inbound media
 const MEDIA_DOWNLOAD_TIMEOUT = 120_000; // 120 seconds
 
+/** True when a media entry is a remote http(s) URL rather than a local fs path. */
+export function isRemoteMediaUrl(entry: string | undefined): boolean {
+  return !!entry && /^https?:\/\//i.test(entry);
+}
+
 /**
- * Derive the inbound media list passed to Core as both MediaPaths (primary,
- * fs-read) and MediaUrls (backward-compatible). File messages carry no inline
- * media here. RichText(=14) yields every locally-downloaded image; other types
- * yield the single current local media path (no remote history URLs).
+ * Derive the inbound media list passed to Core as MediaUrls (backward-compatible
+ * reference list). File messages carry no inline media here. RichText(=14)
+ * yields every image entry (locally-downloaded path, or — on a per-image
+ * download failure — the remote fallback URL so the reference survives); other
+ * types yield the single current local media path (no remote history URLs).
  */
 export function resolveInboundMediaList(args: {
   isFileMessage: boolean;
@@ -626,6 +632,28 @@ export function resolveInboundMediaList(args: {
   if (isFileMessage) return undefined;
   if (inboundMediaUrls?.length) return inboundMediaUrls;
   return inboundMediaUrl ? [inboundMediaUrl] : undefined;
+}
+
+/**
+ * Derive the inbound MediaPaths list: ONLY local fs paths under Core's allowed
+ * media root. Core treats MediaPaths as local fs inputs (normalizeAttachments
+ * prefers them and reads via fs), so a RichText image whose download failed and
+ * fell back to its remote URL must NOT enter MediaPaths — otherwise Core would
+ * try to fs-read a remote URL string and reject it as `blocked`/unreadable.
+ * Failed-fallback remote URLs are excluded here and instead travel via MediaUrls
+ * (Core does not treat MediaUrls as a local fs input), preserving the reference
+ * without violating the "remote media must not be passed as a local path"
+ * convention.
+ */
+export function resolveInboundMediaPaths(args: {
+  isFileMessage: boolean;
+  inboundMediaUrl?: string;
+  inboundMediaUrls?: string[];
+}): string[] | undefined {
+  const list = resolveInboundMediaList(args);
+  if (!list) return undefined;
+  const localOnly = list.filter((entry) => !isRemoteMediaUrl(entry));
+  return localOnly.length > 0 ? localOnly : undefined;
 }
 
 /** Best-effort cleanup of inbound media temp files older than 1 hour */
@@ -2074,18 +2102,34 @@ export async function handleInboundMessage(params: {
     BodyForCommands: commandBody,
     CommandAuthorized: commandAuthorized,
     MediaUrl: isFileMessage ? undefined : inboundMediaUrl,
-    // MediaPath(s): inbound media is downloaded to a Core-allowed local root,
-    // so pass the local fs path(s). normalizeAttachments prefers MediaPaths and
-    // reads via fs — avoiding the readRemoteMediaBuffer http path that throws
-    // MediaFetchError on bare local paths. MediaUrls below is kept at the same
-    // value for backward-compatible consumers.
-    MediaPath: isFileMessage ? undefined : inboundMediaUrl,
-    MediaPaths: resolveInboundMediaList({ isFileMessage, inboundMediaUrl, inboundMediaUrls }),
+    // MediaPath(s): inbound media is downloaded to a Core-allowed local root, so
+    // pass ONLY local fs path(s) here. normalizeAttachments prefers MediaPaths
+    // and reads them via fs — avoiding the readRemoteMediaBuffer http path that
+    // throws MediaFetchError on bare local paths. A RichText image whose
+    // download FAILED falls back to its remote URL (see inboundMediaUrls build
+    // above); that remote URL must NOT enter MediaPaths/MediaPath, or Core would
+    // try to fs-read a remote URL string and reject it as blocked/unreadable.
+    // resolveInboundMediaPaths filters out those remote fallbacks; they instead
+    // travel via MediaUrls (Core does not treat MediaUrls as a local fs input),
+    // preserving the reference without violating "remote media must not be passed
+    // as a local path".
+    MediaPath: (() => {
+      if (isFileMessage) return undefined;
+      return isRemoteMediaUrl(inboundMediaUrl) ? undefined : inboundMediaUrl;
+    })(),
+    MediaPaths: resolveInboundMediaPaths({ isFileMessage, inboundMediaUrl, inboundMediaUrls }),
     MediaUrls: resolveInboundMediaList({ isFileMessage, inboundMediaUrl, inboundMediaUrls }),
     MediaTypes: (() => {
       if (isFileMessage) return undefined;
-      if (inboundMediaUrls?.length) {
-        return inboundMediaUrls.map((u) => guessMime(u, "image/jpeg"));
+      // Align MediaTypes with whichever list Core iterates: MediaPaths when any
+      // local path is present (Core's preferred branch), else the MediaUrls
+      // list. Keeping mime indices aligned with the driving list avoids pairing
+      // a local path with the wrong (failed remote sibling's) mime.
+      const localPaths = resolveInboundMediaPaths({ isFileMessage, inboundMediaUrl, inboundMediaUrls });
+      const driving = localPaths ?? resolveInboundMediaList({ isFileMessage, inboundMediaUrl, inboundMediaUrls });
+      if (driving?.length) {
+        if (inboundMediaUrls?.length) return driving.map((u) => guessMime(u, "image/jpeg"));
+        return resolved.mediaType ? [resolved.mediaType] : driving.map((u) => guessMime(u, "image/jpeg"));
       }
       return resolved.mediaType ? [resolved.mediaType] : undefined;
     })(),


### PR DESCRIPTION
## Problem

octo 插件接收图片后，Core media-understanding 全部抛 `MediaFetchError` —— bot 完全读不到任何入站图片（含 RichText=14 图文混排）。

根因：`finalizeInboundContext` 把裸本地路径只放进 `MediaUrls`（没设 `MediaPaths`）。Core `normalizeAttachments` 把它当远程 URL → `MediaAttachmentCache.getBuffer` 因 path 空落到 `readRemoteMediaBuffer`（纯 http）→ `new URL` guard 失败抛 `MediaFetchError`。且下载目录 `/tmp/octo-media` 不在 Core 默认允许根（`buildMediaLocalRoots`），光改 `MediaPaths` 也会被 `isInboundPathAllowed` 拦成 `blocked` → 两处必须一起改。

## Fix (最小变更，两处一起)

- **A. 下载目录入白名单**：`MEDIA_TEMP_DIR` 从 `/tmp/octo-media` → `/tmp/openclaw/octo-media`。`/tmp/openclaw` 是 Core `buildMediaLocalRoots` 的首个默认根（`POSIX_OPENCLAW_TMP_DIR`），`isInboundPathAllowed` 的 `matchesRootPattern` 接受其下任意子路径。
- **B. 设 `MediaPath`/`MediaPaths`**：与 `MediaUrl`/`MediaUrls`/`MediaTypes` 对齐。`MediaPaths` 是 `normalizeAttachments` 的优先分支，命中走本地 fs 读取，不再 http fetch。`MediaUrls` 保留同值兼容旧消费方。抽出 `resolveInboundMediaList` 纯函数消除重复并便于单测。

## 零回归依据

`MediaPaths` 命中本地 fs 分支；文件落 Core 默认允许根 `/tmp/openclaw` 通过 `isInboundPathAllowed`；不碰发送侧与其他消息类型（File 消息 / RichText / 单图全覆盖）。

## 验证

- `npm run type-check` ✅
- `npx vitest run` ✅ 879 passed（含新增 5 个 `resolveInboundMediaList` 用例 + 更新的下载目录断言）

Fixes #58
