### PR TITLE
feat(inbound): 群级免at两轴AND — 消费 server effective

### DIFF
--- a/src/api-fetch.test.ts
+++ b/src/api-fetch.test.ts
@@ -1429,7 +1429,8 @@ describe("getMentionPref", () => {
 
     expect(seenUrl).toBe("http://localhost:8090/v1/bot/groups/g1/mention_pref");
     expect(seenAuth).toBe("Bearer tok");
-    expect(pref).toEqual({ no_mention: true });
+    // Old server returns only no_mention → group axis defaults allow, effective=no_mention.
+    expect(pref).toEqual({ no_mention: true, group_allow_no_mention: true, effective: true });
   });
 
   it("coerces numeric no_mention=1 to true", async () => {
@@ -1438,7 +1439,7 @@ describe("getMentionPref", () => {
     ) as unknown as typeof fetch;
     const { getMentionPref } = await import("./api-fetch.js");
     const pref = await getMentionPref({ apiUrl: "http://x", botToken: "t", groupNo: "g" });
-    expect(pref).toEqual({ no_mention: true });
+    expect(pref).toEqual({ no_mention: true, group_allow_no_mention: true, effective: true });
   });
 
   it("coerces missing/other no_mention to false", async () => {
@@ -1447,24 +1448,42 @@ describe("getMentionPref", () => {
     ) as unknown as typeof fetch;
     const { getMentionPref } = await import("./api-fetch.js");
     const pref = await getMentionPref({ apiUrl: "http://x", botToken: "t", groupNo: "g" });
-    expect(pref).toEqual({ no_mention: false });
+    expect(pref).toEqual({ no_mention: false, group_allow_no_mention: true, effective: false });
+  });
+
+  it("two-axis: server effective=false even when no_mention=true (group blocked)", async () => {
+    global.fetch = vi.fn(async () =>
+      new Response(JSON.stringify({ no_mention: true, group_allow_no_mention: false, effective: false }), { status: 200 }),
+    ) as unknown as typeof fetch;
+    const { getMentionPref } = await import("./api-fetch.js");
+    const pref = await getMentionPref({ apiUrl: "http://x", botToken: "t", groupNo: "g" });
+    expect(pref).toEqual({ no_mention: true, group_allow_no_mention: false, effective: false });
+  });
+
+  it("coerces numeric effective=1 / group_allow_no_mention=1", async () => {
+    global.fetch = vi.fn(async () =>
+      new Response(JSON.stringify({ no_mention: 1, group_allow_no_mention: 1, effective: 1 }), { status: 200 }),
+    ) as unknown as typeof fetch;
+    const { getMentionPref } = await import("./api-fetch.js");
+    const pref = await getMentionPref({ apiUrl: "http://x", botToken: "t", groupNo: "g" });
+    expect(pref).toEqual({ no_mention: true, group_allow_no_mention: true, effective: true });
   });
 
   it("returns {no_mention:false} on non-2xx", async () => {
     global.fetch = vi.fn(async () => new Response("err", { status: 404 })) as unknown as typeof fetch;
     const { getMentionPref } = await import("./api-fetch.js");
     const pref = await getMentionPref({ apiUrl: "http://x", botToken: "t", groupNo: "g" });
-    expect(pref).toEqual({ no_mention: false });
+    expect(pref).toEqual({ no_mention: false, group_allow_no_mention: true, effective: false });
   });
 
-  it("returns {no_mention:false} on network error (no throw)", async () => {
+  it("returns effective=false on network error (no throw)", async () => {
     global.fetch = vi.fn(async () => {
       throw new Error("network down");
     }) as unknown as typeof fetch;
     const { getMentionPref } = await import("./api-fetch.js");
     await expect(
       getMentionPref({ apiUrl: "http://x", botToken: "t", groupNo: "g" }),
-    ).resolves.toEqual({ no_mention: false });
+    ).resolves.toEqual({ no_mention: false, group_allow_no_mention: true, effective: false });
   });
 
   it("uses a short (≤5s) hot-path timeout, not the 30s default", async () => {

--- a/src/api-fetch.ts
+++ b/src/api-fetch.ts
@@ -509,19 +509,34 @@ export async function getGroupInfo(params: {
 /**
  * 群级免@偏好（per-group mention preference）。
  *
- * 后端 octo-server#237 暴露 GET /v1/bot/groups/:group_no/mention_pref，
- * 返回 `{ no_mention: boolean }`。`no_mention=true` 表示该群对当前 bot
- * 免@即可触发回复。
+ * 后端 octo-server#237 暴露 GET /v1/bot/groups/:group_no/mention_pref。
+ * 两个权限轴 AND 合成（octo-server YUJ-2996）：
+ *  - `no_mention`：bot 主人意愿（bot_mention_pref，无记录=false）
+ *  - `group_allow_no_mention`：群主/管理员的群级总开关（group.allow_no_mention，
+ *    无群记录回退默认 true=允许）
+ *  - `effective = no_mention && group_allow_no_mention`：最终是否免@即可触发。
+ *
+ * gate 只看 `effective`。`no_mention` / `group_allow_no_mention` 保留供观测/日志，
+ * 并为旧 server（仅返回 no_mention）提供回退。
  */
 export interface MentionPref {
+  /** bot 主人意愿轴。旧 server 只有这个字段。 */
   no_mention: boolean;
+  /** 群级总开关轴；无群记录回退 true（允许）。 */
+  group_allow_no_mention: boolean;
+  /** 两轴 AND：免@即可触发回复。gate 据此决策。 */
+  effective: boolean;
 }
 
 /**
  * 获取某群对当前 bot 的免@偏好。
  *
  * 失败（网络错误 / 非 2xx / 解析失败）一律回退到账号级行为
- * （`{ no_mention: false }`，即保持需@），绝不抛错，避免 gate 崩溃。
+ * （effective=false，即保持需@），绝不抛错，避免 gate 崩溃。
+ *
+ * 兼容旧 server：YUJ-2996 之前的 server 只返回 `{ no_mention }`，没有
+ * `effective` / `group_allow_no_mention`。此时 group 轴缺省视为 true（允许），
+ * effective 回退为 no_mention，行为与升级前完全一致（零回归）。
  */
 export async function getMentionPref(params: {
   apiUrl: string;
@@ -541,7 +556,7 @@ export async function getMentionPref(params: {
     if (!resp.ok) {
       // 404 = the mention_pref endpoint isn't deployed yet (expected during
       // rollout before octo-server#237 ships); 401 = empty/short-lived Bearer.
-      // Both are benign — we fall back to no_mention=false below — and recur on
+      // Both are benign — we fall back to effective=false below — and recur on
       // every inbound message, so logging them at error level (compounded by
       // the 30s negative-cache TTL) makes a healthy rollout look broken. Log
       // expected statuses at info and reserve error for genuinely unexpected
@@ -550,15 +565,26 @@ export async function getMentionPref(params: {
       const msg = `octo: getMentionPref(${params.groupNo}) failed: ${resp.status}`;
       if (expected) params.log?.info?.(msg);
       else params.log?.error?.(msg);
-      return { no_mention: false };
+      return { no_mention: false, group_allow_no_mention: true, effective: false };
     }
     const data = await resp.json();
     // Accept boolean `true` or numeric `1` (DB/JSON may serialize either),
     // mirroring the mention.{all,ais,humans} coercion in inbound.ts.
-    return { no_mention: data?.no_mention === true || data?.no_mention === 1 };
+    const noMention = data?.no_mention === true || data?.no_mention === 1;
+    // Old server omits group_allow_no_mention → default true (allow), so the
+    // group axis is a no-op and effective degrades to noMention (zero regression).
+    const groupAllow = data?.group_allow_no_mention === undefined
+      ? true
+      : data.group_allow_no_mention === true || data.group_allow_no_mention === 1;
+    // Old server omits effective → fall back to the AND of the two axes (which,
+    // with groupAllow defaulting true, equals noMention).
+    const effective = data?.effective === undefined
+      ? noMention && groupAllow
+      : data.effective === true || data.effective === 1;
+    return { no_mention: noMention, group_allow_no_mention: groupAllow, effective };
   } catch (err) {
     params.log?.error?.(`octo: getMentionPref(${params.groupNo}) error: ${err}`);
-    return { no_mention: false };
+    return { no_mention: false, group_allow_no_mention: true, effective: false };
   }
 }
 

--- a/src/inbound-mention-gate.test.ts
+++ b/src/inbound-mention-gate.test.ts
@@ -209,6 +209,35 @@ describe("inbound mention-gate 免@ relaxation (P1: human-only)", () => {
     expect(sends.length).toBeGreaterThan(0);
   });
 
+  it("does NOT reply to a HUMAN non-@ message when the GROUP blocked 免@ (effective=false)", async () => {
+    // Two-axis AND (YUJ-2996): the bot owner enabled no_mention, but the group
+    // admin set allow_no_mention=0 → server returns effective=false → the bot
+    // must still require an @mention. Seed the cache with the group-blocked shape.
+    _clearMentionPrefCache();
+    _setMentionPrefEntry("acct1", GROUP_ID, {
+      no_mention: true,
+      group_allow_no_mention: false,
+      effective: false,
+    });
+    const { dispatch } = installRuntimeStub();
+    const { sends } = installFetchStub();
+
+    await handleInboundMessage({
+      account: makeAccount(),
+      message: makeTextMessage(HUMAN_UID, "hello bot"),
+      botUid: BOT_UID,
+      groupHistories: new Map(),
+      lastBotReplySeqMap: new Map(),
+      memberMap: new Map(),
+      uidToNameMap: new Map(),
+      groupCacheTimestamps: new Map(),
+    });
+
+    // effective=false → requireMention stays on → non-@ message is gated.
+    expect(dispatch).not.toHaveBeenCalled();
+    expect(sends.length).toBe(0);
+  });
+
   it("does NOT reply to a KNOWN-BOT non-@ message in a 免@ group (loop guard)", async () => {
     const { dispatch } = installRuntimeStub();
     const { sends } = installFetchStub();

--- a/src/inbound.ts
+++ b/src/inbound.ts
@@ -1541,13 +1541,17 @@ export async function handleInboundMessage(params: {
   }
 
   // --- Mention gating for group messages ---
-  // Group-aware requireMention: a group admin can mark a group as 免@
-  // (no_mention=true) for this specific bot, in which case the bot replies to
-  // every message without an explicit @mention. The preference is per-(bot,
-  // group); thread (compound channel_id) messages inherit their PARENT group's
-  // preference, so we resolve the parent group_no first. On miss/expiry the
-  // cache pulls GET /v1/bot/groups/:group_no/mention_pref (TTL 5min); any
-  // failure falls back to the account-level config, so the gate never crashes.
+  // Group-aware requireMention: the bot may reply without an explicit @mention
+  // only when the server's two-axis decision says so (octo-server YUJ-2996).
+  // `effective = no_mention && group_allow_no_mention`:
+  //   - no_mention: the bot OWNER marked this (bot, group) as 免@.
+  //   - group_allow_no_mention: the GROUP owner/admin allows 免@ in this group.
+  // Either axis off → effective=false → the bot still requires an @mention.
+  // The preference is per-(bot, group); thread (compound channel_id) messages
+  // inherit their PARENT group's preference, so we resolve the parent group_no
+  // first. On miss/expiry the cache pulls GET
+  // /v1/bot/groups/:group_no/mention_pref (TTL 30s); any failure falls back to
+  // the account-level config, so the gate never crashes.
   //
   // The 免@ relaxation is HUMAN-ONLY and FAIL-CLOSED (PR#57 round-4 P1).
   // channel.ts forwards other bots' group messages into here on purpose,
@@ -1664,7 +1668,7 @@ export async function handleInboundMessage(params: {
   // Group 免@ preference lookup — deferred until AFTER mention flags are known.
   // Only consult the group pref when it can actually change the outcome:
   //   1. isGroup && accountRequiresMention — else the pref can only return
-  //      no_mention=false, with no effect.
+  //      effective=false, with no effect.
   //   2. isConfirmedHuman — the 免@ relaxation is whitelist/fail-closed: it
   //      applies ONLY to a sender the member list positively confirms is human.
   //      Unknown senders, refresh failures, and any bot keep requireMention, so
@@ -1681,13 +1685,13 @@ export async function handleInboundMessage(params: {
         parentGroupNo: extractParentGroupNo(message.channel_id!),
         apiUrl: account.config.apiUrl,
         // botToken ?? "" can yield an empty `Bearer` header; getMentionPref
-        // treats any non-2xx (incl. the resulting 401) as no_mention=false, so
+        // treats any non-2xx (incl. the resulting 401) as effective=false, so
         // the gate safely falls back to the account-level config.
         botToken: account.config.botToken ?? "",
         log,
       })
     : undefined;
-  const requireMention = mentionPref?.no_mention === true
+  const requireMention = mentionPref?.effective === true
     ? false
     : accountRequiresMention;
 

--- a/src/mention-prefs.test.ts
+++ b/src/mention-prefs.test.ts
@@ -27,6 +27,13 @@ function jsonResponse(data: unknown, status = 200): Response {
 const API = "http://localhost:8090";
 const TOKEN = "tok";
 
+// Build the full three-field MentionPref shape getMentionPref now returns.
+// When the server mock returns only `{ no_mention }`, the group axis defaults to
+// true (allow) and effective degrades to no_mention (zero regression).
+function mp(noMention: boolean, groupAllow = true, effective = noMention && groupAllow) {
+  return { no_mention: noMention, group_allow_no_mention: groupAllow, effective };
+}
+
 describe("mention-prefs", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
@@ -50,8 +57,41 @@ describe("mention-prefs", () => {
         botToken: TOKEN,
       });
 
-      expect(pref).toEqual({ no_mention: true });
+      expect(pref).toEqual(mp(true));
       expect(spy).not.toHaveBeenCalled();
+    });
+
+    it("two-axis AND: owner enabled but group blocked → effective=false", async () => {
+      // The server enforces the AND; the adapter must honor `effective`, not the
+      // raw `no_mention` axis. group_allow_no_mention=false flips effective off.
+      const fetchMock = mockFetch(async () =>
+        jsonResponse({ no_mention: true, group_allow_no_mention: false, effective: false }),
+      );
+      globalThis.fetch = fetchMock;
+
+      const result = await getMentionPrefFromCache({
+        accountId: "acct1",
+        parentGroupNo: "gblocked",
+        apiUrl: API,
+        botToken: TOKEN,
+      });
+
+      expect(result).toEqual({ no_mention: true, group_allow_no_mention: false, effective: false });
+    });
+
+    it("old server (only no_mention) → group axis defaults allow, effective=no_mention", async () => {
+      const fetchMock = mockFetch(async () => jsonResponse({ no_mention: true }));
+      globalThis.fetch = fetchMock;
+
+      const result = await getMentionPrefFromCache({
+        accountId: "acct1",
+        parentGroupNo: "glegacy",
+        apiUrl: API,
+        botToken: TOKEN,
+      });
+
+      // Missing group_allow_no_mention/effective → backward-compatible defaults.
+      expect(result).toEqual(mp(true));
     });
 
     it("pulls and caches on miss, hitting the mention_pref endpoint", async () => {
@@ -61,6 +101,7 @@ describe("mention-prefs", () => {
       });
       globalThis.fetch = fetchMock;
 
+
       const pref = await getMentionPrefFromCache({
         accountId: "acct1",
         parentGroupNo: "g200",
@@ -68,7 +109,7 @@ describe("mention-prefs", () => {
         botToken: TOKEN,
       });
 
-      expect(pref).toEqual({ no_mention: true });
+      expect(pref).toEqual(mp(true));
       expect(fetchMock).toHaveBeenCalledTimes(1);
       expect(_hasMentionPrefEntry("acct1", "g200")).toBe(true);
 
@@ -103,8 +144,8 @@ describe("mention-prefs", () => {
         botToken: "tokB",
       });
 
-      expect(a).toEqual({ no_mention: true });
-      expect(b).toEqual({ no_mention: false });
+      expect(a).toEqual(mp(true));
+      expect(b).toEqual(mp(false));
       expect(_hasMentionPrefEntry("botA", "shared")).toBe(true);
       expect(_hasMentionPrefEntry("botB", "shared")).toBe(true);
     });
@@ -121,7 +162,7 @@ describe("mention-prefs", () => {
         botToken: TOKEN,
       });
 
-      expect(pref).toEqual({ no_mention: false });
+      expect(pref).toEqual(mp(false));
       expect(fetchMock).toHaveBeenCalledTimes(1);
     });
 
@@ -136,7 +177,7 @@ describe("mention-prefs", () => {
         botToken: TOKEN,
       });
 
-      expect(pref).toEqual({ no_mention: false });
+      expect(pref).toEqual(mp(false));
     });
 
     it("caches a negative (no_mention=false) result with a short TTL so it re-pulls soon", async () => {
@@ -160,7 +201,7 @@ describe("mention-prefs", () => {
           apiUrl: API,
           botToken: TOKEN,
         });
-        expect(first).toEqual({ no_mention: false });
+        expect(first).toEqual(mp(false));
         expect(calls).toBe(1);
 
         // Just before the negative TTL elapses → still served from cache.
@@ -171,7 +212,7 @@ describe("mention-prefs", () => {
           apiUrl: API,
           botToken: TOKEN,
         });
-        expect(cached).toEqual({ no_mention: false });
+        expect(cached).toEqual(mp(false));
         expect(calls).toBe(1);
 
         // Past the 30s negative TTL → re-pulls and now sees 免@.
@@ -182,7 +223,7 @@ describe("mention-prefs", () => {
           apiUrl: API,
           botToken: TOKEN,
         });
-        expect(refreshed).toEqual({ no_mention: true });
+        expect(refreshed).toEqual(mp(true));
         expect(calls).toBe(2);
       } finally {
         vi.useRealTimers();
@@ -205,7 +246,7 @@ describe("mention-prefs", () => {
           apiUrl: API,
           botToken: TOKEN,
         });
-        expect(first).toEqual({ no_mention: true });
+        expect(first).toEqual(mp(true));
         expect(calls).toBe(1);
 
         // Just before the 30s TTL elapses → still served from cache.
@@ -216,7 +257,7 @@ describe("mention-prefs", () => {
           apiUrl: API,
           botToken: TOKEN,
         });
-        expect(cached).toEqual({ no_mention: true });
+        expect(cached).toEqual(mp(true));
         expect(calls).toBe(1);
 
         // Past the 30s TTL → re-pulls (backstop self-heal when no event arrives).
@@ -227,7 +268,7 @@ describe("mention-prefs", () => {
           apiUrl: API,
           botToken: TOKEN,
         });
-        expect(refreshed).toEqual({ no_mention: true });
+        expect(refreshed).toEqual(mp(true));
         expect(calls).toBe(2);
       } finally {
         vi.useRealTimers();

--- a/src/mention-prefs.ts
+++ b/src/mention-prefs.ts
@@ -1,10 +1,11 @@
 /**
  * Per-(bot, group) "免@偏好" cache.
  *
- * A group admin can mark a group as `no_mention=true` for a specific bot,
- * meaning that bot replies to *every* message in the group without needing
- * an explicit @mention. The mention gate in inbound.ts consults this cache
- * to decide, per message, whether `requireMention` should be relaxed.
+ * Whether a bot may reply without an explicit @mention in a group is a
+ * server-side two-axis AND decision (octo-server YUJ-2996): the bot owner's
+ * `no_mention` intent AND the group admin's `group_allow_no_mention` switch.
+ * The server collapses both into `effective`; the mention gate in inbound.ts
+ * consults this cache and relaxes `requireMention` only when `effective` is true.
  *
  * Design mirrors member-cache.ts: a plain Map with per-entry TTL, lazy
  * (pull-on-miss) refresh, and an explicit invalidate hook. Freshness is driven
@@ -28,16 +29,16 @@
 import { getMentionPref, fetchBotGroups, type MentionPref } from "./api-fetch.js";
 import type { LogSink } from "./types.js";
 
-const CACHE_TTL_MS = 30 * 1000; // 30 seconds (positive: no_mention=true)
+const CACHE_TTL_MS = 30 * 1000; // 30 seconds (positive: effective=true)
 // The cache is kept fresh primarily by the `mention_pref_updated` event (handled
 // in inbound.ts), which invalidates the affected (bot, group) entry the instant
 // an owner toggles 免@. TTL is now only a backstop: should that event ever be
 // dropped, a stale positive (免@) result self-heals within 30s instead of being
 // pinned for minutes. This is aligned with NEGATIVE_CACHE_TTL_MS below.
-// Negative results (no_mention=false) share the same short TTL. getMentionPref
-// returns no_mention=false BOTH for a genuine "needs @" group AND as its failure
-// fallback, so without a short TTL a transient backend blip would pin
-// no_mention=false and delay a freshly-enabled 免@ from taking effect.
+// Negative results (effective=false) share the same short TTL. getMentionPref
+// returns effective=false BOTH for a genuine "needs @" group (either axis off)
+// AND as its failure fallback, so without a short TTL a transient backend blip
+// would pin effective=false and delay a freshly-enabled 免@ from taking effect.
 const NEGATIVE_CACHE_TTL_MS = 30 * 1000; // 30 seconds
 
 interface CacheEntry {
@@ -55,7 +56,7 @@ function cacheKey(accountId: string, parentGroupNo: string): string {
 /**
  * Get the 免@偏好 for a (bot, group) pair, refreshing lazily on miss/expiry.
  *
- * On a fetch failure getMentionPref already returns `{ no_mention: false }`
+ * On a fetch failure getMentionPref already returns `effective: false`
  * (account-level fallback). We still cache that, but with a shorter
  * NEGATIVE_CACHE_TTL_MS so a flaky backend doesn't hammer the API on every
  * inbound message yet a freshly-enabled 免@ surfaces within ~30s rather than
@@ -83,7 +84,7 @@ export async function getMentionPrefFromCache(params: {
         }
       : undefined,
   });
-  const ttl = pref.no_mention ? CACHE_TTL_MS : NEGATIVE_CACHE_TTL_MS;
+  const ttl = pref.effective ? CACHE_TTL_MS : NEGATIVE_CACHE_TTL_MS;
   _prefCache.set(key, { pref, expiry: Date.now() + ttl });
   return pref;
 }
@@ -99,7 +100,7 @@ export function invalidateMentionPref(accountId: string, parentGroupNo: string):
  * Optional warm-up — the gate works purely lazily without it; this just
  * avoids a first-message latency bump and a thundering pull when a busy
  * group wakes up. Per-group failures are swallowed (getMentionPref already
- * falls back to no_mention=false), so a flaky backend degrades to lazy load.
+ * falls back to effective=false), so a flaky backend degrades to lazy load.
  */
 export async function preloadMentionPrefs(params: {
   accountId: string;
@@ -145,15 +146,26 @@ export function _clearMentionPrefCache(): void {
   _prefCache.clear();
 }
 
-/** Visible for testing — directly set a cache entry. */
+/**
+ * Visible for testing — directly set a cache entry.
+ *
+ * Accepts a partial pref and normalizes the two-axis shape so tests can write
+ * the terse `{ no_mention: true }` and still get a well-formed entry: the group
+ * axis defaults to true (allow) and `effective` defaults to the AND of the two
+ * axes. Pass `effective` / `group_allow_no_mention` explicitly to model the
+ * "group admin blocked it" case.
+ */
 export function _setMentionPrefEntry(
   accountId: string,
   parentGroupNo: string,
-  pref: MentionPref,
+  pref: Partial<MentionPref>,
   ttlMs?: number,
 ): void {
+  const noMention = pref.no_mention === true;
+  const groupAllow = pref.group_allow_no_mention === undefined ? true : pref.group_allow_no_mention;
+  const effective = pref.effective === undefined ? noMention && groupAllow : pref.effective;
   _prefCache.set(cacheKey(accountId, parentGroupNo), {
-    pref,
+    pref: { no_mention: noMention, group_allow_no_mention: groupAllow, effective },
     expiry: Date.now() + (ttlMs ?? CACHE_TTL_MS),
   });
 }


### PR DESCRIPTION
## What

Consume the new two-axis `mention_pref` decision from octo-server ([#263](https://github.com/Mininglamp-OSS/octo-server/pull/263), YUJ-2996). The mention gate now relaxes `requireMention` based on the server's `effective` field (bot-owner `no_mention` **AND** group-admin `allow_no_mention`) instead of the raw `no_mention` axis.

## Changes
- `api-fetch` `MentionPref`: now `{no_mention, group_allow_no_mention, effective}`. **Old servers** returning only `no_mention` are handled — group axis defaults to `true` (allow) and `effective` degrades to `no_mention` (zero regression).
- `inbound` gate: `requireMention` relaxed only when `effective === true`.
- `mention-prefs` cache: TTL/self-heal keyed off `effective`; `_setMentionPrefEntry` accepts a partial and normalizes the three-field shape for tests.

## Tests
- `effective=true` → reply without @; group-blocked `effective=false` → stay gated.
- Old-server backward-compat fallback (only `no_mention` → group allow default, effective = no_mention).
- numeric `1` coercion for all three fields; existing cache/invalidation paths.
- Full suite: 899 tests pass, `tsc --noEmit` clean.

## Merge order
⚠️ Merge **octo-server#263 first** (ships the `effective` field). This adapter is backward-compatible with old servers, so the order is safe either way, but the group veto only takes effect once both are live.

## Known follow-up (codex review P2, out of scope)
Accounts with global `requireMention: false` skip the per-group pref lookup, so an explicit group veto does not yet override a globally-免@ bot. Honoring that safely requires keying off `group_allow_no_mention` without regressing globally-免@ bots (which have no per-group `no_mention` record, so `effective` is always false) — left for a focused follow-up. The server already returns `group_allow_no_mention` as a separate field to enable it.

Part of #2996