### PR TITLE
ci: add history check (reject orphan-branch PRs)

### DIFF
--- a/.github/workflows/history-check.yml
+++ b/.github/workflows/history-check.yml
@@ -1,0 +1,26 @@
+# History check — reject PRs with no common ancestor on the target branch.
+#
+# Calls the org-wide reusable workflow:
+#   Mininglamp-OSS/.github/.github/workflows/reusable-history-check.yml
+#
+# Why: GitHub's merge UI does NOT refuse merges of unrelated histories.
+# An orphan-branch PR (e.g. `git checkout --orphan` or a re-initialized
+# `.git/`) merges cleanly but grafts a parent-less root commit into the
+# target branch, collapsing `git blame` for every file in that snapshot
+# onto a single commit. Precedent: hermes-agent PR #25045 (May 2026).
+
+name: History Check
+
+on:
+  pull_request:
+    branches: [main]
+
+# Caller permissions act as an upper bound for the reusable workflow.
+# The reusable workflow needs `contents: read` to run `actions/checkout`,
+# so we must grant it here too (a top-level `{}` would block startup).
+permissions:
+  contents: read
+
+jobs:
+  history:
+    uses: Mininglamp-OSS/.github/.github/workflows/reusable-history-check.yml@main


### PR DESCRIPTION
## Summary

Wire up the org-wide reusable history check (Mininglamp-OSS/.github#62) to reject PRs with no common ancestor on the target branch.

## Why

GitHub's merge UI does not refuse merges of unrelated histories. Orphan-branch PRs merge cleanly but collapse `git blame` for every file onto a parent-less root commit. Precedent: hermes-agent PR #25045 (May 2026).

## What

Add `.github/workflows/history-check.yml` that calls `Mininglamp-OSS/.github/.github/workflows/reusable-history-check.yml@main`.

Caller grants `permissions: contents: read` (required upper bound for the reusable workflow's checkout step; `{}` causes startup_failure — validated in pilot).

## Cost & verification

Per-PR: ~5-15s. Pilot Mininglamp-OSS/octo-lib#64 ran in 9s, status `success`.

Part of **T14 — reusable-history-check consumer rollout**.

cc @lml2468