### PR TITLE
refactor(write-secret): drop jail/secretsFileRoot, OS perms are the write boundary

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -123,10 +123,6 @@
                 "onBehalfOf": {
                   "type": "string",
                   "description": "Persona clone: grantor uid — bot acts on behalf of this human"
-                },
-                "secretsFileRoot": {
-                  "type": "string",
-                  "description": "Jail root for write-secret: secret files may only be written under this path (defaults to the plugin process working directory)"
                 }
               }
             }
@@ -134,10 +130,6 @@
           "onBehalfOf": {
             "type": "string",
             "description": "Persona clone: grantor uid — bot acts on behalf of this human"
-          },
-          "secretsFileRoot": {
-            "type": "string",
-            "description": "Jail root for write-secret: secret files may only be written under this path (defaults to the plugin process working directory)"
           }
         }
       }

--- a/src/accounts.ts
+++ b/src/accounts.ts
@@ -19,7 +19,6 @@ export type ResolvedOctoAccount = {
     historyLimit?: number;  // 群聊历史消息条数限制
     historyPromptTemplate?: string;  // Template for group history context injection
     onBehalfOf?: string;  // Persona clone: grantor uid
-    secretsFileRoot?: string;  // Jail root for write-secret file writes
   };
 };
 
@@ -101,7 +100,6 @@ export function resolveOctoAccount(params: {
       historyLimit: accountConfig.historyLimit ?? channel.historyLimit ?? 20,
       historyPromptTemplate: accountConfig.historyPromptTemplate ?? channel.historyPromptTemplate,
       onBehalfOf: accountConfig.onBehalfOf ?? channel.onBehalfOf,
-      secretsFileRoot: accountConfig.secretsFileRoot ?? channel.secretsFileRoot,
     },
   };
 }

--- a/src/agent-tools.test.ts
+++ b/src/agent-tools.test.ts
@@ -25,22 +25,9 @@ vi.mock("./group-md.js", () => ({
   broadcastThreadMdUpdate: vi.fn(),
 }));
 
