### PR TITLE
fix(agent-tools): stop write-secret jail self-locking when root is '/'

### DIFF
--- a/src/agent-tools.test.ts
+++ b/src/agent-tools.test.ts
@@ -1579,6 +1579,83 @@ describe("createOctoManagementTools", () => {
       expect(resolveSecret).not.toHaveBeenCalled();
     });
 
+    // 🔴 P0 REGRESSION — jail root="/" self-lock. In Docker / prod the gateway
+    // CWD is frequently "/". The old `root + sep` containment degenerated to a
+    // "//" prefix that NO normal absolute path matches, so EVERY write was
+    // rejected with "resolves outside the permitted root" even for legitimate
+    // in-jail targets. These cases lock in that root="/" behaves like any other
+    // jail: in-jail paths are accepted, out-of-jail is impossible (everything is
+    // under "/"), and traversal that climbs above "/" still normalizes to "/".
+    describe("jail root = '/' (containment must not self-lock)", () => {
+      it("accepts a legitimate in-jail absolute path when root is '/'", async () => {
+        vi.mocked(resolveSecret).mockResolvedValue({ status: "resolved", value: PLAINTEXT });
+        // root="/" → the candidate sits under it. We must NOT actually write to
+        // the real /tmp during the unit test, so stub fs writes and assert the
+        // confinement check (the thing this bug was about) passes: resolveSecret
+        // runs only AFTER confinement succeeds.
+        setupMocks({ secretsFileRoot: "/" });
+        const target = join(root, "in-jail-secret.env");
+        const result = await writeSecret({ alias: "k", filePath: target });
+        const data = parseText(result);
+        // Confinement passed → it proceeded to resolve + write the secret.
+        expect(data.written).toBe(true);
+        expect(resolveSecret).toHaveBeenCalled();
+        // path is reported jail-relative to "/", i.e. without the leading slash.
+        expect(data.path).toBe(target.replace(/^\//, ""));
+        expect(await readFile(target, "utf8")).toBe(PLAINTEXT);
+        await rm(target, { force: true });
+      });
+
+      it("accepts a relative in-jail path when root is '/'", async () => {
+        // A relative filePath resolves against root="/"; e.g. "tmp/..." lands at
+        // "/tmp/...". Reuse the per-test temp dir (which lives under /tmp) and
+        // pass it as a root-relative path (no leading slash).
+        vi.mocked(resolveSecret).mockResolvedValue({ status: "resolved", value: PLAINTEXT });
+        setupMocks({ secretsFileRoot: "/" });
+        const rel = root.replace(/^\//, "") + "/rel-secret.env";
+        const result = await writeSecret({ alias: "k", filePath: rel });
+        const data = parseText(result);
+        expect(data.written).toBe(true);
+        expect(data.path).toBe(rel);
+        expect(await readFile(join("/", rel), "utf8")).toBe(PLAINTEXT);
+        await rm(join("/", rel), { force: true });
+      });
+
+      it("normalizes traversal above '/' back to '/' (cannot escape the FS root)", async () => {
+        // Climbing past the filesystem root is meaningless: "/../../etc" → "/etc".
+        // It stays in-jail (everything is under "/"), so confinement accepts it.
+        // We don't actually write to /etc — point at our temp dir via excess "..".
+        vi.mocked(resolveSecret).mockResolvedValue({ status: "resolved", value: PLAINTEXT });
+        setupMocks({ secretsFileRoot: "/" });
+        const target = join(root, "climb.env");
+        const result = await writeSecret({
+          alias: "k",
+          filePath: "../../../../../.." + target,
+        });
+        const data = parseText(result);
+        expect(data.written).toBe(true);
+        expect(await readFile(target, "utf8")).toBe(PLAINTEXT);
+        await rm(target, { force: true });
+      });
+
+      it("still enforces the symlink guard even when root is '/'", async () => {
+        // The symlink walk must keep working with root="/" — the prefix-bug fix
+        // must not weaken it. Build a leaf symlink pointing at a not-yet-existing
+        // target: the realpath walk can't verify it stays in-jail (dangling), so
+        // it is rejected UNCONDITIONALLY, exactly as at any other root. This
+        // proves the symlink defenses survive the root="/" containment change.
+        vi.mocked(resolveSecret).mockResolvedValue({ status: "resolved", value: PLAINTEXT });
+        setupMocks({ secretsFileRoot: "/" });
+        const realTarget = join(root, "real.env"); // never created → dangling
+        const linkPath = join(root, "link.env");
+        await symlink(realTarget, linkPath, "file");
+        const result = await writeSecret({ alias: "k", filePath: linkPath });
+        expect(parseText(result).error).toMatch(/symlink|outside the allowed/i);
+        expect(JSON.stringify(result)).not.toContain(PLAINTEXT);
+        await rm(linkPath, { force: true });
+      });
+    });
+
     it("not_found → guides the user to add the key, no plaintext, no write", async () => {
       vi.mocked(resolveSecret).mockResolvedValue({ status: "not_found" });
 

--- a/src/agent-tools.ts
+++ b/src/agent-tools.ts
@@ -43,7 +43,14 @@ import {
 import { broadcastGroupMdUpdate, broadcastThreadMdUpdate } from "./group-md.js";
 import { mkdir, realpath, lstat, open } from "node:fs/promises";
 import { constants as fsConstants } from "node:fs";
-import { basename, dirname, relative, resolve as resolvePath, sep } from "node:path";
+import {
+  basename,
+  dirname,
+  isAbsolute,
+  relative,
+  resolve as resolvePath,
+  sep,
+} from "node:path";
 
 import type { OpenClawConfig } from "openclaw/plugin-sdk";
 import { DEFAULT_ACCOUNT_ID } from "./sdk-compat.js";
@@ -62,6 +69,29 @@ const SECRET_PLACEHOLDER = "{{secret}}";
  * A file that now holds a plaintext API key must not be world/group readable.
  */
 const SECRET_FILE_MODE = 0o600;
+
+/**
+ * True when `candidate` is the jail `root` itself or sits strictly beneath it.
+ *
+ * 🔴 Containment is computed with `path.relative` rather than a `root + sep`
+ * string prefix. The prefix form silently degenerates when `root` is the
+ * filesystem root (`/`): `root + sep` becomes `//`, so NO normal absolute path
+ * (`/home`, `/tmp`, …) `startsWith("//")`, and `candidate !== "/"` is always
+ * true — the jail rejects every path and `write-secret` self-locks. In Docker /
+ * production the gateway CWD is often `/`, so any deployment without an explicit
+ * `secretsFileRoot` hits this. `path.relative` has no such edge case:
+ *   • candidate === root          → "" (relative path to itself) → inside
+ *   • candidate beneath root      → e.g. "a/b", never absolute / never "../…"
+ *   • candidate outside root      → starts with ".." or is absolute → outside
+ * This single predicate replaces all three former `root + sep` checks.
+ */
+function isInsideRoot(root: string, candidate: string): boolean {
+  if (candidate === root) return true;
+  const rel = relative(root, candidate);
+  // Empty rel means same path; a rel that is absolute or climbs out via ".."
+  // escapes the jail. Everything else descends into it.
+  return rel !== "" && !rel.startsWith(`..${sep}`) && rel !== ".." && !isAbsolute(rel);
+}
 
 /**
  * Confine a caller-supplied write target to an operator-approved jail root.
@@ -104,7 +134,9 @@ async function confineSecretPath(
 
   // Lexical containment: candidate must be the root itself or sit strictly
   // beneath it. This already defeats `..` traversal and absolute-elsewhere.
-  if (candidate !== root && !candidate.startsWith(root + sep)) {
+  // isInsideRoot() uses path.relative so a root of "/" is handled correctly
+  // (the old `root + sep` prefix degenerated to "//" and rejected everything).
+  if (!isInsideRoot(root, candidate)) {
     return {
       ok: false,
       error: `Refusing to write the secret outside the allowed directory. "${filePath}" resolves outside the permitted root. Use a path inside the workspace.`,
@@ -125,11 +157,17 @@ async function confineSecretPath(
   //   • a component that simply does not exist (ENOENT on lstat itself, not a
   //     symlink) → it and everything below it will be freshly created as plain
   //     entries inside the already-validated jail, so we can stop walking.
-  const rel = candidate === root ? "" : candidate.slice(root.length + sep.length);
+  // Use path.relative so a root of "/" yields the right segment list. The old
+  // `candidate.slice(root.length + sep.length)` over-sliced by one char when
+  // root === "/" (root.length=1 + sep.length=1 = 2, but "/" + "home" only has
+  // one separator), corrupting the walk. relative() is root-length-agnostic.
+  const rel = candidate === root ? "" : relative(root, candidate);
   const segments = rel ? rel.split(sep) : [];
   let current = root;
   for (const seg of segments) {
-    current = `${current}${sep}${seg}`;
+    // resolvePath joins cleanly even when root === "/" (avoids a "//seg" double
+    // separator that a literal `${current}${sep}${seg}` would produce there).
+    current = resolvePath(current, seg);
     let st;
     try {
       st = await lstat(current);
@@ -149,7 +187,7 @@ async function confineSecretPath(
           error: `Refusing to write the secret: "${filePath}" passes through a symlink that cannot be verified to stay inside the allowed directory.`,
         };
       }
-      if (real !== root && !real.startsWith(root + sep)) {
+      if (!isInsideRoot(root, real)) {
         return {
           ok: false,
           error: `Refusing to write the secret: "${filePath}" resolves through a symlink that escapes the allowed directory.`,
@@ -1011,7 +1049,7 @@ async function handleWriteSecret(params: {
       // containment, then open via the canonical parent + basename so every
       // component is proven to stay inside the root.
       const realDir = await realpath(dir);
-      if (realDir !== root && !realDir.startsWith(root + sep)) {
+      if (!isInsideRoot(root, realDir)) {
         return makeError(
           "Refusing to write the secret: the destination directory escaped the allowed root after creation.",
         );


### PR DESCRIPTION
## Problem
`write-secret` is 100% unusable when `secretsFileRoot` is unconfigured. In Docker/prod the gateway process CWD is frequently `/`, so the jail root falls back to `/` and **every** `filePath` is rejected with `resolves outside the permitted root` — even legitimate in-jail paths.

## Root cause (`src/agent-tools.ts confineSecretPath`)
The containment check used a `root + sep` string prefix. When `root === "/"`:
- `root + sep` → `"//"`; no normal absolute path (`/home`, `/tmp`) `startsWith("//")`, and `candidate !== "/"` is always true → **all writes rejected**.
- The `rel` slice `candidate.slice(root.length + sep.length)` over-sliced by one char (root.length 1 + sep.length 1 = 2, but `/home` has only one separator) → corrupted symlink walk.
- The symlink-walk path join `` `${current}${sep}${seg}` `` produced `//seg`.
- The same `root + sep` degeneration also hit the symlink-walk and post-mkdir `realDir` containment checks.

## Fix
- New `path.relative`-based `isInsideRoot(root, candidate)` helper with no `root="/"` edge case; replaces all three `root + sep` containment checks (lexical, symlink-walk, post-mkdir).
- Compute the walk `rel` via `path.relative` (root-length-agnostic).
- Join walk segments with `resolvePath` (clean join at `/`).

The `..`-traversal, absolute-escape, dangling/escaping-symlink, and TOCTOU defenses (PR #71 red lines) are untouched.

## Tests
- New `jail root = '/'` suite: in-jail absolute + relative paths accepted, traversal above `/` normalized back to `/`, symlink guard still enforced.
- Existing `defaults the jail root to process.cwd()` regression kept.
- Full suite green: **944 passed**, type-check clean.

## Scope
`src/agent-tools.ts` + `src/agent-tools.test.ts` only. No config schema change. `dist/` is gitignored and rebuilt at deploy.

> Base is `feat/agent-tool-write-secret` because `confineSecretPath` lives on that branch (PR #71) and is not yet on `main`.

Part of YUJ-3860.
