### PR TITLE
chore(release): document release flow and auto-sync GH Release notes

### DIFF
--- a/.github/workflows/publish-clawhub.yml
+++ b/.github/workflows/publish-clawhub.yml
@@ -250,8 +250,12 @@ jobs:
             $DRY \
             octo-*.tgz
 
-      - name: publish GitHub Release (upload tarball, or create if missing)
-        if: github.event_name == 'push' && needs.verify.outputs.dry_run != 'true'
+      - name: publish GitHub Release (upload tarball, sync notes from CHANGELOG.md)
+        # `always()` so we still upload the tarball and sync notes even when
+        # `publish to ClawHub` above times out — that step has known server-side
+        # response issues where the package lands but the HTTP response hangs,
+        # and we don't want a ClawHub timeout to also strand the Release.
+        if: always() && github.event_name == 'push' && needs.verify.outputs.dry_run != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ github.ref_name }}
@@ -263,15 +267,14 @@ jobs:
             echo "[publish] uploading tarball to existing release $TAG (created by release-please)"
             gh release upload "$TAG" octo-*.tgz --clobber
 
-            # Backfill release notes if the existing release body is empty.
-            # release-please normally populates the body from generated changelog,
-            # but a configuration hiccup (all commits hidden, generator error, etc.)
-            # can leave it empty — in which case ship the CHANGELOG.md section.
-            EXISTING_BODY=$(gh release view "$TAG" --json body --jq '.body // ""')
-            if [ -z "$EXISTING_BODY" ]; then
-              echo "[publish] existing release body is empty — backfilling from CHANGELOG.md"
-              gh release edit "$TAG" --notes-file /tmp/notes.md
-            fi
+            # Always overwrite the release body with our CHANGELOG.md section.
+            # release-please auto-generates a one-line-per-commit body that
+            # does not match the project's prose style (现象/根因/修复/兼容性).
+            # We rewrite CHANGELOG.md on the release-please PR before merging,
+            # and the release body should mirror that — every release, not
+            # just when the body happens to be empty.
+            echo "[publish] overwriting release body with CHANGELOG.md section"
+            gh release edit "$TAG" --notes-file /tmp/notes.md
 
             # If the existing release is a draft (left over from prior failed run
             # or future release-please config drift), flip to published. Without

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,168 @@
+# 发版流程
+
+本仓库的 release 流程基于 [release-please](https://github.com/googleapis/release-please) + 自动化 CI。这份文档把"想发一版要做什么"按步骤写清楚，新人接手或久未发版回忆细节都看这一份。
+
+## 日常开发约定（决定下次发什么版本号）
+
+PR 的 commit message 用 [Conventional Commits](https://www.conventionalcommits.org/) 前缀。merge 到 `main` 之后 release-please 会按前缀决定版本 bump：
+
+| 前缀 | 含义 | 版本号变化 | 出现在 CHANGELOG |
+|---|---|---|---|
+| `fix:` | bug 修复 | patch (1.0.x) | ✅ |
+| `feat:` | 新功能 | minor (1.x.0) | ✅ |
+| `feat!:` / `fix!:` / commit body 含 `BREAKING CHANGE:` | 不兼容改动 | major (x.0.0) | ✅ |
+| `chore:` / `docs:` / `ci:` / `refactor:` / `test:` | 内部改动 | 不 bump | ❌ |
+
+**关键**：commit message 前缀直接决定下次发什么版本号，认真写。
+
+---
+
+## 想发版时（4 步）
+
+### Step 1：编辑 release-please 自动维护的 release PR
+
+它一直挂着，每次 `main` 有新 commit 自动更新 `package.json` 版本号 + `CHANGELOG.md`。找到它（标题形如 `chore(release): release vX.Y.Z`），把它的 branch 拉下来改 `CHANGELOG.md`：
+
+```bash
+git fetch origin release-please--branches--main--components--octo
+git checkout -b release-edit-X.Y.Z origin/release-please--branches--main--components--octo
+```
+
+**把 release-please 自动生成的一行式 commit dump 重写成我们的 prose 风格** —— 参考 `CHANGELOG.md` 里 1.0.14 / 1.0.13 那种写法：
+
+- 主标题 **bold 一句话症状**，加 `(#issue, PR #pr)` 引用
+- 缩进 bullet 分层写 **根因 / 修复方案 / 影响范围 / 兼容性**
+- 分组用中文 `### Fixed` / `### Added` / `### Changed` / `### Internal`
+
+写完推回 release-please 的 branch：
+
+```bash
+git add CHANGELOG.md
+git commit -m "chore(release): rewrite X.Y.Z CHANGELOG in project house style"
+git push origin release-edit-X.Y.Z:release-please--branches--main--components--octo
+```
+
+release-please 后续再跑会**保留**手工编辑（这是它的官方行为）。
+
+### Step 2：reviewer approve 后点 Merge
+
+merge 之后**全自动**：
+
+- release-please 机器人打 tag `vX.Y.Z`
+- tag push 触发 `.github/workflows/publish-clawhub.yml`
+- 包推到 ClawHub
+- release-please 创建 GitHub Release
+- CI 自动同步 Release notes = CHANGELOG.md 那段（不再是 release-please 自动生成的一行式）
+- CI 自动上传 tarball 到 Release 附件
+
+### Step 3：验证
+
+```bash
+clawhub package inspect octo
+```
+
+看到 `Latest: X.Y.Z` 即可。
+
+⚠️ **不要只看 GitHub Actions 状态** —— ClawHub 服务端目前偶尔有响应回写问题，CI 可能标记 failure 但**包其实已经成功入库**。`clawhub package inspect` 是 ground truth。
+
+另外也建议看一下：
+
+- https://github.com/Mininglamp-OSS/openclaw-channel-octo/releases —— Release notes 是 prose 风格，附件 `octo-X.Y.Z.tgz` 已挂
+- https://github.com/Mininglamp-OSS/openclaw-channel-octo/blob/main/CHANGELOG.md —— 第一段是 X.Y.Z
+
+### Step 4：发面向用户的 changelog 到 OctoPush（手工）
+
+线上 changelog 页面：https://im.deepminer.com.cn/changelog/
+
+这一步**不会自动触发**，因为面向用户的语言跟开发 CHANGELOG 风格完全不一样（参考 web/android/ios 模块的现有条目），需要人工翻译。
+
+调 `octo-changelog` skill：
+
+```
+/octo-changelog 发我们的 changelog
+```
+
+skill 会引导你：
+
+1. 拿仓库 CHANGELOG.md 里 X.Y.Z 那一段作为原料
+2. 翻译成用户语言：去 PR # / 文件路径 / 函数名 / 根因分析；保留"用户能感受到的"
+3. 按 `【修复】/【新增】/【优化】` 分组
+4. **先发测试环境**（`im-test.deepminer.com.cn`）看页面渲染 OK
+5. **再发线上**（`im.deepminer.com.cn`）
+
+⚠️ **entry 一旦 POST 不可撤回**（API 不支持 PUT/PATCH/DELETE，重发同 version 会创建副本不会覆盖）。发线上前必须 100% 确认文案，发错只能找运维直接改 DB。
+
+---
+
+## 异常处理
+
+### ClawHub publish CI 失败但包其实已入库
+
+已知问题，CI 那条路会卡 12 分钟 timeout。判断方式：
+
+```bash
+clawhub package inspect octo
+```
+
+如果 `Latest: X.Y.Z`，发版**已经成功**，CI 红只是个误导信号。Release notes 同步 + tarball 上传那两步因为 workflow 用 `if: always()` 也会跑，应该都齐了；如果没齐手动补：
+
+```bash
+gh release upload vX.Y.Z octo-X.Y.Z.tgz --repo Mininglamp-OSS/openclaw-channel-octo
+gh release edit vX.Y.Z --notes-file <(./scripts/extract-changelog.sh X.Y.Z)
+```
+
+### ClawHub publish 真的没成功（`clawhub package inspect` 看不到新版本）
+
+本地手工兜底：
+
+```bash
+git checkout vX.Y.Z
+npm run build && npm pack
+clawhub auth login   # 如未登录
+clawhub package publish --family code-plugin --version X.Y.Z \
+  --source-repo Mininglamp-OSS/openclaw-channel-octo \
+  --source-commit "$(git rev-parse HEAD)" \
+  --source-ref vX.Y.Z \
+  --changelog "$(./scripts/extract-changelog.sh X.Y.Z)" \
+  octo-X.Y.Z.tgz
+```
+
+### im.deepminer.com.cn changelog 发错了
+
+entry **不能 PUT / DELETE / PATCH**。重发同 version 会创建副本（不会覆盖）。**唯一干净的修法**：找运维直接改 DB 删条目。
+
+### release-please PR 一直不出现
+
+检查 `main` 上最新几个 commit 的 message 有没有 conventional commits 前缀。纯 `chore:` / `docs:` / `ci:` 不会触发新版本——必须至少有一个 `fix:` 或 `feat:`。
+
+---
+
+## 一页 cheatsheet
+
+```
+发版 4 步：
+  1. 改 release-please PR 的 CHANGELOG.md（写人话，prose 风格）
+  2. merge 它（自动打 tag + 推 ClawHub + 同步 Release notes + 上传 tarball）
+  3. clawhub package inspect octo 验证（不要只信 CI 状态）
+  4. /octo-changelog 发用户语言公告到 im.deepminer.com.cn/changelog/
+     （先测试环境后线上；entry 不可撤回，确认文案）
+
+绝对不要：
+  ❌ 手工改 package.json 版本号
+  ❌ 手工改 src/version.ts（prebuild 自动生成）
+  ❌ 手工 git tag
+  ❌ 发 im.deepminer changelog 不先发测试
+  ❌ 假设 CI 失败 = 发版失败（看 clawhub package inspect）
+```
+
+---
+
+## 相关链接
+
+- ClawHub 包页：通过 `clawhub package inspect octo` 查
+- GitHub Releases：https://github.com/Mininglamp-OSS/openclaw-channel-octo/releases
+- 用户面 changelog（线上）：https://im.deepminer.com.cn/changelog/
+- 用户面 changelog（测试）：https://im-test.deepminer.com.cn/changelog/
+- release-please workflow：`.github/workflows/release-please.yml`
+- ClawHub publish workflow：`.github/workflows/publish-clawhub.yml`
+- octo-changelog skill：`~/.claude/skills/octo-changelog/SKILL.md`


### PR DESCRIPTION
## Summary

Two related changes to the release process, motivated by what we hit on v1.0.15:

### 1. New `RELEASE.md` — the release playbook in the repo

A 4-step walkthrough of how to ship a version, plus exception handling. Covers:

- Conventional commit prefix convention (what bumps what)
- How to edit the release-please PR's `CHANGELOG.md` in our prose style before merging
- What auto-runs after merge (tag → ClawHub publish → GH Release sync → tarball upload)
- How to verify (`clawhub package inspect octo`, not CI status)
- **How to publish the user-facing changelog to https://im.deepminer.com.cn/changelog/** via `/octo-changelog` skill
- Exception paths: ClawHub publish timeout, manual fallback, im API entry can't-be-edited rule, release-please PR not appearing

### 2. `publish-clawhub.yml` — auto-sync GH Release notes from `CHANGELOG.md`

Two adjustments to the `publish GitHub Release` step:

- **Always overwrite the Release body** with the `CHANGELOG.md` section, not just when the body is empty. release-please always populates the body with one-line-per-commit content that never matches our prose style — so the "only if empty" branch never fired. We always want the prose version.
- **Add `always()` to the step's `if:` condition** so the tarball upload + notes sync still run when the upstream `publish to ClawHub` step times out. We saw this on v1.0.15: the package landed on ClawHub but the CLI's HTTP response hung, causing the step to fail; the subsequent Release sync was then skipped, leaving the Release with no tarball and ugly auto-generated notes. Both had to be patched up by hand.

## Why this matters

The motivating run was v1.0.15: every minute spent reconciling the Release page after merge was time the user noticed and asked about. This PR makes the post-merge state correct by default.

## Verification

- `npx js-yaml .github/workflows/publish-clawhub.yml` — parses clean
- Diff inspection: the `if: always() && ...` guard preserves all original gating (push event only, not dry-run); the overwrite branch is the only logical change beyond the guard
- Will be observed on the next release (won't run until a `vX.Y.Z` tag is pushed)

## Test plan

- [ ] CI green on this PR
- [ ] On next release: verify Release page on GitHub shows prose CHANGELOG content + tarball attached, regardless of whether `publish to ClawHub` step succeeded or timed out

🤖 Generated with [Claude Code](https://claude.com/claude-code)