### PR TITLE
fix(inbound): bound dispatch + apology + final flush against silent hangs (Refs #75)

### DIFF
--- a/src/inbound-dispatch-timeout.test.ts
+++ b/src/inbound-dispatch-timeout.test.ts
@@ -1,0 +1,358 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { ChannelType, MessageType } from "./types.js";
+import {
+  handleInboundMessage,
+  _setDispatchTimeoutForTests,
+  _setDispatchApologyTimeoutForTests,
+} from "./inbound.js";
+import { setOctoRuntime } from "./runtime.js";
+import { _clearKnownBots } from "./bot-registry.js";
+import type { ResolvedOctoAccount } from "./accounts.js";
+
+/**
+ * Regression tests for issue #75 — upstream
+ * `core.channel.reply.dispatchReplyWithBufferedBlockDispatcher` can hang
+ * indefinitely (no resolve, no reject, no onError). Combined with the
+ * per-group serial inbound queue (`enqueueInbound` in channel.ts), a single
+ * hang locks the entire group: no further messages get processed until the
+ * gateway restarts.
+ *
+ * Scope of this fix (intentionally minimal):
+ *   1. Promise.race + setTimeout makes a hang reject as a timeout error
+ *      → enqueueInbound's outer .catch() advances the queue.
+ *   2. The "处理超时" apology sendMessage carries its own short AbortSignal
+ *      → a sick Octo API does NOT re-hang the timeout path.
+ *   3. The happy-path final flush of buffered text also carries a short
+ *      AbortSignal → even on the success path, a slow API can't strand the
+ *      queue.
+ *   4. Timeout handle is cleared in finally on every path.
+ *
+ * Out of scope (tracked separately): cancellation of an already-in-flight
+ * upstream dispatch / suppression of late deliver/onError callbacks from a
+ * dispatch that "wakes up" after our timeout. If the upstream resumes, the
+ * worst outcome is a delayed real reply on top of the apology — annoying,
+ * not broken.
+ */
+
+const API = "http://octo.test";
+const BOT_UID = "bot_self_0000000000000000000000000000";
+const HUMAN_UID = "human_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const GROUP_ID = "g_room_1";
+
+const originalFetch = globalThis.fetch;
+const originalSetTimeout = globalThis.setTimeout;
+const originalClearTimeout = globalThis.clearTimeout;
+
+// Two intentionally DIFFERENT delays so the timer-cleanup test can tell our
+// dispatch timer apart from the apology / final-flush AbortSignal.timeout
+// timers (both fixed at APOLOGY_TIMEOUT_MS) when filtering setTimeout calls
+// by delay.
+const TIMEOUT_MS_FOR_TESTS = 100;
+const APOLOGY_TIMEOUT_MS_FOR_TESTS = 150;
+
+function makeAccount(): ResolvedOctoAccount {
+  return {
+    accountId: "acct1",
+    enabled: true,
+    configured: true,
+    config: {
+      botToken: "tok",
+      apiUrl: API,
+      pollIntervalMs: 1000,
+      heartbeatIntervalMs: 1000,
+      requireMention: false,
+    },
+  };
+}
+
+function makeAtBotMessage() {
+  return {
+    message_id: "m1",
+    message_seq: 100,
+    from_uid: HUMAN_UID,
+    channel_id: GROUP_ID,
+    channel_type: ChannelType.Group,
+    timestamp: Math.floor(Date.now() / 1000),
+    payload: {
+      type: MessageType.Text,
+      content: "hello bot",
+      mention: { uids: [BOT_UID] },
+    },
+  };
+}
+
+function installFetchStub() {
+  const sends: any[] = [];
+  globalThis.fetch = vi.fn(async (input: any, init?: any) => {
+    const url = typeof input === "string" ? input : input.toString();
+    const json = (data: unknown, status = 200) =>
+      new Response(JSON.stringify(data), { status, headers: { "Content-Type": "application/json" } });
+
+    if (url.includes("/members")) {
+      return json({
+        members: [
+          { uid: HUMAN_UID, name: "Alice", robot: false },
+          { uid: BOT_UID, name: "SelfBot", robot: true },
+        ],
+      });
+    }
+    if (url.includes("/mention_pref")) return json({ no_mention: false });
+    if (url.includes("/md")) return json({ content: "", version: 0, updated_at: null, updated_by: "" });
+    if (url.includes("/messages/sync")) return json({ messages: [] });
+    if (url.includes("/readReceipt")) return json({});
+    if (url.includes("/typing")) return json({});
+    if (url.includes("/sendMessage")) {
+      sends.push(init?.body ? JSON.parse(init.body) : {});
+      return json({ message_id: "reply1", message_seq: 0 });
+    }
+    return json({});
+  }) as unknown as typeof fetch;
+  return { sends };
+}
+
+/**
+ * Network stub variant where /sendMessage HANGS until the request's signal
+ * aborts. Used to verify that AbortSignal.timeout on the apology + final
+ * flush actually interrupts in-flight sends, instead of merely being passed
+ * for show.
+ */
+function installHangingSendFetchStub(): {
+  sends: Array<{ content: string | null; abortedBeforeResolve: boolean }>;
+} {
+  const sends: Array<{ content: string | null; abortedBeforeResolve: boolean }> = [];
+  globalThis.fetch = vi.fn(async (input: any, init?: any) => {
+    const url = typeof input === "string" ? input : input.toString();
+    const json = (data: unknown, status = 200) =>
+      new Response(JSON.stringify(data), { status, headers: { "Content-Type": "application/json" } });
+
+    if (url.includes("/members")) {
+      return json({
+        members: [
+          { uid: HUMAN_UID, name: "Alice", robot: false },
+          { uid: BOT_UID, name: "SelfBot", robot: true },
+        ],
+      });
+    }
+    if (url.includes("/mention_pref")) return json({ no_mention: false });
+    if (url.includes("/md")) return json({ content: "", version: 0, updated_at: null, updated_by: "" });
+    if (url.includes("/messages/sync")) return json({ messages: [] });
+    if (url.includes("/readReceipt")) return json({});
+    if (url.includes("/typing")) return json({});
+    if (url.includes("/sendMessage")) {
+      const body = init?.body ? JSON.parse(init.body) : null;
+      const content: string | null = body?.payload?.content ?? null;
+      const signal: AbortSignal | undefined = init?.signal;
+      const record = { content, abortedBeforeResolve: false };
+      sends.push(record);
+      // If no signal was passed, the stub deliberately hangs forever and the
+      // test will time out — that surfaces missing wiring loudly.
+      if (!signal) {
+        await new Promise<void>(() => {});
+      }
+      // Pre-aborted signal: don't wait for an event that already fired.
+      if (signal.aborted) {
+        record.abortedBeforeResolve = true;
+        throw new Error("aborted");
+      }
+      await new Promise<void>((_, reject) => {
+        signal.addEventListener("abort", () => {
+          record.abortedBeforeResolve = true;
+          reject(new Error("aborted"));
+        }, { once: true });
+      });
+      return json({}); // unreachable
+    }
+    return json({});
+  }) as unknown as typeof fetch;
+  return { sends };
+}
+
+function installHangingRuntime(): { dispatch: ReturnType<typeof vi.fn> } {
+  const dispatch = vi.fn(async () => {
+    await new Promise<void>(() => {}); // never resolves, never rejects
+  });
+  setOctoRuntime({
+    config: { loadConfig: () => ({}) },
+    channel: {
+      reply: {
+        dispatchReplyWithBufferedBlockDispatcher: dispatch,
+        resolveEnvelopeFormatOptions: () => ({}),
+        formatAgentEnvelope: ({ body }: any) => body,
+        finalizeInboundContext: (ctx: any) => ctx,
+      },
+      routing: {
+        resolveAgentRoute: () => ({ agentId: "agent1", sessionKey: "sk1", accountId: "acct1" }),
+      },
+      session: {
+        resolveStorePath: () => "/tmp/store",
+        readSessionUpdatedAt: () => undefined,
+        recordInboundSession: async () => {},
+      },
+    },
+  } as any);
+  return { dispatch };
+}
+
+function installImmediateRuntime(deliverArgs?: { text?: string; kind?: string }) {
+  const dispatch = vi.fn(async (args: any) => {
+    if (deliverArgs) {
+      await args.dispatcherOptions.deliver({ text: deliverArgs.text ?? "hi" }, { kind: deliverArgs.kind ?? "final" });
+    }
+  });
+  setOctoRuntime({
+    config: { loadConfig: () => ({}) },
+    channel: {
+      reply: {
+        dispatchReplyWithBufferedBlockDispatcher: dispatch,
+        resolveEnvelopeFormatOptions: () => ({}),
+        formatAgentEnvelope: ({ body }: any) => body,
+        finalizeInboundContext: (ctx: any) => ctx,
+      },
+      routing: {
+        resolveAgentRoute: () => ({ agentId: "agent1", sessionKey: "sk1", accountId: "acct1" }),
+      },
+      session: {
+        resolveStorePath: () => "/tmp/store",
+        readSessionUpdatedAt: () => undefined,
+        recordInboundSession: async () => {},
+      },
+    },
+  } as any);
+  return { dispatch };
+}
+
+function pickTimeoutSends(sends: any[]) {
+  return sends.filter(
+    (body) => typeof body?.payload?.content === "string" && body.payload.content.includes("处理超时"),
+  );
+}
+
+function runInbound(opts: { log?: any } = {}) {
+  return handleInboundMessage({
+    account: makeAccount(),
+    message: makeAtBotMessage() as any,
+    botUid: BOT_UID,
+    groupHistories: new Map(),
+    lastBotReplySeqMap: new Map(),
+    memberMap: new Map(),
+    uidToNameMap: new Map(),
+    groupCacheTimestamps: new Map(),
+    log: opts.log,
+  });
+}
+
+beforeEach(() => {
+  _clearKnownBots();
+  _setDispatchTimeoutForTests(TIMEOUT_MS_FOR_TESTS);
+  _setDispatchApologyTimeoutForTests(APOLOGY_TIMEOUT_MS_FOR_TESTS);
+});
+
+afterEach(() => {
+  _setDispatchTimeoutForTests(null);
+  _setDispatchApologyTimeoutForTests(null);
+  globalThis.fetch = originalFetch;
+  globalThis.setTimeout = originalSetTimeout;
+  globalThis.clearTimeout = originalClearTimeout;
+  vi.restoreAllMocks();
+});
+
+describe("dispatch timeout guard (issue #75)", () => {
+  it("hang: rejects after timeout, sends 处理超时 apology, would unblock per-group queue", async () => {
+    const { dispatch } = installHangingRuntime();
+    const { sends } = installFetchStub();
+    const warnSpy = vi.fn();
+
+    await expect(runInbound({ log: { debug: () => {}, info: () => {}, warn: warnSpy, error: () => {} } }))
+      .rejects.toThrow();
+
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    expect(pickTimeoutSends(sends)).toHaveLength(1);
+    expect(warnSpy.mock.calls.some((c) => String(c[0]).includes("dispatch hung"))).toBe(true);
+  });
+
+  it("happy path: dispatchTimeoutHandle is cleared (no leaked timer)", async () => {
+    // Spy on setTimeout/clearTimeout to find the specific dispatch-timeout
+    // handle and verify it gets cleared. Filter by delay === TIMEOUT_MS_FOR_TESTS
+    // which is unique (APOLOGY_TIMEOUT_MS_FOR_TESTS is intentionally different).
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout") as any;
+    const clearTimeoutSpy = vi.spyOn(globalThis, "clearTimeout") as any;
+
+    installImmediateRuntime({ text: "hi", kind: "final" });
+    installFetchStub();
+
+    await runInbound({ log: { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} } });
+
+    const dispatchTimerCalls = setTimeoutSpy.mock.calls
+      .map((call: any[], idx: number) => ({ delay: call[1], idx }))
+      .filter((x: any) => x.delay === TIMEOUT_MS_FOR_TESTS);
+    expect(dispatchTimerCalls.length).toBeGreaterThan(0);
+
+    for (const c of dispatchTimerCalls) {
+      const handle = setTimeoutSpy.mock.results[c.idx]?.value;
+      expect(handle).toBeDefined();
+      const cleared = clearTimeoutSpy.mock.calls.some((call: any[]) => call[0] === handle);
+      expect(cleared, `dispatch-timeout handle from setTimeout call ${c.idx} was not cleared`).toBe(true);
+    }
+  });
+
+  it("apology AbortSignal actually fires: sick API doesn't re-hang the queue", async () => {
+    // Simulates the worst meta-case: the same Octo API that caused the
+    // upstream dispatch to hang ALSO hangs when we try to POST the apology.
+    // The apology's AbortSignal.timeout(APOLOGY_TIMEOUT_MS) must fire and
+    // runInbound must still reject within bounded time — otherwise the fix
+    // is self-defeating.
+    installHangingRuntime();
+    const { sends } = installHangingSendFetchStub();
+
+    const start = Date.now();
+    await expect(runInbound({ log: { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} } }))
+      .rejects.toThrow();
+    const elapsed = Date.now() - start;
+    expect(elapsed, "must settle within bound, not hang forever").toBeLessThan(2000);
+
+    const apology = sends.find((s) => s.content?.includes("处理超时"));
+    expect(apology, "apology sendMessage must reach fetch").toBeDefined();
+    expect(apology!.abortedBeforeResolve, "apology must be aborted by its own AbortSignal.timeout").toBe(true);
+  });
+
+  it("happy-path final flush hang: bounded so per-group queue is not stranded", async () => {
+    // Dispatch returns normally with a "block" kind (populates lastText, does
+    // NOT set textSent), so the finally branch hits the final flush. The
+    // Octo API hangs on that POST. Without bounding the final flush, the
+    // function would hang forever even though dispatch succeeded.
+    const dispatch = vi.fn(async (args: any) => {
+      await args.dispatcherOptions.deliver({ text: "buffered-final" }, { kind: "block" });
+    });
+    setOctoRuntime({
+      config: { loadConfig: () => ({}) },
+      channel: {
+        reply: {
+          dispatchReplyWithBufferedBlockDispatcher: dispatch,
+          resolveEnvelopeFormatOptions: () => ({}),
+          formatAgentEnvelope: ({ body }: any) => body,
+          finalizeInboundContext: (ctx: any) => ctx,
+        },
+        routing: {
+          resolveAgentRoute: () => ({ agentId: "agent1", sessionKey: "sk1", accountId: "acct1" }),
+        },
+        session: {
+          resolveStorePath: () => "/tmp/store",
+          readSessionUpdatedAt: () => undefined,
+          recordInboundSession: async () => {},
+        },
+      },
+    } as any);
+    const { sends } = installHangingSendFetchStub();
+
+    const start = Date.now();
+    // Dispatch succeeded → handleInboundMessage does NOT reject; the final
+    // flush error is caught + logged. Just verify it RESOLVES within bound.
+    await runInbound({ log: { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} } });
+    const elapsed = Date.now() - start;
+    expect(elapsed).toBeLessThan(2000);
+
+    const finalFlush = sends.find((s) => s.content === "buffered-final");
+    expect(finalFlush, "final flush sendMessage must reach fetch").toBeDefined();
+    expect(finalFlush!.abortedBeforeResolve, "final flush must be aborted by its own AbortSignal.timeout").toBe(true);
+  });
+});

