### PR TITLE
feat(octo/mention): invalidate mention-pref cache on mention_pref_updated event + drop positive TTL to 30s

### DIFF
--- a/src/inbound-mention-gate.test.ts
+++ b/src/inbound-mention-gate.test.ts
@@ -3,7 +3,7 @@ import { ChannelType, MessageType } from "./types.js";
 import { handleInboundMessage } from "./inbound.js";
 import { setOctoRuntime } from "./runtime.js";
 import { registerKnownBot, _clearKnownBots } from "./bot-registry.js";
-import { _clearMentionPrefCache, _setMentionPrefEntry } from "./mention-prefs.js";
+import { _clearMentionPrefCache, _setMentionPrefEntry, _hasMentionPrefEntry } from "./mention-prefs.js";
 import type { ResolvedOctoAccount } from "./accounts.js";
 
 /**
@@ -471,5 +471,77 @@ describe("inbound mention-gate 免@ relaxation (P1: human-only)", () => {
     expect(memberRobotMap.has(UNKNOWN_UID)).toBe(false);
     expect(dispatch).not.toHaveBeenCalled();
     expect(sends.length).toBe(0);
+  });
+});
+
+describe("inbound mention_pref_updated event → cache invalidation (GH#60)", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    _clearKnownBots();
+    _clearMentionPrefCache();
+  });
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    _clearKnownBots();
+    _clearMentionPrefCache();
+  });
+
+  function makeMentionPrefEvent() {
+    return {
+      message_id: "evt1",
+      message_seq: 200,
+      from_uid: "system",
+      channel_id: GROUP_ID,
+      channel_type: ChannelType.Group,
+      timestamp: Math.floor(Date.now() / 1000),
+      payload: { event: { type: "mention_pref_updated", group_no: GROUP_ID } },
+    };
+  }
+
+  it("invalidates the cached (bot, group) entry and does NOT dispatch to the LLM", async () => {
+    const { dispatch } = installRuntimeStub();
+    const { sends } = installFetchStub();
+
+    // Pre-seed a stale 免@ pref for this (bot, group).
+    _setMentionPrefEntry("acct1", GROUP_ID, { no_mention: true });
+    expect(_hasMentionPrefEntry("acct1", GROUP_ID)).toBe(true);
+
+    await handleInboundMessage({
+      account: makeAccount(),
+      message: makeMentionPrefEvent() as any,
+      botUid: BOT_UID,
+      groupHistories: new Map(),
+      lastBotReplySeqMap: new Map(),
+      memberMap: new Map(),
+      uidToNameMap: new Map(),
+      groupCacheTimestamps: new Map(),
+    });
+
+    // Cache entry was dropped; event was swallowed (no LLM dispatch, no reply).
+    expect(_hasMentionPrefEntry("acct1", GROUP_ID)).toBe(false);
+    expect(dispatch).not.toHaveBeenCalled();
+    expect(sends.length).toBe(0);
+  });
+
+  it("only invalidates the targeted group, leaving other entries intact", async () => {
+    installRuntimeStub();
+    installFetchStub();
+
+    _setMentionPrefEntry("acct1", GROUP_ID, { no_mention: true });
+    _setMentionPrefEntry("acct1", "other_group", { no_mention: true });
+
+    await handleInboundMessage({
+      account: makeAccount(),
+      message: makeMentionPrefEvent() as any,
+      botUid: BOT_UID,
+      groupHistories: new Map(),
+      lastBotReplySeqMap: new Map(),
+      memberMap: new Map(),
+      uidToNameMap: new Map(),
+      groupCacheTimestamps: new Map(),
+    });
+
+    expect(_hasMentionPrefEntry("acct1", GROUP_ID)).toBe(false);
+    expect(_hasMentionPrefEntry("acct1", "other_group")).toBe(true);
   });
 });

--- a/src/inbound.ts
+++ b/src/inbound.ts
@@ -2,7 +2,7 @@ import type { OpenClawConfig } from "openclaw/plugin-sdk";
 import type { ChannelLogSink } from "openclaw/plugin-sdk/channel-contract";
 import { DEFAULT_GROUP_HISTORY_LIMIT } from "openclaw/plugin-sdk/reply-history";
 import { sendMessage, sendReadReceipt, sendTyping, getChannelMessages, getGroupMembers, getGroupMd, postJson, sendMediaMessage, inferContentType, ensureTextCharset, parseImageDimensions, parseImageDimensionsFromFile, getUploadCredentials, uploadFileToCOS, fetchUserInfo } from "./api-fetch.js";
-import { getMentionPrefFromCache } from "./mention-prefs.js";
+import { getMentionPrefFromCache, invalidateMentionPref } from "./mention-prefs.js";
 import type { ResolvedOctoAccount } from "./accounts.js";
 import type { BotMessage } from "./types.js";
 import { ChannelType, MessageType, RICH_TEXT_BLOCK_IMAGE, RICH_TEXT_BLOCK_TEXT, RICH_TEXT_IMAGE_PLACEHOLDER } from "./types.js";
@@ -1293,6 +1293,19 @@ export async function handleInboundMessage(params: {
       log,
     }).catch((err) => log?.error?.(`octo: handleThreadMdEvent failed: ${String(err)}`));
 
+    return;
+  }
+
+  // Detect mention-pref (免@偏好) update notification — invalidate the cached
+  // (bot, group) entry so the next inbound message re-pulls the fresh value, do
+  // NOT pass to LLM. Mirrors the GROUP.md early-event pattern above. The mention
+  // gate caches no_mention per (accountId, parentGroupNo); without this an owner
+  // toggling 免@ would wait up to one TTL window for the change to take effect.
+  // TTL still backstops self-healing if this event is ever dropped.
+  if (earlyEventType === "mention_pref_updated" && message.channel_id) {
+    const groupNo = extractParentGroupNo(message.channel_id);
+    invalidateMentionPref(account.accountId, groupNo);
+    log?.info?.(`octo: mention_pref_updated for ${groupNo}, cache invalidated`);
     return;
   }
 

--- a/src/mention-prefs.test.ts
+++ b/src/mention-prefs.test.ts
@@ -141,9 +141,9 @@ describe("mention-prefs", () => {
 
     it("caches a negative (no_mention=false) result with a short TTL so it re-pulls soon", async () => {
       // Negative results (genuine "needs @" OR failure fallback) must not be
-      // pinned for the full 5min positive TTL — a freshly-enabled 免@ should
-      // surface within the short negative window. We assert the entry expires
-      // well before 5min by advancing the clock past the 30s negative TTL.
+      // pinned for long — a freshly-enabled 免@ should surface within the short
+      // TTL window. We assert the entry expires by advancing the clock past the
+      // 30s negative TTL.
       vi.useFakeTimers();
       try {
         let calls = 0;
@@ -189,10 +189,14 @@ describe("mention-prefs", () => {
       }
     });
 
-    it("caches a positive (no_mention=true) result for the full 5min TTL", async () => {
+    it("caches a positive (no_mention=true) result for the 30s TTL window", async () => {
       vi.useFakeTimers();
       try {
-        const fetchMock = mockFetch(async () => jsonResponse({ no_mention: true }));
+        let calls = 0;
+        const fetchMock = mockFetch(async () => {
+          calls++;
+          return jsonResponse({ no_mention: true });
+        });
         globalThis.fetch = fetchMock;
 
         const first = await getMentionPrefFromCache({
@@ -202,10 +206,10 @@ describe("mention-prefs", () => {
           botToken: TOKEN,
         });
         expect(first).toEqual({ no_mention: true });
-        expect(fetchMock).toHaveBeenCalledTimes(1);
+        expect(calls).toBe(1);
 
-        // Past the 30s negative window but within 5min → still cached (positive TTL).
-        vi.advanceTimersByTime(60 * 1000);
+        // Just before the 30s TTL elapses → still served from cache.
+        vi.advanceTimersByTime(29 * 1000);
         const cached = await getMentionPrefFromCache({
           accountId: "acct1",
           parentGroupNo: "gpos",
@@ -213,7 +217,18 @@ describe("mention-prefs", () => {
           botToken: TOKEN,
         });
         expect(cached).toEqual({ no_mention: true });
-        expect(fetchMock).toHaveBeenCalledTimes(1);
+        expect(calls).toBe(1);
+
+        // Past the 30s TTL → re-pulls (backstop self-heal when no event arrives).
+        vi.advanceTimersByTime(2 * 1000);
+        const refreshed = await getMentionPrefFromCache({
+          accountId: "acct1",
+          parentGroupNo: "gpos",
+          apiUrl: API,
+          botToken: TOKEN,
+        });
+        expect(refreshed).toEqual({ no_mention: true });
+        expect(calls).toBe(2);
       } finally {
         vi.useRealTimers();
       }

--- a/src/mention-prefs.ts
+++ b/src/mention-prefs.ts
@@ -7,10 +7,13 @@
  * to decide, per message, whether `requireMention` should be relaxed.
  *
  * Design mirrors member-cache.ts: a plain Map with per-entry TTL, lazy
- * (pull-on-miss) refresh, and an explicit invalidate hook. There is NO
- * push/event branch — the backend (octo-server#237) exposes only the
- * GET /v1/bot/groups/:group_no/mention_pref pull endpoint; there is no
- * config push bus. Edits propagate within at most one TTL window.
+ * (pull-on-miss) refresh, and an explicit invalidate hook. Freshness is driven
+ * primarily by an event: the backend (octo-server#242) pushes a
+ * `mention_pref_updated` notification when an owner toggles 免@, which inbound.ts
+ * intercepts and turns into invalidateMentionPref(accountId, groupNo) so the
+ * next message re-pulls via GET /v1/bot/groups/:group_no/mention_pref
+ * (octo-server#237). TTL is only a backstop should that event be dropped — a
+ * stale entry self-heals within one (short) TTL window.
  *
  * IMPORTANT: the cache key is the COMPOSITE `${accountId}:${parentGroupNo}`,
  * never the bare groupNo. The preference is per-bot — two bots in the same
@@ -25,13 +28,16 @@
 import { getMentionPref, fetchBotGroups, type MentionPref } from "./api-fetch.js";
 import type { LogSink } from "./types.js";
 
-const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes (positive: no_mention=true)
-// Negative results (no_mention=false) get a shorter TTL. getMentionPref returns
-// no_mention=false BOTH for a genuine "needs @" group AND as its failure
-// fallback, so a transient backend blip would otherwise pin no_mention=false
-// for a full 5min — delaying a freshly-enabled 免@ from taking effect. A short
-// negative TTL bounds that staleness while positive (免@) results, which are
-// the stable steady state, still cache for the full window.
+const CACHE_TTL_MS = 30 * 1000; // 30 seconds (positive: no_mention=true)
+// The cache is kept fresh primarily by the `mention_pref_updated` event (handled
+// in inbound.ts), which invalidates the affected (bot, group) entry the instant
+// an owner toggles 免@. TTL is now only a backstop: should that event ever be
+// dropped, a stale positive (免@) result self-heals within 30s instead of being
+// pinned for minutes. This is aligned with NEGATIVE_CACHE_TTL_MS below.
+// Negative results (no_mention=false) share the same short TTL. getMentionPref
+// returns no_mention=false BOTH for a genuine "needs @" group AND as its failure
+// fallback, so without a short TTL a transient backend blip would pin
+// no_mention=false and delay a freshly-enabled 免@ from taking effect.
 const NEGATIVE_CACHE_TTL_MS = 30 * 1000; // 30 seconds
 
 interface CacheEntry {
@@ -53,7 +59,7 @@ function cacheKey(accountId: string, parentGroupNo: string): string {
  * (account-level fallback). We still cache that, but with a shorter
  * NEGATIVE_CACHE_TTL_MS so a flaky backend doesn't hammer the API on every
  * inbound message yet a freshly-enabled 免@ surfaces within ~30s rather than
- * being masked for the full positive TTL.
+ * being masked for longer.
  */
 export async function getMentionPrefFromCache(params: {
   accountId: string;


### PR DESCRIPTION
## What

Eliminates the "owner toggles 免@ but it takes up to 5min to apply" delay by making the mention-pref cache event-driven, with TTL demoted to a backstop.

## Changes

1. **inbound.ts** — new early-event branch for `mention_pref_updated` (mirrors the existing `group_md_updated` / `thread_md_updated` pattern). Resolves the parent `group_no` via `extractParentGroupNo`, calls `invalidateMentionPref(account.accountId, groupNo)`, logs, and `return`s without passing the notification to the LLM. The next inbound message re-pulls the fresh value on cache miss.
2. **mention-prefs.ts** — `invalidateMentionPref(accountId, groupNo)` already existed (deletes the composite key `${accountId}:${parentGroupNo}`); confirmed exported. `CACHE_TTL_MS` lowered 5min → 30s to align with `NEGATIVE_CACHE_TTL_MS`. The event is now the primary freshness mechanism; TTL only self-heals (≤30s) if an event is ever dropped. Stale header doc ("NO push/event branch") updated.
3. **tests** — cover the `mention_pref_updated` branch (invalidate + no LLM dispatch + targeted-group-only); positive-TTL test updated to the new 30s window.

## Verification

- `npm run type-check` ✅
- `npm run build` ✅
- `npm test` ✅ (876 tests)

## Dependency

Depends on octo-server#242 pushing the `mention_pref_updated` event. Adapter side is complete; end-to-end verification awaits the backend.

Fixes #60