### PR TITLE
fix(mention): resolve outbound @mention failures in proactive sends (#85)

### DIFF
--- a/src/actions.test.ts
+++ b/src/actions.test.ts
@@ -380,7 +380,7 @@ describe("handleOctoMessageAction", () => {
   });
 
   describe("send — invalid uid in v2 (uid not in uidToNameMap)", () => {
-    it("should create entities for all structured mentions including unknown uids", async () => {
+    it("drops non-hex unknown uids via the outbound guard, keeps known ones", async () => {
       let sentPayload: any = null;
       globalThis.fetch = mockFetch({
         "/v1/bot/sendMessage": async (_url, init) => {
@@ -392,7 +392,9 @@ describe("handleOctoMessageAction", () => {
       const uidToNameMap = new Map([
         ["uid_bob", "bob"],
       ]);
-      // uid_unknown is NOT in uidToNameMap
+      // uid_unknown is NOT in uidToNameMap and is not a 32-hex / space-prefixed
+      // uid, so the P0-3 outbound guard strips it (server would reject it
+      // anyway). uid_bob is in the map → kept.
 
       const { handleOctoMessageAction } = await import("./actions.js");
       const result = await handleOctoMessageAction({
@@ -404,13 +406,12 @@ describe("handleOctoMessageAction", () => {
       });
 
       expect(result.ok).toBe(true);
-      // Format is still converted for both
+      // Format is still converted for both (text is human-readable @name)
       expect(sentPayload.payload.content).toBe("Hello @Ghost and @bob!");
-      // All structured mentions get entities (uid trusted from LLM)
+      // Only the valid (in-map) uid survives the outbound guard.
       const entities = sentPayload.payload.mention.entities;
-      expect(entities).toHaveLength(2);
-      expect(entities[0]).toMatchObject({ uid: "uid_unknown" });
-      expect(entities[1]).toMatchObject({ uid: "uid_bob" });
+      expect(entities).toHaveLength(1);
+      expect(entities[0]).toMatchObject({ uid: "uid_bob" });
     });
   });
 
@@ -438,6 +439,103 @@ describe("handleOctoMessageAction", () => {
       expect(result.ok).toBe(true);
       // No mention field when UIDs can't be resolved
       expect(sentPayload.payload.mention).toBeUndefined();
+    });
+  });
+
+  describe("send — P0-3 outbound sanitizer", () => {
+    const HEX_A = "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6";
+
+    it("bracketless @uid:name (valid uid) → @displayName + entity, no raw uid:name leaked", async () => {
+      let sentPayload: any = null;
+      globalThis.fetch = mockFetch({
+        "/v1/bot/sendMessage": async (_url, init) => {
+          sentPayload = JSON.parse(init?.body as string);
+          return jsonResponse({ message_id: 1, message_seq: 1 });
+        },
+      });
+
+      const uidToNameMap = new Map([[HEX_A, "Alice"]]);
+      const { handleOctoMessageAction } = await import("./actions.js");
+      const result = await handleOctoMessageAction({
+        action: "send",
+        args: { target: "group:grp1", message: `Hi @${HEX_A}:Alice!` },
+        apiUrl: "http://localhost:8090",
+        botToken: "test-token",
+        uidToNameMap,
+      });
+
+      expect(result.ok).toBe(true);
+      expect(sentPayload.payload.content).toBe("Hi @Alice!");
+      expect(sentPayload.payload.content).not.toContain(`${HEX_A}:`);
+      expect(sentPayload.payload.mention.entities).toEqual([
+        { uid: HEX_A, offset: 3, length: 6 },
+      ]);
+    });
+
+    it("bracketless @uid:name (token not uid-shaped) → left untouched, no mention", async () => {
+      let sentPayload: any = null;
+      globalThis.fetch = mockFetch({
+        "/v1/bot/sendMessage": async (_url, init) => {
+          sentPayload = JSON.parse(init?.body as string);
+          return jsonResponse({ message_id: 1, message_seq: 1 });
+        },
+      });
+
+      const uidToNameMap = new Map([[HEX_A, "Alice"]]);
+      const { handleOctoMessageAction } = await import("./actions.js");
+      const result = await handleOctoMessageAction({
+        action: "send",
+        args: { target: "group:grp1", message: "Hi @uid:Alice!" },
+        apiUrl: "http://localhost:8090",
+        botToken: "test-token",
+        uidToNameMap,
+      });
+
+      expect(result.ok).toBe(true);
+      // "uid" is not uid-shaped (not 32-hex, not in map, not a real
+      // space-prefix), so the sanitizer leaves the ambiguous text intact —
+      // the hard guarantee is only that no illegal mention is emitted.
+      expect(sentPayload.payload.content).toBe("Hi @uid:Alice!");
+      expect(sentPayload.payload.mention).toBeUndefined();
+    });
+  });
+
+  describe("send — P0-1 sub-topic parent group prefetch", () => {
+    const HEX_A = "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6";
+
+    it("fetches members from the PARENT group_no for a sub-topic target", async () => {
+      let memberGroupNo: string | null = null;
+      let sentPayload: any = null;
+      globalThis.fetch = mockFetch({
+        "/members": async (url) => {
+          // /v1/bot/groups/<groupNo>/members
+          const m = url.match(/\/groups\/([^/]+)\/members/);
+          memberGroupNo = m ? m[1] : null;
+          return jsonResponse([{ uid: HEX_A, name: "Alice" }]);
+        },
+        "/v1/bot/sendMessage": async (_url, init) => {
+          sentPayload = JSON.parse(init?.body as string);
+          return jsonResponse({ message_id: 1, message_seq: 1 });
+        },
+      });
+
+      const memberMap = new Map<string, string>();
+      const uidToNameMap = new Map<string, string>();
+      const { handleOctoMessageAction } = await import("./actions.js");
+      const result = await handleOctoMessageAction({
+        action: "send",
+        args: { target: "group:parentG____topic1", message: "ping @Alice" },
+        apiUrl: "http://localhost:8090",
+        botToken: "test-token",
+        memberMap,
+        uidToNameMap,
+      });
+
+      expect(result.ok).toBe(true);
+      expect(memberGroupNo).toBe("parentG");
+      // prefetched member resolved @Alice into an entity
+      expect(sentPayload.payload.content).toBe("ping @Alice");
+      expect(sentPayload.payload.mention.entities[0]).toMatchObject({ uid: HEX_A });
     });
   });
 

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -20,8 +20,8 @@ import {
   updateGroupMd,
 } from "./api-fetch.js";
 import { uploadAndSendMedia, uploadMedia, resolveRichTextContent, type UploadedMedia } from "./inbound.js";
-import { buildEntitiesFromFallback, parseStructuredMentions, convertStructuredMentions } from "./mention-utils.js";
-import { getKnownGroupIds } from "./group-md.js";
+import { buildEntitiesFromFallback, parseStructuredMentions, convertStructuredMentions, sanitizeOutboundMentions } from "./mention-utils.js";
+import { getKnownGroupIds, extractParentGroupNo } from "./group-md.js";
 import { checkPermission } from "./permission.js";
 import { emitAuditLog } from "./audit.js";
 import { getGroupMembersFromCache, findSharedGroupsFromCache } from "./member-cache.js";
@@ -488,6 +488,33 @@ async function handleSend(params: {
 
   const { channelId, channelType } = resolveOutboundOctoTarget(target, effectiveThreadId);
 
+  // P0-1: ensure member maps are populated before @ conversion. The message-tool
+  // send path (agent-initiated @, new sub-topic) has no inbound refresh, so the
+  // passed-in maps can be empty/stale. Only when the message contains an `@`,
+  // pull the target group's members from the shared 5-min-TTL cache (cache hit =
+  // zero cost) and fill both maps. Threads only carry the parent group_no for
+  // the member API, so strip the `____` suffix. Best-effort, silent on failure.
+  if (
+    (channelType === ChannelType.Group || channelType === ChannelType.CommunityTopic) &&
+    typeof message === "string" &&
+    message.includes("@")
+  ) {
+    try {
+      const groupNo = extractParentGroupNo(channelId);
+      if (groupNo) {
+        const members = await getGroupMembersFromCache({ apiUrl, botToken, groupNo, log });
+        for (const mb of members) {
+          if (mb.name && mb.uid) {
+            memberMap?.set(mb.name, mb.uid);
+            uidToNameMap?.set(mb.uid, mb.name);
+          }
+        }
+      }
+    } catch (err) {
+      log?.error?.(`octo: handleSend member prefetch failed: ${err}`);
+    }
+  }
+
   // UX warning for a specific foot-gun on the message-tool path (#232 review):
   // the agent is replying inside a sub-topic (session's currentChannelId carries
   // `____`) but explicitly passed a bare parent-group target matching the
@@ -555,6 +582,21 @@ async function handleSend(params: {
       if (mentionEntities.length > 0) {
         mentionEntities.sort((a, b) => a.offset - b.offset);
         mentionUids = mentionEntities.map(e => e.uid);
+      }
+
+      // P0-3: last-line guard — rewrite/downgrade/strip malformed @ that the
+      // conversion+fallback couldn't resolve, and drop illegal uids so a bad
+      // mention is never leaked to the server.
+      if (uidToNameMap) {
+        const sanitized = sanitizeOutboundMentions({
+          content: finalMessage,
+          entities: mentionEntities,
+          uids: mentionUids,
+          uidToNameMap,
+        });
+        finalMessage = sanitized.content;
+        mentionEntities = sanitized.entities;
+        mentionUids = sanitized.uids;
       }
     }
 

--- a/src/channel.test.ts
+++ b/src/channel.test.ts
@@ -32,6 +32,7 @@ vi.mock("./api-fetch.js", async () => {
     registerBot: vi.fn(),
     sendHeartbeat: vi.fn(),
     fetchBotGroups: vi.fn().mockResolvedValue([]),
+    getGroupMembers: vi.fn().mockResolvedValue([]),
     getGroupMd: vi.fn(),
   };
 });
@@ -829,5 +830,135 @@ describe("outbound sendText/sendMedia — messageId propagation (#51)", () => {
     } as any);
 
     expect(result.messageId).toBe("media-xyz");
+  });
+});
+
+// ─── P0-2: messageToolHints @mention format hint ─────────────────────────────
+
+describe("agentPrompt.messageToolHints — @mention format hint", () => {
+  it("appends the shared MENTION_FORMAT_HINT with group-members + anti-patterns", async () => {
+    const { octoPlugin } = await import("./channel.js");
+    const { MENTION_FORMAT_HINT } = await import("./mention-utils.js");
+    const hints: string[] = (octoPlugin as any).agentPrompt.messageToolHints({
+      cfg: {},
+      accountId: "default",
+    });
+    const joined = hints.join("\n");
+    expect(joined).toContain("group-members");
+    expect(joined).toContain(MENTION_FORMAT_HINT);
+    // anti-patterns + single-colon + brackets reachable through the shared hint
+    expect(joined).toContain("ONE colon");
+    expect(joined).toContain("username/bot_id");
+    expect(joined).toContain('"uid"');
+  });
+
+  it("hint text never parses into an illegal {uid:'uid'} structured mention", async () => {
+    const { octoPlugin } = await import("./channel.js");
+    const { parseStructuredMentions } = await import("./mention-utils.js");
+    const hints: string[] = (octoPlugin as any).agentPrompt.messageToolHints({
+      cfg: {},
+      accountId: "default",
+    });
+    const parsed = parseStructuredMentions(hints.join("\n"));
+    expect(parsed.every((m) => m.uid !== "uid")).toBe(true);
+  });
+});
+
+// ─── P0-1: outbound member prefetch (cold start) ─────────────────────────────
+
+describe("outbound.sendText — P0-1 member prefetch", () => {
+  const cfg = {
+    channels: {
+      octo: {
+        apiUrl: "https://api.example",
+        accounts: {
+          default: { botToken: "bf_test", apiUrl: "https://api.example" },
+        },
+      },
+    },
+  };
+
+  beforeEach(async () => {
+    const apiFetch = await import("./api-fetch.js");
+    (apiFetch.sendMessage as any).mockClear();
+    (apiFetch.getGroupMembers as any).mockClear();
+    (apiFetch.getGroupMembers as any).mockResolvedValue([]);
+    const memberCache = await import("./member-cache.js");
+    memberCache._clearMemberCache();
+  });
+
+  it("cold map: fetches members for the target group and resolves @displayName to an entity", async () => {
+    const apiFetch = await import("./api-fetch.js");
+    (apiFetch.getGroupMembers as any).mockResolvedValue([
+      { uid: "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6", name: "Alice" },
+    ]);
+    const { octoPlugin } = await import("./channel.js");
+
+    await octoPlugin.outbound!.sendText!({
+      cfg,
+      to: "group:grpcold",
+      text: "hello @Alice",
+      accountId: "default",
+    } as any);
+
+    const memberCall = (apiFetch.getGroupMembers as any).mock.calls[0][0];
+    expect(memberCall.groupNo).toBe("grpcold");
+
+    const call = (apiFetch.sendMessage as any).mock.calls[0][0];
+    expect(call.content).toBe("hello @Alice");
+    expect(call.mentionEntities).toEqual([
+      { uid: "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6", offset: 6, length: 6 },
+    ]);
+  });
+
+  it("sub-topic target: prefetch uses the PARENT group_no (strips ____ suffix)", async () => {
+    const apiFetch = await import("./api-fetch.js");
+    (apiFetch.getGroupMembers as any).mockResolvedValue([
+      { uid: "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6", name: "Alice" },
+    ]);
+    const { octoPlugin } = await import("./channel.js");
+
+    await octoPlugin.outbound!.sendText!({
+      cfg,
+      to: "group:parentG____topic1",
+      text: "ping @Alice",
+      accountId: "default",
+    } as any);
+
+    const memberCall = (apiFetch.getGroupMembers as any).mock.calls[0][0];
+    expect(memberCall.groupNo).toBe("parentG");
+  });
+
+  it("no @ in text: skips the member fetch entirely", async () => {
+    const apiFetch = await import("./api-fetch.js");
+    const { octoPlugin } = await import("./channel.js");
+
+    await octoPlugin.outbound!.sendText!({
+      cfg,
+      to: "group:grpcold",
+      text: "no mentions here",
+      accountId: "default",
+    } as any);
+
+    expect((apiFetch.getGroupMembers as any).mock.calls.length).toBe(0);
+  });
+
+  it("member fetch failure degrades silently (still sends)", async () => {
+    const apiFetch = await import("./api-fetch.js");
+    (apiFetch.getGroupMembers as any).mockRejectedValue(new Error("boom"));
+    const { octoPlugin } = await import("./channel.js");
+
+    const result = await octoPlugin.outbound!.sendText!({
+      cfg,
+      to: "group:grpcold",
+      text: "hi @Ghost",
+      accountId: "default",
+    } as any);
+
+    expect(result.messageId).toBe("test-msg-id");
+    const call = (apiFetch.sendMessage as any).mock.calls[0][0];
+    // unresolved @Ghost left as plain text, no illegal mention leaked
+    expect(call.content).toBe("hi @Ghost");
+    expect(call.mentionEntities).toBeUndefined();
   });
 });

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -28,10 +28,10 @@ function getAgentVersion(): string {
 import { WKSocket } from "./socket.js";
 import { handleInboundMessage, type OctoStatusSink, sanitizeFilename } from "./inbound.js";
 import { ChannelType, MessageType, type BotMessage, type MessagePayload, type SendMessageResult } from "./types.js";
-import { buildEntitiesFromFallback, parseStructuredMentions, convertStructuredMentions } from "./mention-utils.js";
+import { buildEntitiesFromFallback, parseStructuredMentions, convertStructuredMentions, sanitizeOutboundMentions, MENTION_FORMAT_HINT } from "./mention-utils.js";
 import type { MentionEntity } from "./types.js";
 import { handleOctoMessageAction, parseTarget, resolveOutboundOctoTarget, normalizeOutboundChannelPrefix, extractInlineMentionUids } from "./actions.js";
-import { getOrCreateGroupMdCache, registerBotGroupIds, getKnownGroupIds, writeGroupMdToDisk } from "./group-md.js";
+import { getOrCreateGroupMdCache, registerBotGroupIds, getKnownGroupIds, writeGroupMdToDisk, extractParentGroupNo } from "./group-md.js";
 import { registerOwnerUid } from "./owner-registry.js";
 import { registerKnownBot, isKnownBot } from "./bot-registry.js";
 import { preloadGroupMemberCache, getGroupMembersFromCache } from "./member-cache.js";
@@ -247,6 +247,49 @@ function getOrCreateGroupCacheTimestamps(accountId: string): Map<string, number>
     _groupCacheTimestamps.set(id, m);
   }
   return m;
+}
+
+/**
+ * Outbound @mention prefetch (P0-1).
+ *
+ * Proactive sends (cron, new sub-topic, agent-initiated @) never go through the
+ * inbound member-cache refresh, so the per-account memberMap/uidToNameMap can be
+ * empty or stale at send time. Before converting, if the text contains an `@`,
+ * pull the target group's members from the shared 5-min-TTL cache and fill both
+ * maps. Cache hit = zero cost; on a cold start (cache miss) this performs one
+ * synchronous member-list API round-trip on the send path. Threads only know the
+ * parent group_no for the member API, so strip the `____` sub-topic suffix.
+ * Best-effort: any failure degrades silently (the outbound sanitizer is the real
+ * safety net).
+ */
+async function prefetchOutboundMembers(opts: {
+  content: string;
+  channelId: string;
+  apiUrl: string;
+  botToken: string;
+  memberMap: Map<string, string>;
+  uidToNameMap: Map<string, string>;
+  log?: { info?: (msg: string) => void; error?: (msg: string) => void };
+}): Promise<void> {
+  if (!opts.content.includes("@")) return;
+  try {
+    const groupNo = extractParentGroupNo(opts.channelId);
+    if (!groupNo) return;
+    const members = await getGroupMembersFromCache({
+      apiUrl: opts.apiUrl,
+      botToken: opts.botToken,
+      groupNo,
+      log: opts.log,
+    });
+    for (const m of members) {
+      if (m.name && m.uid) {
+        opts.memberMap.set(m.name, m.uid);
+        opts.uidToNameMap.set(m.uid, m.name);
+      }
+    }
+  } catch (err) {
+    opts.log?.error?.(`octo: prefetchOutboundMembers failed: ${err}`);
+  }
 }
 
 // Module-level robot flags: uid -> robot (server-authoritative GroupMember.robot)
@@ -702,6 +745,7 @@ export const octoPlugin: ChannelPlugin<ResolvedOctoAccount> = {
         `For threads/sub-topics: if you are explicitly targeting a thread, the target MUST be the full "group:<group_no>____<short_id>" (four underscores) — do not send just the parent "group:<group_no>" or the reply will land in the parent group instead of the thread. The same rule applies to file uploads.`,
         `For reading message history: use action="read" with target="user:<uid>" to read DM history, or target="group:<groupId>" to read group message history. Cross-channel queries require the requester to be a participant of the target channel.`,
         `For searching: use action="search" with query="shared-groups" to find groups that the bot and the current user both belong to.`,
+        `For @mentions in a group: FIRST look up the target member's real uid + display name with octo_management action="group-members" (target="group:<groupId>"). ${MENTION_FORMAT_HINT}`,
       ];
     },
   },
@@ -769,6 +813,17 @@ export const octoPlugin: ChannelPlugin<ResolvedOctoAccount> = {
         const accountMemberMap = getOrCreateMemberMap(accountId);
         const uidToNameMap = getOrCreateUidToNameMap(accountId);
 
+        // P0-1: ensure member maps are populated for proactive sends (cron / new
+        // sub-topic / agent-initiated @) where the inbound refresh never ran.
+        await prefetchOutboundMembers({
+          content: finalContent,
+          channelId,
+          apiUrl: account.config.apiUrl,
+          botToken: account.config.botToken,
+          memberMap: accountMemberMap,
+          uidToNameMap,
+        });
+
         // v2 path: convert @[uid:name] → @name + entities
         const structuredMentions = parseStructuredMentions(finalContent);
         if (structuredMentions.length > 0) {
@@ -795,6 +850,20 @@ export const octoPlugin: ChannelPlugin<ResolvedOctoAccount> = {
             mentionUids.push(uid);
           }
         }
+
+        // P0-3: last-line guard — rewrite/downgrade/strip any malformed @ the
+        // conversion+fallback couldn't resolve, and drop illegal uids so a bad
+        // mention is never leaked to the server.
+        const sanitized = sanitizeOutboundMentions({
+          content: finalContent,
+          entities: mentionEntities,
+          uids: mentionUids,
+          uidToNameMap,
+        });
+        finalContent = sanitized.content;
+        mentionEntities = sanitized.entities;
+        mentionUids.length = 0;
+        mentionUids.push(...sanitized.uids);
       }
 
       // Detect @all/@所有人 in content

--- a/src/inbound.test.ts
+++ b/src/inbound.test.ts
@@ -27,7 +27,7 @@ import {
   isRemoteMediaUrl,
   type ResolveFileResult,
 } from "./inbound.js";
-import { extractMentionUids } from "./mention-utils.js";
+import { extractMentionUids, parseStructuredMentions } from "./mention-utils.js";
 import { normalizeMediaAttachments } from "openclaw/plugin-sdk/media-runtime";
 import { existsSync, unlinkSync, readFileSync } from "node:fs";
 
@@ -1417,7 +1417,10 @@ describe("buildMemberListPrefix", () => {
     expect(result).toContain("Alice (uid_alice)");
     expect(result).toContain("Bob (uid_bob)");
     expect(result).toContain("陈皮皮 (uid_chen)");
-    expect(result).toContain("@[uid:displayName]");
+    // Format hint uses angle-bracket placeholder slots (never the literal
+    // @[uid:displayName] trap that parses into {uid:"uid"}).
+    expect(result).toContain("@[<uid>:<displayName>]");
+    expect(result).not.toContain("@[uid:displayName]");
   });
 
   it("should inject full member list when exactly 10 members", () => {
@@ -1452,6 +1455,50 @@ describe("buildMemberListPrefix", () => {
     const result = buildMemberListPrefix(map);
     expect(result).toContain("[Group Info]");
     expect(result).toContain("50 members");
+  });
+
+  it(">10 branch names the real group-members action + a real-form hex anchor", () => {
+    const map = new Map<string, string>();
+    for (let i = 1; i <= 13; i++) map.set(`uid_${i}`, `User${i}`);
+    const result = buildMemberListPrefix(map);
+    // points at the real octo_management action, not a vague "tool"
+    expect(result).toContain("group-members");
+    // real-form hex example anchor (32-hex), never the literal word "uid"
+    expect(result).toContain("@[a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6:Alice]");
+  });
+
+  it(">10 branch carries the convert promise, single-colon, brackets and anti-patterns", () => {
+    const map = new Map<string, string>();
+    for (let i = 1; i <= 13; i++) map.set(`uid_${i}`, `User${i}`);
+    const result = buildMemberListPrefix(map);
+    expect(result).toContain("I will convert");
+    expect(result).toContain("ONE colon");
+    expect(result).toContain("REQUIRED");
+    expect(result).toContain("username/bot_id");
+    expect(result).toContain('"uid"');
+    expect(result).toContain("bare uid");
+    expect(result).toMatch(/\n\n$/); // still terminated with a blank line
+  });
+
+  it("regression guard (test #13): >10 text parses to exactly ONE legal structured mention", () => {
+    const map = new Map<string, string>();
+    for (let i = 1; i <= 13; i++) map.set(`uid_${i}`, `User${i}`);
+    const result = buildMemberListPrefix(map);
+    const parsed = parseStructuredMentions(result);
+    expect(parsed.every((mtn) => mtn.uid !== "uid")).toBe(true);
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].uid).toBe("a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6");
+  });
+
+  it("≤10 and >10 branches share the MENTION_FORMAT_HINT core (no drift)", () => {
+    const small = new Map<string, string>([["uid_a", "Alice"], ["uid_b", "Bob"]]);
+    const large = new Map<string, string>();
+    for (let i = 1; i <= 13; i++) large.set(`uid_${i}`, `User${i}`);
+    const core = "@[<uid>:<displayName>]";
+    expect(buildMemberListPrefix(small)).toContain(core);
+    expect(buildMemberListPrefix(large)).toContain(core);
+    expect(buildMemberListPrefix(small)).toContain("ONE colon");
+    expect(buildMemberListPrefix(large)).toContain("ONE colon");
   });
 });
 

--- a/src/inbound.ts
+++ b/src/inbound.ts
@@ -19,6 +19,7 @@ import {
   parseStructuredMentions,
   convertStructuredMentions,
   buildEntitiesFromFallback,
+  MENTION_FORMAT_HINT,
 } from "./mention-utils.js";
 import type { MentionPayload, MentionEntity, SendMessageResult } from "./types.js";
 import { registerGroupAccount, ensureGroupMd, handleGroupMdEvent, broadcastGroupMdUpdate, extractParentGroupNo, extractThreadShortId, ensureThreadMd, handleThreadMdEvent } from "./group-md.js";
@@ -1229,10 +1230,20 @@ export function buildMemberListPrefix(uidToNameMap: Map<string, string>): string
     const memberLines = members
       .map(([uid, name]) => `  ${name} (${uid})`)
       .join("\n");
-    return `[Group Members]\n${memberLines}\n\nWhen mentioning a group member, use the format @[uid:displayName] (e.g. @[${members[0][0]}:${members[0][1]}]). I will convert it to the correct format before sending.\n\n`;
+    // 真实形态示例锚点用真名 + 真 uid（来自内联名单）；格式说明/anti-pattern
+    // 取自共享常量，三处同源不 drift。占位槽用尖括号，避免示例本身被
+    // STRUCTURED_MENTION_PATTERN 解析成非法 {uid:"uid"}。
+    return `[Group Members]\n${memberLines}\n\n${MENTION_FORMAT_HINT}\n(e.g. @[${members[0][0]}:${members[0][1]}]).\n\n`;
   }
 