--- a/src/inbound.ts
+++ b/src/inbound.ts
@@ -30,6 +30,38 @@ import { mkdir, unlink, readdir, stat } from "node:fs/promises";
 import { join, basename } from "node:path";
 import { randomUUID } from "node:crypto";
 
+// Per-inbound dispatch timeout (issue #75). The upstream OpenClaw runtime call
+// `core.channel.reply.dispatchReplyWithBufferedBlockDispatcher` is observed to
+// occasionally hang indefinitely (no resolve, no reject, no onError) — likely
+// in agent/runtime layers, not in this plugin. Combined with the per-group
+// serial inbound queue (`enqueueInbound` in channel.ts), a single hang locks
+// the entire group: no further messages get processed until the gateway
+// restarts. This wrapper turns "silent permanent block" into "single-message
+// timeout with a warn log + user-facing apology + queue advances".
+//
+// 5 minutes is intentionally generous — longer than any normal LLM round-trip,
+// short enough that a stuck group recovers within one user attention span.
+// Tests override via `_setDispatchTimeoutForTests` to keep the suite fast.
+const DISPATCH_TIMEOUT_DEFAULT_MS = 5 * 60 * 1000;
+let DISPATCH_TIMEOUT_MS = DISPATCH_TIMEOUT_DEFAULT_MS;
+// How long we wait for the user-facing "处理超时" apology to post, AND for the
+// happy-path buffered-text final flush, before giving up. The whole point of
+// issue #75 is that an Octo API call can hang; these recovery/flush calls hit
+// the same Octo API, so they MUST themselves be bounded or
+// `handleInboundMessage` is still vulnerable to the same hang. 10s is long
+// enough for a healthy API round-trip and short enough that a sick API
+// releases the per-group queue promptly.
+const DISPATCH_TIMEOUT_APOLOGY_DEFAULT_MS = 10_000;
+let DISPATCH_TIMEOUT_APOLOGY_MS = DISPATCH_TIMEOUT_APOLOGY_DEFAULT_MS;
+
+export function _setDispatchTimeoutForTests(ms: number | null): void {
+  DISPATCH_TIMEOUT_MS = ms === null ? DISPATCH_TIMEOUT_DEFAULT_MS : ms;
+}
+
+export function _setDispatchApologyTimeoutForTests(ms: number | null): void {
+  DISPATCH_TIMEOUT_APOLOGY_MS = ms === null ? DISPATCH_TIMEOUT_APOLOGY_DEFAULT_MS : ms;
+}
+
 // Pending inbound context for before_prompt_build hook injection.
 // handleInboundMessage writes here; the hook reads and clears per sessionKey.
 export const pendingInboundContext = new Map<string, { historyPrefix: string; memberListPrefix: string }>();
