### PR TITLE
chore(skill): drop stale Save Locally curl instruction

### DIFF
--- a/skills/octo-bot-api/SKILL.md
+++ b/skills/octo-bot-api/SKILL.md
@@ -8,12 +8,6 @@ metadata: {"octo":{"category":"messaging","api_base":"<apiUrl>"}}
 
 Connect an AI Agent to Octo messaging platform with full real-time capabilities.
 
-### Save Locally (Recommended)
-
-```bash
-curl -s <apiUrl>/v1/bot/skill.md > ~/.openclaw/skills/octo/SKILL.md
-```
-
 ## Step 1: Register
 
 ```bash


### PR DESCRIPTION
## Summary

Removes the now-stale "Save Locally (Recommended)" curl instruction from `skills/octo-bot-api/SKILL.md` (lines 11–15 on main). The instruction read:

```bash
curl -s <apiUrl>/v1/bot/skill.md > ~/.openclaw/skills/octo/SKILL.md
```

## Why

The `/v1/bot/skill.md` endpoint is being deprecated in **Mininglamp-OSS/octo-server#325** — the server-side response is gutted from the full SKILL body to a short deprecation pointer that redirects readers to this very repo's `skills/octo-bot-api/SKILL.md` as the canonical source.

Leaving the curl line in place would actively mislead readers of this SKILL — anyone running the command after octo-server#325 lands would:

1. Pull the deprecation pointer text (not the real SKILL) into `~/.openclaw/skills/octo/SKILL.md`
2. Register it under slug `octo` (different from this plugin's bundled slug `octo-bot-api`), so OpenClaw would load **two** skills: one real (`octo-bot-api`) + one polluted (`octo` = deprecation pointer)
3. The agent's context window then contains both, with the polluted one confusing API guidance

## Coordination

This PR completes the plugin-side half of the deprecation that **octo-server#325** drives. Together with PR #90 (upload deprecation + `version` field removal) they form a three-piece change set:

- `octo-server#325` — gut server endpoint to compatibility pointer + update BotFather setup docs to point here
- `openclaw-channel-octo#90` (merged) — upload endpoint deprecation + drop unused `version` frontmatter
- `openclaw-channel-octo` **this PR** — drop the curl instruction now invalidated by `octo-server#325`

## Impact on existing users

None. This is a docs-only deletion in plugin-bundled SKILL.md:

- Users on old plugin versions keep their old `SKILL.md` with the curl line intact (we don't push updates; OpenClaw is pull-based)
- Users who previously cached `~/.openclaw/skills/octo/SKILL.md` from a past curl keep that file as-is — nothing on disk is touched by this change
- Users who upgrade plugin pick up the cleaned doc and avoid stepping on the now-invalid instruction

## Test plan

- [x] `npm run type-check` clean
- [x] visual diff confirms only the 6 lines are removed (section header + blank + code fence + curl + code fence + blank)

🤖 Generated with [Claude Code](https://claude.com/claude-code)