-  return `[Group Info] This group has ${uidToNameMap.size} members. Use the group management tool to look up member info when needed. When mentioning a group member, use the format @[uid:displayName].\n\n`;
+  return (
+    `[Group Info] This group has ${uidToNameMap.size} members — too many to list here.\n` +
+    `To @mention someone, FIRST look up their real uid and display name with the ` +
+    `group management tool (octo_management action="group-members", ` +
+    `target="group:<groupId>"); it returns each member's { uid, name }.\n` +
+    `THEN write the mention. ${MENTION_FORMAT_HINT}\n` +
+    `Real example: @[a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6:Alice].\n\n`
+  );
 }
 
 /**

--- a/src/mention-utils.test.ts
+++ b/src/mention-utils.test.ts
@@ -757,6 +757,7 @@ describe("inbound text fallback regex", () => {
 
 const HEX_A = "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6"; // Alice
 const HEX_B = "0f1e2d3c4b5a69788796a5b4c3d2e1f0"; // Bob
+const HEX_C = "1234567890abcdef1234567890abcdef"; // hallucinated bare hex
 
 describe("isValidOutboundUid", () => {
   const map = new Map<string, string>([[HEX_A, "Alice"]]);
@@ -782,6 +783,47 @@ describe("isValidOutboundUid", () => {
 });
 
 describe("sanitizeOutboundMentions", () => {
+  it("cold-start inline uids survive empty map (target-suffix mention path)", () => {
+    // target=`group:<gid>@uid1,uid2` 抽出的 inline uid 经 params.uids 传入。
+    // 正文无 @、prefetch 短路 → uidToNameMap 为空；caller 没给 entity。
+    // inline uid 是框架权威意图，必须存活、被 @ 的人才能收到通知。
+    const r = sanitizeOutboundMentions({
+      content: "Reminder for the project team",
+      entities: [],
+      uids: [HEX_A, HEX_B],
+      uidToNameMap: new Map(),
+    });
+    expect(r.uids).toEqual([HEX_A, HEX_B]);
+    // caller 没给 entity 就不凭空造 entity。
+    expect(r.entities).toEqual([]);
+  });
+
+  it("hallucinated bare @<hex> in body (no caller uids) is still dropped", () => {
+    // HEX_C 是模型在正文里瞎编的裸 hex；caller 既没传 entity 也没传 uids。
+    // 放宽 trustedUids 纳入 params.uids 后，这条防幻觉链路必须照旧拦截。
+    const r = sanitizeOutboundMentions({
+      content: `ping @${HEX_C} now`,
+      entities: [],
+      uids: [],
+      uidToNameMap: new Map(),
+    });
+    expect(r.uids).not.toContain(HEX_C);
+    expect(r.entities.some((e) => e.uid === HEX_C)).toBe(false);
+  });
+
+  it("fake space-prefix inline uid (non-hex base) is rejected, not revived", () => {
+    // "s1_haha" 的 base 非 32-hex，isWellFormedUid 不认 → 不进 trustedUids。
+    // 确认放宽 trustedUids 没让伪 space-prefix 复活。
+    const r = sanitizeOutboundMentions({
+      content: "Reminder for the project team",
+      entities: [],
+      uids: ["s1_haha", HEX_A],
+      uidToNameMap: new Map(),
+    });
+    expect(r.uids).not.toContain("s1_haha");
+    expect(r.uids).toContain(HEX_A);
+  });
+
   it("bracketless @uid:name with valid (in-map) uid → @displayName + entity, no raw uid:name", () => {
     const uidToNameMap = new Map([[HEX_A, "Alice"]]);
     const r = sanitizeOutboundMentions({

--- a/src/mention-utils.test.ts
+++ b/src/mention-utils.test.ts
@@ -11,6 +11,9 @@ import {
   convertContentForLLM,
   buildSenderPrefix,
   tryLongestMemberMatch,
+  sanitizeOutboundMentions,
+  isValidOutboundUid,
+  MENTION_FORMAT_HINT,
 } from "./mention-utils.js";
 import type { MentionPayload } from "./types.js";
 
@@ -747,5 +750,326 @@ describe("inbound text fallback regex", () => {
 
   it("does NOT match CJK bot name followed by CJK", () => {
     expect(buildFallbackRegex("小助手").test("@小助手好")).toBe(false);
+  });
+});
+
+// ── Outbound mention sanitizer (P0-3) + shared format hint (P1) ──────────────
+
+const HEX_A = "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6"; // Alice
+const HEX_B = "0f1e2d3c4b5a69788796a5b4c3d2e1f0"; // Bob
+
+describe("isValidOutboundUid", () => {
+  const map = new Map<string, string>([[HEX_A, "Alice"]]);
+
+  it("accepts a uid present in uidToNameMap", () => {
+    expect(isValidOutboundUid(HEX_A, map)).toBe(true);
+  });
+  it("rejects the literal word 'uid'", () => {
+    expect(isValidOutboundUid("uid", map)).toBe(false);
+  });
+  it("rejects a guessed username/bot_id", () => {
+    expect(isValidOutboundUid("somebody_bot", map)).toBe(false);
+  });
+  it("rejects a 32-hex uid that is not in the map (hallucinated)", () => {
+    expect(isValidOutboundUid(HEX_B, map)).toBe(false);
+  });
+  it("rejects a fake space-prefix whose base is not 32-hex", () => {
+    expect(isValidOutboundUid("s1_haha", map)).toBe(false);
+  });
+  it("accepts a space-prefixed uid whose base IS 32-hex", () => {
+    expect(isValidOutboundUid("s14_" + HEX_B, map)).toBe(true);
+  });
+});
+
+describe("sanitizeOutboundMentions", () => {
+  it("bracketless @uid:name with valid (in-map) uid → @displayName + entity, no raw uid:name", () => {
+    const uidToNameMap = new Map([[HEX_A, "Alice"]]);
+    const r = sanitizeOutboundMentions({
+      content: `Hi @${HEX_A}:Alice!`,
+      entities: [],
+      uids: [],
+      uidToNameMap,
+    });
+    expect(r.content).toBe("Hi @Alice!");
+    expect(r.content).not.toContain(`${HEX_A}:`);
+    expect(r.entities).toHaveLength(1);
+    expect(r.entities[0]).toMatchObject({ uid: HEX_A, offset: 3, length: 6 });
+    expect(r.uids).toEqual([HEX_A]);
+  });
+
+  it("bracketless @uid:name where token is not uid-shaped → left untouched, no entity", () => {
+    // The literal word "uid" doesn't look like a uid (not 32-hex, not in map,
+    // not a real space-prefix), so the sanitizer must NOT rewrite it — leaving
+    // ambiguous text intact is safer than mangling it. The only hard guarantee
+    // is that no illegal mention entity leaks.
+    const uidToNameMap = new Map([[HEX_A, "Alice"]]);
+    const r = sanitizeOutboundMentions({
+      content: "Hi @uid:Alice!",
+      entities: [],
+      uids: [],
+      uidToNameMap,
+    });
+    expect(r.content).toBe("Hi @uid:Alice!");
+    expect(r.entities).toHaveLength(0);
+    expect(r.uids).not.toContain("uid");
+  });
+
+  it("@username with no usernameMap → left as plain text, never sent as uid", () => {
+    const uidToNameMap = new Map([[HEX_A, "Alice"]]);
+    const r = sanitizeOutboundMentions({
+      content: "Ping @somebody_bot please",
+      entities: [],
+      uids: [],
+      uidToNameMap,
+    });
+    expect(r.content).toBe("Ping @somebody_bot please");
+    expect(r.entities).toHaveLength(0);
+    expect(r.uids).not.toContain("somebody_bot");
+  });
+
+  it("@username with usernameMap hit → reverse-looked-up entity (P2)", () => {
+    const uidToNameMap = new Map([[HEX_A, "Alice"]]);
+    const usernameMap = new Map([["somebody_bot", HEX_A]]);
+    const r = sanitizeOutboundMentions({
+      content: "Ping @somebody_bot please",
+      entities: [],
+      uids: [],
+      uidToNameMap,
+      usernameMap,
+    });
+    expect(r.content).toBe("Ping @Alice please");
+    expect(r.entities).toHaveLength(1);
+    expect(r.entities[0].uid).toBe(HEX_A);
+    expect(r.uids).toEqual([HEX_A]);
+  });
+
+  it("bare @<32hex> hit in uidToNameMap → @displayName + entity", () => {
+    const uidToNameMap = new Map([[HEX_A, "Alice"]]);
+    const r = sanitizeOutboundMentions({
+      content: `Hey @${HEX_A} hi`,
+      entities: [],
+      uids: [],
+      uidToNameMap,
+    });
+    expect(r.content).toBe("Hey @Alice hi");
+    expect(r.entities).toHaveLength(1);
+    expect(r.entities[0].uid).toBe(HEX_A);
+  });
+
+  it("bare @<32hex> not in map → @ stripped, no entity", () => {
+    const uidToNameMap = new Map<string, string>();
+    const r = sanitizeOutboundMentions({
+      content: `Hey @${HEX_B} hi`,
+      entities: [],
+      uids: [],
+      uidToNameMap,
+    });
+    expect(r.content).toBe(`Hey ${HEX_B} hi`);
+    expect(r.entities).toHaveLength(0);
+    expect(r.uids).toHaveLength(0);
+  });
+
+  it("offset drift: pre-existing entity offsets stay aligned after rewrites", () => {
+    // Leading converted v2 mention @Bob (entity) + a bracketless @uid:name later.
+    const uidToNameMap = new Map([
+      [HEX_B, "Bob"],
+      [HEX_A, "Alice"],
+    ]);
+    const content = `@Bob ping @${HEX_A}:Alice end`;
+    const r = sanitizeOutboundMentions({
+      content,
+      entities: [{ uid: HEX_B, offset: 0, length: 4 }],
+      uids: [HEX_B],
+      uidToNameMap,
+    });
+    expect(r.content).toBe("@Bob ping @Alice end");
+    // Every entity offset must point at its @name in the rewritten content.
+    for (const e of r.entities) {
+      const slice = r.content.slice(e.offset, e.offset + e.length);
+      expect(slice.startsWith("@")).toBe(true);
+    }
+    const bob = r.entities.find((e) => e.uid === HEX_B)!;
+    expect(r.content.slice(bob.offset, bob.offset + bob.length)).toBe("@Bob");
+    const alice = r.entities.find((e) => e.uid === HEX_A)!;
+    expect(r.content.slice(alice.offset, alice.offset + alice.length)).toBe("@Alice");
+  });
+
+  it("does not damage a space-prefixed uid mention", () => {
+    const spaceUid = "s14_" + HEX_A;
+    const uidToNameMap = new Map([[spaceUid, "Alice"]]);
+    const r = sanitizeOutboundMentions({
+      content: `Hi @${spaceUid}:Alice!`,
+      entities: [],
+      uids: [],
+      uidToNameMap,
+    });
+    expect(r.content).toBe("Hi @Alice!");
+    expect(r.entities).toHaveLength(1);
+    expect(r.entities[0].uid).toBe(spaceUid);
+    expect(r.uids).toEqual([spaceUid]);
+  });
+
+  it("space-nickname + bracketless uid", () => {
+    const uidToNameMap = new Map([[HEX_A, "Alice Smith"]]);
+    const r = sanitizeOutboundMentions({
+      content: `Hi @${HEX_A}:Alice Smith!`,
+      entities: [],
+      uids: [],
+      uidToNameMap,
+    });
+    expect(r.content).toBe("Hi @Alice Smith!");
+    expect(r.entities).toHaveLength(1);
+    expect(r.entities[0].uid).toBe(HEX_A);
+    expect(r.content.slice(r.entities[0].offset, r.entities[0].offset + r.entities[0].length)).toBe(
+      "@Alice Smith",
+    );
+  });
+
+  it("final guard filters illegal uids out of the supplied uids list", () => {
+    const uidToNameMap = new Map([[HEX_A, "Alice"]]);
+    const r = sanitizeOutboundMentions({
+      content: "plain text no mentions",
+      entities: [],
+      uids: [HEX_A, "uid", "somebody_bot"],
+      uidToNameMap,
+    });
+    expect(r.uids).toEqual([HEX_A]);
+  });
+
+  // ── Negative cases: normal colon-bearing text must NOT be mangled (#1) ──────
+  describe("does not damage normal colon-bearing text", () => {
+    const uidToNameMap = new Map([[HEX_A, "Alice"]]);
+
+    it("leaves a time like @12:30 untouched", () => {
+      const r = sanitizeOutboundMentions({
+        content: "lets meet @12:30 today",
+        entities: [],
+        uids: [],
+        uidToNameMap,
+      });
+      expect(r.content).toBe("lets meet @12:30 today");
+      expect(r.entities).toHaveLength(0);
+      expect(r.uids).toHaveLength(0);
+    });
+
+    it("leaves an SSH-style git@github.com:org/repo untouched", () => {
+      const r = sanitizeOutboundMentions({
+        content: "deploy git@github.com:org/repo now",
+        entities: [],
+        uids: [],
+        uidToNameMap,
+      });
+      expect(r.content).toBe("deploy git@github.com:org/repo now");
+      expect(r.entities).toHaveLength(0);
+      expect(r.uids).toHaveLength(0);
+    });
+
+    it("leaves a ratio like @3:1 untouched", () => {
+      const r = sanitizeOutboundMentions({
+        content: "ratio @3:1 split",
+        entities: [],
+        uids: [],
+        uidToNameMap,
+      });
+      expect(r.content).toBe("ratio @3:1 split");
+      expect(r.entities).toHaveLength(0);
+      expect(r.uids).toHaveLength(0);
+    });
+
+    it("leaves a URL with userinfo+port untouched", () => {
+      const r = sanitizeOutboundMentions({
+        content: "see http://a@host:8080/p here",
+        entities: [],
+        uids: [],
+        uidToNameMap,
+      });
+      expect(r.content).toBe("see http://a@host:8080/p here");
+      expect(r.entities).toHaveLength(0);
+      expect(r.uids).toHaveLength(0);
+    });
+  });
+
+  // ── Hole B: fake space-prefix must not produce a junk uid entity (#2) ───────
+  it("fake space-prefix @s1_haha:Bob → no entity with uid 's1_haha'", () => {
+    const uidToNameMap = new Map([[HEX_A, "Alice"]]);
+    const r = sanitizeOutboundMentions({
+      content: "hi @s1_haha:Bob",
+      entities: [],
+      uids: [],
+      uidToNameMap,
+    });
+    expect(r.entities.some((e) => e.uid === "s1_haha")).toBe(false);
+    expect(r.uids).not.toContain("s1_haha");
+  });
+
+  // ── Hole A: hallucinated 32-hex not in map must not be sent as entity (#2) ──
+  it("hallucinated @<32hex>:Ghost not in map → downgraded, no entity", () => {
+    const uidToNameMap = new Map([[HEX_A, "Alice"]]);
+    const r = sanitizeOutboundMentions({
+      content: `hi @${HEX_B}:Ghost`,
+      entities: [],
+      uids: [],
+      uidToNameMap,
+    });
+    // hex is uid-shaped but not in map → downgrade to @Ghost, drop the uid.
+    expect(r.content).toBe("hi @Ghost");
+    expect(r.entities.some((e) => e.uid === HEX_B)).toBe(false);
+    expect(r.uids).not.toContain(HEX_B);
+  });
+
+  // ── Main path must not regress: real member @[uid:Alice] (#2) ───────────────
+  it("real in-map member uid is converted + kept as entity (main path)", () => {
+    const uidToNameMap = new Map([[HEX_A, "Alice"]]);
+    const mentions = parseStructuredMentions(`ping @[${HEX_A}:Alice] ok`);
+    const converted = convertStructuredMentions(`ping @[${HEX_A}:Alice] ok`, mentions);
+    const r = sanitizeOutboundMentions({
+      content: converted.content,
+      entities: converted.entities,
+      uids: converted.uids,
+      uidToNameMap,
+    });
+    expect(r.content).toBe("ping @Alice ok");
+    expect(r.entities).toHaveLength(1);
+    expect(r.entities[0].uid).toBe(HEX_A);
+    expect(r.uids).toEqual([HEX_A]);
+  });
+
+  // ── space-prefix real member with 32-hex base stays valid (#2) ─────────────
+  it("real space-prefixed member @s14_<32hex> stays valid", () => {
+    const spaceUid = "s14_" + HEX_A;
+    const uidToNameMap = new Map([[spaceUid, "Alice"]]);
+    const r = sanitizeOutboundMentions({
+      content: `hi @${spaceUid}:Alice!`,
+      entities: [],
+      uids: [],
+      uidToNameMap,
+    });
+    expect(r.content).toBe("hi @Alice!");
+    expect(r.entities).toHaveLength(1);
+    expect(r.entities[0].uid).toBe(spaceUid);
+    expect(r.uids).toEqual([spaceUid]);
+  });
+});
+
+describe("MENTION_FORMAT_HINT (P1) + >10 prefix regression guard (test #13)", () => {
+  it("never itself parses into an illegal {uid:'uid'} mention", () => {
+    const parsed = parseStructuredMentions(MENTION_FORMAT_HINT);
+    expect(parsed.every((m) => m.uid !== "uid")).toBe(true);
+    // angle-bracket placeholder slots are not parseable structured mentions
+    expect(parsed).toHaveLength(0);
+  });
+
+  it("uses angle-bracket placeholder slots, not the literal @[uid:displayName] trap", () => {
+    expect(MENTION_FORMAT_HINT).toContain("@[<uid>:<displayName>]");
+    expect(MENTION_FORMAT_HINT).not.toContain("@[uid:displayName]");
+  });
+
+  it("contains single-colon, brackets, convert promise, and three anti-patterns", () => {
+    expect(MENTION_FORMAT_HINT).toContain("ONE colon");
+    expect(MENTION_FORMAT_HINT).toContain("REQUIRED");
+    expect(MENTION_FORMAT_HINT).toContain("I will convert");
+    expect(MENTION_FORMAT_HINT).toContain("username/bot_id");
+    expect(MENTION_FORMAT_HINT).toContain('"uid"');
+    expect(MENTION_FORMAT_HINT).toContain("bare uid");
   });
 });

--- a/src/mention-utils.test.ts
+++ b/src/mention-utils.test.ts
@@ -1049,6 +1049,105 @@ describe("sanitizeOutboundMentions", () => {
     expect(r.entities[0].uid).toBe(spaceUid);
     expect(r.uids).toEqual([spaceUid]);
   });
+
+  // ── Blocking #1: bareHex left-boundary anchor — @<32hex> embedded inside an
+  // email local part / SSH URL / mailto must NOT be matched (the @ used to be
+  // swallowed, corrupting the surrounding text). ──────────────────────────────
+  describe("bareHex left boundary: email / SSH / mailto preserved", () => {
+    const uidToNameMap = new Map([[HEX_A, "Alice"]]);
+
+    it("email local part @<32hex> is left intact (@ not swallowed)", () => {
+      const content = `mail user@${HEX_B} now`;
+      const r = sanitizeOutboundMentions({
+        content,
+        entities: [],
+        uids: [],
+        uidToNameMap,
+      });
+      expect(r.content).toBe(content);
+      expect(r.entities).toHaveLength(0);
+      expect(r.uids).toHaveLength(0);
+    });
+
+    it("SSH-style git@<32hex>.com:org/repo is left intact", () => {
+      const content = `clone git@${HEX_B}.com:org/repo done`;
+      const r = sanitizeOutboundMentions({
+        content,
+        entities: [],
+        uids: [],
+        uidToNameMap,
+      });
+      expect(r.content).toBe(content);
+      expect(r.entities).toHaveLength(0);
+      expect(r.uids).toHaveLength(0);
+    });
+
+    it("mailto link [x](mailto:noreply@<32hex>.com) is left intact", () => {
+      const content = `[click](mailto:noreply@${HEX_B}.com)`;
+      const r = sanitizeOutboundMentions({
+        content,
+        entities: [],
+        uids: [],
+        uidToNameMap,
+      });
+      expect(r.content).toBe(content);
+      expect(r.entities).toHaveLength(0);
+      expect(r.uids).toHaveLength(0);
+    });
+
+    it("line-start bare @<32hex> not in map still downgrades (behavior unchanged)", () => {
+      // A legitimately uid-shaped bare hex at line start (left boundary = ^) is
+      // still a hallucinated, not-in-map token → @ stripped, no entity. The new
+      // anchor must not regress this established behavior.
+      const r = sanitizeOutboundMentions({
+        content: `@${HEX_B} hello`,
+        entities: [],
+        uids: [],
+        uidToNameMap,
+      });
+      expect(r.content).toBe(`${HEX_B} hello`);
+      expect(r.entities).toHaveLength(0);
+      expect(r.uids).toHaveLength(0);
+    });
+  });
+
+  // ── Blocking #2: cold-start (empty map) structured mention must survive ──────
+  it("cold start (empty uidToNameMap): structured @[uid:name] uid survives the final guard", () => {
+    // prefetch failed → uidToNameMap empty. Agent wrote a correct @[uid:Alice].
+    // The structured-source uid is trusted and must NOT be dropped by the guard,
+    // otherwise the server receives no mention and Alice gets no notification.
+    const emptyMap = new Map<string, string>();
+    const input = `Hi @[${HEX_A}:Alice]!`;
+    const mentions = parseStructuredMentions(input);
+    const converted = convertStructuredMentions(input, mentions);
+    const r = sanitizeOutboundMentions({
+      content: converted.content,
+      entities: converted.entities,
+      uids: converted.uids,
+      uidToNameMap: emptyMap,
+    });
+    expect(r.content).toBe("Hi @Alice!");
+    expect(r.entities).toHaveLength(1);
+    expect(r.entities[0].uid).toBe(HEX_A);
+    expect(r.uids).toEqual([HEX_A]);
+  });
+
+  it("cold start does NOT whitewash a hallucinated bare @<32hex> (not structured-source)", () => {
+    // Regression guard for the trustedUids relaxation: a bare hex produced by
+    // the model (NOT via @[uid:name], so not in the trusted entities) must still
+    // be stripped/downgraded even when the map is empty — it never enters
+    // trustedUids, so the final guard keeps blocking it.
+    const emptyMap = new Map<string, string>();
+    const r = sanitizeOutboundMentions({
+      content: `ping @${HEX_B} now`,
+      entities: [],
+      uids: [],
+      uidToNameMap: emptyMap,
+    });
+    expect(r.content).toBe(`ping ${HEX_B} now`);
+    expect(r.entities.some((e) => e.uid === HEX_B)).toBe(false);
+    expect(r.uids).not.toContain(HEX_B);
+  });
 });
 
 describe("MENTION_FORMAT_HINT (P1) + >10 prefix regression guard (test #13)", () => {

--- a/src/mention-utils.ts
+++ b/src/mention-utils.ts
@@ -317,7 +317,10 @@ export interface SanitizeResult {
  *   3. 裸 `@<32hex>`         —— 命中 uidToNameMap → 重写 `@displayName` + entity；
  *      未命中 → 剥掉 `@`，不发非法 mention。
  *
- * 最终守卫：过滤 entities/uids，只保留 isValidOutboundUid 通过的项。
+ * 最终守卫：过滤 entities/uids，保留 isValidOutboundUid 通过、或来自结构化
+ * `@[uid:name]` 形式（传入的 entities，形态合法）的可信 uid。详见函数内
+ * trustedUids 注释——结构化来源是 agent 的权威意图，冷启动空 map 下也放行；
+ * 兜底分支新产生的幻觉 hex 不可信，仍被拦截。
  *
  * 重写改变字符串长度，故所有改写统一从后向前 splice，并同步调整既有
  * entity 的 offset，避免漂移。
@@ -335,6 +338,23 @@ export function sanitizeOutboundMentions(params: {
   let content = params.content;
   // 既有 entity 的工作副本（offset 会随重写调整）
   const entities: MentionEntity[] = params.entities.map((e) => ({ ...e }));
+
+  // 可信 uid 集合：传入的 entities 来自 convertStructuredMentions —— 即 agent
+  // 显式写出的 @[uid:name] 结构化形式。结构化 uid 是 agent 的权威意图，应被
+  // 信任，即便冷启动下 uidToNameMap 为空（prefetch best-effort 失败）也要放
+  // 行，否则真实成员的合法 mention 会被最终守卫误删、对方收不到通知。
+  //
+  // 关键区分：只信任**结构化来源**的 uid（此处的 params.entities），且仅当其
+  // 形态合法（裸 32-hex 或 space-prefixed 32-hex base）。sanitize 内部由
+  // bracketless/bareHex 兜底分支**新产生**的 entity 不进此集合——那些可能源自
+  // 模型瞎编的幻觉 hex，仍须经 isValidOutboundUid 校验，照旧被守卫/降级。
+  const isWellFormedUid = (uid: string): boolean =>
+    HEX32_RE.test(extractBaseUid(uid));
+  const trustedUids = new Set<string>(
+    params.entities.map((e) => e.uid).filter(isWellFormedUid),
+  );
+  const passesFinalGuard = (uid: string): boolean =>
+    isValidOutboundUid(uid, uidToNameMap) || trustedUids.has(uid);
 
   interface Edit {
     start: number;
@@ -400,7 +420,12 @@ export function sanitizeOutboundMentions(params: {
     }
 
     // ② 裸 @<32hex>
-    const bareHex = /@([0-9a-fA-F]{32})/g;
+    // 前置边界对齐 ①/MENTION_PATTERN：@ 前须为行首/空白/非字母数字。缺这个
+    // 锚点时，email 本地部分、SSH URL、mailto 里的 `@<32hex>` 会被误匹配并
+    // 损坏（user@<hex>、git@<hex>.com:org、mailto:noreply@<hex>.com）。
+    // lookbehind/^ 均为零宽，m.index 仍指向 @、m[0] 仍以 @ 开头，故下方
+    // start/end/claimed 计算与既有逻辑完全一致，无需调整。
+    const bareHex = /(?:^|(?<=\s|[^a-zA-Z0-9]))@([0-9a-fA-F]{32})/g;
     while ((m = bareHex.exec(content)) !== null) {
       const hex = m[1];
       const start = m.index;
@@ -451,9 +476,13 @@ export function sanitizeOutboundMentions(params: {
     }
   }
 
-  // 最终守卫：丢弃非法 uid 的 entity / uid
+  // 最终守卫：丢弃非法 uid 的 entity / uid。
+  // 放行条件 = isValidOutboundUid（in-map / space-prefixed 32-hex base）
+  //          OR  结构化来源的可信 uid（trustedUids，已预筛形态合法）。
+  // 这样冷启动下结构化 @[uid:name] 的真实 uid（未命中空 map）能存活，而兜底
+  // 分支新产生的幻觉 hex（不在 trustedUids）仍被拦截。
   const finalEntities = entities
-    .filter((e) => isValidOutboundUid(e.uid, uidToNameMap))
+    .filter((e) => passesFinalGuard(e.uid))
     .sort((a, b) => a.offset - b.offset);
 
   const seen = new Set<string>();
@@ -465,7 +494,7 @@ export function sanitizeOutboundMentions(params: {
     }
   }
   for (const u of params.uids) {
-    if (isValidOutboundUid(u, uidToNameMap) && !seen.has(u)) {
+    if (passesFinalGuard(u) && !seen.has(u)) {
       seen.add(u);
       finalUids.push(u);
     }

--- a/src/mention-utils.ts
+++ b/src/mention-utils.ts
@@ -35,6 +35,26 @@ export const MENTION_PATTERN =
 export const STRUCTURED_MENTION_PATTERN = /@\[([\w.\-]+):([^\]\n]+)\]/g;
 
 /**
+ * Shared @mention format instruction.
+ *
+ * Single source of truth reused by the inbound member-list prefix (both the
+ * ≤10 and >10 branches) and the outbound message-tool hints, so the format
+ * rules and anti-patterns can never drift between the three injection points.
+ *
+ * The placeholder slots are written as `@[<uid>:<displayName>]` (angle
+ * brackets), NOT `@[uid:displayName]`. The angle brackets keep the literal
+ * placeholder out of STRUCTURED_MENTION_PATTERN's uid char class ([\w.\-]),
+ * so this hint text itself never parses into an illegal `{uid:"uid"}` mention
+ * that a model could copy verbatim into a payload.
+ */
+export const MENTION_FORMAT_HINT =
+  `To @mention a member, use @[<uid>:<displayName>] where <uid> is the member's REAL ` +
+  `32-char hex id, with exactly ONE colon and the square brackets are REQUIRED. ` +
+  `Never use a username/bot_id (e.g. @somebody_bot), never copy the literal word ` +
+  `"uid", never write a bare uid without brackets, never omit the brackets. ` +
+  `I will convert the @[<uid>:<displayName>] form to the correct mention before sending.`;
+
+/**
  * Parse @mentions from message content.
  * Returns an array of mentioned names (without the @ prefix).
  *
@@ -235,7 +255,224 @@ export function buildEntitiesFromFallback(
   return { entities, uids };
 }
 
-// ── Extract UIDs from MentionPayload (entities-first with fallback) ──────────
+// ── Outbound mention sanitizer (last-line guard before send) ─────────────────
+
+/** Octo uids are random 32-char hex hashes. */
+const HEX32_RE = /^[0-9a-fA-F]{32}$/;
+
+/**
+ * 判定一个 uid 是否可作为出站 mention 发出。
+ *
+ * 白名单（保守策略，与 bareHex 兜底分支口径一致）：
+ *   1. 在 uidToNameMap 中命中（v2 主路径的真实成员 uid 走这里放行）。
+ *   2. space-prefixed（s{digits}_<base>）且剥离后的 base 为标准 32-hex。
+ *
+ * 故意 **不** 放行"未命中 map 的裸 32-hex"：模型幻觉出的随机 32-hex 不在本
+ * 群成员表里，若放行会被当 entity 发给服务端（幻觉提醒）。bareHex 兜底分支
+ * 对未命中 hex 已采取"剥掉 @、不发 mention"的保守处理，这里与之统一。
+ *
+ * 其余（字面词 "uid"、猜测的 username/bot_id、伪 space-prefix 如 s1_haha）
+ * 一律视为非法。
+ */
+export function isValidOutboundUid(
+  uid: string,
+  uidToNameMap: Map<string, string>,
+): boolean {
+  if (uidToNameMap.has(uid)) return true;
+  // space-prefixed uid（s14_<32hex>）：base 必须是标准 32-hex 才算合法，
+  // 避免伪造的 s1_haha 这类"能剥就放行"导致垃圾 uid entity 泄露。
+  const base = extractBaseUid(uid);
+  if (base !== uid && HEX32_RE.test(base)) return true;
+  return false;
+}
+
+/**
+ * 形态预筛：判断 token 是否"长得像一个 uid"，决定出站兜底是否要触碰这段文本。
+ *
+ * 比 isValidOutboundUid 略宽——额外把"裸 32-hex"也算 uid 形态，使得
+ * `@<32hex>:Name`（即便 hex 未命中 map）能进入重写路径并降级为 `@Name`，
+ * 而 `@12:30`/`@3:1`/`git@github.com:org` 这类普通含冒号文本（token 形态完全
+ * 不像 uid）被直接跳过、原样保留，不做任何改写。
+ */
+function isUidShaped(uid: string, uidToNameMap: Map<string, string>): boolean {
+  if (isValidOutboundUid(uid, uidToNameMap)) return true;
+  if (HEX32_RE.test(uid)) return true; // 裸 32-hex（可能未命中 map）
+  return false;
+}
+
+export interface SanitizeResult {
+  content: string;
+  entities: MentionEntity[];
+  uids: string[];
+}
+
+/**
+ * 出站宽松兜底 + 守卫：在 v2/v1 转换之后、send 之前调用。
+ *
+ * 修复三类模型常写错、转换/兜底都救不回的坏 @：
+ *   1. 缺方括号 `@uid:name`  —— uid 合法 → 重写 `@displayName` + entity；
+ *      非法 → 降级 `@name`（剥掉 uid），绝不发 `uid:name` 整段。
+ *   2. `@username`/猜测句柄  —— 有 usernameMap 命中 → 反查补 entity；
+ *      否则保持纯文本（无 entity），绝不把非法 token 当 uid。
+ *   3. 裸 `@<32hex>`         —— 命中 uidToNameMap → 重写 `@displayName` + entity；
+ *      未命中 → 剥掉 `@`，不发非法 mention。
+ *
+ * 最终守卫：过滤 entities/uids，只保留 isValidOutboundUid 通过的项。
+ *
+ * 重写改变字符串长度，故所有改写统一从后向前 splice，并同步调整既有
+ * entity 的 offset，避免漂移。
+ */
+export function sanitizeOutboundMentions(params: {
+  content: string;
+  entities: MentionEntity[];
+  uids: string[];
+  uidToNameMap: Map<string, string>;
+  // 预留：@username → uid 反查表（P2 能力）。当前生产路径尚未接线（仅测试
+  // 传入），故 ③ 分支线上不可达；接入后即可对 @handle 自动补 entity。
+  usernameMap?: Map<string, string>;
+}): SanitizeResult {
+  const { uidToNameMap, usernameMap } = params;
+  let content = params.content;
+  // 既有 entity 的工作副本（offset 会随重写调整）
+  const entities: MentionEntity[] = params.entities.map((e) => ({ ...e }));
+
+  interface Edit {
+    start: number;
+    end: number;
+    replacement: string;
+    uid?: string;
+  }
+  const edits: Edit[] = [];
+
+  // 已被既有 entity / 已决定的 edit 占用的区间，避免重复处理同一段文本
+  const claimed: Array<[number, number]> = entities.map((e) => [
+    e.offset,
+    e.offset + e.length,
+  ]);
+  const overlaps = (s: number, e: number): boolean =>
+    claimed.some(([cs, ce]) => s < ce && e > cs);
+
+  // 前置短路：正文不含 @ 时无需扫描任何 mention 形态（出站群消息正文绝大多数
+  // 没有 @）。最终 uid/entity 守卫仍会执行（见末尾），故传入的 uids 仍被过滤。
+  if (content.includes("@")) {
+    // ① 缺方括号 @uid:name（name 字符集复用 MENTION_PATTERN 的内部集合）
+    // 前置边界对齐 MENTION_PATTERN：@ 前须为行首/空白/非字母数字，排除
+    // git@github.com:org、http://x@host:8080 这类中缀 @ 误匹配。
+    const bracketless =
+      /(?:^|(?<=\s|[^a-zA-Z0-9]))@([\w.\-]+):([\wÀ-ɏ一-鿿぀-ヿ가-힯.\-]+)/g;
+    let m: RegExpExecArray | null;
+    while ((m = bracketless.exec(content)) !== null) {
+      const uidTok = m[1];
+      if (uidTok.toLowerCase() === "all") continue;
+      // 形态预筛：只有"确实像一个 uid"的 token 才进入重写/降级。普通含冒号
+      // 文本（@12:30 时间、@3:1 比例、github.com 等）形态不像 uid → 原样保留。
+      if (!isUidShaped(uidTok, uidToNameMap)) continue;
+      const start = m.index;
+      let end = m.index + m[0].length;
+      if (overlaps(start, end)) continue;
+
+      const canonical =
+        uidToNameMap.get(uidTok) ??
+        (extractBaseUid(uidTok) !== uidTok
+          ? uidToNameMap.get(extractBaseUid(uidTok))
+          : undefined);
+
+      let replacement: string;
+      let uid: string | undefined;
+      if (isValidOutboundUid(uidTok, uidToNameMap)) {
+        // 合法 uid → 重写为真名（优先用映射的规范名）+ entity
+        const dispName = canonical ?? m[2];
+        // 含空格昵称：若冒号后紧跟规范名，扩展消费范围把整段名字吃掉
+        const colonEnd = start + 1 + uidTok.length + 1; // @ + uid + ':'
+        if (canonical && content.startsWith(canonical, colonEnd)) {
+          end = colonEnd + canonical.length;
+        }
+        replacement = `@${dispName}`;
+        uid = uidTok;
+      } else {
+        // 形态像 uid 但不合法（如未命中 map 的幻觉 32-hex）→ 降级为 @name
+        //（剥掉 uid 段），不发非法 mention。
+        replacement = `@${m[2]}`;
+        uid = undefined;
+      }
+      edits.push({ start, end, replacement, uid });
+      claimed.push([start, end]);
+    }
+
+    // ② 裸 @<32hex>
+    const bareHex = /@([0-9a-fA-F]{32})/g;
+    while ((m = bareHex.exec(content)) !== null) {
+      const hex = m[1];
+      const start = m.index;
+      const end = m.index + m[0].length;
+      if (overlaps(start, end)) continue;
+      const name = uidToNameMap.get(hex);
+      if (name) {
+        edits.push({ start, end, replacement: `@${name}`, uid: hex });
+      } else {
+        // 未命中 → 剥掉 @，不当作 mention 发出
+        edits.push({ start, end, replacement: hex, uid: undefined });
+      }
+      claimed.push([start, end]);
+    }
+
+    // ③ @username（仅当 usernameMap 命中时反查补回；否则保持纯文本）
+    if (usernameMap && usernameMap.size > 0) {
+      const userPat = /@([a-zA-Z0-9_]+)/g;
+      while ((m = userPat.exec(content)) !== null) {
+        const username = m[1];
+        if (username.toLowerCase() === "all") continue;
+        const start = m.index;
+        const end = m.index + m[0].length;
+        if (overlaps(start, end)) continue;
+        const uid = usernameMap.get(username);
+        if (!uid) continue;
+        const name = uidToNameMap.get(uid) ?? username;
+        edits.push({ start, end, replacement: `@${name}`, uid });
+        claimed.push([start, end]);
+      }
+    }
+  }
+
+  // 从后向前应用所有 edit，同步调整既有/新增 entity 的 offset
+  edits.sort((a, b) => b.start - a.start);
+  for (const ed of edits) {
+    const delta = ed.replacement.length - (ed.end - ed.start);
+    content = content.slice(0, ed.start) + ed.replacement + content.slice(ed.end);
+    for (const e of entities) {
+      if (e.offset >= ed.end) e.offset += delta;
+    }
+    if (ed.uid) {
+      entities.push({
+        uid: ed.uid,
+        offset: ed.start,
+        length: ed.replacement.length,
+      });
+    }
+  }
+
+  // 最终守卫：丢弃非法 uid 的 entity / uid
+  const finalEntities = entities
+    .filter((e) => isValidOutboundUid(e.uid, uidToNameMap))
+    .sort((a, b) => a.offset - b.offset);
+
+  const seen = new Set<string>();
+  const finalUids: string[] = [];
+  for (const e of finalEntities) {
+    if (!seen.has(e.uid)) {
+      seen.add(e.uid);
+      finalUids.push(e.uid);
+    }
+  }
+  for (const u of params.uids) {
+    if (isValidOutboundUid(u, uidToNameMap) && !seen.has(u)) {
+      seen.add(u);
+      finalUids.push(u);
+    }
+  }
+
+  return { content, entities: finalEntities, uids: finalUids };
+}
 
 /**
  * 兼容提取 mention 中的 uid 列表。

--- a/src/mention-utils.ts
+++ b/src/mention-utils.ts
@@ -339,19 +339,26 @@ export function sanitizeOutboundMentions(params: {
   // 既有 entity 的工作副本（offset 会随重写调整）
   const entities: MentionEntity[] = params.entities.map((e) => ({ ...e }));
 
-  // 可信 uid 集合：传入的 entities 来自 convertStructuredMentions —— 即 agent
-  // 显式写出的 @[uid:name] 结构化形式。结构化 uid 是 agent 的权威意图，应被
-  // 信任，即便冷启动下 uidToNameMap 为空（prefetch best-effort 失败）也要放
-  // 行，否则真实成员的合法 mention 会被最终守卫误删、对方收不到通知。
+  // 可信 uid 集合：两个来源都来自 caller 入参，都是框架/agent 的权威意图：
+  //   1. params.entities —— 来自 convertStructuredMentions，即 agent 显式写出的
+  //      @[uid:name] 结构化形式；
+  //   2. params.uids —— 由框架从 target 后缀（group:<gid>@uid1,uid2）等渠道抽出
+  //      的 inline mention uid（正文里没有 @，但调用方明确要 @ 这些人）。
+  // 两者都应被信任，即便冷启动下 uidToNameMap 为空（prefetch best-effort 失败、
+  // 正文无 @ 而短路）也要放行，否则真实成员的合法 mention 会被最终守卫误删、对
+  // 方收不到通知。
   //
-  // 关键区分：只信任**结构化来源**的 uid（此处的 params.entities），且仅当其
-  // 形态合法（裸 32-hex 或 space-prefixed 32-hex base）。sanitize 内部由
-  // bracketless/bareHex 兜底分支**新产生**的 entity 不进此集合——那些可能源自
-  // 模型瞎编的幻觉 hex，仍须经 isValidOutboundUid 校验，照旧被守卫/降级。
+  // 关键区分：只信任**来自 caller 入参**的 uid（params.entities + params.uids），
+  // 且仅当其形态合法（裸 32-hex 或 space-prefixed 32-hex base）。sanitize 内部由
+  // bracketless/bareHex 兜底分支**新产生**、push 进局部 entities 的 uid 不进此集
+  // 合——那些可能源自模型瞎编的幻觉 hex，仍须经 isValidOutboundUid 校验，照旧被
+  // 守卫/降级。
   const isWellFormedUid = (uid: string): boolean =>
     HEX32_RE.test(extractBaseUid(uid));
   const trustedUids = new Set<string>(
-    params.entities.map((e) => e.uid).filter(isWellFormedUid),
+    [...params.entities.map((e) => e.uid), ...params.uids].filter(
+      isWellFormedUid,
+    ),
   );
   const passesFinalGuard = (uid: string): boolean =>
     isValidOutboundUid(uid, uidToNameMap) || trustedUids.has(uid);


### PR DESCRIPTION
Closes #85.

## Problem

Proactive outbound messages (cron jobs, newly-created threads, agent-initiated sends) produced broken `@mentions` that never resolved — a bare `@<uid>:<name>` (raw uid leaked into the rendered text) or `@<bot_username>` (an id that can never match a member). This reproduced on small groups too, so it was not a member-count issue. The same content sent as an inbound reply resolved correctly.

## Root cause

Two gaps, both on the proactive outbound path:

1. The account-level member maps are only populated on the inbound path, so outbound `sendText` / `handleSend` ran mention conversion against empty/expired maps and emitted the malformed text verbatim.
2. The member list + mention-format guidance is only injected on the inbound reply path. Proactive turns got no member list and no format hint; the `>10`-member prompt branch in particular gave no real example and invited copying the literal placeholder and dropping the brackets. There was also no outbound guard to recover or strip a malformed mention.

## Changes

- **Prefetch members before conversion** (`channel.ts` `sendText`, `actions.ts` `handleSend`): when the text contains `@`, fetch the target group's members via the group-level cache and populate the maps; silent on failure.
- **`sanitizeOutboundMentions` guard** (`mention-utils.ts`): recover bracketless `@uid:name`, bare `@<hex>` and `@username` when they map to a real member, otherwise downgrade to plain `@name` or strip; filter illegal uids so a raw uid never leaks. Bounded by a strict uid-shape pre-filter so ordinary text (`@12:30`, `git@host:port`, URLs, ratios) is left untouched.
- **Tighten `isValidOutboundUid`**: reject hallucinated hex and fake space-prefixed uids; only map-hits and real space-prefixed hex pass.
- **Rewrite the `>10`-member prompt**: guide a member lookup first, with a real-shaped example, a single colon, required brackets and the conversion promise; share one `MENTION_FORMAT_HINT` across all sites and use angle-bracket placeholder slots so the example itself is not parsed.

## Tests

Adds coverage for cold-start prefetch, thread parent extraction, bracketless / username / bare-hex recovery and downgrade, offset rewriting, guard filtering, prompt snapshots, and colon-text negatives (`@12:30`, `git@host:port`, URLs).

- `npm test`: 972 passed (24 files)
- `npx tsc --noEmit`: clean