@@ -2319,7 +2351,7 @@ export async function handleInboundMessage(params: {
   const sentMediaUrls = new Set<string>();
 
   // --- Shared helper: resolve mentions and send text ---
-  const resolveAndSendText = async (content: string): Promise<SendMessageResult | undefined> => {
+  const resolveAndSendText = async (content: string, signal?: AbortSignal): Promise<SendMessageResult | undefined> => {
     let replyMentionUids: string[] = [];
     let replyMentionEntities: MentionEntity[] = [];
     let finalContent = content;
@@ -2427,6 +2459,7 @@ export async function handleInboundMessage(params: {
       ...(replyMentionEntities.length > 0 ? { mentionEntities: replyMentionEntities } : {}),
       mentionAll: hasAtAll || undefined,
       ...(effectiveOnBehalfOf ? { onBehalfOf: effectiveOnBehalfOf } : {}),
+      ...(signal ? { signal } : {}),
     });
     statusSink?.({ lastOutboundAt: Date.now(), lastError: null });
     return result;
@@ -2434,8 +2467,34 @@ export async function handleInboundMessage(params: {
 
   let replySucceeded = false;
 
+  // Timeout guard: see DISPATCH_TIMEOUT_MS at top of file. Without this, an
+  // upstream dispatch hang would leave the per-group queue's Promise chain
+  // unresolved forever — see issue #75.
+  //
+  // Scope note: we intentionally do NOT try to cancel an already-in-flight
+  // dispatch or gate late deliver/onError callbacks from a "woken up" old
+  // dispatch. Those are second-order consistency concerns, not the reported
+  // symptom (silent permanent stuck). If a hung dispatch resumes after our
+  // timeout, the worst outcome is a delayed real reply arriving after the
+  // "处理超时" apology — annoying, not broken. Adding cancel/gate semantics
+  // is tracked separately and intentionally kept out of this issue.
+  //
+  // timeoutError: a per-invocation Error so the outer catch identifies "this
+  // is OUR timeout" by reference equality, never by string comparison —
+  // protects against a same-text upstream error being misclassified.
+  let dispatchTimeoutHandle: ReturnType<typeof setTimeout> | undefined;
+  const timeoutError = new Error(
+    `octo: dispatch timed out after ${DISPATCH_TIMEOUT_MS}ms`,
+  );
+  const dispatchTimeoutPromise = new Promise<never>((_, reject) => {
+    dispatchTimeoutHandle = setTimeout(() => {
+      reject(timeoutError);
+    }, DISPATCH_TIMEOUT_MS);
+  });
+
   try {
-    await core.channel.reply.dispatchReplyWithBufferedBlockDispatcher({
+    await Promise.race([
+      core.channel.reply.dispatchReplyWithBufferedBlockDispatcher({
       ctx: ctxPayload,
       cfg: config,
       replyOptions: {},
@@ -2513,8 +2572,43 @@ export async function handleInboundMessage(params: {
           }
         },
       },
-    });
+      }),
+      dispatchTimeoutPromise,
+    ]);
+  } catch (err) {
+    // Timeout: dispatch never returned within DISPATCH_TIMEOUT_MS. Tell the
+    // user, suppress any stale buffered text + any late deliver/onError
+    // callbacks from the still-running upstream dispatch, then rethrow so the
+    // per-group queue's outer .catch() (channel.ts#enqueueInbound) can
+    // advance to the next message (otherwise this group stays stuck forever
+    // — see issue #75).
+    if (err === timeoutError) {
+      clearInterval(typingInterval);
+      log?.warn?.(
+        `octo: dispatch hung past ${DISPATCH_TIMEOUT_MS}ms, aborting to unblock per-group queue (session=${route?.sessionKey ?? "?"})`,
+      );
+      deliverBuffer.lastText = null;
+      deliverBuffer.textSent = true;
+      try {
+        // The apology call itself MUST be bounded — otherwise a sick Octo API
+        // hangs this sendMessage too, defeating the whole timeout fix. See
+        // DISPATCH_TIMEOUT_APOLOGY_MS above.
+        await sendMessage({
+          apiUrl,
+          botToken,
+          channelId: replyChannelId,
+          channelType: replyChannelType,
+          content: "⚠️ 处理超时，请稍后重试。",
+          ...(effectiveOnBehalfOf ? { onBehalfOf: effectiveOnBehalfOf } : {}),
+          signal: AbortSignal.timeout(DISPATCH_TIMEOUT_APOLOGY_MS),
+        });
+      } catch (sendErr) {
+        log?.error?.(`octo: failed to send timeout message: ${String(sendErr)}`);
+      }
+    }
+    throw err;
   } finally {
+    if (dispatchTimeoutHandle) clearTimeout(dispatchTimeoutHandle);
     // --- Debug: log dispatch outcome ---
     log?.debug?.(`octo: [dispatch-result] replySucceeded=${replySucceeded} bufferedText=${deliverBuffer.lastText?.length ?? 0} textSent=${deliverBuffer.textSent} effectiveOBO=${effectiveOnBehalfOf ?? 'none'}`);
 
@@ -2522,7 +2616,14 @@ export async function handleInboundMessage(params: {
     if (deliverBuffer.lastText && !deliverBuffer.textSent) {
       deliverBuffer.textSent = true;
       try {
-        await resolveAndSendText(deliverBuffer.lastText);
+        // Bounded signal so a sick Octo API can't strand the per-group queue
+        // on the happy path either — dispatch may have completed normally
+        // but if the final POST hangs, handleInboundMessage would never
+        // settle. See DISPATCH_TIMEOUT_APOLOGY_MS comment at top of file.
+        await resolveAndSendText(
+          deliverBuffer.lastText,
+          AbortSignal.timeout(DISPATCH_TIMEOUT_APOLOGY_MS),
+        );
         replySucceeded = true;
         log?.info?.(`octo: [deliver-buffer] fallback text sent (${deliverBuffer.lastText.length} chars)`);
       } catch (finalSendErr) {

--- a/src/inbound.ts
+++ b/src/inbound.ts
@@ -2566,6 +2566,11 @@ export async function handleInboundMessage(params: {
               channelType: replyChannelType,
               content: "⚠️ 抱歉，处理您的消息时遇到了问题，请稍后重试。",
               ...(effectiveOnBehalfOf ? { onBehalfOf: effectiveOnBehalfOf } : {}),
+              // Same bounded signal as the timeout-path apology: if upstream
+              // signals an error AND the Octo API is also sick, this recovery
+              // sendMessage would otherwise hold the per-group queue until
+              // the outer dispatch timeout kicks in (5min). PR #83 review.
+              signal: AbortSignal.timeout(DISPATCH_TIMEOUT_APOLOGY_MS),
             });
           } catch (sendErr) {
             log?.error?.(`octo: failed to send error message: ${String(sendErr)}`);
@@ -2577,11 +2582,14 @@ export async function handleInboundMessage(params: {
     ]);
   } catch (err) {
     // Timeout: dispatch never returned within DISPATCH_TIMEOUT_MS. Tell the
-    // user, suppress any stale buffered text + any late deliver/onError
-    // callbacks from the still-running upstream dispatch, then rethrow so the
-    // per-group queue's outer .catch() (channel.ts#enqueueInbound) can
-    // advance to the next message (otherwise this group stays stuck forever
-    // — see issue #75).
+    // user, suppress any stale buffered text (so the finally-flush branch
+    // does not double-send), then rethrow so the per-group queue's outer
+    // .catch() (channel.ts#enqueueInbound) can advance to the next message
+    // — otherwise this group stays stuck forever, see issue #75.
+    //
+    // We do NOT gate late deliver/onError callbacks from the still-running
+    // upstream dispatch — that "ghost reply" suppression is intentionally
+    // out of scope for #75 (see scope-note comment above timeoutError).
     if (err === timeoutError) {
       clearInterval(typingInterval);
       log?.warn?.(


### PR DESCRIPTION
Refs #75 (intentionally **not** \`Fixes #75\` / \`Closes #75\` — see "Why not auto-close" below)

## Summary

Defensive bound around the upstream dispatch call so a single hang in
\`core.channel.reply.dispatchReplyWithBufferedBlockDispatcher\` no longer
locks the entire per-group inbound queue forever.

- Dispatch call: wrapped in \`Promise.race\` with a 5-minute timeout. On timeout, throws a per-invocation error → \`enqueueInbound\`'s outer \`.catch()\` fires → queue advances to the next message.
- "⚠️ 处理超时" apology \`sendMessage\`: carries its own short \`AbortSignal.timeout(10s)\` so a sick Octo API can't re-hang the recovery path.
- Happy-path final flush of buffered text: also carries the same bounded signal, so even when dispatch succeeded normally, a slow API on the final POST can't strand the queue.

## What this PR addresses (and what it doesn't)

**Addresses the reported symptom in #75:**
> bot 收到 recv + readReceipt + typing，但没有 AI 处理记录，整群无回复，必须私聊 bot 才能 "激活"

After this PR, a single upstream hang produces a single "处理超时" message to the affected sender, then the queue advances to the next message. No more silent permanent stuck.

**Out of scope (tracked for separate work):**

- Cancellation of an already-in-flight dispatch via shared AbortController.
- Suppression of late \`deliver\`/\`onError\` callbacks from a dispatch that "wakes up" after our timeout (the "ghost reply" scenario — user sees apology + delayed real reply).
- Threading \`AbortSignal\` through the media upload path (\`uploadAndSendMedia\` / \`uploadMedia\` / COS upload).

These are real second-order consistency concerns, not the reported #75 symptom. If the upstream dispatch resumes after our timeout, the worst outcome is a delayed real reply on top of the apology — annoying, not broken. Eliminating that requires cancellation semantics the dispatch API doesn't currently expose, and gating every outbound send under a shared controller is a much larger surface area. **Codex review explicitly agreed (round 4 arbitration) that pulling those in would be scope creep beyond #75.**

## Why not auto-close (POSTMORTEM)

⚠️ Earlier revision of this description had the line \`**F​ixes the reported symptom in #75:**\` which tripped GitHub's auto-close keyword regex when this PR merged, even though the description simultaneously said "intentionally not Fixes". GitHub does not read the surrounding sentence — only the keyword. The issue was reopened manually after merge; lesson learned: never put \`Fixes #N\` / \`Closes #N\` / \`Resolves #N\` anywhere in PR title or body when you don't actually want auto-close, regardless of how the sentence reads to a human.

The root cause of the reported symptom is upstream — somewhere in OpenClaw runtime / agent runtime, \`dispatchReplyWithBufferedBlockDispatcher\` hangs. This PR is a defensive bound, not a root-cause fix. #75 should stay open until the reporter (王凯旋) confirms in their environment that:

- The "silent stuck" symptom no longer occurs after upgrading to the version containing this PR
- They no longer need the "private message to reactivate" workaround

Once confirmed, the maintainer manually closes #75. If they instead see occasional "⚠️ 处理超时" warns, that surfaces the upstream hang — separate follow-up.

## Verification

- \`npm run type-check\` clean
- \`npm test\` 942/942 pass (4 new tests added in \`src/inbound-dispatch-timeout.test.ts\`)
- Codex review converged after scope arbitration (rounds 1-3 progressively expanded scope; round 4 agreed Mid-A is the right minimum); final pass: LGTM

## Test plan

- [x] CI green
- [ ] After release: reporter (王凯旋) retests the original repro on this version and reports back on #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)