-// NOTE: only mkdir from node:fs/promises is wrapped (see the vi.mock below); all
-// other fs calls run for real. The write-secret tests exercise the real
-// path-confinement + write path against an OS temp directory so that traversal /
-// absolute-escape / symlink rejection is genuinely tested.
-
-// NOTE: node:fs/promises is passed through to the REAL implementation for every
-// call EXCEPT mkdir, which is wrapped in a vi.fn that delegates to the genuine
-// mkdir by default. The write-secret tests still exercise real path-confinement
-// + write against an OS temp directory (so traversal / absolute-escape / symlink
-// rejection is genuinely tested); the wrapper only lets the intermediate-dir
-// TOCTOU regression test inject a symlink swap in the race window between
-// mkdir() and open().
-vi.mock("node:fs/promises", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("node:fs/promises")>();
-  return { ...actual, mkdir: vi.fn(actual.mkdir) };
-});
+// NOTE: node:fs/promises runs against the REAL implementation. The write-secret
+// tests exercise the real write path against an OS temp directory, so writing,
+// templating, appending, and permission behavior is genuinely tested.
 
 import { createOctoManagementTools } from "./agent-tools.js";
 import {
@@ -68,7 +55,6 @@ import {
   readFile,
   rm,
   stat,
-  symlink,
   writeFile as fsWriteFile,
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -82,14 +68,12 @@ function setupMocks(overrides?: {
   configured?: boolean;
   botToken?: string;
   apiUrl?: string;
-  secretsFileRoot?: string;
 }) {
   const {
     enabled = true,
     configured = true,
     botToken = "tok-secret",
     apiUrl = "http://api.test",
-    secretsFileRoot,
   } = overrides ?? {};
 
   vi.mocked(listOctoAccountIds).mockReturnValue(["default"]);
@@ -103,7 +87,6 @@ function setupMocks(overrides?: {
       apiUrl,
       pollIntervalMs: 2000,
       heartbeatIntervalMs: 30000,
-      ...(secretsFileRoot ? { secretsFileRoot } : {}),
     },
   });
 }
@@ -1209,15 +1192,15 @@ describe("createOctoManagementTools", () => {
     // feature is that THIS string never appears in a tool return value.
     const PLAINTEXT = "sk-live-SUPER-SECRET-VALUE-123";
 
-    // Real OS temp dir used as the operator-configured jail root. Using the
-    // real filesystem (not a mock) is what makes the traversal / absolute /
-    // symlink rejection tests meaningful.
+    // Real OS temp dir used as a writable scratch area. There is no
+    // application-level jail any more: filePath is resolved with path.resolve
+    // and the write boundary is the OS process's own filesystem permissions.
+    // Tests pass absolute paths under this temp dir so they stay self-contained.
     let root: string;
 
     beforeEach(async () => {
       root = await mkdtemp(join(tmpdir(), "octo-secret-test-"));
-      // Re-arm mocks with this run's jail root.
-      setupMocks({ secretsFileRoot: root });
+      setupMocks();
     });
 
     afterEach(async () => {
@@ -1232,7 +1215,7 @@ describe("createOctoManagementTools", () => {
       expect(tools[0].parameters.properties.action.enum).toContain("write-secret");
     });
 
-    it("resolves the alias and writes the raw value into the jail", async () => {
+    it("resolves the alias and writes the raw value", async () => {
       vi.mocked(resolveSecret).mockResolvedValue({
         status: "resolved",
         value: PLAINTEXT,
@@ -1240,7 +1223,8 @@ describe("createOctoManagementTools", () => {
         display_name: "openai key",
       });
 
-      const result = await writeSecret({ alias: "openai key", filePath: "secrets/.env" });
+      const target = join(root, "secrets/.env");
+      const result = await writeSecret({ alias: "openai key", filePath: target });
       const data = parseText(result);
 
       // resolve is use-time: called with the bot token + alias.
@@ -1250,14 +1234,12 @@ describe("createOctoManagementTools", () => {
         alias: "openai key",
       });
 
-      // raw value written verbatim (no template) under the jail root.
-      const target = join(root, "secrets/.env");
+      // raw value written verbatim (no template).
       expect(await readFile(target, "utf8")).toBe(PLAINTEXT);
 
       expect(data.written).toBe(true);
-      // path is jail-relative — the absolute jail root is never disclosed.
-      expect(data.path).toBe(join("secrets", ".env"));
-      expect(data.path).not.toContain(root);
+      // path is the resolved absolute destination.
+      expect(data.path).toBe(target);
       expect(data.mode).toBe("overwrite");
       expect(data.display_name).toBe("openai key");
       // No secret-derived length field is exposed.
@@ -1267,7 +1249,7 @@ describe("createOctoManagementTools", () => {
     it("creates the secret file 0o600 (owner-only)", async () => {
       vi.mocked(resolveSecret).mockResolvedValue({ status: "resolved", value: PLAINTEXT });
 
-      await writeSecret({ alias: "k", filePath: "key.txt" });
+      await writeSecret({ alias: "k", filePath: join(root, "key.txt") });
 
       const st = await stat(join(root, "key.txt"));
       // Mask to permission bits. Skipped on platforms without POSIX perms.
@@ -1281,7 +1263,7 @@ describe("createOctoManagementTools", () => {
 
       await writeSecret({
         alias: "openai key",
-        filePath: ".env",
+        filePath: join(root, ".env"),
         template: "OPENAI_API_KEY={{secret}}\n",
       });
 
@@ -1295,7 +1277,7 @@ describe("createOctoManagementTools", () => {
 
       await writeSecret({
         alias: "k",
-        filePath: "dup.txt",
+        filePath: join(root, "dup.txt"),
         template: "a={{secret}};b={{secret}}",
       });
 
@@ -1312,7 +1294,7 @@ describe("createOctoManagementTools", () => {
         value: "val-{{secret}}-end",
       });
 
-      await writeSecret({ alias: "k", filePath: "weird.txt", template: "X={{secret}}" });
+      await writeSecret({ alias: "k", filePath: join(root, "weird.txt"), template: "X={{secret}}" });
 
       expect(await readFile(join(root, "weird.txt"), "utf8")).toBe("X=val-{{secret}}-end");
     });
@@ -1320,7 +1302,7 @@ describe("createOctoManagementTools", () => {
     it("rejects a template that lacks the {{secret}} placeholder", async () => {
       const result = await writeSecret({
         alias: "k",
-        filePath: ".env",
+        filePath: join(root, ".env"),
         template: "OPENAI_API_KEY=", // no placeholder → would silently write raw
       });
       expect(parseText(result).error).toContain("{{secret}} placeholder");
@@ -1331,10 +1313,10 @@ describe("createOctoManagementTools", () => {
     it("appends when mode=append", async () => {
       vi.mocked(resolveSecret).mockResolvedValue({ status: "resolved", value: PLAINTEXT });
 
-      // seed an existing file inside the jail
+      // seed an existing file
       await fsWriteFile(join(root, ".env"), "EXISTING\n", "utf8");
 
-      const result = await writeSecret({ alias: "k", filePath: ".env", mode: "append" });
+      const result = await writeSecret({ alias: "k", filePath: join(root, ".env"), mode: "append" });
       const data = parseText(result);
 
       expect(await readFile(join(root, ".env"), "utf8")).toBe(`EXISTING\n${PLAINTEXT}`);
@@ -1344,7 +1326,7 @@ describe("createOctoManagementTools", () => {
     it("creates the parent directory before writing", async () => {
       vi.mocked(resolveSecret).mockResolvedValue({ status: "resolved", value: PLAINTEXT });
 
-      await writeSecret({ alias: "k", filePath: "nested/dir/.env" });
+      await writeSecret({ alias: "k", filePath: join(root, "nested/dir/.env") });
 
       expect(await readFile(join(root, "nested/dir/.env"), "utf8")).toBe(PLAINTEXT);
     });
@@ -1361,7 +1343,7 @@ describe("createOctoManagementTools", () => {
 
       const result = await writeSecret({
         alias: "openai key",
-        filePath: ".env",
+        filePath: join(root, ".env"),
         template: "OPENAI_API_KEY={{secret}}\n",
       });
 
@@ -1373,221 +1355,69 @@ describe("createOctoManagementTools", () => {
 
     it("NEVER returns the plaintext value — raw write (red line)", async () => {
       vi.mocked(resolveSecret).mockResolvedValue({ status: "resolved", value: PLAINTEXT });
-      const result = await writeSecret({ alias: "k", filePath: "k.txt" });
+      const result = await writeSecret({ alias: "k", filePath: join(root, "k.txt") });
       expect(JSON.stringify(result)).not.toContain(PLAINTEXT);
     });
 
     it("NEVER returns the plaintext value — append (red line)", async () => {
       vi.mocked(resolveSecret).mockResolvedValue({ status: "resolved", value: PLAINTEXT });
-      const result = await writeSecret({ alias: "k", filePath: "k.txt", mode: "append" });
+      const result = await writeSecret({ alias: "k", filePath: join(root, "k.txt"), mode: "append" });
       expect(JSON.stringify(result)).not.toContain(PLAINTEXT);
     });
 
     // -------------------------------------------------------------------
-    // 🔴 PATH CONFINEMENT (P0): the file destination must stay in the jail.
+    // Write boundary is OS permissions (no application-level jail). `..` and
+    // absolute paths are allowed: the owner's process writes where the owner
+    // can write. This is the intended semantic change (YUJ-3917).
     // -------------------------------------------------------------------
-    it("rejects parent-directory traversal, no resolve, no write", async () => {
-      const result = await writeSecret({ alias: "k", filePath: "../escape.txt" });
-      expect(parseText(result).error).toMatch(/outside the allowed directory/i);
-      expect(resolveSecret).not.toHaveBeenCalled();
-    });
-
-    it("rejects a deep traversal that climbs past the root", async () => {
-      const result = await writeSecret({ alias: "k", filePath: "a/b/../../../etc/passwd" });
-      expect(parseText(result).error).toMatch(/outside the allowed directory/i);
-      expect(resolveSecret).not.toHaveBeenCalled();
-    });
-
-    it("rejects an absolute path outside the jail", async () => {
-      const result = await writeSecret({ alias: "k", filePath: "/etc/cron.d/x" });
-      expect(parseText(result).error).toMatch(/outside the allowed directory/i);
-      expect(resolveSecret).not.toHaveBeenCalled();
-    });
-
-    it("rejects a write through a symlinked dir that escapes the jail", async () => {
-      // outside/  ← real target outside the jail
-      // root/link → outside  (symlink inside the jail pointing out)
-      const outside = await mkdtemp(join(tmpdir(), "octo-outside-"));
-      try {
-        await symlink(outside, join(root, "link"), "dir");
-        const result = await writeSecret({ alias: "k", filePath: "link/pwn.txt" });
-        expect(parseText(result).error).toMatch(/symlink|outside the allowed/i);
-        expect(resolveSecret).not.toHaveBeenCalled();
-      } finally {
-        await rm(outside, { recursive: true, force: true });
-      }
-    });
-
-    it("rejects when the target itself is a symlink escaping the jail", async () => {
-      const outside = await mkdtemp(join(tmpdir(), "octo-outside-"));
-      try {
-        const realTarget = join(outside, "victim.txt");
-        await fsWriteFile(realTarget, "orig", "utf8");
-        await symlink(realTarget, join(root, "evil.txt"), "file");
-        const result = await writeSecret({ alias: "k", filePath: "evil.txt" });
-        expect(parseText(result).error).toMatch(/symlink|outside the allowed/i);
-        expect(resolveSecret).not.toHaveBeenCalled();
-        // The out-of-jail victim must be untouched.
-        expect(await readFile(realTarget, "utf8")).toBe("orig");
-      } finally {
-        await rm(outside, { recursive: true, force: true });
-      }
-    });
-
-    // 🔴 P0 REGRESSION — dangling-symlink jail escape. The earlier guard only
-    // rejected symlinks whose target ALREADY existed; a symlink pointing OUT of
-    // the jail at a target that does NOT yet exist (dangling) slipped through,
-    // and writeFile() then created the plaintext secret at the out-of-jail
-    // target via O_CREAT. The two tests below are real PoCs against the real
-    // exported handler: they build a genuine dangling symlink in the jail, call
-    // write-secret, and assert (a) it is rejected, (b) resolveSecret is never
-    // called, (c) NO file appears at the out-of-jail target.
-    it("rejects when the target itself is a DANGLING symlink escaping the jail", async () => {
+    it("follows '..' segments normally — write boundary is OS permissions, not a jail", async () => {
       vi.mocked(resolveSecret).mockResolvedValue({ status: "resolved", value: PLAINTEXT });
-      const outside = await mkdtemp(join(tmpdir(), "octo-outside-"));
-      try {
-        // Target does NOT exist yet (dangling). link inside jail → outside.
-        const danglingTarget = join(outside, "not-yet.txt");
-        await symlink(danglingTarget, join(root, "evil.txt"), "file");
 
-        const result = await writeSecret({ alias: "k", filePath: "evil.txt" });
+      // <root>/sub/../target.txt resolves to <root>/target.txt and is written.
+      await mkdir(join(root, "sub"), { recursive: true });
+      const result = await writeSecret({ alias: "k", filePath: join(root, "sub", "..", "target.txt") });
+      const data = parseText(result);
 
-        expect(parseText(result).error).toMatch(/symlink|verified|outside the allowed/i);
-        // Never resolved → plaintext never fetched.
-        expect(resolveSecret).not.toHaveBeenCalled();
-        // 🔴 The out-of-jail target must NOT have been created.
-        await expect(readFile(danglingTarget, "utf8")).rejects.toThrow();
-        // And no plaintext anywhere in the LLM-visible return.
-        expect(JSON.stringify(result)).not.toContain(PLAINTEXT);
-      } finally {
-        await rm(outside, { recursive: true, force: true });
-      }
+      expect(data.written).toBe(true);
+      expect(data.path).toBe(join(root, "target.txt"));
+      expect(await readFile(join(root, "target.txt"), "utf8")).toBe(PLAINTEXT);
     });
 
-    it("rejects a DANGLING symlinked DIRECTORY escaping the jail", async () => {
+    it("writes to an absolute path the process can write to", async () => {
       vi.mocked(resolveSecret).mockResolvedValue({ status: "resolved", value: PLAINTEXT });
-      const outside = await mkdtemp(join(tmpdir(), "octo-outside-"));
-      try {
-        // An intermediate dir symlink pointing to a not-yet-existing out-of-jail
-        // location. Writing "link/secret.txt" would otherwise create the file
-        // (and the dir) outside the jail.
-        const danglingDir = join(outside, "does-not-exist-dir");
-        await symlink(danglingDir, join(root, "link"), "dir");
 
-        const result = await writeSecret({ alias: "k", filePath: "link/secret.txt" });
+      const abs = join(root, "abs-target.env");
+      const result = await writeSecret({ alias: "k", filePath: abs });
+      const data = parseText(result);
 
-        expect(parseText(result).error).toMatch(/symlink|verified|outside the allowed/i);
-        expect(resolveSecret).not.toHaveBeenCalled();
-        // 🔴 Nothing created at the out-of-jail location.
-        await expect(readFile(join(danglingDir, "secret.txt"), "utf8")).rejects.toThrow();
-        expect(JSON.stringify(result)).not.toContain(PLAINTEXT);
-      } finally {
-        await rm(outside, { recursive: true, force: true });
-      }
+      expect(data.written).toBe(true);
+      expect(data.path).toBe(abs);
+      expect(await readFile(abs, "utf8")).toBe(PLAINTEXT);
     });
 
-    it("rejects a DANGLING symlink that points back INSIDE the jail too (unverifiable → deny)", async () => {
-      // Even a dangling link whose lexical target is inside the jail cannot be
-      // proven safe (realpath throws), so we deny it. Conservative but correct:
-      // the caller can just write the plain path directly.
+    it("surfaces the OS error when the process cannot write the path", async () => {
       vi.mocked(resolveSecret).mockResolvedValue({ status: "resolved", value: PLAINTEXT });
-      const inJailButMissing = join(root, "later.txt");
-      await symlink(inJailButMissing, join(root, "ptr.txt"), "file");
+      // Make the target unwritable: create a directory where the file should go.
+      await mkdir(join(root, "isdir"), { recursive: true });
 
-      const result = await writeSecret({ alias: "k", filePath: "ptr.txt" });
+      const result = await writeSecret({ alias: "k", filePath: join(root, "isdir") });
+      const data = parseText(result);
 
-      expect(parseText(result).error).toMatch(/symlink|verified|outside the allowed/i);
-      expect(resolveSecret).not.toHaveBeenCalled();
-      await expect(readFile(inJailButMissing, "utf8")).rejects.toThrow();
-    });
-
-    // 🔴 P1 REGRESSION — intermediate-dir symlink TOCTOU. confineSecretPath()
-    // walks the path BEFORE the parent dirs exist, so it cannot catch a symlink
-    // swapped onto a parent AFTER mkdir creates it. O_NOFOLLOW only guards the
-    // leaf basename, not intermediate components — the kernel still follows a
-    // parent symlink. The fix re-canonicalizes the parent after mkdir and
-    // re-checks containment. This PoC drives the mocked mkdir to swap the
-    // freshly-created parent dir for an out-of-jail symlink in the race window
-    // between mkdir and open, then asserts the write is refused and nothing
-    // lands outside the jail.
-    it("rejects when an intermediate dir is symlink-swapped AFTER mkdir (TOCTOU)", async () => {
-      vi.mocked(resolveSecret).mockResolvedValue({ status: "resolved", value: PLAINTEXT });
-      const outside = await mkdtemp(join(tmpdir(), "octo-outside-"));
-      const realMkdir = (await vi.importActual<typeof import("node:fs/promises")>(
-        "node:fs/promises",
-      )).mkdir;
-      try {
-        const subdir = join(root, "sub");
-        vi.mocked(mkdir).mockImplementationOnce(async (...args: any[]) => {
-          // Let the real mkdir create <root>/sub as a genuine directory…
-          const ret = await (realMkdir as any)(...args);
-          // …then, in the race window before open(), swap it for a symlink that
-          // escapes the jail. open() via the canonical parent must refuse it.
-          await rm(subdir, { recursive: true, force: true });
-          await symlink(outside, subdir, "dir");
-          return ret;
-        });
-
-        const result = await writeSecret({ alias: "k", filePath: "sub/secret.env" });
-
-        expect(parseText(result).error).toMatch(/escaped the allowed root|outside the allowed/i);
-        // 🔴 The out-of-jail target must NOT have been created.
-        await expect(readFile(join(outside, "secret.env"), "utf8")).rejects.toThrow();
-        // No plaintext anywhere in the LLM-visible return.
-        expect(JSON.stringify(result)).not.toContain(PLAINTEXT);
-      } finally {
-        await rm(outside, { recursive: true, force: true });
-      }
-    });
-
-    it("rejects a write whose realpath'd parent escapes the root after creation", async () => {
-      // A narrower unit-level check on the post-mkdir containment guard: the
-      // parent resolves outside root → refuse, regardless of how it got there.
-      vi.mocked(resolveSecret).mockResolvedValue({ status: "resolved", value: PLAINTEXT });
-      const outside = await mkdtemp(join(tmpdir(), "octo-outside-"));
-      try {
-        const subdir = join(root, "deep");
-        vi.mocked(mkdir).mockImplementationOnce(async () => {
-          // Skip creating a real dir; install an escaping symlink as the parent.
-          await symlink(outside, subdir, "dir");
-          return undefined;
-        });
-
-        const result = await writeSecret({ alias: "k", filePath: "deep/k.env" });
-
-        expect(parseText(result).error).toMatch(/escaped the allowed root/i);
-        await expect(readFile(join(outside, "k.env"), "utf8")).rejects.toThrow();
-        expect(JSON.stringify(result)).not.toContain(PLAINTEXT);
-      } finally {
-        await rm(outside, { recursive: true, force: true });
-      }
-    });
-
-    it("allows the jail root itself as a relative '.' is not valid but a file at root is", async () => {
-      vi.mocked(resolveSecret).mockResolvedValue({ status: "resolved", value: PLAINTEXT });
-      const result = await writeSecret({ alias: "k", filePath: "atroot.txt" });
-      expect(parseText(result).written).toBe(true);
-      expect(await readFile(join(root, "atroot.txt"), "utf8")).toBe(PLAINTEXT);
-    });
-
-    it("defaults the jail root to process.cwd() when secretsFileRoot is unset", async () => {
-      // No secretsFileRoot configured → CWD is the root. A path that escapes
-      // CWD must still be rejected.
-      setupMocks(); // no secretsFileRoot
-      const result = await writeSecret({ alias: "k", filePath: "../../../../etc/passwd" });
-      expect(parseText(result).error).toMatch(/outside the allowed directory/i);
-      expect(resolveSecret).not.toHaveBeenCalled();
+      expect(data.error).toContain("failed to write");
+      expect(data.error).toContain("isdir");
+      // The OS error never leaks the secret value.
+      expect(JSON.stringify(result)).not.toContain(PLAINTEXT);
     });
 
     it("not_found → guides the user to add the key, no plaintext, no write", async () => {
       vi.mocked(resolveSecret).mockResolvedValue({ status: "not_found" });
 
-      const result = await writeSecret({ alias: "ghost key", filePath: ".env" });
+      const result = await writeSecret({ alias: "ghost key", filePath: join(root, ".env") });
       const data = parseText(result);
 
       expect(data.error).toContain("No stored secret matches");
       expect(data.error).toContain("ghost key");
-      // nothing written into the jail
+      // nothing written
       await expect(readFile(join(root, ".env"), "utf8")).rejects.toThrow();
     });
 
@@ -1600,7 +1430,7 @@ describe("createOctoManagementTools", () => {
         ],
       });
 
-      const result = await writeSecret({ alias: "openai", filePath: ".env" });
+      const result = await writeSecret({ alias: "openai", filePath: join(root, ".env") });
       const data = parseText(result);
 
       expect(data.written).toBe(false);
@@ -1616,7 +1446,7 @@ describe("createOctoManagementTools", () => {
         new Error("resolveSecret failed (500)"),
       );
 
-      const result = await writeSecret({ alias: "k", filePath: ".env" });
+      const result = await writeSecret({ alias: "k", filePath: join(root, ".env") });
       const data = parseText(result);
 
       expect(data.error).toContain("Could not resolve secret");
@@ -1624,21 +1454,8 @@ describe("createOctoManagementTools", () => {
       await expect(readFile(join(root, ".env"), "utf8")).rejects.toThrow();
     });
 
-    it("write failure after resolve → error mentions path but not the value", async () => {
-      vi.mocked(resolveSecret).mockResolvedValue({ status: "resolved", value: PLAINTEXT });
-      // Make the target unwritable: create a directory where the file should go.
-      await mkdir(join(root, "isdir"), { recursive: true });
-
-      const result = await writeSecret({ alias: "k", filePath: "isdir" });
-      const data = parseText(result);
-
-      expect(data.error).toContain("failed to write");
-      expect(data.error).toContain("isdir");
-      expect(JSON.stringify(result)).not.toContain(PLAINTEXT);
-    });
-
     it("requires alias", async () => {
-      const result = await writeSecret({ filePath: ".env" });
+      const result = await writeSecret({ filePath: join(root, ".env") });
       expect(parseText(result).error).toContain("alias is required");
       expect(resolveSecret).not.toHaveBeenCalled();
     });
@@ -1650,7 +1467,7 @@ describe("createOctoManagementTools", () => {
     });
 
     it("rejects an invalid mode", async () => {
-      const result = await writeSecret({ alias: "k", filePath: ".env", mode: "sideways" });
+      const result = await writeSecret({ alias: "k", filePath: join(root, ".env"), mode: "sideways" });
       expect(parseText(result).error).toContain("Invalid mode");
       expect(resolveSecret).not.toHaveBeenCalled();
     });
@@ -1660,8 +1477,8 @@ describe("createOctoManagementTools", () => {
         .mockResolvedValueOnce({ status: "resolved", value: "old-value" })
         .mockResolvedValueOnce({ status: "resolved", value: "rotated-value" });
 
-      await writeSecret({ alias: "k", filePath: ".env" });
-      await writeSecret({ alias: "k", filePath: ".env" });
+      await writeSecret({ alias: "k", filePath: join(root, ".env") });
+      await writeSecret({ alias: "k", filePath: join(root, ".env") });
 
       expect(resolveSecret).toHaveBeenCalledTimes(2);
       // overwrite mode → file ends up with the latest value.

--- a/src/agent-tools.ts
+++ b/src/agent-tools.ts
@@ -41,9 +41,8 @@ import {
   resolveSecret,
 } from "./api-fetch.js";
 import { broadcastGroupMdUpdate, broadcastThreadMdUpdate } from "./group-md.js";
-import { mkdir, realpath, lstat, open } from "node:fs/promises";
-import { constants as fsConstants } from "node:fs";
-import { basename, dirname, relative, resolve as resolvePath, sep } from "node:path";
+import { mkdir, writeFile, appendFile, chmod } from "node:fs/promises";
+import { dirname, resolve as resolvePath } from "node:path";
 
 import type { OpenClawConfig } from "openclaw/plugin-sdk";
 import { DEFAULT_ACCOUNT_ID } from "./sdk-compat.js";
@@ -62,107 +61,6 @@ const SECRET_PLACEHOLDER = "{{secret}}";
  * A file that now holds a plaintext API key must not be world/group readable.
  */
 const SECRET_FILE_MODE = 0o600;
-
-/**
- * Confine a caller-supplied write target to an operator-approved jail root.
- *
- * 🔴 SECURITY (P0): `filePath` comes from the LLM tool call, which is reachable
- * via inbound group-chat messages — an untrusted, prompt-injectable surface.
- * Without confinement, `write-secret` is an arbitrary-file-write of the owner's
- * plaintext secret (e.g. "append my key to ~/.bashrc" / ".ssh/authorized_keys"
- * / a web root). We therefore resolve the requested path against a fixed root
- * (`secretsFileRoot` from config, else the plugin process CWD) and reject
- * anything that escapes it — including `..` traversal, absolute paths pointing
- * elsewhere, and symlink escapes (resolved, dangling, or otherwise
- * unverifiable). The actual write additionally uses O_NOFOLLOW to defeat a
- * TOCTOU swap between this check and the write.
- *
- * Returns the safe absolute path, or an error string describing the rejection
- * (never echoing secret material — only the caller-typed path).
- */
-async function confineSecretPath(
-  filePath: string,
-  rootInput: string | undefined,
-): Promise<{ ok: true; abs: string; root: string } | { ok: false; error: string }> {
-  // The jail root: operator config wins; otherwise the plugin's working dir.
-  // Resolve it to an absolute, symlink-free canonical form so containment
-  // checks compare apples to apples.
-  const rootRaw = rootInput && rootInput.trim() ? rootInput.trim() : process.cwd();
-  let root: string;
-  try {
-    root = await realpath(resolvePath(rootRaw));
-  } catch {
-    // Root doesn't exist yet (or isn't reachable): fall back to its lexical
-    // absolute form. We can still enforce containment lexically below.
-    root = resolvePath(rootRaw);
-  }
-
-  // Resolve the requested path against the root. resolvePath collapses any
-  // `..`/`.` segments; an absolute `filePath` replaces the root entirely, which
-  // the containment check below then rejects unless it still lands inside root.
-  const candidate = resolvePath(root, filePath);
-
-  // Lexical containment: candidate must be the root itself or sit strictly
-  // beneath it. This already defeats `..` traversal and absolute-elsewhere.
-  if (candidate !== root && !candidate.startsWith(root + sep)) {
-    return {
-      ok: false,
-      error: `Refusing to write the secret outside the allowed directory. "${filePath}" resolves outside the permitted root. Use a path inside the workspace.`,
-    };
-  }
-
-  // Symlink-escape guard: walk the path one component at a time, from the root
-  // down to the target. At each component that exists on disk:
-  //   • a symlink whose canonical target stays inside the jail → keep walking;
-  //   • a symlink whose canonical target escapes the jail       → reject;
-  //   • a symlink that does NOT resolve (dangling / unverifiable) → reject
-  //     UNCONDITIONALLY. This is the key fix: a dangling symlink inside the jail
-  //     (lstat() succeeds, isSymbolicLink()=true, but realpath() throws ENOENT
-  //     because the target does not exist yet) would otherwise be mistaken for
-  //     "a plain file that will be created here". writeFile() FOLLOWS the link
-  //     and creates the plaintext secret at the link's out-of-jail target. We
-  //     never trust a symlink we cannot prove lands inside the jail.
-  //   • a component that simply does not exist (ENOENT on lstat itself, not a
-  //     symlink) → it and everything below it will be freshly created as plain
-  //     entries inside the already-validated jail, so we can stop walking.
-  const rel = candidate === root ? "" : candidate.slice(root.length + sep.length);
-  const segments = rel ? rel.split(sep) : [];
-  let current = root;
-  for (const seg of segments) {
-    current = `${current}${sep}${seg}`;
-    let st;
-    try {
-      st = await lstat(current);
-    } catch {
-      // This component does not exist. Deeper components don't either; they will
-      // be created as plain files/dirs inside the validated jail. Safe to stop.
-      break;
-    }
-    if (st.isSymbolicLink()) {
-      let real: string;
-      try {
-        real = await realpath(current);
-      } catch {
-        // Dangling or otherwise unverifiable symlink — never trust it.
-        return {
-          ok: false,
-          error: `Refusing to write the secret: "${filePath}" passes through a symlink that cannot be verified to stay inside the allowed directory.`,
-        };
-      }
-      if (real !== root && !real.startsWith(root + sep)) {
-        return {
-          ok: false,
-          error: `Refusing to write the secret: "${filePath}" resolves through a symlink that escapes the allowed directory.`,
-        };
-      }
-      // Symlink stays inside the jail: deeper components are re-checked on the
-      // next iterations (lstat naturally follows this contained intermediate
-      // link), so continue.
-    }
-  }
-
-  return { ok: true, abs: candidate, root };
-}
 
 // ---------------------------------------------------------------------------
 // Types
@@ -310,10 +208,10 @@ export function createOctoManagementTools(params: {
         filePath: {
           type: "string",
           description:
-            "For write-secret only. Path of the local file to write the secret into, relative to the " +
-            "configured workspace root (e.g. \".env\" or \"config/keys.json\"). Choose the path based on the " +
-            "user's instruction. Writes are confined to the workspace root: paths that escape it (via '..', " +
-            "an absolute path elsewhere, or a symlink) are rejected.",
+            "For write-secret only. Path of the local file to write the secret into (e.g. \".env\" or " +
+            "\"config/keys.json\", or an absolute path). Relative paths resolve against the plugin process " +
+            "working directory. Choose the path based on the user's instruction. Writes are bounded by the " +
+            "process's OS filesystem permissions: a path the process cannot write to fails with the OS error.",
         },
         template: {
           type: "string",
@@ -682,7 +580,6 @@ export function createOctoManagementTools(params: {
               filePath,
               template,
               mode: rawMode === "append" ? "append" : "overwrite",
-              secretsFileRoot: account.config.secretsFileRoot,
             });
           }
 
@@ -912,22 +809,23 @@ async function handleVoiceContextDelete(params: {
  * Resolve a user-managed secret alias and write its current plaintext into a
  * local file.
  *
- * 🔴 RED LINE — plaintext containment (two channels, both closed):
- *   1. Transcript: the resolved value is read from resolveSecret(), substituted
- *      into the (optional) caller template, and written to disk. It is consumed
- *      ENTIRELY inside this function. The ToolResult returned to the LLM
- *      contains only { written, path, mode, display_name? } on success and
- *      structured non-plaintext feedback otherwise — never the value, the
- *      rendered content, or the template-with-secret, so nothing reaches the
- *      transcript / Octo. (No length field either: a byte count is
- *      secret-derived metadata, so we omit it.)
- *   2. Filesystem: `filePath` is attacker-influenceable (the tool is reachable
- *      from inbound chat). confineSecretPath() jails every write under an
- *      operator-approved root, rejecting `..`, absolute-elsewhere, and symlink
- *      escapes (including dangling/unverifiable links) BEFORE the secret is ever
- *      resolved. The write opens the target with O_NOFOLLOW to close any TOCTOU
- *      symlink swap, and the file is created 0o600 so a plaintext key is not
- *      left world/group readable.
+ * 🔴 RED LINE — transcript plaintext containment (kept intact):
+ *   The resolved value is read from resolveSecret(), substituted into the
+ *   (optional) caller template, and written to disk. It is consumed ENTIRELY
+ *   inside this function. The ToolResult returned to the LLM contains only
+ *   { written, path, mode, display_name? } on success and structured
+ *   non-plaintext feedback otherwise — never the value, the rendered content, or
+ *   the template-with-secret, so nothing reaches the transcript / Octo. (No
+ *   length field either: a byte count is secret-derived metadata, so we omit it.)
+ *
+ * Write boundary — OS process permissions:
+ *   `filePath` is normalized with path.resolve and written directly. The write
+ *   boundary is the gateway process's own filesystem permissions: it can only
+ *   write where the OS lets it, and an attempt outside that ceiling fails with
+ *   an OS errno that is surfaced verbatim. There is no application-level jail —
+ *   the owner's process writing to a path the owner can write to is the intended
+ *   semantics (see YUJ-3917). `..` traversal and absolute paths are therefore
+ *   allowed and bounded only by OS permissions.
  *
  * Use-time resolution: resolveSecret is called on every invocation, so the
  * latest value is always written (owner key rotation takes effect with no
@@ -940,16 +838,10 @@ async function handleWriteSecret(params: {
   filePath: string;
   template?: string;
   mode: "overwrite" | "append";
-  secretsFileRoot?: string;
 }): Promise<ToolResult> {
-  // Confine the destination BEFORE resolving the secret. If the path is unsafe
-  // we never fetch the plaintext at all — minimizing its lifetime.
-  const confined = await confineSecretPath(params.filePath, params.secretsFileRoot);
-  if (!confined.ok) {
-    return makeError(confined.error);
-  }
-  const absPath = confined.abs;
-  const root = confined.root;
+  // Normalize the destination to an absolute path. No application-level jail:
+  // the OS process permissions are the write boundary.
+  const absPath = resolvePath(params.filePath);
 
   let resolved;
   try {
@@ -999,63 +891,34 @@ async function handleWriteSecret(params: {
 
   try {
     const dir = dirname(absPath);
-    let openTarget = absPath;
     if (dir && dir !== "." && dir !== absPath) {
       await mkdir(dir, { recursive: true });
-      // 🔴 TOCTOU close-out for INTERMEDIATE components. O_NOFOLLOW below only
-      // protects the final basename — the kernel still follows any symlink on
-      // the parent path. confineSecretPath() walked the path BEFORE mkdir, when
-      // the parent dirs did not yet exist, so a symlink swapped onto a parent
-      // AFTER mkdir creates it (and before open) would redirect the write out of
-      // the jail. Re-canonicalize the parent now that it is on disk and re-check
-      // containment, then open via the canonical parent + basename so every
-      // component is proven to stay inside the root.
-      const realDir = await realpath(dir);
-      if (realDir !== root && !realDir.startsWith(root + sep)) {
-        return makeError(
-          "Refusing to write the secret: the destination directory escaped the allowed root after creation.",
-        );
-      }
-      openTarget = resolvePath(realDir, basename(absPath));
     }
-    // 🔴 TOCTOU close-out for the LEAF: confineSecretPath() validated the path,
-    // but between that check and the write an attacker with filesystem access
-    // could swap the target for a symlink. We open the final component with
-    // O_NOFOLLOW so the kernel refuses to follow a symlink AT the target — the
-    // write either lands on the real in-jail file or fails (ELOOP), never on a
-    // redirected target. O_CREAT applies the 0o600 mode atomically on creation.
-    const flags =
-      (params.mode === "append"
-        ? fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_APPEND
-        : fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_TRUNC) |
-      fsConstants.O_NOFOLLOW;
-    const handle = await open(openTarget, flags, SECRET_FILE_MODE);
-    try {
-      await handle.write(content, null, "utf8");
-      // writeFile/open's `mode` only applies when CREATING the file; a
-      // pre-existing target keeps its old perms. fchmod unconditionally so a
-      // plaintext key is always owner-only (0o600), never world-readable.
-      await handle.chmod(SECRET_FILE_MODE);
-    } finally {
-      await handle.close();
+    if (params.mode === "append") {
+      await appendFile(absPath, content, { encoding: "utf8", mode: SECRET_FILE_MODE });
+    } else {
+      await writeFile(absPath, content, { encoding: "utf8", mode: SECRET_FILE_MODE });
     }
+    // The `mode` option only applies when CREATING the file; a pre-existing
+    // target keeps its old perms. chmod unconditionally so a plaintext key is
+    // always owner-only (0o600), never world-readable.
+    await chmod(absPath, SECRET_FILE_MODE);
   } catch (err) {
-    // A write error message can include the path but never the content. Echo the
-    // jail-relative path only — never the absolute path, which would leak the
-    // operator's jail root into the LLM-visible transcript.
+    // A write error message can include the path but never the content. If the
+    // OS refuses the write (EACCES/EROFS/…), the errno is surfaced verbatim —
+    // OS permissions are the write boundary.
     return makeError(
-      `Resolved the secret but failed to write it to "${relative(root, absPath)}": ${
+      `Resolved the secret but failed to write it to "${params.filePath}": ${
         err instanceof Error ? err.message : String(err)
       }`,
     );
   }
 
   // 🔴 Success payload is plaintext-free by construction (no value, no rendered
-  // content, no byte length). The path is jail-relative so the absolute jail
-  // root is never disclosed to the LLM / transcript.
+  // content, no byte length).
   return makeSuccess({
     written: true,
-    path: relative(root, absPath),
+    path: absPath,
     mode: params.mode,
     ...(resolved.display_name ? { display_name: resolved.display_name } : {}),
   });

--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -14,7 +14,6 @@ export interface OctoAccountConfig {
   historyLimit?: number;  // 群聊历史消息条数限制（默认20）
   historyPromptTemplate?: string;  // Template for group history context injection
   onBehalfOf?: string;  // Persona clone: grantor uid — bot acts on behalf of this human
-  secretsFileRoot?: string;  // Jail root for write-secret: secret files may only be written under this absolute path (defaults to the plugin process CWD)
 }
 
 export interface OctoConfig {
@@ -31,7 +30,6 @@ export interface OctoConfig {
   historyLimit?: number;  // 群聊历史消息条数限制（默认20）
   historyPromptTemplate?: string;  // Template for group history context injection
   onBehalfOf?: string;  // Persona clone: grantor uid — bot acts on behalf of this human
-  secretsFileRoot?: string;  // Jail root for write-secret (see OctoAccountConfig)
   accounts?: Record<string, OctoAccountConfig | undefined>;
 }
 
@@ -57,7 +55,6 @@ export const OctoConfigJsonSchema = {
       historyLimit: { type: "number", minimum: 1, maximum: 100 },
       historyPromptTemplate: { type: "string" },
       onBehalfOf: { type: "string" },
-      secretsFileRoot: { type: "string" },
       accounts: {
         type: "object",
         additionalProperties: {
@@ -76,7 +73,6 @@ export const OctoConfigJsonSchema = {
             historyLimit: { type: "number", minimum: 1, maximum: 100 },
             historyPromptTemplate: { type: "string" },
             onBehalfOf: { type: "string" },
-            secretsFileRoot: { type: "string" },
           },
         },
       },


### PR DESCRIPTION
## What

Removes the application-level filesystem **jail** from the `write-secret` agent tool. The gateway runs as an ordinary OS user, so its filesystem permissions already cap where it can write — an application-layer jail on top was redundant and had shipped two real bugs (`root="/"` self-lock; the self-lock fix then degraded the jail to a fail-open no-op when `root="/"`). **OS process permissions are now the true write boundary.**

This is stacked on PR #71 (`feat/agent-tool-write-secret`) and targets that branch. Owner decision (Yu): delete the jail. As a consequence, **PR #87** (the jail self-lock fix) should be **closed** — its reason to exist disappears with the jail.

## Changes

- **`confineSecretPath()` removed** — along with all its symlink-walk / lexical containment / dangling-link rejection / post-mkdir re-canonicalization / `O_NOFOLLOW` logic. `filePath` is now normalized with `path.resolve` and written directly via `writeFile`/`appendFile` + `chmod 0o600`. An unwritable path fails with the OS errno surfaced verbatim to the user.
- **`secretsFileRoot` config field removed** everywhere: `config-schema.ts` (channel + per-account), `accounts.ts` (type + fallback merge), `openclaw.plugin.json` manifest (both schema blocks), and the `agent-tools.ts` call site.
- Success payload now returns the resolved **absolute** path (no more jail-relative path, since there is no root to hide).
- **Tests reworked** (`agent-tools.test.ts`): dropped every jail / `..`-traversal-reject / absolute-reject / symlink / dangling-symlink / TOCTOU / `secretsFileRoot` case and the `node:fs/promises` mkdir mock they required. Added OS-boundary cases: `..` segments are followed normally, an absolute path is honored, and an unwritable path surfaces the OS error.

## 🔴 Red line preserved — plaintext never reaches the transcript

The transcript containment core is **untouched**.王麻子 only ever passes an alias; `resolveSecret` fetches the plaintext internally and it is consumed entirely inside `handleWriteSecret` — never returned to the LLM, never in the tool result/details. The regression tests asserting this are kept verbatim:

- `NEVER returns the plaintext value — templated path (red line)`
- `NEVER returns the plaintext value — raw write (red line)`
- `NEVER returns the plaintext value — append (red line)`
- plus `not.toContain(PLAINTEXT)` assertions on the not_found / ambiguous / resolve-failure / write-failure branches.

`..` traversal and absolute paths are now **allowed by design** — the owner's process writing where the owner can write. This is the intended semantic change; OS permissions bound it.

## Verification

- `npm run type-check` ✅
- `npm test` → **930 passed (21 files)** ✅
- `npm run build` ✅

Part of YUJ-3860.
