### PR TITLE
fix(account-id): make all accountId handling case-insensitive (Fixes #33)

### DIFF
--- a/src/account-id.test.ts
+++ b/src/account-id.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { normalizeAccountId } from "./account-id.js";
+
+describe("normalizeAccountId", () => {
+  it("lowercases ASCII letters", () => {
+    expect(normalizeAccountId("27pBwzf2F6bfa5cd142_bot"))
+      .toBe("27pbwzf2f6bfa5cd142_bot");
+  });
+
+  it("leaves already-lowercase IDs unchanged", () => {
+    expect(normalizeAccountId("27pbwzf2_bot")).toBe("27pbwzf2_bot");
+  });
+
+  it("is idempotent (normalize ∘ normalize == normalize)", () => {
+    const id = "AaBbCc_bot";
+    expect(normalizeAccountId(normalizeAccountId(id))).toBe(normalizeAccountId(id));
+  });
+
+  it("leaves digits and underscores untouched", () => {
+    expect(normalizeAccountId("123_bot")).toBe("123_bot");
+    expect(normalizeAccountId("a_b_c_bot")).toBe("a_b_c_bot");
+  });
+
+  it("handles full uppercase", () => {
+    expect(normalizeAccountId("BOTNAME_BOT")).toBe("botname_bot");
+  });
+});

--- a/src/account-id.ts
+++ b/src/account-id.ts
@@ -1,0 +1,17 @@
+// Single source of truth for accountId normalization.
+//
+// OpenClaw routing/session-binding normalizes accountId to lowercase before
+// lookup (via normalizeOptionalLowercaseString in the SDK). Any plugin code
+// that uses accountId as a Map/Set key, composite key segment, or disk path
+// segment MUST go through this helper, or it silently misses the SDK-
+// normalized form for mixed-case IDs created by octo-server BotFather.
+//
+// Contract for callers: every exported function (including exported
+// test-only `_xxx` helpers) that takes `accountId: string` as a parameter,
+// or accepts an object with an accountId field, normalizes at entry. We do
+// NOT trust callers to pre-normalize.
+//
+// See: issues openclaw-channel-octo#33 and octo-server#302.
+export function normalizeAccountId(accountId: string): string {
+  return accountId.toLowerCase();
+}

--- a/src/channel.test.ts
+++ b/src/channel.test.ts
@@ -195,8 +195,9 @@ describe("resolveOutboundAccountId", () => {
     registerGroupToAccount("abc", "acct_A");
 
     // "group:abc@uid1,uid2" → should strip @uid1,uid2, resolve group "abc"
+    // Returned accountId is normalized to lowercase (see issue #33).
     const result = resolveOutboundAccountId("group:abc@uid1,uid2", "fallback");
-    expect(result).toBe("acct_A");
+    expect(result).toBe("acct_a");
   });
 
   it("should resolve plain group target without @suffix", async () => {
@@ -204,8 +205,9 @@ describe("resolveOutboundAccountId", () => {
 
     registerGroupToAccount("abc", "acct_B");
 
+    // Returned accountId is normalized to lowercase.
     const result = resolveOutboundAccountId("group:abc", "fallback");
-    expect(result).toBe("acct_B");
+    expect(result).toBe("acct_b");
   });
 
   it("should return fallback for DM targets (no correction)", async () => {

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -38,6 +38,7 @@ import { preloadGroupMemberCache, getGroupMembersFromCache } from "./member-cach
 import { preloadMentionPrefs } from "./mention-prefs.js";
 import { initPersonaPromptCache, stopPersonaPromptCache } from "./persona-prompt.js";
 import { registerOctoThreadBindingAdapter } from "./thread-binding-adapter.js";
+import { normalizeAccountId } from "./account-id.js";
 import path from "node:path";
 import os from "node:os";
 import { mkdir, readFile, writeFile, unlink } from "node:fs/promises";
@@ -120,13 +121,17 @@ async function cleanupOldUploadTempFiles(): Promise<void> {
   } catch { /* dir may not exist */ }
 }
 
-// Module-level history storage — survives auto-restarts
+// Module-level history storage — survives auto-restarts.
+// All accountId-keyed in-memory state below normalizes accountId at the
+// helper boundary (see ./account-id.ts), so mixed-case BotFather IDs
+// (issue #33) cannot split a single bot's cache across two map slots.
 const _historyMaps = new Map<string, Map<string, any[]>>();
 function getOrCreateHistoryMap(accountId: string): Map<string, any[]> {
-  let m = _historyMaps.get(accountId);
+  const id = normalizeAccountId(accountId);
+  let m = _historyMaps.get(id);
   if (!m) {
     m = new Map<string, any[]>();
-    _historyMaps.set(accountId, m);
+    _historyMaps.set(id, m);
   }
   return m;
 }
@@ -136,10 +141,11 @@ function getOrCreateHistoryMap(accountId: string): Map<string, any[]> {
 // NOT the bot's own reply message_seq (sendMessage API returns 0 for that).
 const _lastBotReplySeq = new Map<string, Map<string, number>>();
 function getOrCreateLastBotReplySeqMap(accountId: string): Map<string, number> {
-  let m = _lastBotReplySeq.get(accountId);
+  const id = normalizeAccountId(accountId);
+  let m = _lastBotReplySeq.get(id);
   if (!m) {
     m = new Map<string, number>();
-    _lastBotReplySeq.set(accountId, m);
+    _lastBotReplySeq.set(id, m);
   }
   return m;
 }
@@ -147,6 +153,7 @@ function getOrCreateLastBotReplySeqMap(accountId: string): Map<string, number> {
 const _inboundQueues = new Map<string, Promise<void>>();
 
 function getInboundQueueKey(accountId: string, msg: BotMessage): string {
+  const id = normalizeAccountId(accountId);
   const isGroup =
     typeof msg.channel_id === "string" &&
     msg.channel_id.length > 0 &&
@@ -154,7 +161,7 @@ function getInboundQueueKey(accountId: string, msg: BotMessage): string {
      msg.channel_type === ChannelType.CommunityTopic);
 
   if (isGroup) {
-    return `${accountId}:group:${msg.channel_id}`;
+    return `${id}:group:${msg.channel_id}`;
   }
 
   let spaceId = "";
@@ -175,7 +182,7 @@ function getInboundQueueKey(accountId: string, msg: BotMessage): string {
   const sessionId = spaceId
     ? `${spaceId}:${effectiveChannelId}`
     : effectiveChannelId;
-  return `${accountId}:dm:${sessionId}`;
+  return `${id}:dm:${sessionId}`;
 }
 
 function enqueueInbound(
@@ -208,10 +215,11 @@ function enqueueInbound(
 // Used to resolve @mentions in AI replies
 const _memberMaps = new Map<string, Map<string, string>>();
 export function getOrCreateMemberMap(accountId: string): Map<string, string> {
-  let m = _memberMaps.get(accountId);
+  const id = normalizeAccountId(accountId);
+  let m = _memberMaps.get(id);
   if (!m) {
     m = new Map<string, string>();
-    _memberMaps.set(accountId, m);
+    _memberMaps.set(id, m);
   }
   return m;
 }
@@ -220,10 +228,11 @@ export function getOrCreateMemberMap(accountId: string): Map<string, string> {
 // Used to show display names instead of uids in replies
 const _uidToNameMaps = new Map<string, Map<string, string>>();
 export function getOrCreateUidToNameMap(accountId: string): Map<string, string> {
-  let m = _uidToNameMaps.get(accountId);
+  const id = normalizeAccountId(accountId);
+  let m = _uidToNameMaps.get(id);
   if (!m) {
     m = new Map<string, string>();
-    _uidToNameMaps.set(accountId, m);
+    _uidToNameMaps.set(id, m);
   }
   return m;
 }
@@ -231,10 +240,11 @@ export function getOrCreateUidToNameMap(accountId: string): Map<string, string> 
 // Group member cache timestamps: groupId -> lastFetchedAt (ms)
 const _groupCacheTimestamps = new Map<string, Map<string, number>>();
 function getOrCreateGroupCacheTimestamps(accountId: string): Map<string, number> {
-  let m = _groupCacheTimestamps.get(accountId);
+  const id = normalizeAccountId(accountId);
+  let m = _groupCacheTimestamps.get(id);
   if (!m) {
     m = new Map<string, number>();
-    _groupCacheTimestamps.set(accountId, m);
+    _groupCacheTimestamps.set(id, m);
   }
   return m;
 }
@@ -245,10 +255,11 @@ function getOrCreateGroupCacheTimestamps(accountId: string): Map<string, number>
 // Flat uid→robot map (not keyed by groupId), like uidToNameMap.
 const _memberRobotMaps = new Map<string, Map<string, boolean>>();
 function getOrCreateMemberRobotMap(accountId: string): Map<string, boolean> {
-  let m = _memberRobotMaps.get(accountId);
+  const id = normalizeAccountId(accountId);
+  let m = _memberRobotMaps.get(id);
   if (!m) {
     m = new Map<string, boolean>();
-    _memberRobotMaps.set(accountId, m);
+    _memberRobotMaps.set(id, m);
   }
   return m;
 }
@@ -257,12 +268,17 @@ function getOrCreateMemberRobotMap(accountId: string): Map<string, boolean> {
 // --- Group → Account mapping: tracks which accounts are active in each group ---
 // Used by handleAction to resolve the correct account when framework passes wrong accountId
 // A group may have multiple bots (1:N), so we store a Set of accountIds per group.
-const _groupToAccounts = new Map<string, Set<string>>(); // groupNo → Set of accountIds
+//
+// Both the registration side AND the query side normalize accountId — Set
+// membership checks are case-sensitive, so storing the raw mixed-case form
+// would make later lowercase queries miss (and vice versa). See issue #33.
+const _groupToAccounts = new Map<string, Set<string>>(); // groupNo → Set of <normalized accountIds>
 
 export function registerGroupToAccount(groupNo: string, accountId: string): void {
+  const id = normalizeAccountId(accountId);
   let s = _groupToAccounts.get(groupNo);
   if (!s) { s = new Set(); _groupToAccounts.set(groupNo, s); }
-  s.add(accountId);
+  s.add(id);
 }
 
 /**
@@ -270,6 +286,8 @@ export function registerGroupToAccount(groupNo: string, accountId: string): void
  * - If the group has exactly one registered account → return it (safe to correct).
  * - If the group has multiple accounts (shared group) → return undefined (don't override).
  * - If the group is unknown → return undefined.
+ *
+ * Returned id is always normalized (registration side normalizes).
  */
 export function resolveAccountForGroup(groupNo: string): string | undefined {
   const s = _groupToAccounts.get(groupNo);
@@ -279,7 +297,7 @@ export function resolveAccountForGroup(groupNo: string): string | undefined {
 
 /** Check if a specific accountId is registered for a group. */
 export function isAccountRegisteredForGroup(groupNo: string, accountId: string): boolean {
-  return _groupToAccounts.get(groupNo)?.has(accountId) ?? false;
+  return _groupToAccounts.get(groupNo)?.has(normalizeAccountId(accountId)) ?? false;
 }
 
 // --- Cache cleanup: evict groups inactive for >4 hours ---
@@ -288,8 +306,9 @@ const CACHE_CLEANUP_INTERVAL_MS = 30 * 60 * 1000;
 const _cacheActivity = new Map<string, Map<string, number>>();
 
 function touchCache(accountId: string, groupId: string): void {
-  let m = _cacheActivity.get(accountId);
-  if (!m) { m = new Map(); _cacheActivity.set(accountId, m); }
+  const id = normalizeAccountId(accountId);
+  let m = _cacheActivity.get(id);
+  if (!m) { m = new Map(); _cacheActivity.set(id, m); }
   m.set(groupId, Date.now());
 }
 
@@ -986,6 +1005,22 @@ export const octoPlugin: ChannelPlugin<ResolvedOctoAccount> = {
       const log = ctx.log;
       const statusSink: OctoStatusSink = (patch) =>
         ctx.setStatus({ accountId: account.accountId, ...patch });
+
+      // Operator-facing one-shot audit: if any configured accountId contains
+      // uppercase characters, log the count (NOT the IDs themselves — avoids
+      // leaking bot identifiers). All internal storage is normalized so this
+      // is informational only; it helps operators decide whether to clean up
+      // legacy disk dirs or notify users to rotate to lowercase bots. See
+      // issue #33 / octo-server#302.
+      try {
+        const allIds = listOctoAccountIds(ctx.cfg);
+        const mixedCount = allIds.filter((id) => id !== id.toLowerCase()).length;
+        if (mixedCount > 0) {
+          log?.info?.(
+            `octo: detected ${mixedCount} mixed-case Octo accountId(s); internal storage normalized (see openclaw-channel-octo#33)`,
+          );
+        }
+      } catch { /* config snapshot inaccessible — non-fatal */ }
 
       log?.info?.(`[${account.accountId}] registering Octo bot...`);
 

--- a/src/group-md.test.ts
+++ b/src/group-md.test.ts
@@ -943,3 +943,99 @@ describe("handleThreadMdEvent", () => {
     fetchSpy.mockRestore();
   });
 });
+
+// ─── issue #33: case-insensitive accountId across GROUP/THREAD chains ──────
+
+import * as path from "node:path";
+import { homedir } from "node:os";
+import { readdirSync, existsSync as _exists } from "node:fs";
+
+describe("group-md case-insensitive accountId — disk path single directory (issue #33)", () => {
+  // Reuse the file-level beforeEach which redirects HOME to a tmpdir, so we
+  // don't pollute the real workspace. workspaceRoot is captured per-test
+  // (inside the test body) AFTER HOME has been swapped — capturing at
+  // describe-level would lock in the pre-swap real HOME and the path
+  // assertions below would never match writeGroupMdToDisk's actual target.
+  const groupNo = `caseTest_${Date.now()}_${Math.floor(Math.random() * 1e6)}`;
+  const lowerAcct = `case_acct_bot_${Date.now()}`;
+  const mixedAcct = lowerAcct.replace("acct", "Acct").replace("bot", "BOT");
+
+  it("writeGroupMdToDisk with mixed-case accountId persists under lowercase dir; read with either case hits it", () => {
+    const workspaceRoot = join(homedir(), ".openclaw", "workspace", "octo");
+    const meta = {
+      version: 1,
+      updated_at: "2026-06-08T00:00:00Z",
+      updated_by: "test",
+      fetched_at: "2026-06-08T00:00:00Z",
+      account_id: mixedAcct,
+    };
+    writeGroupMdToDisk({ accountId: mixedAcct, groupNo, content: "hello", meta });
+
+    // Reading with the SAME mixed-case input should succeed (paths normalize).
+    expect(readGroupMdFromDisk(mixedAcct, groupNo)).toBe("hello");
+    // Reading with the lowercase form should also succeed (same dir).
+    expect(readGroupMdFromDisk(lowerAcct, groupNo)).toBe("hello");
+
+    // Verify the on-disk directory name has the EXPECTED case form (lowercase).
+    // We can't use `existsSync(mixedPath)` to assert non-existence because
+    // macOS APFS is case-insensitive by default — both case forms resolve to
+    // the same inode. Instead, readdirSync returns the actual stored name,
+    // which preserves the case the dir was created with.
+    const dirs = readdirSync(workspaceRoot, { withFileTypes: true })
+      .filter(d => d.isDirectory())
+      .map(d => d.name);
+    // The lowercase form must be present.
+    expect(dirs).toContain(lowerAcct);
+    // The mixed-case form must NOT — production code normalized before mkdir.
+    expect(dirs).not.toContain(mixedAcct);
+  });
+
+  it("getOrCreateGroupMdCache returns the same Map for mixed-case and lowercase accountIds", () => {
+    const a = getOrCreateGroupMdCache(mixedAcct);
+    const b = getOrCreateGroupMdCache(lowerAcct);
+    expect(a).toBe(b);
+
+    // Sanity: mutating a is observable via b
+    a.set(groupNo, { content: "x", version: 1 });
+    expect(b.get(groupNo)?.content).toBe("x");
+  });
+});
+
+describe("group-md case-insensitive accountId — THREAD chain (issue #33)", () => {
+  const shortId = `thr_${Date.now()}_${Math.floor(Math.random() * 1e6)}`;
+  const lowerAcct = `thread_acct_bot_${Date.now()}`;
+  const mixedAcct = lowerAcct.replace("acct", "Acct").replace("bot", "BOT");
+  // Use a distinct groupNo to keep this test independent of the GROUP test above.
+  const groupNo = `threadgrp_${Date.now()}_${Math.floor(Math.random() * 1e6)}`;
+
+  it("writeThreadMdToDisk with mixed-case accountId persists under lowercase dir; read with either case hits it", () => {
+    const workspaceRoot = join(homedir(), ".openclaw", "workspace", "octo");
+    const meta = {
+      version: 1,
+      updated_at: "2026-06-08T00:00:00Z",
+      updated_by: "test",
+      fetched_at: "2026-06-08T00:00:00Z",
+      account_id: mixedAcct,
+    };
+    writeThreadMdToDisk({ accountId: mixedAcct, groupNo, shortId, content: "thread-hello", meta });
+
+    // Reads with either case form hit the same dir.
+    expect(readThreadMdFromDisk(mixedAcct, groupNo, shortId)).toBe("thread-hello");
+    expect(readThreadMdFromDisk(lowerAcct, groupNo, shortId)).toBe("thread-hello");
+
+    // Directory name on disk is the lowercase form (readdirSync preserves
+    // case even on case-insensitive FS).
+    const dirs = readdirSync(workspaceRoot, { withFileTypes: true })
+      .filter(d => d.isDirectory())
+      .map(d => d.name);
+    expect(dirs).toContain(lowerAcct);
+    expect(dirs).not.toContain(mixedAcct);
+
+    // The persisted meta JSON must also carry the normalized account_id —
+    // otherwise downstream consumers of meta (e.g. scanForAccountId) would
+    // see mixed-case and re-split.
+    const metaPath = join(workspaceRoot, lowerAcct, "groups", groupNo, "threads", shortId, "THREAD.meta.json");
+    const parsed = JSON.parse(readFileSync(metaPath, "utf-8"));
+    expect(parsed.account_id).toBe(lowerAcct);
+  });
+});

--- a/src/group-md.ts
+++ b/src/group-md.ts
@@ -8,6 +8,15 @@
  * Memory maps (rebuilt from inbound messages after restart):
  *   _groupAccountMap: "agentId:groupNo" → accountId
  *   _checkedGroups: Set<"accountId/groupNo"> — tracks groups checked this session
+ *
+ * accountId case-insensitivity (issue #33):
+ *   octo-server BotFather historically emitted mixed-case bot IDs (e.g.
+ *   `27pBwzf2F6bfa5cd142_bot`). OpenClaw normalizes them to lowercase at the
+ *   routing boundary, so any disk path / cache key / Set key here that uses
+ *   accountId verbatim would split a single bot's storage across two
+ *   directories or two cache slots. All path helpers and exported APIs that
+ *   take `accountId` normalize at entry via `normalizeAccountId` to keep one
+ *   bot → one directory / one cache key.
  */
 
 import { readFileSync, writeFileSync, mkdirSync, existsSync, unlinkSync, readdirSync } from "node:fs";
@@ -15,6 +24,7 @@ import { join } from "node:path";
 import { homedir } from "node:os";
 import type { ChannelLogSink } from "openclaw/plugin-sdk/channel-contract";
 import { CHANNEL_ID } from "./constants.js";
+import { normalizeAccountId } from "./account-id.js";
 
 // --- Channel ID helpers ---
 
@@ -86,22 +96,28 @@ const _checkedGroups = new Set<string>();
 const _groupMdCache = new Map<string, Map<string, { content: string; version: number }>>();
 
 export function getOrCreateGroupMdCache(accountId: string): Map<string, { content: string; version: number }> {
-  let m = _groupMdCache.get(accountId);
+  const id = normalizeAccountId(accountId);
+  let m = _groupMdCache.get(id);
   if (!m) {
     m = new Map<string, { content: string; version: number }>();
-    _groupMdCache.set(accountId, m);
+    _groupMdCache.set(id, m);
   }
   return m;
 }
 
 // --- Path helpers ---
+//
+// All three normalize accountId at entry so disk paths are always
+// `~/.openclaw/.../<lowercased-accountId>/...`. This is the single
+// chokepoint that guarantees one bot → one directory tree, even when
+// callers pass mixed-case accountIds (BotFather legacy, see issue #33).
 
 function workspaceBase(): string {
   return join(homedir(), ".openclaw", "workspace", CHANNEL_ID);
 }
 
 function groupDir(accountId: string, groupNo: string): string {
-  return join(workspaceBase(), accountId, "groups", groupNo);
+  return join(workspaceBase(), normalizeAccountId(accountId), "groups", groupNo);
 }
 
 function groupMdPath(accountId: string, groupNo: string): string {
@@ -120,7 +136,9 @@ function groupMetaPath(accountId: string, groupNo: string): string {
  */
 export function registerGroupAccount(groupNo: string, accountId: string, agentId?: string): void {
   if (agentId) {
-    _groupAccountMap.set(`${agentId}:${groupNo}`, accountId);
+    // Store the normalized accountId so downstream resolveAccountId callers
+    // see the canonical form regardless of which case the inbound carried.
+    _groupAccountMap.set(`${agentId}:${groupNo}`, normalizeAccountId(accountId));
   }
   // Do NOT register bare groupNo key — it causes cross-agent contamination on multi-bot nodes
 }
@@ -128,6 +146,11 @@ export function registerGroupAccount(groupNo: string, accountId: string, agentId
 /**
  * Scan disk for accountId when memory map misses.
  * Looks through all accountId directories for a matching groupNo with a meta file.
+ *
+ * NOTE: path helpers normalize accountId, so this only finds bots whose
+ * persisted disk dir is already lowercase. Legacy mixed-case directories
+ * left over from pre-fix writes become orphaned (will not be discovered
+ * here, but a fresh API fetch on next inbound will rebuild a lowercase entry).
  */
 export function scanForAccountId(agentId: string, groupNo: string): string | null {
   const base = workspaceBase();
@@ -148,8 +171,11 @@ export function scanForAccountId(agentId: string, groupNo: string): string | nul
       try {
         const meta = JSON.parse(readFileSync(metaFile, "utf-8")) as GroupMdMeta;
         if (meta.account_id) {
-          _groupAccountMap.set(`${agentId}:${groupNo}`, meta.account_id);
-          return meta.account_id;
+          // Normalize what we store so resolveAccountId always returns
+          // canonical form, even if a legacy meta still holds mixed-case.
+          const normalizedAcct = normalizeAccountId(meta.account_id);
+          _groupAccountMap.set(`${agentId}:${groupNo}`, normalizedAcct);
+          return normalizedAcct;
         }
       } catch {
         // corrupted meta, skip
@@ -201,6 +227,11 @@ async function fetchGroupMdFromApi(params: {
 
 /**
  * Write GROUP.md and meta to disk.
+ *
+ * Normalizes accountId at the boundary so meta.account_id stored on disk
+ * is always canonical (lowercase), even if a caller passes mixed-case.
+ * Path helpers below also normalize, but persisting normalized meta means
+ * scanForAccountId returning a meta read still sees the canonical form.
  */
 export function writeGroupMdToDisk(params: {
   accountId: string;
@@ -208,10 +239,15 @@ export function writeGroupMdToDisk(params: {
   content: string;
   meta: GroupMdMeta;
 }): void {
-  const dir = groupDir(params.accountId, params.groupNo);
+  const accountId = normalizeAccountId(params.accountId);
+  const dir = groupDir(accountId, params.groupNo);
   mkdirSync(dir, { recursive: true });
-  writeFileSync(groupMdPath(params.accountId, params.groupNo), params.content, "utf-8");
-  writeFileSync(groupMetaPath(params.accountId, params.groupNo), JSON.stringify(params.meta, null, 2), "utf-8");
+  writeFileSync(groupMdPath(accountId, params.groupNo), params.content, "utf-8");
+  // Override meta.account_id with the normalized form so the persisted JSON
+  // matches the disk path it lives in. Any caller-supplied mixed-case value
+  // is replaced — this is intentional, per the issue #33 contract.
+  const meta: GroupMdMeta = { ...params.meta, account_id: accountId };
+  writeFileSync(groupMetaPath(accountId, params.groupNo), JSON.stringify(meta, null, 2), "utf-8");
 }
 
 /**
@@ -259,7 +295,8 @@ export async function ensureGroupMd(params: {
   botToken: string;
   log?: ChannelLogSink;
 }): Promise<void> {
-  const { agentId, accountId, groupNo, apiUrl, botToken, log } = params;
+  const { agentId, groupNo, apiUrl, botToken, log } = params;
+  const accountId = normalizeAccountId(params.accountId);
   const key = `${accountId}/${groupNo}`;
   if (_checkedGroups.has(key)) return;
   _checkedGroups.add(key);
@@ -302,7 +339,8 @@ export async function handleGroupMdEvent(params: {
   botToken: string;
   log?: ChannelLogSink;
 }): Promise<void> {
-  const { agentId, accountId, groupNo, eventType, apiUrl, botToken, log } = params;
+  const { groupNo, eventType, apiUrl, botToken, log } = params;
+  const accountId = normalizeAccountId(params.accountId);
 
   if (eventType === "group_md_deleted") {
     deleteGroupMdFromDisk(accountId, groupNo);
@@ -371,7 +409,7 @@ export function getGroupMdForPrompt(ctx: {
  * Clear the checked flag for a group, forcing re-fetch on next encounter.
  */
 export function clearGroupMdChecked(accountId: string, groupNo: string): void {
-  _checkedGroups.delete(`${accountId}/${groupNo}`);
+  _checkedGroups.delete(`${normalizeAccountId(accountId)}/${groupNo}`);
 }
 
 /**
@@ -384,7 +422,8 @@ export function broadcastGroupMdUpdate(params: {
   content: string;
   version: number;
 }): void {
-  const { accountId, groupNo, content, version } = params;
+  const { groupNo, content, version } = params;
+  const accountId = normalizeAccountId(params.accountId);
   const meta: GroupMdMeta = {
     version,
     updated_at: new Date().toISOString(),
@@ -426,10 +465,10 @@ export function getKnownGroupIds(): Set<string> {
 // --- Thread (子区) THREAD.md disk cache ---
 
 /** Tracks threads checked this session to avoid redundant API calls */
-const _checkedThreads = new Set<string>(); // "accountId/groupNo/shortId"
+const _checkedThreads = new Set<string>(); // "<lowercased-accountId>/<groupNo>/<shortId>"
 
 function threadDir(accountId: string, groupNo: string, shortId: string): string {
-  return join(workspaceBase(), accountId, "groups", groupNo, "threads", shortId);
+  return join(workspaceBase(), normalizeAccountId(accountId), "groups", groupNo, "threads", shortId);
 }
 
 function threadMdPath(accountId: string, groupNo: string, shortId: string): string {
@@ -447,10 +486,13 @@ export function writeThreadMdToDisk(params: {
   content: string;
   meta: GroupMdMeta;
 }): void {
-  const dir = threadDir(params.accountId, params.groupNo, params.shortId);
+  const accountId = normalizeAccountId(params.accountId);
+  const dir = threadDir(accountId, params.groupNo, params.shortId);
   mkdirSync(dir, { recursive: true });
-  writeFileSync(threadMdPath(params.accountId, params.groupNo, params.shortId), params.content, "utf-8");
-  writeFileSync(threadMetaPath(params.accountId, params.groupNo, params.shortId), JSON.stringify(params.meta, null, 2), "utf-8");
+  writeFileSync(threadMdPath(accountId, params.groupNo, params.shortId), params.content, "utf-8");
+  // Persist normalized meta.account_id (see writeGroupMdToDisk comment).
+  const meta: GroupMdMeta = { ...params.meta, account_id: accountId };
+  writeFileSync(threadMetaPath(accountId, params.groupNo, params.shortId), JSON.stringify(meta, null, 2), "utf-8");
 }
 
 export function readThreadMdFromDisk(accountId: string, groupNo: string, shortId: string): string | null {
@@ -524,7 +566,8 @@ export async function ensureThreadMd(params: {
   botToken: string;
   log?: ChannelLogSink;
 }): Promise<void> {
-  const { accountId, groupNo, shortId, apiUrl, botToken, log } = params;
+  const { groupNo, shortId, apiUrl, botToken, log } = params;
+  const accountId = normalizeAccountId(params.accountId);
   const key = `${accountId}/${groupNo}/${shortId}`;
   if (_checkedThreads.has(key)) return;
   _checkedThreads.add(key);
@@ -563,7 +606,8 @@ export async function handleThreadMdEvent(params: {
   botToken: string;
   log?: ChannelLogSink;
 }): Promise<void> {
-  const { accountId, groupNo, shortId, eventType, apiUrl, botToken, log } = params;
+  const { groupNo, shortId, eventType, apiUrl, botToken, log } = params;
+  const accountId = normalizeAccountId(params.accountId);
 
   if (eventType === "thread_md_deleted") {
     deleteThreadMdFromDisk(accountId, groupNo, shortId);
@@ -604,7 +648,8 @@ export function broadcastThreadMdUpdate(params: {
   content: string;
   version: number;
 }): void {
-  const { accountId, groupNo, shortId, content, version } = params;
+  const { groupNo, shortId, content, version } = params;
+  const accountId = normalizeAccountId(params.accountId);
   const meta: GroupMdMeta = {
     version,
     updated_at: new Date().toISOString(),

--- a/src/inbound.test.ts
+++ b/src/inbound.test.ts
@@ -20,6 +20,7 @@ import {
   pendingInboundContext,
   sessionAccountMap,
   buildSessionAccountKey,
+  recordSessionAccount,
   segmentHistoryEntries,
   resolveInboundMediaList,
   resolveInboundMediaPaths,
@@ -3366,5 +3367,51 @@ describe("group-path persona system hint decision matrix (GH#64)", () => {
     expect(
       buggy({ from_uid: "bob_uid" }, { onBehalfOf: grantorUid }),
     ).toBeUndefined();
+  });
+});
+
+// ─── issue #33: case-insensitive accountId in sessionAccountMap ─────────────
+
+describe("buildSessionAccountKey case-insensitive accountId (issue #33)", () => {
+  it("produces identical keys for any case form of the same accountId", () => {
+    expect(buildSessionAccountKey("Mixed_Bot", "sess1"))
+      .toBe(buildSessionAccountKey("mixed_bot", "sess1"));
+    expect(buildSessionAccountKey("MIXED_BOT", "sess1"))
+      .toBe(buildSessionAccountKey("mixed_bot", "sess1"));
+  });
+
+  it("key segment uses normalized (lowercase) accountId", () => {
+    expect(buildSessionAccountKey("Mixed_Bot", "sess1")).toBe("mixed_bot:sess1");
+  });
+});
+
+describe("recordSessionAccount normalizes both key AND value", () => {
+  beforeEach(() => sessionAccountMap.clear());
+
+  it("stores normalized accountId at normalized composite key", () => {
+    recordSessionAccount("Mixed_Bot", "sess1");
+    // Lookup via the public key builder hits the entry regardless of input case
+    expect(sessionAccountMap.get(buildSessionAccountKey("Mixed_Bot", "sess1")))
+      .toBe("mixed_bot");
+    expect(sessionAccountMap.get(buildSessionAccountKey("mixed_bot", "sess1")))
+      .toBe("mixed_bot");
+    // Direct lowercase key works too — both segments are normalized
+    expect(sessionAccountMap.get("mixed_bot:sess1")).toBe("mixed_bot");
+  });
+
+  it("repeated registration with different cases is idempotent (single map entry)", () => {
+    recordSessionAccount("Mixed_Bot", "sess1");
+    recordSessionAccount("mixed_bot", "sess1");
+    recordSessionAccount("MIXED_BOT", "sess1");
+    expect(sessionAccountMap.size).toBe(1);
+    expect(sessionAccountMap.get("mixed_bot:sess1")).toBe("mixed_bot");
+  });
+
+  it("different sessionKeys produce distinct entries even for same account", () => {
+    recordSessionAccount("Mixed_Bot", "sess1");
+    recordSessionAccount("Mixed_Bot", "sess2");
+    expect(sessionAccountMap.size).toBe(2);
+    expect(sessionAccountMap.get("mixed_bot:sess1")).toBe("mixed_bot");
+    expect(sessionAccountMap.get("mixed_bot:sess2")).toBe("mixed_bot");
   });
 });

--- a/src/inbound.ts
+++ b/src/inbound.ts
@@ -3,6 +3,7 @@ import type { ChannelLogSink } from "openclaw/plugin-sdk/channel-contract";
 import { DEFAULT_GROUP_HISTORY_LIMIT } from "openclaw/plugin-sdk/reply-history";
 import { sendMessage, sendReadReceipt, sendTyping, getChannelMessages, getGroupMembers, getGroupMd, postJson, sendMediaMessage, inferContentType, ensureTextCharset, parseImageDimensions, parseImageDimensionsFromFile, getUploadCredentials, uploadFileToCOS, fetchUserInfo } from "./api-fetch.js";
 import { getMentionPrefFromCache, invalidateMentionPref } from "./mention-prefs.js";
+import { normalizeAccountId } from "./account-id.js";
 import type { ResolvedOctoAccount } from "./accounts.js";
 import type { BotMessage } from "./types.js";
 import { ChannelType, MessageType, RICH_TEXT_BLOCK_IMAGE, RICH_TEXT_BLOCK_TEXT, RICH_TEXT_IMAGE_PLACEHOLDER } from "./types.js";
@@ -62,11 +63,32 @@ export const pendingInboundContext = new Map<string, { historyPrefix: string; me
 // Sessions are bounded by accounts, so the map size is bounded by
 // (active accounts × active session keys per account) — no unbounded growth
 // in practice.
+//
+// All entries are stored with NORMALIZED (lowercase) accountId in both the
+// composite key AND the stored value, so mixed-case BotFather IDs (see
+// issue #33) cannot split a single bot's presence across two map entries.
+// Use the helpers below instead of touching the map directly.
 export const sessionAccountMap = new Map<string, string>();
 
-/** Build the composite key used to record `(accountId, sessionKey)` pairs. */
+/**
+ * Build the composite key used to record `(accountId, sessionKey)` pairs.
+ * Normalizes accountId so callers passing any case form hit the same entry.
+ */
 export function buildSessionAccountKey(accountId: string, sessionKey: string): string {
-  return `${accountId}:${sessionKey}`;
+  return `${normalizeAccountId(accountId)}:${sessionKey}`;
+}
+
+/**
+ * Register an account's presence on a session.
+ *
+ * Encapsulates the write to `sessionAccountMap` so both the composite key
+ * AND the stored value are normalized — and so unit tests can exercise this
+ * single helper instead of mocking the full `handleInboundMessage` flow.
+ * Called from the inbound dispatch right after the route is resolved.
+ */
+export function recordSessionAccount(accountId: string, sessionKey: string): void {
+  const id = normalizeAccountId(accountId);
+  sessionAccountMap.set(buildSessionAccountKey(id, sessionKey), id);
 }
 
 export type OctoStatusSink = (patch: {
@@ -1975,7 +1997,9 @@ export async function handleInboundMessage(params: {
   // accountId). The composite key is required for multi-account isolation —
   // see the doc comment on sessionAccountMap above.
   // Required by persona-prompt injection (GH octo-adapters#68).
-  sessionAccountMap.set(buildSessionAccountKey(account.accountId, route.sessionKey), account.accountId);
+  // recordSessionAccount normalizes both key AND value so mixed-case bot
+  // ids (issue #33) cannot split a single bot's presence across two entries.
+  recordSessionAccount(account.accountId, route.sessionKey);
 
   const finalBody = quotePrefix ? (quotePrefix + rawBody) : rawBody;
 

--- a/src/mention-prefs.test.ts
+++ b/src/mention-prefs.test.ts
@@ -315,3 +315,45 @@ describe("mention-prefs", () => {
     });
   });
 });
+
+// ─── issue #33: case-insensitive accountId in composite cacheKey ────────────
+
+describe("mention-prefs cacheKey case-insensitive accountId (issue #33)", () => {
+  beforeEach(() => _clearMentionPrefCache());
+
+  it("set mixed-case → get lowercase hits the same entry", () => {
+    _setMentionPrefEntry("Mixed_Bot", "grp1", { effective: true });
+    expect(_hasMentionPrefEntry("mixed_bot", "grp1")).toBe(true);
+  });
+
+  it("set lowercase → get mixed-case hits the same entry", () => {
+    _setMentionPrefEntry("mixed_bot", "grp1", { effective: true });
+    expect(_hasMentionPrefEntry("Mixed_Bot", "grp1")).toBe(true);
+    expect(_hasMentionPrefEntry("MIXED_BOT", "grp1")).toBe(true);
+  });
+
+  it("getMentionPrefFromCache returns same pref regardless of accountId case", async () => {
+    _setMentionPrefEntry("MyBot_bot", "g1", { effective: true });
+
+    const a = await getMentionPrefFromCache({
+      accountId: "MyBot_bot",
+      parentGroupNo: "g1",
+      apiUrl: "http://unused",
+      botToken: "unused",
+    });
+    const b = await getMentionPrefFromCache({
+      accountId: "mybot_bot",
+      parentGroupNo: "g1",
+      apiUrl: "http://unused",
+      botToken: "unused",
+    });
+    expect(a.effective).toBe(true);
+    expect(b.effective).toBe(true);
+  });
+
+  it("invalidate with one case clears the entry for all cases", () => {
+    _setMentionPrefEntry("BotX_bot", "g7", { effective: true });
+    invalidateMentionPref("botx_bot", "g7"); // lowercase invalidate
+    expect(_hasMentionPrefEntry("BotX_bot", "g7")).toBe(false);
+  });
+});

--- a/src/mention-prefs.ts
+++ b/src/mention-prefs.ts
@@ -27,6 +27,7 @@
  */
 
 import { getMentionPref, fetchBotGroups, type MentionPref } from "./api-fetch.js";
+import { normalizeAccountId } from "./account-id.js";
 import type { LogSink } from "./types.js";
 
 const CACHE_TTL_MS = 30 * 1000; // 30 seconds (positive: effective=true)
@@ -48,9 +49,17 @@ interface CacheEntry {
 
 const _prefCache = new Map<string, CacheEntry>();
 
-/** Build the composite per-bot cache key. */
+/**
+ * Build the composite per-bot cache key.
+ *
+ * Centralizes accountId normalization for the whole module: every callsite
+ * that reads/writes _prefCache routes through this builder, so mixed-case
+ * accountIds emitted by octo-server BotFather (see issue #33) cannot
+ * silently bypass cache hits or leave stale entries unreachable to invalidate.
+ * The _set/_has test helpers below inherit this guarantee transitively.
+ */
 function cacheKey(accountId: string, parentGroupNo: string): string {
-  return `${accountId}:${parentGroupNo}`;
+  return `${normalizeAccountId(accountId)}:${parentGroupNo}`;
 }
 
 /**

--- a/src/multi-bot-isolation.test.ts
+++ b/src/multi-bot-isolation.test.ts
@@ -20,7 +20,8 @@ describe("registerGroupToAccount + resolveAccountForGroup", () => {
 
     registerGroupToAccount("group-001", "botA");
 
-    expect(resolveAccountForGroup("group-001")).toBe("botA");
+    // Returned accountId is normalized to lowercase (see issue #33).
+    expect(resolveAccountForGroup("group-001")).toBe("bota");
   });
 
   it("multi-bot same group — resolveAccountForGroup returns undefined", async () => {
@@ -44,8 +45,8 @@ describe("registerGroupToAccount + resolveAccountForGroup", () => {
     registerGroupToAccount("group-001", "botA");
     registerGroupToAccount("group-001", "botA");
 
-    // Still size 1 → should return the accountId
-    expect(resolveAccountForGroup("group-001")).toBe("botA");
+    // Still size 1 → should return the accountId (normalized).
+    expect(resolveAccountForGroup("group-001")).toBe("bota");
   });
 
   it("different groups with different bots resolve independently", async () => {
@@ -54,8 +55,8 @@ describe("registerGroupToAccount + resolveAccountForGroup", () => {
     registerGroupToAccount("group-001", "botA");
     registerGroupToAccount("group-002", "botB");
 
-    expect(resolveAccountForGroup("group-001")).toBe("botA");
-    expect(resolveAccountForGroup("group-002")).toBe("botB");
+    expect(resolveAccountForGroup("group-001")).toBe("bota");
+    expect(resolveAccountForGroup("group-002")).toBe("botb");
   });
 });
 

--- a/src/owner-registry.test.ts
+++ b/src/owner-registry.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  registerOwnerUid,
+  isOwner,
+  _clearOwnerRegistry,
+} from "./owner-registry.js";
+
+describe("owner-registry case-insensitive accountId (issue #33)", () => {
+  beforeEach(() => _clearOwnerRegistry());
+
+  it("registered lowercase, queried lowercase → hit", () => {
+    registerOwnerUid("27pb_bot", "owner-uid");
+    expect(isOwner("27pb_bot", "owner-uid")).toBe(true);
+  });
+
+  it("registered lowercase, queried mixed-case → hit", () => {
+    registerOwnerUid("27pb_bot", "owner-uid");
+    expect(isOwner("27Pb_bot", "owner-uid")).toBe(true);
+  });
+
+  it("registered mixed-case, queried lowercase → hit (the main bug case)", () => {
+    // This is the scenario from PR#55 / issue #33: BotFather emits
+    // mixed-case ID, channel registers it, OpenClaw routes a lowercased
+    // version into isOwner — strict equality used to miss here.
+    registerOwnerUid("27Pb_bot", "owner-uid");
+    expect(isOwner("27pb_bot", "owner-uid")).toBe(true);
+  });
+
+  it("registered mixed-case A, queried mixed-case B (different case form) → hit", () => {
+    registerOwnerUid("AbCd_bot", "owner-uid");
+    expect(isOwner("aBcD_bot", "owner-uid")).toBe(true);
+    expect(isOwner("ABCD_bot", "owner-uid")).toBe(true);
+  });
+
+  it("wrong uid still returns false (case fix doesn't break uid check)", () => {
+    registerOwnerUid("AbCd_bot", "owner-uid");
+    expect(isOwner("abcd_bot", "wrong-uid")).toBe(false);
+  });
+
+  it("unregistered account returns false regardless of case", () => {
+    expect(isOwner("never_registered_bot", "anyuid")).toBe(false);
+    expect(isOwner("NEVER_REGISTERED_BOT", "anyuid")).toBe(false);
+  });
+
+  it("re-registering with different case overwrites the owner uid", () => {
+    registerOwnerUid("Bot_bot", "owner-one");
+    registerOwnerUid("BOT_bot", "owner-two"); // same canonical id
+    expect(isOwner("bot_bot", "owner-one")).toBe(false);
+    expect(isOwner("bot_bot", "owner-two")).toBe(true);
+  });
+});

--- a/src/owner-registry.ts
+++ b/src/owner-registry.ts
@@ -3,16 +3,23 @@
  *
  * The owner_uid is obtained from registerBot() and registered during startAccount().
  * Owner users have full access to all cross-session queries.
+ *
+ * Case-insensitive lookup: octo-server BotFather can emit mixed-case bot IDs.
+ * OpenClaw routes lowercased ones to plugin code, so this map normalizes at
+ * the boundary to ensure register / query against any case form hits the
+ * same entry. See issue #33 / src/account-id.ts.
  */
 
-const _ownerUidMap = new Map<string, string>(); // accountId → owner_uid
+import { normalizeAccountId } from "./account-id.js";
+
+const _ownerUidMap = new Map<string, string>(); // normalized accountId → owner_uid
 
 export function registerOwnerUid(accountId: string, ownerUid: string): void {
-  _ownerUidMap.set(accountId, ownerUid);
+  _ownerUidMap.set(normalizeAccountId(accountId), ownerUid);
 }
 
 export function isOwner(accountId: string, uid: string): boolean {
-  return _ownerUidMap.get(accountId) === uid;
+  return _ownerUidMap.get(normalizeAccountId(accountId)) === uid;
 }
 
 /** Visible for testing — clears all owner registrations. */

--- a/src/persona-prompt.test.ts
+++ b/src/persona-prompt.test.ts
@@ -712,3 +712,162 @@ describe("resolvePersonaHintForSession — multi-account isolation (PR#69 R3)", 
     stopPersonaPromptCache("persona_cold");
   });
 });
+
+// ─── issue #33: case-insensitive accountId in persona cache ────────────────
+
+describe("persona-prompt case-insensitive accountId (issue #33)", () => {
+  beforeEach(() => _resetPersonaPromptCacheForTests());
+
+  it("refreshPersonaPromptCache writes under normalized accountId; getPersonaPromptForSession hits either case", async () => {
+    global.fetch = mockFetchOnce({
+      has_grant: true,
+      active: true,
+      persona_prompt: "always reply in English",
+      grantor_name: "Alice",
+      grantor_uid: "alice_uid",
+    });
+
+    await refreshPersonaPromptCache({
+      accountId: "Mixed_Bot",   // mixed-case input
+      apiUrl: "http://api",
+      botToken: "tk",
+      onBehalfOf: "alice_uid",
+    });
+
+    // Lookup with either case form should hit the same cache entry
+    expect(getPersonaPromptForSession("mixed_bot")).toContain("Alice");
+    expect(getPersonaPromptForSession("Mixed_Bot")).toContain("Alice");
+    expect(getPersonaPromptForSession("MIXED_BOT")).toContain("Alice");
+  });
+
+  it("getRegisteredPersonaAccountIds returns normalized ids only", async () => {
+    global.fetch = vi.fn(async () => new Response(JSON.stringify({
+      has_grant: true, active: true,
+      persona_prompt: "x", grantor_name: "G", grantor_uid: "g",
+    }), { status: 200 })) as any;
+
+    initPersonaPromptCache({
+      accountId: "MixedCase_Bot",
+      apiUrl: "http://api",
+      botToken: "tk",
+      onBehalfOf: "g",
+    });
+
+    expect(getRegisteredPersonaAccountIds()).toContain("mixedcase_bot");
+    expect(getRegisteredPersonaAccountIds()).not.toContain("MixedCase_Bot");
+
+    stopPersonaPromptCache("mixedcase_bot");
+  });
+
+  it("stopPersonaPromptCache with mixed-case accountId clears the lowercase entry", async () => {
+    global.fetch = vi.fn(async () => new Response(JSON.stringify({
+      has_grant: true, active: true,
+      persona_prompt: "x", grantor_name: "G", grantor_uid: "g",
+    }), { status: 200 })) as any;
+
+    await refreshPersonaPromptCache({
+      accountId: "MyBot_bot",
+      apiUrl: "http://api",
+      botToken: "tk",
+      onBehalfOf: "g",
+    });
+    expect(getPersonaPromptForSession("mybot_bot")).toBeDefined();
+
+    // Stop using a DIFFERENT case form than what was registered.
+    stopPersonaPromptCache("MYBOT_BOT");
+
+    // Cache should be cleared regardless of original case.
+    expect(getPersonaPromptForSession("mybot_bot")).toBeUndefined();
+    expect(getPersonaPromptForSession("MyBot_bot")).toBeUndefined();
+  });
+
+  it("stop+init race with mixed-case is generation-safe (stop side)", async () => {
+    // Background: bumpGeneration / _currentGeneration take raw accountId; if
+    // either splits the normalized vs raw form into separate counters, the
+    // post-stop refresh fetch would not see a generation mismatch and could
+    // resurrect a stale cache entry. This test asserts the counter is shared.
+    let resolveFetch!: (v: Response) => void;
+    global.fetch = vi.fn(() => new Promise<Response>((res) => { resolveFetch = res; })) as any;
+
+    // Kick off an async refresh under mixed-case (don't await — fetch is gated)
+    const inflight = refreshPersonaPromptCache({
+      accountId: "RaceBot_bot",
+      apiUrl: "http://api",
+      botToken: "tk",
+      onBehalfOf: "g",
+    });
+
+    // Stop with a DIFFERENT case form than the in-flight refresh.
+    // _bumpGeneration normalizes, so the counter bump must invalidate
+    // the in-flight refresh regardless of which case the stop used.
+    stopPersonaPromptCache("racebot_bot");
+
+    // Now let the stale fetch resolve. The refresh should detect the
+    // generation mismatch and bail before writing _cache.
+    resolveFetch(new Response(JSON.stringify({
+      has_grant: true, active: true,
+      persona_prompt: "stale", grantor_name: "X", grantor_uid: "g",
+    }), { status: 200 }));
+    await inflight;
+
+    expect(getPersonaPromptForSession("racebot_bot")).toBeUndefined();
+  });
+
+  it("stop+init race with mixed-case is generation-safe (re-init after stop)", async () => {
+    // Background: after stopping under one case form, an init under a
+    // different case form should produce a fresh, isolated cache entry.
+    // A previously-issued stale fetch must NOT overwrite the new entry.
+    let resolveStaleFetch!: (v: Response) => void;
+    let fetchCallCount = 0;
+    global.fetch = vi.fn(() => {
+      fetchCallCount++;
+      if (fetchCallCount === 1) {
+        // First call — gated, simulates the stale in-flight refresh
+        return new Promise<Response>((res) => { resolveStaleFetch = res; });
+      }
+      // Second call — fresh init's initial fetch resolves immediately
+      return Promise.resolve(new Response(JSON.stringify({
+        has_grant: true, active: true,
+        persona_prompt: "fresh", grantor_name: "FreshOwner", grantor_uid: "g2",
+      }), { status: 200 }));
+    }) as any;
+
+    // 1. Refresh under mixed-case (will hang on first fetch).
+    const stale = refreshPersonaPromptCache({
+      accountId: "RaceBot_bot",
+      apiUrl: "http://api",
+      botToken: "tk",
+      onBehalfOf: "g",
+    });
+
+    // 2. Stop with a different case form.
+    stopPersonaPromptCache("RACEBOT_BOT");
+
+    // 3. Re-init under yet another case form — kicks off a fresh fetch
+    //    that resolves immediately (second mock call).
+    initPersonaPromptCache({
+      accountId: "RACEBOT_BOT",
+      apiUrl: "http://api",
+      botToken: "tk",
+      onBehalfOf: "g2",
+    });
+    // Wait for the fresh init's initial fetch to settle.
+    await vi.waitFor(() => {
+      expect(getPersonaPromptForSession("racebot_bot")).toContain("FreshOwner");
+    });
+
+    // 4. Now resolve the stale fetch from step 1. It should detect the
+    //    generation bump and NOT overwrite the fresh cache entry.
+    resolveStaleFetch(new Response(JSON.stringify({
+      has_grant: true, active: true,
+      persona_prompt: "stale", grantor_name: "OldOwner", grantor_uid: "g",
+    }), { status: 200 }));
+    await stale;
+
+    // Fresh hint must survive.
+    expect(getPersonaPromptForSession("racebot_bot")).toContain("FreshOwner");
+    expect(getPersonaPromptForSession("racebot_bot")).not.toContain("OldOwner");
+
+    stopPersonaPromptCache("racebot_bot");
+  });
+});

--- a/src/persona-prompt.ts
+++ b/src/persona-prompt.ts
@@ -27,6 +27,7 @@
 
 import type { ChannelLogSink } from "openclaw/plugin-sdk/channel-contract";
 import { getBotOboGrant, type BotOboGrant } from "./api-fetch.js";
+import { normalizeAccountId } from "./account-id.js";
 
 const DEFAULT_REFRESH_INTERVAL_MS = 60_000;
 
@@ -67,14 +68,31 @@ const _firstFetchLogged = new Set<string>();
  */
 const _generation = new Map<string, number>();
 
+/**
+ * Clone the input with `accountId` normalized to lowercase. Used at the
+ * top of every exported function that takes a PersonaAccountInput so all
+ * downstream Map/Set/log lookups speak the canonical id. PersonaAccountInput
+ * only contains string/optional-string fields, so the spread is safe.
+ *
+ * See ./account-id.ts for the normalize contract (issue #33 / octo-server#302).
+ */
+function withNormalizedAccount(account: PersonaAccountInput): PersonaAccountInput {
+  return { ...account, accountId: normalizeAccountId(account.accountId) };
+}
+
 function _bumpGeneration(accountId: string): number {
-  const next = (_generation.get(accountId) ?? 0) + 1;
-  _generation.set(accountId, next);
+  // Defense in depth — callers should already pass normalized form, but
+  // we normalize here too so a stray raw-id callsite cannot split the
+  // generation counter into two parallel sequences.
+  const id = normalizeAccountId(accountId);
+  const next = (_generation.get(id) ?? 0) + 1;
+  _generation.set(id, next);
   return next;
 }
 
 function _currentGeneration(accountId: string): number {
-  return _generation.get(accountId) ?? 0;
+  const id = normalizeAccountId(accountId);
+  return _generation.get(id) ?? 0;
 }
 
 /**
@@ -136,20 +154,21 @@ export async function refreshPersonaPromptCache(
   account: PersonaAccountInput,
   log?: ChannelLogSink,
 ): Promise<void> {
-  if (!account.onBehalfOf) return;
-  const myGeneration = _currentGeneration(account.accountId);
+  const acc = withNormalizedAccount(account);
+  if (!acc.onBehalfOf) return;
+  const myGeneration = _currentGeneration(acc.accountId);
   let grant: BotOboGrant | null;
   try {
     grant = await getBotOboGrant({
-      apiUrl: account.apiUrl,
-      botToken: account.botToken,
+      apiUrl: acc.apiUrl,
+      botToken: acc.botToken,
     });
   } catch (err) {
     // Even logging on a superseded fetch is noise — but skipping it
     // could mask real failures. Keep the warn but suppress cache writes.
-    if (_currentGeneration(account.accountId) !== myGeneration) return;
+    if (_currentGeneration(acc.accountId) !== myGeneration) return;
     log?.warn?.(
-      `octo: persona_prompt fetch failed for ${account.accountId}: ${err instanceof Error ? err.message : String(err)}`,
+      `octo: persona_prompt fetch failed for ${acc.accountId}: ${err instanceof Error ? err.message : String(err)}`,
     );
     return;
   }
@@ -157,28 +176,28 @@ export async function refreshPersonaPromptCache(
   // Drop this result if the account was stopped or reconfigured while
   // the fetch was outstanding. Without this check, a stale grant could
   // overwrite the cleared cache or the next init's fresh entry.
-  if (_currentGeneration(account.accountId) !== myGeneration) return;
+  if (_currentGeneration(acc.accountId) !== myGeneration) return;
 
   const hint = grant ? composePersonaHint(grant) : undefined;
-  const prev = _cache.get(account.accountId);
-  _cache.set(account.accountId, { hint, fetchedAt: Date.now() });
+  const prev = _cache.get(acc.accountId);
+  _cache.set(acc.accountId, { hint, fetchedAt: Date.now() });
 
-  if (!_firstFetchLogged.has(account.accountId)) {
-    _firstFetchLogged.add(account.accountId);
+  if (!_firstFetchLogged.has(acc.accountId)) {
+    _firstFetchLogged.add(acc.accountId);
     if (hint) {
       log?.info?.(
-        `octo: persona_prompt loaded for ${account.accountId} (grantor=${account.onBehalfOf}, ${hint.length} chars)`,
+        `octo: persona_prompt loaded for ${acc.accountId} (grantor=${acc.onBehalfOf}, ${hint.length} chars)`,
       );
     } else {
       log?.info?.(
-        `octo: persona_prompt not active for ${account.accountId} (grantor=${account.onBehalfOf}); cache will retry every ${_refreshIntervalMs}ms`,
+        `octo: persona_prompt not active for ${acc.accountId} (grantor=${acc.onBehalfOf}); cache will retry every ${_refreshIntervalMs}ms`,
       );
     }
     return;
   }
   if (prev?.hint !== hint) {
     log?.info?.(
-      `octo: persona_prompt refreshed for ${account.accountId} (changed=${prev?.hint !== hint}, hasHint=${Boolean(hint)})`,
+      `octo: persona_prompt refreshed for ${acc.accountId} (changed=${prev?.hint !== hint}, hasHint=${Boolean(hint)})`,
     );
   }
 }
@@ -195,26 +214,27 @@ export function initPersonaPromptCache(
   account: PersonaAccountInput,
   log?: ChannelLogSink,
 ): void {
-  if (!account.onBehalfOf) {
+  const acc = withNormalizedAccount(account);
+  if (!acc.onBehalfOf) {
     // PR#69 R4 (Jerry-Xin) Blocking 1: when an account is reconfigured
     // from persona-clone (`onBehalfOf` set) to a regular bot (`onBehalfOf`
     // cleared), a bare early return would leave the previous timer and
     // cached hint in place, so the before_prompt_build hook would keep
     // injecting the old grantor's persona prompt into a now-plain bot.
     // Tear down any prior state for this accountId before bailing out.
-    stopPersonaPromptCache(account.accountId);
+    stopPersonaPromptCache(acc.accountId);
     return;
   }
 
   // Drop any pre-existing timer for this account so repeated calls
   // (hot reload, account reconfigure) don't leak intervals.
-  const existing = _timers.get(account.accountId);
+  const existing = _timers.get(acc.accountId);
   if (existing) clearInterval(existing);
 
   // Bump generation so any fetch from a previous init/start-cycle that
   // is still in flight will see a generation mismatch when it resolves
   // and bail out before mutating _cache.
-  _bumpGeneration(account.accountId);
+  _bumpGeneration(acc.accountId);
 
   // PR#69 R4 (Jerry-Xin) Blocking 2: on reconfigure (e.g. grantor
   // switched from A to B), the previous grantor's hint is still sitting
@@ -223,22 +243,25 @@ export function initPersonaPromptCache(
   // grantor's prompt. Clear the cache eagerly so the hook fails safe
   // (returns undefined → no persona injection) during the refetch
   // window, rather than leaking stale identity into the new context.
-  _cache.delete(account.accountId);
+  _cache.delete(acc.accountId);
   // Allow the next successful fetch for this account to re-emit the
   // one-shot "loaded" / "not active" info log, so operators can see the
   // post-reconfigure state in logs.
-  _firstFetchLogged.delete(account.accountId);
+  _firstFetchLogged.delete(acc.accountId);
 
   // Fire-and-forget initial fetch. We deliberately don't await
   // because account start should not block on persona init.
-  void refreshPersonaPromptCache(account, log);
+  // Pass the already-normalized acc so refreshPersonaPromptCache doesn't
+  // re-clone (it would still normalize internally; passing acc just avoids
+  // an extra spread per timer tick).
+  void refreshPersonaPromptCache(acc, log);
 
   const timer = setInterval(() => {
-    void refreshPersonaPromptCache(account, log);
+    void refreshPersonaPromptCache(acc, log);
   }, _refreshIntervalMs);
   // Refresh timer alone must not keep the Node process alive.
   timer.unref?.();
-  _timers.set(account.accountId, timer);
+  _timers.set(acc.accountId, timer);
 }
 
 /**
@@ -246,14 +269,15 @@ export function initPersonaPromptCache(
  * Called when the account is shut down or reconfigured.
  */
 export function stopPersonaPromptCache(accountId: string): void {
+  const id = normalizeAccountId(accountId);
   // Bump generation BEFORE clearing state so any fetch that resolves
   // after this point sees the mismatch and skips its cache write.
-  _bumpGeneration(accountId);
-  const timer = _timers.get(accountId);
+  _bumpGeneration(id);
+  const timer = _timers.get(id);
   if (timer) clearInterval(timer);
-  _timers.delete(accountId);
-  _cache.delete(accountId);
-  _firstFetchLogged.delete(accountId);
+  _timers.delete(id);
+  _cache.delete(id);
+  _firstFetchLogged.delete(id);
 }
 
 /**
@@ -271,7 +295,7 @@ export function stopPersonaPromptCache(accountId: string): void {
 export function getPersonaPromptForSession(
   accountId: string,
 ): string | undefined {
-  return _cache.get(accountId)?.hint;
+  return _cache.get(normalizeAccountId(accountId))?.hint;
 }
 
 /**
@@ -279,6 +303,10 @@ export function getPersonaPromptForSession(
  * via `initPersonaPromptCache`. This is the set of accounts the
  * `before_prompt_build` hook should consider when resolving persona identity
  * for a given sessionKey.
+ *
+ * The returned ids are always normalized to lowercase (init stores them that
+ * way), so callers can compare them directly against other normalized ids
+ * without doing case folding themselves.
  *
  * Returning only persona-clone accounts (those with `account.config.onBehalfOf`
  * set, since `initPersonaPromptCache` is a no-op for non-persona accounts)

--- a/src/thread-binding-adapter.ts
+++ b/src/thread-binding-adapter.ts
@@ -35,6 +35,7 @@ import {
 } from "openclaw/plugin-sdk/thread-bindings-runtime";
 import { CHANNEL_ID, THREAD_ID_SEPARATOR } from "./constants.js";
 import { createThread } from "./api-fetch.js";
+import { normalizeAccountId } from "./account-id.js";
 
 // SDK's `thread-bindings-runtime` only re-exports the adapter + record types.
 // Derive the input types from the adapter signature itself to stay loosely
@@ -43,20 +44,9 @@ type SessionBindingBindInput = Parameters<NonNullable<SessionBindingAdapter["bin
 type SessionBindingUnbindInput = Parameters<NonNullable<SessionBindingAdapter["unbind"]>>[0];
 type ConversationRef = Parameters<SessionBindingAdapter["resolveByConversation"]>[0];
 
-/**
- * OpenClaw's session-binding service normalizes account IDs to lowercase
- * before invoking adapter methods (see `normalizeOptionalLowercaseString`
- * inside `session-binding-service`). BotFather can emit mixed-case bot IDs
- * (e.g. `27pBwzf2F6bfa5cd142_bot`), so storing/comparing against the raw
- * registration accountId silently breaks `resolveByConversation` for those
- * accounts — bindings succeed (SDK passes the lowercased id into `bind`)
- * but reverse lookup misses because the closure compares against the
- * mixed-case original. Normalize once at registration and use the result
- * everywhere internal.
- */
-function normalizeAccountId(accountId: string): string {
-  return accountId.toLowerCase();
-}
+// normalizeAccountId moved to ./account-id.ts as the single source of truth
+// for plugin-wide accountId normalization. See that file's doc for context
+// (issue #33). All other modules that key on accountId import from there too.
 
 type Logger = {
   info?: (msg: string) => void;


### PR DESCRIPTION
## Summary

Make all `accountId` handling case-insensitive across the plugin, so mixed-case BotFather IDs (e.g. `27pBwzf2F6bfa5cd142_bot`) no longer mismatch OpenClaw's lowercase normalize layer on the routing side.

- Single source of truth: new `src/account-id.ts` with `normalizeAccountId()`
- Contract: every exported function (including test-only helpers) that receives `accountId` (or a parameter object containing it) normalizes on the first line
- Surfaces normalized: owner-registry, channel (8 per-account Maps + group→account Set, both write + read sides), inbound (composite session key), group-md (GROUP + THREAD chain — paths, read/write/delete/ensure, meta persisted normalized), mention-prefs, persona-prompt (5 exported APIs + defense-in-depth on internal generation), thread-binding-adapter
- Startup audit: logs count of mixed-case accounts detected so operators can track legacy bots

## Why

Closes #33 — BotFather historically generated mixed-case bot IDs. OpenClaw routes lowercase, but the plugin previously did strict equality lookups, causing silent misroutes in owner checks, persona cache, group/thread MD caches, mention-prefs, and group→account mapping.

## Compat for existing mixed-case bots

- ✅ Bot tokens / `openclaw.json` config / WuKongIM channels: unchanged
- ✅ macOS (APFS case-insensitive FS): zero observable change
- ⚠️ Linux (case-sensitive FS): single cache-miss on first inbound per group/thread after upgrade (path moves from `<BotA>/` to `<bota>/`), then settles. Old dirs become harmless orphans.
- ✅ Owner permission: previously broken-but-silent for mixed-case bots, now correctly works (improvement, not regression)

## Companion fix

Server-side fix at Mininglamp-OSS/octo-server#302 makes all NEW bot IDs lowercase. This plugin PR closes #33 because it covers both the legacy mixed-case bot population AND new lowercase bots transparently — no hard dependency on the server PR.

## Test plan

- [x] 5 new test files: `account-id.test.ts`, `owner-registry.test.ts`, `inbound.test.ts` (session-account map block), `persona-prompt.test.ts` (incl. stop+init race), `group-md.test.ts` (GROUP + THREAD via case-preserving `readdirSync` + `meta.account_id` assertion)
- [x] 4 updated suites for case-insensitive behavior (`channel.test.ts`, `mention-prefs.test.ts`, `multi-bot-isolation.test.ts`, `persona-prompt.test.ts`)
- [x] 5 rounds of `codex` review on the plan (12 → 8 → 6 → 2 → 0 findings) and 2 rounds on the implementation (1 BLOCKER + 3 MINOR → APPROVED)
- [x] Local end-to-end on a fresh `octo-server` (fix branch) + this plugin: legacy mixed-case bot `daemon` (`27uG1CHzdo4f7d50129_bot`) receives + processes group messages OK; new lowercase bot created in the local environment receives + replies via `agent test`
- [x] `npm test` + `npm run type-check` + `npm run pack:check`
