### PR TITLE
feat(octo write-secret): default jail to agent workspace (still fail-closed), drop mandatory secretsFileRoot + fix manifest description

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -80,7 +80,11 @@ export default defineBundledChannelEntry({
       (ctx: OpenClawPluginToolContext) => {
         const cfg = ctx.getRuntimeConfig?.() ?? ctx.runtimeConfig ?? ctx.config;
         if (!cfg) return null;
-        return createOctoManagementTools({ cfg, agentAccountId: ctx.agentAccountId });
+        return createOctoManagementTools({
+          cfg,
+          agentAccountId: ctx.agentAccountId,
+          agentId: ctx.agentId,
+        });
       },
       { names: ['octo_management'] },
     );

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -126,7 +126,7 @@
                 },
                 "secretsFileRoot": {
                   "type": "string",
-                  "description": "Jail root for write-secret: secret files may only be written under this path (defaults to the plugin process working directory)"
+                  "description": "Jail root for write-secret: secret files may only be written under this path. When unset, defaults to the agent's workspace (agents.list[].workspace matched to the agent, else agents.defaults.workspace). If neither resolves to a usable directory, write-secret is unavailable (fail-closed); there is no process working-directory fallback."
                 }
               }
             }
@@ -137,7 +137,7 @@
           },
           "secretsFileRoot": {
             "type": "string",
-            "description": "Jail root for write-secret: secret files may only be written under this path (defaults to the plugin process working directory)"
+            "description": "Jail root for write-secret: secret files may only be written under this path. When unset, defaults to the agent's workspace (agents.list[].workspace matched to the agent, else agents.defaults.workspace). If neither resolves to a usable directory, write-secret is unavailable (fail-closed); there is no process working-directory fallback."
           }
         }
       }

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -123,6 +123,10 @@
                 "onBehalfOf": {
                   "type": "string",
                   "description": "Persona clone: grantor uid — bot acts on behalf of this human"
+                },
+                "secretsFileRoot": {
+                  "type": "string",
+                  "description": "Jail root for write-secret: secret files may only be written under this path (defaults to the plugin process working directory)"
                 }
               }
             }
@@ -130,6 +134,10 @@
           "onBehalfOf": {
             "type": "string",
             "description": "Persona clone: grantor uid — bot acts on behalf of this human"
+          },
+          "secretsFileRoot": {
+            "type": "string",
+            "description": "Jail root for write-secret: secret files may only be written under this path (defaults to the plugin process working directory)"
           }
         }
       }

--- a/src/accounts.ts
+++ b/src/accounts.ts
@@ -19,6 +19,7 @@ export type ResolvedOctoAccount = {
     historyLimit?: number;  // 群聊历史消息条数限制
     historyPromptTemplate?: string;  // Template for group history context injection
     onBehalfOf?: string;  // Persona clone: grantor uid
+    secretsFileRoot?: string;  // Jail root for write-secret file writes
   };
 };
 
@@ -100,6 +101,7 @@ export function resolveOctoAccount(params: {
       historyLimit: accountConfig.historyLimit ?? channel.historyLimit ?? 20,
       historyPromptTemplate: accountConfig.historyPromptTemplate ?? channel.historyPromptTemplate,
       onBehalfOf: accountConfig.onBehalfOf ?? channel.onBehalfOf,
+      secretsFileRoot: accountConfig.secretsFileRoot ?? channel.secretsFileRoot,
     },
   };
 }

--- a/src/agent-tools.test.ts
+++ b/src/agent-tools.test.ts
@@ -25,9 +25,22 @@ vi.mock("./group-md.js", () => ({
   broadcastThreadMdUpdate: vi.fn(),
 }));
 
-// NOTE: node:fs/promises is intentionally NOT mocked. The write-secret tests
-// exercise the real path-confinement + write path against an OS temp directory
-// so that traversal / absolute-escape / symlink rejection is genuinely tested.
+// NOTE: only mkdir from node:fs/promises is wrapped (see the vi.mock below); all
+// other fs calls run for real. The write-secret tests exercise the real
+// path-confinement + write path against an OS temp directory so that traversal /
+// absolute-escape / symlink rejection is genuinely tested.
+
+// NOTE: node:fs/promises is passed through to the REAL implementation for every
+// call EXCEPT mkdir, which is wrapped in a vi.fn that delegates to the genuine
+// mkdir by default. The write-secret tests still exercise real path-confinement
+// + write against an OS temp directory (so traversal / absolute-escape / symlink
+// rejection is genuinely tested); the wrapper only lets the intermediate-dir
+// TOCTOU regression test inject a symlink swap in the race window between
+// mkdir() and open().
+vi.mock("node:fs/promises", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs/promises")>();
+  return { ...actual, mkdir: vi.fn(actual.mkdir) };
+});
 
 import { createOctoManagementTools } from "./agent-tools.js";
 import {
@@ -1242,7 +1255,9 @@ describe("createOctoManagementTools", () => {
       expect(await readFile(target, "utf8")).toBe(PLAINTEXT);
 
       expect(data.written).toBe(true);
-      expect(data.path).toBe(target);
+      // path is jail-relative — the absolute jail root is never disclosed.
+      expect(data.path).toBe(join("secrets", ".env"));
+      expect(data.path).not.toContain(root);
       expect(data.mode).toBe("overwrite");
       expect(data.display_name).toBe("openai key");
       // No secret-derived length field is exposed.
@@ -1484,6 +1499,68 @@ describe("createOctoManagementTools", () => {
       expect(parseText(result).error).toMatch(/symlink|verified|outside the allowed/i);
       expect(resolveSecret).not.toHaveBeenCalled();
       await expect(readFile(inJailButMissing, "utf8")).rejects.toThrow();
+    });
+
+    // 🔴 P1 REGRESSION — intermediate-dir symlink TOCTOU. confineSecretPath()
+    // walks the path BEFORE the parent dirs exist, so it cannot catch a symlink
+    // swapped onto a parent AFTER mkdir creates it. O_NOFOLLOW only guards the
+    // leaf basename, not intermediate components — the kernel still follows a
+    // parent symlink. The fix re-canonicalizes the parent after mkdir and
+    // re-checks containment. This PoC drives the mocked mkdir to swap the
+    // freshly-created parent dir for an out-of-jail symlink in the race window
+    // between mkdir and open, then asserts the write is refused and nothing
+    // lands outside the jail.
+    it("rejects when an intermediate dir is symlink-swapped AFTER mkdir (TOCTOU)", async () => {
+      vi.mocked(resolveSecret).mockResolvedValue({ status: "resolved", value: PLAINTEXT });
+      const outside = await mkdtemp(join(tmpdir(), "octo-outside-"));
+      const realMkdir = (await vi.importActual<typeof import("node:fs/promises")>(
+        "node:fs/promises",
+      )).mkdir;
+      try {
+        const subdir = join(root, "sub");
+        vi.mocked(mkdir).mockImplementationOnce(async (...args: any[]) => {
+          // Let the real mkdir create <root>/sub as a genuine directory…
+          const ret = await (realMkdir as any)(...args);
+          // …then, in the race window before open(), swap it for a symlink that
+          // escapes the jail. open() via the canonical parent must refuse it.
+          await rm(subdir, { recursive: true, force: true });
+          await symlink(outside, subdir, "dir");
+          return ret;
+        });
+
+        const result = await writeSecret({ alias: "k", filePath: "sub/secret.env" });
+
+        expect(parseText(result).error).toMatch(/escaped the allowed root|outside the allowed/i);
+        // 🔴 The out-of-jail target must NOT have been created.
+        await expect(readFile(join(outside, "secret.env"), "utf8")).rejects.toThrow();
+        // No plaintext anywhere in the LLM-visible return.
+        expect(JSON.stringify(result)).not.toContain(PLAINTEXT);
+      } finally {
+        await rm(outside, { recursive: true, force: true });
+      }
+    });
+
+    it("rejects a write whose realpath'd parent escapes the root after creation", async () => {
+      // A narrower unit-level check on the post-mkdir containment guard: the
+      // parent resolves outside root → refuse, regardless of how it got there.
+      vi.mocked(resolveSecret).mockResolvedValue({ status: "resolved", value: PLAINTEXT });
+      const outside = await mkdtemp(join(tmpdir(), "octo-outside-"));
+      try {
+        const subdir = join(root, "deep");
+        vi.mocked(mkdir).mockImplementationOnce(async () => {
+          // Skip creating a real dir; install an escaping symlink as the parent.
+          await symlink(outside, subdir, "dir");
+          return undefined;
+        });
+
+        const result = await writeSecret({ alias: "k", filePath: "deep/k.env" });
+
+        expect(parseText(result).error).toMatch(/escaped the allowed root/i);
+        await expect(readFile(join(outside, "k.env"), "utf8")).rejects.toThrow();
+        expect(JSON.stringify(result)).not.toContain(PLAINTEXT);
+      } finally {
+        await rm(outside, { recursive: true, force: true });
+      }
     });
 
     it("allows the jail root itself as a relative '.' is not valid but a file at root is", async () => {

--- a/src/agent-tools.test.ts
+++ b/src/agent-tools.test.ts
@@ -1706,5 +1706,166 @@ describe("createOctoManagementTools", () => {
       // overwrite mode → file ends up with the latest value.
       expect(await readFile(join(root, ".env"), "utf8")).toBe("rotated-value");
     });
+
+    // -----------------------------------------------------------------------
+    // Jail root DEFAULT = agent workspace (YUJ-3947)
+    //
+    // When no explicit secretsFileRoot is configured, the jail root falls back
+    // to the agent's workspace (cfg.agents.list[].workspace matched by
+    // agentAccountId, else cfg.agents.defaults.workspace). This removes the
+    // "operator must hand-configure secretsFileRoot" step from PR#92 WITHOUT
+    // weakening the security model: if no usable (non-root) workspace resolves,
+    // the write still FAILS CLOSED — there is NO process.cwd() fallback.
+    // -----------------------------------------------------------------------
+    describe("jail root default = agent workspace", () => {
+      // Build an execute() bound to a cfg with agents config + an agentAccountId,
+      // so the workspace-default resolution path is exercised. setupMocks (run in
+      // the parent beforeEach) controls the account-level secretsFileRoot.
+      const executeWithAgents = (
+        agents: unknown,
+        agentAccountId: string | undefined,
+      ) => {
+        const cfg = { ...mockCfg, agents } as any;
+        const tools = createOctoManagementTools({ cfg, agentAccountId });
+        expect(tools).toHaveLength(1);
+        return (args: Record<string, unknown>) =>
+          (tools[0].execute as any)("tc", { action: "write-secret", ...args });
+      };
+
+      it("jails to the matched agent's workspace when secretsFileRoot is unset", async () => {
+        setupMocks(); // no secretsFileRoot → falls back to workspace
+        vi.mocked(resolveSecret).mockResolvedValue({ status: "resolved", value: PLAINTEXT });
+        const exec = executeWithAgents(
+          { defaults: { workspace: "/nope" }, list: [{ id: "bot-A", workspace: root }] },
+          "bot-A",
+        );
+
+        const result = await exec({ alias: "k", filePath: "in-jail.env" });
+        const data = parseText(result);
+
+        expect(data.written).toBe(true);
+        expect(await readFile(join(root, "in-jail.env"), "utf8")).toBe(PLAINTEXT);
+        expect(JSON.stringify(result)).not.toContain(PLAINTEXT);
+      });
+
+      it("rejects an out-of-jail path under the agent-workspace default", async () => {
+        setupMocks();
+        vi.mocked(resolveSecret).mockResolvedValue({ status: "resolved", value: PLAINTEXT });
+        const exec = executeWithAgents(
+          { list: [{ id: "bot-A", workspace: root }] },
+          "bot-A",
+        );
+
+        const result = await exec({ alias: "k", filePath: "../escape.env" });
+        const data = parseText(result);
+
+        expect(data.error).toMatch(/outside the allowed|permitted root/i);
+        // Plaintext never fetched / leaked on a confinement reject.
+        expect(resolveSecret).not.toHaveBeenCalled();
+        expect(JSON.stringify(result)).not.toContain(PLAINTEXT);
+      });
+
+      it("falls back to defaults.workspace when the agent has no own workspace", async () => {
+        setupMocks();
+        vi.mocked(resolveSecret).mockResolvedValue({ status: "resolved", value: PLAINTEXT });
+        const exec = executeWithAgents(
+          { defaults: { workspace: root }, list: [{ id: "bot-A" }] },
+          "bot-A",
+        );
+
+        const result = await exec({ alias: "k", filePath: "via-defaults.env" });
+        const data = parseText(result);
+
+        expect(data.written).toBe(true);
+        expect(await readFile(join(root, "via-defaults.env"), "utf8")).toBe(PLAINTEXT);
+      });
+
+      it("falls back to defaults.workspace when no agent matches agentAccountId", async () => {
+        setupMocks();
+        vi.mocked(resolveSecret).mockResolvedValue({ status: "resolved", value: PLAINTEXT });
+        const exec = executeWithAgents(
+          { defaults: { workspace: root }, list: [{ id: "someone-else", workspace: "/x" }] },
+          "bot-A",
+        );
+
+        const result = await exec({ alias: "k", filePath: "no-match.env" });
+        expect(parseText(result).written).toBe(true);
+        expect(await readFile(join(root, "no-match.env"), "utf8")).toBe(PLAINTEXT);
+      });
+
+      it("explicit secretsFileRoot still wins over the agent-workspace default", async () => {
+        // Operator wants a NARROWER jail than the workspace: secretsFileRoot must
+        // take precedence. Point the workspace at a sibling temp dir and assert
+        // the file lands under secretsFileRoot (root), not the workspace.
+        const otherWorkspace = await mkdtemp(join(tmpdir(), "octo-ws-"));
+        try {
+          setupMocks({ secretsFileRoot: root });
+          vi.mocked(resolveSecret).mockResolvedValue({ status: "resolved", value: PLAINTEXT });
+          const exec = executeWithAgents(
+            { list: [{ id: "bot-A", workspace: otherWorkspace }] },
+            "bot-A",
+          );
+
+          const result = await exec({ alias: "k", filePath: "explicit.env" });
+          expect(parseText(result).written).toBe(true);
+          // Written under the explicit root…
+          expect(await readFile(join(root, "explicit.env"), "utf8")).toBe(PLAINTEXT);
+          // …NOT under the workspace.
+          await expect(
+            readFile(join(otherWorkspace, "explicit.env"), "utf8"),
+          ).rejects.toThrow();
+        } finally {
+          await rm(otherWorkspace, { recursive: true, force: true });
+        }
+      });
+
+      it("fails closed when neither secretsFileRoot nor any workspace is set", async () => {
+        setupMocks(); // no secretsFileRoot
+        vi.mocked(resolveSecret).mockResolvedValue({ status: "resolved", value: PLAINTEXT });
+        const exec = executeWithAgents({ list: [{ id: "bot-A" }] }, "bot-A");
+
+        const result = await exec({ alias: "k", filePath: "key.env" });
+        const data = parseText(result);
+
+        expect(data.error).toMatch(/not configured/i);
+        expect(resolveSecret).not.toHaveBeenCalled();
+        expect(JSON.stringify(result)).not.toContain(PLAINTEXT);
+      });
+
+      it("fails closed when cfg has no agents block at all", async () => {
+        setupMocks();
+        vi.mocked(resolveSecret).mockResolvedValue({ status: "resolved", value: PLAINTEXT });
+        const exec = executeWithAgents(undefined, "bot-A");
+
+        const result = await exec({ alias: "k", filePath: "key.env" });
+        expect(parseText(result).error).toMatch(/not configured/i);
+        expect(resolveSecret).not.toHaveBeenCalled();
+      });
+
+      it("fails closed when defaults.workspace resolves to '/' (degenerate root)", async () => {
+        // A defaults.workspace mistakenly set to "/" must NOT become a root-wide
+        // secret jail — treat it as no usable default and fail closed.
+        setupMocks();
+        vi.mocked(resolveSecret).mockResolvedValue({ status: "resolved", value: PLAINTEXT });
+        const exec = executeWithAgents({ defaults: { workspace: "/" } }, "bot-A");
+
+        const result = await exec({ alias: "k", filePath: "key.env" });
+        expect(parseText(result).error).toMatch(/not configured/i);
+        expect(resolveSecret).not.toHaveBeenCalled();
+      });
+
+      it("fails closed when the agent workspace is an empty/whitespace string", async () => {
+        setupMocks();
+        vi.mocked(resolveSecret).mockResolvedValue({ status: "resolved", value: PLAINTEXT });
+        const exec = executeWithAgents(
+          { defaults: { workspace: "   " }, list: [{ id: "bot-A", workspace: "" }] },
+          "bot-A",
+        );
+
+        const result = await exec({ alias: "k", filePath: "key.env" });
+        expect(parseText(result).error).toMatch(/not configured/i);
+        expect(resolveSecret).not.toHaveBeenCalled();
+      });
+    });
   });
 });

--- a/src/agent-tools.test.ts
+++ b/src/agent-tools.test.ts
@@ -71,7 +71,7 @@ import {
   symlink,
   writeFile as fsWriteFile,
 } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { tmpdir, homedir } from "node:os";
 import { join, relative } from "node:path";
 
 // Minimal config stub — mocked account functions don't inspect it
@@ -1724,9 +1724,10 @@ describe("createOctoManagementTools", () => {
       const executeWithAgents = (
         agents: unknown,
         agentAccountId: string | undefined,
+        agentId?: string,
       ) => {
         const cfg = { ...mockCfg, agents } as any;
-        const tools = createOctoManagementTools({ cfg, agentAccountId });
+        const tools = createOctoManagementTools({ cfg, agentAccountId, agentId });
         expect(tools).toHaveLength(1);
         return (args: Record<string, unknown>) =>
           (tools[0].execute as any)("tc", { action: "write-secret", ...args });
@@ -1865,6 +1866,175 @@ describe("createOctoManagementTools", () => {
         const result = await exec({ alias: "k", filePath: "key.env" });
         expect(parseText(result).error).toMatch(/not configured/i);
         expect(resolveSecret).not.toHaveBeenCalled();
+      });
+
+      // 🔴 BLOCKING REGRESSION (Jerry-Xin) — symlink-to-`/` fail-open.
+      // The old guard checked the LEXICAL form (`resolvePath(workspace) === sep`),
+      // so a workspace configured as a symlink whose REAL target is "/" slipped
+      // past it (the lexical path is the link, ≠ "/") and only degenerated into a
+      // root-wide jail later inside confineSecretPath's realpath(). The fix moves
+      // the degenerate-root check to AFTER realpath canonicalization, so a
+      // workspace that resolves to "/" now fails closed here.
+      it("fails closed when the agent workspace is a symlink to '/' (realpath-after-canon)", async () => {
+        setupMocks();
+        vi.mocked(resolveSecret).mockResolvedValue({ status: "resolved", value: PLAINTEXT });
+        const linkToRoot = join(root, "ws-root-link");
+        await symlink("/", linkToRoot, "dir");
+        // Sanity: lexically the workspace is NOT "/", so the old guard would pass it.
+        expect(linkToRoot).not.toBe("/");
+
+        const exec = executeWithAgents(
+          { list: [{ id: "bot-A", workspace: linkToRoot }] },
+          "bot-A",
+        );
+
+        const result = await exec({ alias: "k", filePath: "key.env" });
+        expect(parseText(result).error).toMatch(/not configured/i);
+        // Plaintext never fetched / leaked on the fail-closed path.
+        expect(resolveSecret).not.toHaveBeenCalled();
+        expect(JSON.stringify(result)).not.toContain(PLAINTEXT);
+      });
+
+      // 🔴 BLOCKING (Jerry-Xin) — Windows drive root must fail closed too. The old
+      // `=== sep` compare never matched "C:\\" (resolvePath("C:\\") !== "/"), so a
+      // drive-root workspace would have degenerated into a root-wide jail. The
+      // path.parse(p).root === p check covers POSIX and Windows roots alike.
+      // Drive roots only exist on win32, so this assertion is platform-gated.
+      it("fails closed when the agent workspace is a Windows drive root", async () => {
+        if (process.platform !== "win32") return; // drive roots are win32-only
+        setupMocks();
+        vi.mocked(resolveSecret).mockResolvedValue({ status: "resolved", value: PLAINTEXT });
+        const exec = executeWithAgents(
+          { list: [{ id: "bot-A", workspace: "C:\\" }] },
+          "bot-A",
+        );
+
+        const result = await exec({ alias: "k", filePath: "key.env" });
+        expect(parseText(result).error).toMatch(/not configured/i);
+        expect(resolveSecret).not.toHaveBeenCalled();
+      });
+
+      // 必修2 — match key namespace. The workspace is indexed by OpenClaw AGENT
+      // id, not the channel/Octo account id. When the two differ (e.g. agent
+      // `main` ↔ octo account `default`), keying on the account id silently misses
+      // the per-agent workspace and falls back to defaults. Assert that passing a
+      // distinct agentId hits the per-agent workspace even though agentAccountId
+      // points at a different entry.
+      it("matches the per-agent workspace by agentId when account id ≠ agent id", async () => {
+        setupMocks(); // no secretsFileRoot → workspace default
+        vi.mocked(resolveSecret).mockResolvedValue({ status: "resolved", value: PLAINTEXT });
+        const exec = executeWithAgents(
+          {
+            defaults: { workspace: "/nope" },
+            // The agent we want is keyed by agent id "main"; the octo account id
+            // is the unrelated "default".
+            list: [{ id: "main", workspace: root }],
+          },
+          "default", // agentAccountId (octo account) — does NOT match list[].id
+          "main", // agentId (OpenClaw agent) — DOES match
+        );
+
+        const result = await exec({ alias: "k", filePath: "by-agent-id.env" });
+        const data = parseText(result);
+
+        expect(data.written).toBe(true);
+        expect(await readFile(join(root, "by-agent-id.env"), "utf8")).toBe(PLAINTEXT);
+        expect(JSON.stringify(result)).not.toContain(PLAINTEXT);
+      });
+
+      // 必修2 — agentId takes precedence over agentAccountId when both match
+      // different entries. The correct (per-agent-id) workspace must win.
+      it("prefers agentId over agentAccountId when both match different entries", async () => {
+        setupMocks();
+        vi.mocked(resolveSecret).mockResolvedValue({ status: "resolved", value: PLAINTEXT });
+        const wrongWorkspace = await mkdtemp(join(tmpdir(), "octo-ws-wrong-"));
+        try {
+          const exec = executeWithAgents(
+            {
+              list: [
+                { id: "main", workspace: root }, // matched by agentId
+                { id: "default", workspace: wrongWorkspace }, // matched by accountId
+              ],
+            },
+            "default", // agentAccountId
+            "main", // agentId — should win
+          );
+
+          const result = await exec({ alias: "k", filePath: "pref.env" });
+          expect(parseText(result).written).toBe(true);
+          // Written under the agentId-matched workspace…
+          expect(await readFile(join(root, "pref.env"), "utf8")).toBe(PLAINTEXT);
+          // …NOT under the accountId-matched one.
+          await expect(
+            readFile(join(wrongWorkspace, "pref.env"), "utf8"),
+          ).rejects.toThrow();
+        } finally {
+          await rm(wrongWorkspace, { recursive: true, force: true });
+        }
+      });
+
+      // 必修2 — agent id matching is namespace-normalized (lower/slug), matching
+      // the platform's normalizeAgentId. A config entry id with different casing
+      // must still match the runtime agent id.
+      it("matches the agent workspace case-insensitively (normalizeAgentId)", async () => {
+        setupMocks();
+        vi.mocked(resolveSecret).mockResolvedValue({ status: "resolved", value: PLAINTEXT });
+        const exec = executeWithAgents(
+          { list: [{ id: "Bot-A", workspace: root }] },
+          undefined,
+          "bot-a", // differs only in casing
+        );
+
+        const result = await exec({ alias: "k", filePath: "case.env" });
+        expect(parseText(result).written).toBe(true);
+        expect(await readFile(join(root, "case.env"), "utf8")).toBe(PLAINTEXT);
+      });
+
+      // 必修3 — `~` expansion. A workspace configured as "~/<subdir>" must expand
+      // to $HOME, matching the platform's canonical resolveAgentWorkspaceDir,
+      // rather than being treated as a literal "./~" segment.
+      it("expands a leading ~ in the workspace to the home directory", async () => {
+        setupMocks();
+        vi.mocked(resolveSecret).mockResolvedValue({ status: "resolved", value: PLAINTEXT });
+        // Carve a real workspace under HOME so realpath canonicalization succeeds.
+        const home = homedir();
+        const wsName = `octo-tilde-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+        const wsAbs = join(home, wsName);
+        await mkdir(wsAbs, { recursive: true });
+        try {
+          const exec = executeWithAgents(
+            { list: [{ id: "bot-A", workspace: `~/${wsName}` }] },
+            "bot-A",
+          );
+
+          const result = await exec({ alias: "k", filePath: "tilde.env" });
+          expect(parseText(result).written).toBe(true);
+          expect(await readFile(join(wsAbs, "tilde.env"), "utf8")).toBe(PLAINTEXT);
+        } finally {
+          await rm(wsAbs, { recursive: true, force: true });
+        }
+      });
+
+      // 必修3 — $VAR / ${VAR} expansion. A workspace parameterized by an env var
+      // must expand before the path is used as the jail root.
+      it("expands $VAR / ${VAR} in the workspace path", async () => {
+        setupMocks();
+        vi.mocked(resolveSecret).mockResolvedValue({ status: "resolved", value: PLAINTEXT });
+        const prev = process.env.OCTO_TEST_WS;
+        process.env.OCTO_TEST_WS = root;
+        try {
+          const exec = executeWithAgents(
+            { list: [{ id: "bot-A", workspace: "${OCTO_TEST_WS}/sub" }] },
+            "bot-A",
+          );
+
+          const result = await exec({ alias: "k", filePath: "envvar.env" });
+          expect(parseText(result).written).toBe(true);
+          expect(await readFile(join(root, "sub", "envvar.env"), "utf8")).toBe(PLAINTEXT);
+        } finally {
+          if (prev === undefined) delete process.env.OCTO_TEST_WS;
+          else process.env.OCTO_TEST_WS = prev;
+        }
       });
     });
   });

--- a/src/agent-tools.test.ts
+++ b/src/agent-tools.test.ts
@@ -17,11 +17,18 @@ vi.mock("./api-fetch.js", () => ({
   deleteVoiceContext: vi.fn(),
   getThreadMd: vi.fn(),
   updateThreadMd: vi.fn(),
+  resolveSecret: vi.fn(),
 }));
 
 vi.mock("./group-md.js", () => ({
   broadcastGroupMdUpdate: vi.fn(),
   broadcastThreadMdUpdate: vi.fn(),
+}));
+
+vi.mock("node:fs/promises", () => ({
+  mkdir: vi.fn().mockResolvedValue(undefined),
+  writeFile: vi.fn().mockResolvedValue(undefined),
+  appendFile: vi.fn().mockResolvedValue(undefined),
 }));
 
 import { createOctoManagementTools } from "./agent-tools.js";
@@ -41,8 +48,10 @@ import {
   deleteVoiceContext,
   getThreadMd,
   updateThreadMd,
+  resolveSecret,
 } from "./api-fetch.js";
 import { broadcastGroupMdUpdate, broadcastThreadMdUpdate } from "./group-md.js";
+import { mkdir, writeFile, appendFile } from "node:fs/promises";
 
 // Minimal config stub — mocked account functions don't inspect it
 const mockCfg = { channels: { octo: { botToken: "tok-secret" } } } as any;
@@ -1165,6 +1174,241 @@ describe("createOctoManagementTools", () => {
       });
       const data = parseText(result);
       expect(data.error).toContain("thread-md-update failed");
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // write-secret (user-managed external keys; internal deref)
+  // -----------------------------------------------------------------------
+  describe("execute — write-secret", () => {
+    // The plaintext value any resolved secret yields. The whole point of this
+    // feature is that THIS string never appears in a tool return value.
+    const PLAINTEXT = "sk-live-SUPER-SECRET-VALUE-123";
+
+    it("tool schema includes the write-secret action", () => {
+      const tools = createOctoManagementTools({ cfg: mockCfg });
+      expect(tools[0].parameters.properties.action.enum).toContain("write-secret");
+    });
+
+    it("resolves the alias and writes the raw value to the file", async () => {
+      vi.mocked(resolveSecret).mockResolvedValue({
+        status: "resolved",
+        value: PLAINTEXT,
+        secret_id: "sec_1",
+        display_name: "openai key",
+      });
+
+      const result = await getExecute()("tc", {
+        action: "write-secret",
+        alias: "openai key",
+        filePath: "/work/secrets/.env",
+      });
+      const data = parseText(result);
+
+      // resolve is use-time: called with the bot token + alias.
+      expect(resolveSecret).toHaveBeenCalledWith({
+        apiUrl: "http://api.test",
+        botToken: "tok-secret",
+        alias: "openai key",
+      });
+      // raw value written verbatim (no template).
+      expect(writeFile).toHaveBeenCalledWith("/work/secrets/.env", PLAINTEXT, "utf8");
+      expect(appendFile).not.toHaveBeenCalled();
+
+      expect(data.written).toBe(true);
+      expect(data.path).toBe("/work/secrets/.env");
+      expect(data.mode).toBe("overwrite");
+      expect(data.display_name).toBe("openai key");
+      expect(data.bytesWritten).toBe(Buffer.byteLength(PLAINTEXT, "utf8"));
+    });
+
+    it("substitutes {{secret}} inside the caller template", async () => {
+      vi.mocked(resolveSecret).mockResolvedValue({
+        status: "resolved",
+        value: PLAINTEXT,
+      });
+
+      await getExecute()("tc", {
+        action: "write-secret",
+        alias: "openai key",
+        filePath: "/work/.env",
+        template: "OPENAI_API_KEY={{secret}}\n",
+      });
+
+      expect(writeFile).toHaveBeenCalledWith(
+        "/work/.env",
+        `OPENAI_API_KEY=${PLAINTEXT}\n`,
+        "utf8",
+      );
+    });
+
+    it("appends when mode=append", async () => {
+      vi.mocked(resolveSecret).mockResolvedValue({ status: "resolved", value: PLAINTEXT });
+
+      const result = await getExecute()("tc", {
+        action: "write-secret",
+        alias: "k",
+        filePath: "/work/.env",
+        mode: "append",
+      });
+      const data = parseText(result);
+
+      expect(appendFile).toHaveBeenCalledWith("/work/.env", PLAINTEXT, "utf8");
+      expect(writeFile).not.toHaveBeenCalled();
+      expect(data.mode).toBe("append");
+    });
+
+    it("creates the parent directory before writing", async () => {
+      vi.mocked(resolveSecret).mockResolvedValue({ status: "resolved", value: PLAINTEXT });
+
+      await getExecute()("tc", {
+        action: "write-secret",
+        alias: "k",
+        filePath: "/work/nested/dir/.env",
+      });
+
+      expect(mkdir).toHaveBeenCalledWith("/work/nested/dir", { recursive: true });
+    });
+
+    // 🔴 RED LINE: plaintext must never appear in the LLM-visible return value.
+    it("NEVER returns the plaintext value (red line)", async () => {
+      vi.mocked(resolveSecret).mockResolvedValue({
+        status: "resolved",
+        value: PLAINTEXT,
+        secret_id: "sec_1",
+        display_name: "openai key",
+      });
+
+      const result = await getExecute()("tc", {
+        action: "write-secret",
+        alias: "openai key",
+        filePath: "/work/.env",
+        template: "OPENAI_API_KEY={{secret}}\n",
+      });
+
+      // Check BOTH the text channel and the structured details — every path the
+      // LLM / transcript can observe.
+      const serialized = JSON.stringify(result);
+      expect(serialized).not.toContain(PLAINTEXT);
+      expect(result.content[0].text).not.toContain(PLAINTEXT);
+      expect(JSON.stringify(result.details)).not.toContain(PLAINTEXT);
+    });
+
+    it("not_found → guides the user to add the key, no plaintext", async () => {
+      vi.mocked(resolveSecret).mockResolvedValue({ status: "not_found" });
+
+      const result = await getExecute()("tc", {
+        action: "write-secret",
+        alias: "ghost key",
+        filePath: "/work/.env",
+      });
+      const data = parseText(result);
+
+      expect(data.error).toContain("No stored secret matches");
+      expect(data.error).toContain("ghost key");
+      expect(writeFile).not.toHaveBeenCalled();
+      expect(appendFile).not.toHaveBeenCalled();
+    });
+
+    it("ambiguous → returns label-only candidates, never plaintext, no write", async () => {
+      vi.mocked(resolveSecret).mockResolvedValue({
+        status: "ambiguous",
+        candidates: [
+          { secret_id: "a", display_name: "openai prod" },
+          { secret_id: "b", display_name: "openai test" },
+        ],
+      });
+
+      const result = await getExecute()("tc", {
+        action: "write-secret",
+        alias: "openai",
+        filePath: "/work/.env",
+      });
+      const data = parseText(result);
+
+      expect(data.written).toBe(false);
+      expect(data.ambiguous).toBe(true);
+      expect(data.candidates).toHaveLength(2);
+      expect(data.candidates[0].display_name).toBe("openai prod");
+      // Candidates carry no secret value.
+      expect(JSON.stringify(result)).not.toContain(PLAINTEXT);
+      expect(writeFile).not.toHaveBeenCalled();
+    });
+
+    it("resolve failure → actionable re-set hint, no write", async () => {
+      vi.mocked(resolveSecret).mockRejectedValue(
+        new Error("resolveSecret failed (500): boom"),
+      );
+
+      const result = await getExecute()("tc", {
+        action: "write-secret",
+        alias: "k",
+        filePath: "/work/.env",
+      });
+      const data = parseText(result);
+
+      expect(data.error).toContain("Could not resolve secret");
+      expect(data.error).toContain("re-add");
+      expect(writeFile).not.toHaveBeenCalled();
+    });
+
+    it("write failure after resolve → error mentions path but not the value", async () => {
+      vi.mocked(resolveSecret).mockResolvedValue({ status: "resolved", value: PLAINTEXT });
+      vi.mocked(writeFile).mockRejectedValueOnce(new Error("EACCES: permission denied"));
+
+      const result = await getExecute()("tc", {
+        action: "write-secret",
+        alias: "k",
+        filePath: "/root/.env",
+      });
+      const data = parseText(result);
+
+      expect(data.error).toContain("failed to write");
+      expect(data.error).toContain("/root/.env");
+      expect(JSON.stringify(result)).not.toContain(PLAINTEXT);
+    });
+
+    it("requires alias", async () => {
+      const result = await getExecute()("tc", {
+        action: "write-secret",
+        filePath: "/work/.env",
+      });
+      expect(parseText(result).error).toContain("alias is required");
+      expect(resolveSecret).not.toHaveBeenCalled();
+    });
+
+    it("requires filePath", async () => {
+      const result = await getExecute()("tc", {
+        action: "write-secret",
+        alias: "k",
+      });
+      expect(parseText(result).error).toContain("filePath is required");
+      expect(resolveSecret).not.toHaveBeenCalled();
+    });
+
+    it("rejects an invalid mode", async () => {
+      const result = await getExecute()("tc", {
+        action: "write-secret",
+        alias: "k",
+        filePath: "/work/.env",
+        mode: "sideways",
+      });
+      expect(parseText(result).error).toContain("Invalid mode");
+      expect(resolveSecret).not.toHaveBeenCalled();
+    });
+
+    it("resolves use-time on every call (latest value, no caching)", async () => {
+      vi.mocked(resolveSecret)
+        .mockResolvedValueOnce({ status: "resolved", value: "old-value" })
+        .mockResolvedValueOnce({ status: "resolved", value: "rotated-value" });
+
+      const execute = getExecute();
+      await execute("tc", { action: "write-secret", alias: "k", filePath: "/work/.env" });
+      await execute("tc", { action: "write-secret", alias: "k", filePath: "/work/.env" });
+
+      expect(resolveSecret).toHaveBeenCalledTimes(2);
+      expect(writeFile).toHaveBeenNthCalledWith(1, "/work/.env", "old-value", "utf8");
+      expect(writeFile).toHaveBeenNthCalledWith(2, "/work/.env", "rotated-value", "utf8");
     });
   });
 });

--- a/src/agent-tools.test.ts
+++ b/src/agent-tools.test.ts
@@ -72,7 +72,7 @@ import {
   writeFile as fsWriteFile,
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, relative } from "node:path";
 
 // Minimal config stub — mocked account functions don't inspect it
 const mockCfg = { channels: { octo: { botToken: "tok-secret" } } } as any;
@@ -1570,13 +1570,52 @@ describe("createOctoManagementTools", () => {
       expect(await readFile(join(root, "atroot.txt"), "utf8")).toBe(PLAINTEXT);
     });
 
-    it("defaults the jail root to process.cwd() when secretsFileRoot is unset", async () => {
-      // No secretsFileRoot configured → CWD is the root. A path that escapes
-      // CWD must still be rejected.
+    // 🔴 FAIL-CLOSED (P0): no secretsFileRoot configured → refuse every write.
+    // There is deliberately NO process.cwd() fallback (that fallback was the
+    // root cause of the `/`-degenerate self-lock + fail-open bugs).
+    it("fails closed when secretsFileRoot is unset — no resolve, no write", async () => {
       setupMocks(); // no secretsFileRoot
-      const result = await writeSecret({ alias: "k", filePath: "../../../../etc/passwd" });
-      expect(parseText(result).error).toMatch(/outside the allowed directory/i);
+      vi.mocked(resolveSecret).mockResolvedValue({ status: "resolved", value: PLAINTEXT });
+      const result = await writeSecret({ alias: "k", filePath: "key.txt" });
+      const data = parseText(result);
+      // Explicit, operator-actionable message about the missing config.
+      expect(data.error).toMatch(/not configured/i);
+      expect(data.error).toMatch(/secretsFileRoot/);
+      // Plaintext is never fetched and never leaks into the error.
       expect(resolveSecret).not.toHaveBeenCalled();
+      expect(JSON.stringify(result)).not.toContain(PLAINTEXT);
+    });
+
+    it("fails closed for ANY filePath when secretsFileRoot is unset (even a plain name)", async () => {
+      setupMocks(); // no secretsFileRoot
+      for (const filePath of [".env", "secrets/.env", "/etc/passwd", "../x"]) {
+        const result = await writeSecret({ alias: "k", filePath });
+        expect(parseText(result).error).toMatch(/not configured/i);
+      }
+      expect(resolveSecret).not.toHaveBeenCalled();
+    });
+
+    // 🔴 REGRESSION: the old `root + sep` containment self-locked when root="/"
+    // (`//` prefix matched nothing → reject everything) and a later patch made
+    // root="/" fail-open. The path.relative containment has neither pathology.
+    // The fail-closed default means a degenerate root="/" can never arise from
+    // an unset config, but an operator could still set it explicitly, so pin the
+    // behavior: a path inside "/" is contained, an absolute-elsewhere is not
+    // (here everything is under "/", so it is accepted — the point is the jail
+    // does NOT self-lock and does NOT crash).
+    it("does not self-lock when secretsFileRoot is explicitly '/'", async () => {
+      setupMocks({ secretsFileRoot: "/" });
+      vi.mocked(resolveSecret).mockResolvedValue({ status: "resolved", value: PLAINTEXT });
+      const target = join(root, "explicit-root-slash.txt");
+      // Use the real temp path (which is under "/") as the relative target so we
+      // do not actually write to a sensitive location.
+      const rel = relative("/", target);
+      const result = await writeSecret({ alias: "k", filePath: rel });
+      const data = parseText(result);
+      expect(data.written).toBe(true);
+      expect(await readFile(target, "utf8")).toBe(PLAINTEXT);
+      // jail-relative path never leaks the absolute root layout.
+      expect(JSON.stringify(result)).not.toContain(PLAINTEXT);
     });
 
     it("not_found → guides the user to add the key, no plaintext, no write", async () => {

--- a/src/agent-tools.test.ts
+++ b/src/agent-tools.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 vi.mock("./accounts.js", () => ({
   listOctoAccountIds: vi.fn(),
@@ -25,11 +25,9 @@ vi.mock("./group-md.js", () => ({
   broadcastThreadMdUpdate: vi.fn(),
 }));
 
-vi.mock("node:fs/promises", () => ({
-  mkdir: vi.fn().mockResolvedValue(undefined),
-  writeFile: vi.fn().mockResolvedValue(undefined),
-  appendFile: vi.fn().mockResolvedValue(undefined),
-}));
+// NOTE: node:fs/promises is intentionally NOT mocked. The write-secret tests
+// exercise the real path-confinement + write path against an OS temp directory
+// so that traversal / absolute-escape / symlink rejection is genuinely tested.
 
 import { createOctoManagementTools } from "./agent-tools.js";
 import {
@@ -51,7 +49,17 @@ import {
   resolveSecret,
 } from "./api-fetch.js";
 import { broadcastGroupMdUpdate, broadcastThreadMdUpdate } from "./group-md.js";
-import { mkdir, writeFile, appendFile } from "node:fs/promises";
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  stat,
+  symlink,
+  writeFile as fsWriteFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 // Minimal config stub — mocked account functions don't inspect it
 const mockCfg = { channels: { octo: { botToken: "tok-secret" } } } as any;
@@ -61,12 +69,14 @@ function setupMocks(overrides?: {
   configured?: boolean;
   botToken?: string;
   apiUrl?: string;
+  secretsFileRoot?: string;
 }) {
   const {
     enabled = true,
     configured = true,
     botToken = "tok-secret",
     apiUrl = "http://api.test",
+    secretsFileRoot,
   } = overrides ?? {};
 
   vi.mocked(listOctoAccountIds).mockReturnValue(["default"]);
@@ -80,6 +90,7 @@ function setupMocks(overrides?: {
       apiUrl,
       pollIntervalMs: 2000,
       heartbeatIntervalMs: 30000,
+      ...(secretsFileRoot ? { secretsFileRoot } : {}),
     },
   });
 }
@@ -1185,12 +1196,30 @@ describe("createOctoManagementTools", () => {
     // feature is that THIS string never appears in a tool return value.
     const PLAINTEXT = "sk-live-SUPER-SECRET-VALUE-123";
 
+    // Real OS temp dir used as the operator-configured jail root. Using the
+    // real filesystem (not a mock) is what makes the traversal / absolute /
+    // symlink rejection tests meaningful.
+    let root: string;
+
+    beforeEach(async () => {
+      root = await mkdtemp(join(tmpdir(), "octo-secret-test-"));
+      // Re-arm mocks with this run's jail root.
+      setupMocks({ secretsFileRoot: root });
+    });
+
+    afterEach(async () => {
+      await rm(root, { recursive: true, force: true });
+    });
+
+    const writeSecret = (args: Record<string, unknown>) =>
+      getExecute()("tc", { action: "write-secret", ...args });
+
     it("tool schema includes the write-secret action", () => {
       const tools = createOctoManagementTools({ cfg: mockCfg });
       expect(tools[0].parameters.properties.action.enum).toContain("write-secret");
     });
 
-    it("resolves the alias and writes the raw value to the file", async () => {
+    it("resolves the alias and writes the raw value into the jail", async () => {
       vi.mocked(resolveSecret).mockResolvedValue({
         status: "resolved",
         value: PLAINTEXT,
@@ -1198,11 +1227,7 @@ describe("createOctoManagementTools", () => {
         display_name: "openai key",
       });
 
-      const result = await getExecute()("tc", {
-        action: "write-secret",
-        alias: "openai key",
-        filePath: "/work/secrets/.env",
-      });
+      const result = await writeSecret({ alias: "openai key", filePath: "secrets/.env" });
       const data = parseText(result);
 
       // resolve is use-time: called with the bot token + alias.
@@ -1211,67 +1236,107 @@ describe("createOctoManagementTools", () => {
         botToken: "tok-secret",
         alias: "openai key",
       });
-      // raw value written verbatim (no template).
-      expect(writeFile).toHaveBeenCalledWith("/work/secrets/.env", PLAINTEXT, "utf8");
-      expect(appendFile).not.toHaveBeenCalled();
+
+      // raw value written verbatim (no template) under the jail root.
+      const target = join(root, "secrets/.env");
+      expect(await readFile(target, "utf8")).toBe(PLAINTEXT);
 
       expect(data.written).toBe(true);
-      expect(data.path).toBe("/work/secrets/.env");
+      expect(data.path).toBe(target);
       expect(data.mode).toBe("overwrite");
       expect(data.display_name).toBe("openai key");
-      expect(data.bytesWritten).toBe(Buffer.byteLength(PLAINTEXT, "utf8"));
+      // No secret-derived length field is exposed.
+      expect(data).not.toHaveProperty("bytesWritten");
+    });
+
+    it("creates the secret file 0o600 (owner-only)", async () => {
+      vi.mocked(resolveSecret).mockResolvedValue({ status: "resolved", value: PLAINTEXT });
+
+      await writeSecret({ alias: "k", filePath: "key.txt" });
+
+      const st = await stat(join(root, "key.txt"));
+      // Mask to permission bits. Skipped on platforms without POSIX perms.
+      if (process.platform !== "win32") {
+        expect(st.mode & 0o777).toBe(0o600);
+      }
     });
 
     it("substitutes {{secret}} inside the caller template", async () => {
-      vi.mocked(resolveSecret).mockResolvedValue({
-        status: "resolved",
-        value: PLAINTEXT,
-      });
+      vi.mocked(resolveSecret).mockResolvedValue({ status: "resolved", value: PLAINTEXT });
 
-      await getExecute()("tc", {
-        action: "write-secret",
+      await writeSecret({
         alias: "openai key",
-        filePath: "/work/.env",
+        filePath: ".env",
         template: "OPENAI_API_KEY={{secret}}\n",
       });
 
-      expect(writeFile).toHaveBeenCalledWith(
-        "/work/.env",
+      expect(await readFile(join(root, ".env"), "utf8")).toBe(
         `OPENAI_API_KEY=${PLAINTEXT}\n`,
-        "utf8",
       );
+    });
+
+    it("substitutes every {{secret}} occurrence (multi-placeholder)", async () => {
+      vi.mocked(resolveSecret).mockResolvedValue({ status: "resolved", value: PLAINTEXT });
+
+      await writeSecret({
+        alias: "k",
+        filePath: "dup.txt",
+        template: "a={{secret}};b={{secret}}",
+      });
+
+      expect(await readFile(join(root, "dup.txt"), "utf8")).toBe(
+        `a=${PLAINTEXT};b=${PLAINTEXT}`,
+      );
+    });
+
+    it("handles a resolved value that itself contains {{secret}}", async () => {
+      // The single-pass split/join must not re-expand a literal placeholder
+      // that happens to live inside the secret value.
+      vi.mocked(resolveSecret).mockResolvedValue({
+        status: "resolved",
+        value: "val-{{secret}}-end",
+      });
+
+      await writeSecret({ alias: "k", filePath: "weird.txt", template: "X={{secret}}" });
+
+      expect(await readFile(join(root, "weird.txt"), "utf8")).toBe("X=val-{{secret}}-end");
+    });
+
+    it("rejects a template that lacks the {{secret}} placeholder", async () => {
+      const result = await writeSecret({
+        alias: "k",
+        filePath: ".env",
+        template: "OPENAI_API_KEY=", // no placeholder → would silently write raw
+      });
+      expect(parseText(result).error).toContain("{{secret}} placeholder");
+      // Never resolved nor wrote anything.
+      expect(resolveSecret).not.toHaveBeenCalled();
     });
 
     it("appends when mode=append", async () => {
       vi.mocked(resolveSecret).mockResolvedValue({ status: "resolved", value: PLAINTEXT });
 
-      const result = await getExecute()("tc", {
-        action: "write-secret",
-        alias: "k",
-        filePath: "/work/.env",
-        mode: "append",
-      });
+      // seed an existing file inside the jail
+      await fsWriteFile(join(root, ".env"), "EXISTING\n", "utf8");
+
+      const result = await writeSecret({ alias: "k", filePath: ".env", mode: "append" });
       const data = parseText(result);
 
-      expect(appendFile).toHaveBeenCalledWith("/work/.env", PLAINTEXT, "utf8");
-      expect(writeFile).not.toHaveBeenCalled();
+      expect(await readFile(join(root, ".env"), "utf8")).toBe(`EXISTING\n${PLAINTEXT}`);
       expect(data.mode).toBe("append");
     });
 
     it("creates the parent directory before writing", async () => {
       vi.mocked(resolveSecret).mockResolvedValue({ status: "resolved", value: PLAINTEXT });
 
-      await getExecute()("tc", {
-        action: "write-secret",
-        alias: "k",
-        filePath: "/work/nested/dir/.env",
-      });
+      await writeSecret({ alias: "k", filePath: "nested/dir/.env" });
 
-      expect(mkdir).toHaveBeenCalledWith("/work/nested/dir", { recursive: true });
+      expect(await readFile(join(root, "nested/dir/.env"), "utf8")).toBe(PLAINTEXT);
     });
 
-    // 🔴 RED LINE: plaintext must never appear in the LLM-visible return value.
-    it("NEVER returns the plaintext value (red line)", async () => {
+    // 🔴 RED LINE: plaintext must never appear in the LLM-visible return value,
+    // on ANY branch (templated, raw, append).
+    it("NEVER returns the plaintext value — templated path (red line)", async () => {
       vi.mocked(resolveSecret).mockResolvedValue({
         status: "resolved",
         value: PLAINTEXT,
@@ -1279,35 +1344,107 @@ describe("createOctoManagementTools", () => {
         display_name: "openai key",
       });
 
-      const result = await getExecute()("tc", {
-        action: "write-secret",
+      const result = await writeSecret({
         alias: "openai key",
-        filePath: "/work/.env",
+        filePath: ".env",
         template: "OPENAI_API_KEY={{secret}}\n",
       });
 
-      // Check BOTH the text channel and the structured details — every path the
-      // LLM / transcript can observe.
       const serialized = JSON.stringify(result);
       expect(serialized).not.toContain(PLAINTEXT);
       expect(result.content[0].text).not.toContain(PLAINTEXT);
       expect(JSON.stringify(result.details)).not.toContain(PLAINTEXT);
     });
 
-    it("not_found → guides the user to add the key, no plaintext", async () => {
+    it("NEVER returns the plaintext value — raw write (red line)", async () => {
+      vi.mocked(resolveSecret).mockResolvedValue({ status: "resolved", value: PLAINTEXT });
+      const result = await writeSecret({ alias: "k", filePath: "k.txt" });
+      expect(JSON.stringify(result)).not.toContain(PLAINTEXT);
+    });
+
+    it("NEVER returns the plaintext value — append (red line)", async () => {
+      vi.mocked(resolveSecret).mockResolvedValue({ status: "resolved", value: PLAINTEXT });
+      const result = await writeSecret({ alias: "k", filePath: "k.txt", mode: "append" });
+      expect(JSON.stringify(result)).not.toContain(PLAINTEXT);
+    });
+
+    // -------------------------------------------------------------------
+    // 🔴 PATH CONFINEMENT (P0): the file destination must stay in the jail.
+    // -------------------------------------------------------------------
+    it("rejects parent-directory traversal, no resolve, no write", async () => {
+      const result = await writeSecret({ alias: "k", filePath: "../escape.txt" });
+      expect(parseText(result).error).toMatch(/outside the allowed directory/i);
+      expect(resolveSecret).not.toHaveBeenCalled();
+    });
+
+    it("rejects a deep traversal that climbs past the root", async () => {
+      const result = await writeSecret({ alias: "k", filePath: "a/b/../../../etc/passwd" });
+      expect(parseText(result).error).toMatch(/outside the allowed directory/i);
+      expect(resolveSecret).not.toHaveBeenCalled();
+    });
+
+    it("rejects an absolute path outside the jail", async () => {
+      const result = await writeSecret({ alias: "k", filePath: "/etc/cron.d/x" });
+      expect(parseText(result).error).toMatch(/outside the allowed directory/i);
+      expect(resolveSecret).not.toHaveBeenCalled();
+    });
+
+    it("rejects a write through a symlinked dir that escapes the jail", async () => {
+      // outside/  ← real target outside the jail
+      // root/link → outside  (symlink inside the jail pointing out)
+      const outside = await mkdtemp(join(tmpdir(), "octo-outside-"));
+      try {
+        await symlink(outside, join(root, "link"), "dir");
+        const result = await writeSecret({ alias: "k", filePath: "link/pwn.txt" });
+        expect(parseText(result).error).toMatch(/symlink|outside the allowed/i);
+        expect(resolveSecret).not.toHaveBeenCalled();
+      } finally {
+        await rm(outside, { recursive: true, force: true });
+      }
+    });
+
+    it("rejects when the target itself is a symlink escaping the jail", async () => {
+      const outside = await mkdtemp(join(tmpdir(), "octo-outside-"));
+      try {
+        const realTarget = join(outside, "victim.txt");
+        await fsWriteFile(realTarget, "orig", "utf8");
+        await symlink(realTarget, join(root, "evil.txt"), "file");
+        const result = await writeSecret({ alias: "k", filePath: "evil.txt" });
+        expect(parseText(result).error).toMatch(/symlink|outside the allowed/i);
+        expect(resolveSecret).not.toHaveBeenCalled();
+        // The out-of-jail victim must be untouched.
+        expect(await readFile(realTarget, "utf8")).toBe("orig");
+      } finally {
+        await rm(outside, { recursive: true, force: true });
+      }
+    });
+
+    it("allows the jail root itself as a relative '.' is not valid but a file at root is", async () => {
+      vi.mocked(resolveSecret).mockResolvedValue({ status: "resolved", value: PLAINTEXT });
+      const result = await writeSecret({ alias: "k", filePath: "atroot.txt" });
+      expect(parseText(result).written).toBe(true);
+      expect(await readFile(join(root, "atroot.txt"), "utf8")).toBe(PLAINTEXT);
+    });
+
+    it("defaults the jail root to process.cwd() when secretsFileRoot is unset", async () => {
+      // No secretsFileRoot configured → CWD is the root. A path that escapes
+      // CWD must still be rejected.
+      setupMocks(); // no secretsFileRoot
+      const result = await writeSecret({ alias: "k", filePath: "../../../../etc/passwd" });
+      expect(parseText(result).error).toMatch(/outside the allowed directory/i);
+      expect(resolveSecret).not.toHaveBeenCalled();
+    });
+
+    it("not_found → guides the user to add the key, no plaintext, no write", async () => {
       vi.mocked(resolveSecret).mockResolvedValue({ status: "not_found" });
 
-      const result = await getExecute()("tc", {
-        action: "write-secret",
-        alias: "ghost key",
-        filePath: "/work/.env",
-      });
+      const result = await writeSecret({ alias: "ghost key", filePath: ".env" });
       const data = parseText(result);
 
       expect(data.error).toContain("No stored secret matches");
       expect(data.error).toContain("ghost key");
-      expect(writeFile).not.toHaveBeenCalled();
-      expect(appendFile).not.toHaveBeenCalled();
+      // nothing written into the jail
+      await expect(readFile(join(root, ".env"), "utf8")).rejects.toThrow();
     });
 
     it("ambiguous → returns label-only candidates, never plaintext, no write", async () => {
@@ -1319,80 +1456,57 @@ describe("createOctoManagementTools", () => {
         ],
       });
 
-      const result = await getExecute()("tc", {
-        action: "write-secret",
-        alias: "openai",
-        filePath: "/work/.env",
-      });
+      const result = await writeSecret({ alias: "openai", filePath: ".env" });
       const data = parseText(result);
 
       expect(data.written).toBe(false);
       expect(data.ambiguous).toBe(true);
       expect(data.candidates).toHaveLength(2);
       expect(data.candidates[0].display_name).toBe("openai prod");
-      // Candidates carry no secret value.
       expect(JSON.stringify(result)).not.toContain(PLAINTEXT);
-      expect(writeFile).not.toHaveBeenCalled();
+      await expect(readFile(join(root, ".env"), "utf8")).rejects.toThrow();
     });
 
     it("resolve failure → actionable re-set hint, no write", async () => {
       vi.mocked(resolveSecret).mockRejectedValue(
-        new Error("resolveSecret failed (500): boom"),
+        new Error("resolveSecret failed (500)"),
       );
 
-      const result = await getExecute()("tc", {
-        action: "write-secret",
-        alias: "k",
-        filePath: "/work/.env",
-      });
+      const result = await writeSecret({ alias: "k", filePath: ".env" });
       const data = parseText(result);
 
       expect(data.error).toContain("Could not resolve secret");
       expect(data.error).toContain("re-add");
-      expect(writeFile).not.toHaveBeenCalled();
+      await expect(readFile(join(root, ".env"), "utf8")).rejects.toThrow();
     });
 
     it("write failure after resolve → error mentions path but not the value", async () => {
       vi.mocked(resolveSecret).mockResolvedValue({ status: "resolved", value: PLAINTEXT });
-      vi.mocked(writeFile).mockRejectedValueOnce(new Error("EACCES: permission denied"));
+      // Make the target unwritable: create a directory where the file should go.
+      await mkdir(join(root, "isdir"), { recursive: true });
 
-      const result = await getExecute()("tc", {
-        action: "write-secret",
-        alias: "k",
-        filePath: "/root/.env",
-      });
+      const result = await writeSecret({ alias: "k", filePath: "isdir" });
       const data = parseText(result);
 
       expect(data.error).toContain("failed to write");
-      expect(data.error).toContain("/root/.env");
+      expect(data.error).toContain("isdir");
       expect(JSON.stringify(result)).not.toContain(PLAINTEXT);
     });
 
     it("requires alias", async () => {
-      const result = await getExecute()("tc", {
-        action: "write-secret",
-        filePath: "/work/.env",
-      });
+      const result = await writeSecret({ filePath: ".env" });
       expect(parseText(result).error).toContain("alias is required");
       expect(resolveSecret).not.toHaveBeenCalled();
     });
 
     it("requires filePath", async () => {
-      const result = await getExecute()("tc", {
-        action: "write-secret",
-        alias: "k",
-      });
+      const result = await writeSecret({ alias: "k" });
       expect(parseText(result).error).toContain("filePath is required");
       expect(resolveSecret).not.toHaveBeenCalled();
     });
 
     it("rejects an invalid mode", async () => {
-      const result = await getExecute()("tc", {
-        action: "write-secret",
-        alias: "k",
-        filePath: "/work/.env",
-        mode: "sideways",
-      });
+      const result = await writeSecret({ alias: "k", filePath: ".env", mode: "sideways" });
       expect(parseText(result).error).toContain("Invalid mode");
       expect(resolveSecret).not.toHaveBeenCalled();
     });
@@ -1402,13 +1516,12 @@ describe("createOctoManagementTools", () => {
         .mockResolvedValueOnce({ status: "resolved", value: "old-value" })
         .mockResolvedValueOnce({ status: "resolved", value: "rotated-value" });
 
-      const execute = getExecute();
-      await execute("tc", { action: "write-secret", alias: "k", filePath: "/work/.env" });
-      await execute("tc", { action: "write-secret", alias: "k", filePath: "/work/.env" });
+      await writeSecret({ alias: "k", filePath: ".env" });
+      await writeSecret({ alias: "k", filePath: ".env" });
 
       expect(resolveSecret).toHaveBeenCalledTimes(2);
-      expect(writeFile).toHaveBeenNthCalledWith(1, "/work/.env", "old-value", "utf8");
-      expect(writeFile).toHaveBeenNthCalledWith(2, "/work/.env", "rotated-value", "utf8");
+      // overwrite mode → file ends up with the latest value.
+      expect(await readFile(join(root, ".env"), "utf8")).toBe("rotated-value");
     });
   });
 });

--- a/src/agent-tools.test.ts
+++ b/src/agent-tools.test.ts
@@ -1419,6 +1419,73 @@ describe("createOctoManagementTools", () => {
       }
     });
 
+    // 🔴 P0 REGRESSION — dangling-symlink jail escape. The earlier guard only
+    // rejected symlinks whose target ALREADY existed; a symlink pointing OUT of
+    // the jail at a target that does NOT yet exist (dangling) slipped through,
+    // and writeFile() then created the plaintext secret at the out-of-jail
+    // target via O_CREAT. The two tests below are real PoCs against the real
+    // exported handler: they build a genuine dangling symlink in the jail, call
+    // write-secret, and assert (a) it is rejected, (b) resolveSecret is never
+    // called, (c) NO file appears at the out-of-jail target.
+    it("rejects when the target itself is a DANGLING symlink escaping the jail", async () => {
+      vi.mocked(resolveSecret).mockResolvedValue({ status: "resolved", value: PLAINTEXT });
+      const outside = await mkdtemp(join(tmpdir(), "octo-outside-"));
+      try {
+        // Target does NOT exist yet (dangling). link inside jail → outside.
+        const danglingTarget = join(outside, "not-yet.txt");
+        await symlink(danglingTarget, join(root, "evil.txt"), "file");
+
+        const result = await writeSecret({ alias: "k", filePath: "evil.txt" });
+
+        expect(parseText(result).error).toMatch(/symlink|verified|outside the allowed/i);
+        // Never resolved → plaintext never fetched.
+        expect(resolveSecret).not.toHaveBeenCalled();
+        // 🔴 The out-of-jail target must NOT have been created.
+        await expect(readFile(danglingTarget, "utf8")).rejects.toThrow();
+        // And no plaintext anywhere in the LLM-visible return.
+        expect(JSON.stringify(result)).not.toContain(PLAINTEXT);
+      } finally {
+        await rm(outside, { recursive: true, force: true });
+      }
+    });
+
+    it("rejects a DANGLING symlinked DIRECTORY escaping the jail", async () => {
+      vi.mocked(resolveSecret).mockResolvedValue({ status: "resolved", value: PLAINTEXT });
+      const outside = await mkdtemp(join(tmpdir(), "octo-outside-"));
+      try {
+        // An intermediate dir symlink pointing to a not-yet-existing out-of-jail
+        // location. Writing "link/secret.txt" would otherwise create the file
+        // (and the dir) outside the jail.
+        const danglingDir = join(outside, "does-not-exist-dir");
+        await symlink(danglingDir, join(root, "link"), "dir");
+
+        const result = await writeSecret({ alias: "k", filePath: "link/secret.txt" });
+
+        expect(parseText(result).error).toMatch(/symlink|verified|outside the allowed/i);
+        expect(resolveSecret).not.toHaveBeenCalled();
+        // 🔴 Nothing created at the out-of-jail location.
+        await expect(readFile(join(danglingDir, "secret.txt"), "utf8")).rejects.toThrow();
+        expect(JSON.stringify(result)).not.toContain(PLAINTEXT);
+      } finally {
+        await rm(outside, { recursive: true, force: true });
+      }
+    });
+
+    it("rejects a DANGLING symlink that points back INSIDE the jail too (unverifiable → deny)", async () => {
+      // Even a dangling link whose lexical target is inside the jail cannot be
+      // proven safe (realpath throws), so we deny it. Conservative but correct:
+      // the caller can just write the plain path directly.
+      vi.mocked(resolveSecret).mockResolvedValue({ status: "resolved", value: PLAINTEXT });
+      const inJailButMissing = join(root, "later.txt");
+      await symlink(inJailButMissing, join(root, "ptr.txt"), "file");
+
+      const result = await writeSecret({ alias: "k", filePath: "ptr.txt" });
+
+      expect(parseText(result).error).toMatch(/symlink|verified|outside the allowed/i);
+      expect(resolveSecret).not.toHaveBeenCalled();
+      await expect(readFile(inJailButMissing, "utf8")).rejects.toThrow();
+    });
+
     it("allows the jail root itself as a relative '.' is not valid but a file at root is", async () => {
       vi.mocked(resolveSecret).mockResolvedValue({ status: "resolved", value: PLAINTEXT });
       const result = await writeSecret({ alias: "k", filePath: "atroot.txt" });

--- a/src/agent-tools.ts
+++ b/src/agent-tools.ts
@@ -43,10 +43,12 @@ import {
 import { broadcastGroupMdUpdate, broadcastThreadMdUpdate } from "./group-md.js";
 import { mkdir, realpath, lstat, open } from "node:fs/promises";
 import { constants as fsConstants } from "node:fs";
+import { homedir } from "node:os";
 import {
   basename,
   dirname,
   isAbsolute,
+  parse as parsePath,
   relative,
   resolve as resolvePath,
   sep,
@@ -134,7 +136,7 @@ async function confineSecretPath(
     return {
       ok: false,
       error:
-        "write-secret is not configured: the operator must explicitly set secretsFileRoot (the directory secrets may be written under) before this action can be used.",
+        "write-secret is not configured: no jail root could be resolved. Set an explicit secretsFileRoot (the directory secrets may be written under), or configure the agent's workspace via agents.list[].workspace or agents.defaults.workspace, before this action can be used.",
     };
   }
 
@@ -218,42 +220,155 @@ async function confineSecretPath(
 }
 
 /**
+ * Canonical agent-id matcher, aligned with the platform's `normalizeAgentId`
+ * (openclaw/plugin-sdk/routing). Agent entries in `cfg.agents.list[]` are keyed
+ * by OpenClaw agent id, which is lower-cased and slug-normalized; comparing raw
+ * strings (the previous `a.id === agentAccountId`) misses legitimate matches
+ * whenever casing or punctuation differs. We normalize BOTH sides before
+ * comparison so the match key lives in the same namespace as the platform.
+ */
+const VALID_AGENT_ID_RE = /^[a-z0-9][a-z0-9_-]{0,63}$/i;
+function normalizeAgentId(value: string | undefined | null): string {
+  const trimmed = (value ?? "").trim();
+  if (!trimmed) return "main";
+  const lower = trimmed.toLowerCase();
+  if (VALID_AGENT_ID_RE.test(trimmed)) return lower;
+  return (
+    lower
+      .replace(/[^a-z0-9_-]+/g, "-")
+      .replace(/^-+/, "")
+      .replace(/-+$/, "")
+      .slice(0, 64) || "main"
+  );
+}
+
+/**
+ * Expand a configured workspace string the same way the platform's canonical
+ * `resolveAgentWorkspaceDir` does before it is used as a path:
+ *   • leading `~` / `~/…` → the user's home directory (matches the platform's
+ *     `resolveUserPath` / `expandHomePrefix`);
+ *   • `$VAR` and `${VAR}` (and Windows `%VAR%`) → the matching environment
+ *     variable, so an operator can parameterize the jail root.
+ * A raw config string fed straight into `resolvePath` (the previous behavior)
+ * would treat `~`/`$VAR` as literal path segments, jailing secrets under a
+ * bogus `./~/…` directory instead of the intended workspace.
+ */
+function expandWorkspacePath(input: string): string {
+  let out = input;
+  // $VAR / ${VAR}
+  out = out.replace(/\$\{([A-Za-z_][A-Za-z0-9_]*)\}|\$([A-Za-z_][A-Za-z0-9_]*)/g, (m, a, b) => {
+    const name = a ?? b;
+    const val = process.env[name];
+    return val !== undefined ? val : m;
+  });
+  // Windows %VAR%
+  out = out.replace(/%([A-Za-z_][A-Za-z0-9_]*)%/g, (m, name) => {
+    const val = process.env[name];
+    return val !== undefined ? val : m;
+  });
+  // Leading ~ → home
+  if (out === "~" || out.startsWith("~/") || out.startsWith("~\\")) {
+    try {
+      const home = homedir();
+      if (home) out = out.replace(/^~(?=$|[\\/])/, home);
+    } catch {
+      // homedir() unavailable — leave the literal "~", resolvePath will treat it
+      // as a relative segment and the (non-root) result still fails safe.
+    }
+  }
+  return out;
+}
+
+/**
+ * Is `p` a filesystem root — POSIX `/` or a Windows drive root like `C:\`?
+ *
+ * `path.parse(p).root === p` is true exactly for those roots and nothing else,
+ * which is why we use it instead of a bare `=== sep` compare: the old check
+ * missed Windows drive roots (`resolvePath("C:\\") !== "/"`), and — crucially —
+ * it ran on the LEXICAL form, so a workspace configured as a symlink TO `/`
+ * (e.g. `/tmp/ws-link` → `/`) sailed past it and only degenerated into a
+ * root-wide jail later, inside confineSecretPath's realpath().
+ */
+function isFilesystemRoot(p: string): boolean {
+  return parsePath(p).root === p;
+}
+
+/**
  * Resolve the DEFAULT jail root for write-secret from the agent's workspace.
  *
  * This is the fallback used when no explicit per-account `secretsFileRoot` is
  * configured (the explicit value is handled by the caller and ALWAYS wins over
  * this default, so an operator can still lock writes to a narrower directory).
  *
- * Resolution order:
- *   1. The `cfg.agents.list[]` entry whose `id === agentAccountId` → its
- *      `workspace`.
+ * Resolution order (matched against the OpenClaw **agent id**, the namespace
+ * `cfg.agents.list[]` is keyed by — see normalizeAgentId):
+ *   1. The matched `cfg.agents.list[]` entry → its `workspace`.
  *   2. `cfg.agents.defaults.workspace` (when the matched agent has no own
  *      workspace, or no agent matched).
+ * The OpenClaw agent id (`agentId`) is preferred; the channel/Octo account id
+ * (`agentAccountId`) is only a fallback, because account id ≠ agent id in
+ * multi-agent deployments (e.g. agent `main` ↔ octo account `default`) and
+ * keying on the account id would silently miss the per-agent workspace.
  *
- * 🔴 SECURITY: this NEVER falls back to `process.cwd()` — that fallback was the
- * source of the historical `/`-degenerate self-lock + fail-open bugs. If no
- * workspace is configured, OR the configured value is empty, OR it resolves to
- * the filesystem root ("/"), we return `undefined` so the caller FAILS CLOSED
- * (refuses the write) rather than jailing owner secrets to a root-wide or
- * process-relative directory. A `defaults.workspace` mistakenly set to "/" must
- * not silently become a root-wide secret jail.
+ * 🔴 SECURITY — realpath-after-canon degenerate guard: this NEVER falls back to
+ * `process.cwd()` (the source of the historical `/`-degenerate self-lock +
+ * fail-open bugs). The configured workspace is home/env-expanded, then
+ * **realpath-canonicalized**, and ONLY THEN checked for the filesystem-root
+ * degeneracy. Doing the check after canonicalization closes the symlink-to-`/`
+ * fail-open: a workspace pointed at a symlink whose real target is `/` (or a
+ * drive root) now resolves to that root and is rejected here, instead of
+ * slipping through a lexical `!== "/"` test and degenerating into a root-wide
+ * jail downstream. If no workspace is configured, the value is empty, or it
+ * canonicalizes to a filesystem root, we return `undefined` so the caller FAILS
+ * CLOSED. (An operator who *explicitly* sets secretsFileRoot="/" is a separate,
+ * deliberate opt-in handled by the caller and is intentionally NOT subject to
+ * this default-degeneracy guard.)
  */
-function resolveAgentWorkspaceRoot(
+async function resolveAgentWorkspaceRoot(
   cfg: OpenClawConfig,
+  agentId: string | undefined,
   agentAccountId: string | undefined,
-): string | undefined {
+): Promise<string | undefined> {
   const agents = cfg.agents;
   if (!agents) return undefined;
-  const matched = agentAccountId
-    ? agents.list?.find((a) => a.id === agentAccountId)
-    : undefined;
+
+  // Match on the OpenClaw agent id first (the namespace list[] is keyed by),
+  // then fall back to the channel/Octo account id for deployments where the two
+  // coincide. Normalize both sides so casing/punctuation can't cause a miss.
+  const list = agents.list;
+  let matched: { workspace?: string } | undefined;
+  for (const candidate of [agentId, agentAccountId]) {
+    if (!candidate) continue;
+    const norm = normalizeAgentId(candidate);
+    matched = list?.find(
+      (a) => a.id != null && normalizeAgentId(a.id) === norm,
+    );
+    if (matched) break;
+  }
+
   const workspace = (matched?.workspace ?? agents.defaults?.workspace)?.trim();
   if (!workspace) return undefined;
-  // 🔴 Degenerate-root guard: a workspace configured as "/" (or anything that
-  // resolves to the filesystem root) must NOT become a root-wide secret jail.
-  // Treat it as "no usable default" so the caller fails closed.
-  if (resolvePath(workspace) === sep) return undefined;
-  return workspace;
+
+  // Home/env-expand to align with the platform's canonical workspace resolver,
+  // then realpath-canonicalize so the degenerate-root check below runs on the
+  // REAL target (defeats a symlink-to-`/` fail-open).
+  const expanded = resolvePath(expandWorkspacePath(workspace));
+  let canonical: string;
+  try {
+    canonical = await realpath(expanded);
+  } catch {
+    // Workspace doesn't exist yet (or is unreachable): a non-existent path can't
+    // be a symlink, so its lexical absolute form is its effective target. We can
+    // still apply the degenerate-root guard against it.
+    canonical = expanded;
+  }
+
+  // 🔴 Degenerate-root guard, AFTER canonicalization: a workspace that resolves
+  // to a filesystem root (POSIX "/" or a Windows drive root) must NOT become a
+  // root-wide secret jail. Treat it as "no usable default" so the caller fails
+  // closed.
+  if (isFilesystemRoot(canonical)) return undefined;
+  return canonical;
 }
 
 // ---------------------------------------------------------------------------
@@ -277,9 +392,11 @@ type LogSink = {
 export function createOctoManagementTools(params: {
   cfg?: OpenClawConfig;
   agentAccountId?: string;
+  agentId?: string;
 }): any[] {
   const cfg = params.cfg;
   const agentAccountId = params.agentAccountId;
+  const agentId = params.agentId;
   if (!cfg) return [];
 
   // Check if any account is configured
@@ -770,13 +887,14 @@ export function createOctoManagementTools(params: {
             // Jail root resolution (highest priority first):
             //   1. explicit per-account/channel secretsFileRoot (operator can
             //      lock writes to a narrower directory — this always wins).
-            //   2. DEFAULT: the agent's workspace (cfg.agents.list[].workspace
-            //      matched by agentAccountId, else cfg.agents.defaults.workspace).
+            //   2. DEFAULT: the agent's workspace, matched by OpenClaw agent id
+            //      (cfg.agents.list[].workspace, else cfg.agents.defaults.workspace),
+            //      home/env-expanded + realpath-canonicalized.
             // If neither yields a usable non-root directory, confineSecretPath
             // fails closed — there is NO process.cwd() fallback.
             const effectiveSecretsRoot =
               account.config.secretsFileRoot?.trim() ||
-              resolveAgentWorkspaceRoot(cfg, agentAccountId);
+              (await resolveAgentWorkspaceRoot(cfg, agentId, agentAccountId));
             return await handleWriteSecret({
               apiUrl,
               botToken,

--- a/src/agent-tools.ts
+++ b/src/agent-tools.ts
@@ -43,7 +43,14 @@ import {
 import { broadcastGroupMdUpdate, broadcastThreadMdUpdate } from "./group-md.js";
 import { mkdir, realpath, lstat, open } from "node:fs/promises";
 import { constants as fsConstants } from "node:fs";
-import { basename, dirname, relative, resolve as resolvePath, sep } from "node:path";
+import {
+  basename,
+  dirname,
+  isAbsolute,
+  relative,
+  resolve as resolvePath,
+  sep,
+} from "node:path";
 
 import type { OpenClawConfig } from "openclaw/plugin-sdk";
 import { DEFAULT_ACCOUNT_ID } from "./sdk-compat.js";
@@ -64,18 +71,52 @@ const SECRET_PLACEHOLDER = "{{secret}}";
 const SECRET_FILE_MODE = 0o600;
 
 /**
+ * Containment test: is `candidate` the jail `root` itself or a path strictly
+ * beneath it?
+ *
+ * We use `path.relative(root, candidate)` rather than string-prefix matching on
+ * `root + sep`. The prefix form has two failure modes that BOTH bit us in
+ * production:
+ *   • `root === "/"` makes `root + sep === "//"`, so `candidate.startsWith("//")`
+ *     is false for every real path → the jail rejects everything (self-lock).
+ *   • Patching that special-case the other way (treating `/` as "always inside")
+ *     turns the jail into a no-op fail-open.
+ * `path.relative` has neither pathology: the candidate is inside the root iff
+ * the relative path is empty (candidate === root), does not start with `..`
+ * (would climb out), and is not itself absolute (different root / drive on
+ * Windows). The same predicate is reused at every containment site (lexical
+ * check, symlink walk, post-mkdir re-check) so they cannot drift apart.
+ */
+function isInsideRoot(root: string, candidate: string): boolean {
+  if (candidate === root) return true;
+  const rel = relative(root, candidate);
+  return rel !== "" && !rel.startsWith(`..${sep}`) && rel !== ".." && !isAbsolute(rel);
+}
+
+/**
  * Confine a caller-supplied write target to an operator-approved jail root.
  *
  * 🔴 SECURITY (P0): `filePath` comes from the LLM tool call, which is reachable
  * via inbound group-chat messages — an untrusted, prompt-injectable surface.
  * Without confinement, `write-secret` is an arbitrary-file-write of the owner's
  * plaintext secret (e.g. "append my key to ~/.bashrc" / ".ssh/authorized_keys"
- * / a web root). We therefore resolve the requested path against a fixed root
- * (`secretsFileRoot` from config, else the plugin process CWD) and reject
- * anything that escapes it — including `..` traversal, absolute paths pointing
- * elsewhere, and symlink escapes (resolved, dangling, or otherwise
- * unverifiable). The actual write additionally uses O_NOFOLLOW to defeat a
- * TOCTOU swap between this check and the write.
+ * / a web root). The OWNER may have triggered the conversation, but the caller
+ * that actually picks `filePath`/`template` is a prompt-injectable LLM driven by
+ * arbitrary group-chat members, so OS-level "owner can write anyway" reasoning
+ * does NOT make the jail redundant — it is the only boundary between an injected
+ * instruction and an arbitrary owner-writable file.
+ *
+ * 🔴 FAIL-CLOSED: the jail root comes ONLY from `secretsFileRoot` config. There
+ * is deliberately NO fallback to `process.cwd()`: a CWD of `/` is exactly what
+ * produced the historical self-lock and fail-open bugs, and silently writing
+ * owner secrets under whatever directory the process happens to run in is itself
+ * unsafe. If the operator has not configured a root, we refuse the write
+ * outright rather than guess one.
+ *
+ * When a root IS configured, we reject anything that escapes it — `..`
+ * traversal, absolute paths pointing elsewhere, and symlink escapes (resolved,
+ * dangling, or otherwise unverifiable). The actual write additionally uses
+ * O_NOFOLLOW to defeat a TOCTOU swap between this check and the write.
  *
  * Returns the safe absolute path, or an error string describing the rejection
  * (never echoing secret material — only the caller-typed path).
@@ -84,10 +125,19 @@ async function confineSecretPath(
   filePath: string,
   rootInput: string | undefined,
 ): Promise<{ ok: true; abs: string; root: string } | { ok: false; error: string }> {
-  // The jail root: operator config wins; otherwise the plugin's working dir.
-  // Resolve it to an absolute, symlink-free canonical form so containment
-  // checks compare apples to apples.
-  const rootRaw = rootInput && rootInput.trim() ? rootInput.trim() : process.cwd();
+  // 🔴 FAIL-CLOSED: no operator-configured root → refuse. Never fall back to
+  // process.cwd() (the source of the `/`-degenerate self-lock + fail-open bugs).
+  const rootRaw = rootInput?.trim();
+  if (!rootRaw) {
+    return {
+      ok: false,
+      error:
+        "write-secret is not configured: the operator must explicitly set secretsFileRoot (the directory secrets may be written under) before this action can be used.",
+    };
+  }
+
+  // Resolve the configured root to an absolute, symlink-free canonical form so
+  // containment checks compare apples to apples.
   let root: string;
   try {
     root = await realpath(resolvePath(rootRaw));
@@ -102,9 +152,10 @@ async function confineSecretPath(
   // the containment check below then rejects unless it still lands inside root.
   const candidate = resolvePath(root, filePath);
 
-  // Lexical containment: candidate must be the root itself or sit strictly
-  // beneath it. This already defeats `..` traversal and absolute-elsewhere.
-  if (candidate !== root && !candidate.startsWith(root + sep)) {
+  // Lexical containment (path.relative form): candidate must be the root itself
+  // or sit strictly beneath it. This defeats `..` traversal and
+  // absolute-elsewhere without the `root + sep` self-lock/fail-open pitfalls.
+  if (!isInsideRoot(root, candidate)) {
     return {
       ok: false,
       error: `Refusing to write the secret outside the allowed directory. "${filePath}" resolves outside the permitted root. Use a path inside the workspace.`,
@@ -125,7 +176,7 @@ async function confineSecretPath(
   //   • a component that simply does not exist (ENOENT on lstat itself, not a
   //     symlink) → it and everything below it will be freshly created as plain
   //     entries inside the already-validated jail, so we can stop walking.
-  const rel = candidate === root ? "" : candidate.slice(root.length + sep.length);
+  const rel = candidate === root ? "" : relative(root, candidate);
   const segments = rel ? rel.split(sep) : [];
   let current = root;
   for (const seg of segments) {
@@ -149,7 +200,7 @@ async function confineSecretPath(
           error: `Refusing to write the secret: "${filePath}" passes through a symlink that cannot be verified to stay inside the allowed directory.`,
         };
       }
-      if (real !== root && !real.startsWith(root + sep)) {
+      if (!isInsideRoot(root, real)) {
         return {
           ok: false,
           error: `Refusing to write the secret: "${filePath}" resolves through a symlink that escapes the allowed directory.`,
@@ -1011,7 +1062,7 @@ async function handleWriteSecret(params: {
       // containment, then open via the canonical parent + basename so every
       // component is proven to stay inside the root.
       const realDir = await realpath(dir);
-      if (realDir !== root && !realDir.startsWith(root + sep)) {
+      if (!isInsideRoot(root, realDir)) {
         return makeError(
           "Refusing to write the secret: the destination directory escaped the allowed root after creation.",
         );

--- a/src/agent-tools.ts
+++ b/src/agent-tools.ts
@@ -106,12 +106,14 @@ function isInsideRoot(root: string, candidate: string): boolean {
  * does NOT make the jail redundant — it is the only boundary between an injected
  * instruction and an arbitrary owner-writable file.
  *
- * 🔴 FAIL-CLOSED: the jail root comes ONLY from `secretsFileRoot` config. There
- * is deliberately NO fallback to `process.cwd()`: a CWD of `/` is exactly what
- * produced the historical self-lock and fail-open bugs, and silently writing
- * owner secrets under whatever directory the process happens to run in is itself
- * unsafe. If the operator has not configured a root, we refuse the write
- * outright rather than guess one.
+ * 🔴 FAIL-CLOSED: the jail root is resolved by the caller — an explicit
+ * `secretsFileRoot` if configured, otherwise the agent's workspace (see
+ * resolveAgentWorkspaceRoot). There is deliberately NO fallback to
+ * `process.cwd()`: a CWD of `/` is exactly what produced the historical
+ * self-lock and fail-open bugs, and silently writing owner secrets under
+ * whatever directory the process happens to run in is itself unsafe. If neither
+ * an explicit root nor a workspace resolves to a usable (non-root) directory,
+ * we refuse the write outright rather than guess one.
  *
  * When a root IS configured, we reject anything that escapes it — `..`
  * traversal, absolute paths pointing elsewhere, and symlink escapes (resolved,
@@ -213,6 +215,45 @@ async function confineSecretPath(
   }
 
   return { ok: true, abs: candidate, root };
+}
+
+/**
+ * Resolve the DEFAULT jail root for write-secret from the agent's workspace.
+ *
+ * This is the fallback used when no explicit per-account `secretsFileRoot` is
+ * configured (the explicit value is handled by the caller and ALWAYS wins over
+ * this default, so an operator can still lock writes to a narrower directory).
+ *
+ * Resolution order:
+ *   1. The `cfg.agents.list[]` entry whose `id === agentAccountId` → its
+ *      `workspace`.
+ *   2. `cfg.agents.defaults.workspace` (when the matched agent has no own
+ *      workspace, or no agent matched).
+ *
+ * 🔴 SECURITY: this NEVER falls back to `process.cwd()` — that fallback was the
+ * source of the historical `/`-degenerate self-lock + fail-open bugs. If no
+ * workspace is configured, OR the configured value is empty, OR it resolves to
+ * the filesystem root ("/"), we return `undefined` so the caller FAILS CLOSED
+ * (refuses the write) rather than jailing owner secrets to a root-wide or
+ * process-relative directory. A `defaults.workspace` mistakenly set to "/" must
+ * not silently become a root-wide secret jail.
+ */
+function resolveAgentWorkspaceRoot(
+  cfg: OpenClawConfig,
+  agentAccountId: string | undefined,
+): string | undefined {
+  const agents = cfg.agents;
+  if (!agents) return undefined;
+  const matched = agentAccountId
+    ? agents.list?.find((a) => a.id === agentAccountId)
+    : undefined;
+  const workspace = (matched?.workspace ?? agents.defaults?.workspace)?.trim();
+  if (!workspace) return undefined;
+  // 🔴 Degenerate-root guard: a workspace configured as "/" (or anything that
+  // resolves to the filesystem root) must NOT become a root-wide secret jail.
+  // Treat it as "no usable default" so the caller fails closed.
+  if (resolvePath(workspace) === sep) return undefined;
+  return workspace;
 }
 
 // ---------------------------------------------------------------------------
@@ -726,6 +767,16 @@ export function createOctoManagementTools(params: {
                 `Invalid mode "${rawMode}" for write-secret; use "overwrite" or "append"`,
               );
             }
+            // Jail root resolution (highest priority first):
+            //   1. explicit per-account/channel secretsFileRoot (operator can
+            //      lock writes to a narrower directory — this always wins).
+            //   2. DEFAULT: the agent's workspace (cfg.agents.list[].workspace
+            //      matched by agentAccountId, else cfg.agents.defaults.workspace).
+            // If neither yields a usable non-root directory, confineSecretPath
+            // fails closed — there is NO process.cwd() fallback.
+            const effectiveSecretsRoot =
+              account.config.secretsFileRoot?.trim() ||
+              resolveAgentWorkspaceRoot(cfg, agentAccountId);
             return await handleWriteSecret({
               apiUrl,
               botToken,
@@ -733,7 +784,7 @@ export function createOctoManagementTools(params: {
               filePath,
               template,
               mode: rawMode === "append" ? "append" : "overwrite",
-              secretsFileRoot: account.config.secretsFileRoot,
+              secretsFileRoot: effectiveSecretsRoot,
             });
           }
 

--- a/src/agent-tools.ts
+++ b/src/agent-tools.ts
@@ -41,7 +41,8 @@ import {
   resolveSecret,
 } from "./api-fetch.js";
 import { broadcastGroupMdUpdate, broadcastThreadMdUpdate } from "./group-md.js";
-import { mkdir, writeFile, appendFile, chmod, realpath, lstat } from "node:fs/promises";
+import { mkdir, realpath, lstat, open } from "node:fs/promises";
+import { constants as fsConstants } from "node:fs";
 import { dirname, resolve as resolvePath, sep } from "node:path";
 
 import type { OpenClawConfig } from "openclaw/plugin-sdk";
@@ -72,7 +73,9 @@ const SECRET_FILE_MODE = 0o600;
  * / a web root). We therefore resolve the requested path against a fixed root
  * (`secretsFileRoot` from config, else the plugin process CWD) and reject
  * anything that escapes it — including `..` traversal, absolute paths pointing
- * elsewhere, and symlink escapes.
+ * elsewhere, and symlink escapes (resolved, dangling, or otherwise
+ * unverifiable). The actual write additionally uses O_NOFOLLOW to defeat a
+ * TOCTOU swap between this check and the write.
  *
  * Returns the safe absolute path, or an error string describing the rejection
  * (never echoing secret material — only the caller-typed path).
@@ -108,47 +111,54 @@ async function confineSecretPath(
     };
   }
 
-  // Symlink-escape guard: walk up to the nearest existing ancestor and
-  // canonicalize it. If a real path component is a symlink pointing out of the
-  // jail, the canonical form will fall outside root and we reject.
-  let probe = candidate;
-  // Find the deepest ancestor that exists on disk.
-  // (candidate itself may not exist yet for overwrite/append-create.)
-  // We stop at root because root is already canonical.
-  while (probe !== root && probe.startsWith(root + sep)) {
+  // Symlink-escape guard: walk the path one component at a time, from the root
+  // down to the target. At each component that exists on disk:
+  //   • a symlink whose canonical target stays inside the jail → keep walking;
+  //   • a symlink whose canonical target escapes the jail       → reject;
+  //   • a symlink that does NOT resolve (dangling / unverifiable) → reject
+  //     UNCONDITIONALLY. This is the key fix: a dangling symlink inside the jail
+  //     (lstat() succeeds, isSymbolicLink()=true, but realpath() throws ENOENT
+  //     because the target does not exist yet) would otherwise be mistaken for
+  //     "a plain file that will be created here". writeFile() FOLLOWS the link
+  //     and creates the plaintext secret at the link's out-of-jail target. We
+  //     never trust a symlink we cannot prove lands inside the jail.
+  //   • a component that simply does not exist (ENOENT on lstat itself, not a
+  //     symlink) → it and everything below it will be freshly created as plain
+  //     entries inside the already-validated jail, so we can stop walking.
+  const rel = candidate === root ? "" : candidate.slice(root.length + sep.length);
+  const segments = rel ? rel.split(sep) : [];
+  let current = root;
+  for (const seg of segments) {
+    current = `${current}${sep}${seg}`;
+    let st;
     try {
-      const real = await realpath(probe);
+      st = await lstat(current);
+    } catch {
+      // This component does not exist. Deeper components don't either; they will
+      // be created as plain files/dirs inside the validated jail. Safe to stop.
+      break;
+    }
+    if (st.isSymbolicLink()) {
+      let real: string;
+      try {
+        real = await realpath(current);
+      } catch {
+        // Dangling or otherwise unverifiable symlink — never trust it.
+        return {
+          ok: false,
+          error: `Refusing to write the secret: "${filePath}" passes through a symlink that cannot be verified to stay inside the allowed directory.`,
+        };
+      }
       if (real !== root && !real.startsWith(root + sep)) {
         return {
           ok: false,
           error: `Refusing to write the secret: "${filePath}" resolves through a symlink that escapes the allowed directory.`,
         };
       }
-      break; // first existing ancestor is contained → safe
-    } catch {
-      // probe doesn't exist; step up one level and retry.
-      const parent = dirname(probe);
-      if (parent === probe) break;
-      probe = parent;
+      // Symlink stays inside the jail: deeper components are re-checked on the
+      // next iterations (lstat naturally follows this contained intermediate
+      // link), so continue.
     }
-  }
-
-  // If the final target already exists, make sure it isn't itself a symlink out
-  // of the jail (realpath above only canonicalizes existing ancestors; an
-  // existing target symlink is caught here for the overwrite/append case).
-  try {
-    const st = await lstat(candidate);
-    if (st.isSymbolicLink()) {
-      const real = await realpath(candidate);
-      if (real !== root && !real.startsWith(root + sep)) {
-        return {
-          ok: false,
-          error: `Refusing to write the secret: "${filePath}" is a symlink that escapes the allowed directory.`,
-        };
-      }
-    }
-  } catch {
-    // Target doesn't exist yet — fine, it will be created inside the jail.
   }
 
   return { ok: true, abs: candidate };
@@ -914,8 +924,10 @@ async function handleVoiceContextDelete(params: {
  *   2. Filesystem: `filePath` is attacker-influenceable (the tool is reachable
  *      from inbound chat). confineSecretPath() jails every write under an
  *      operator-approved root, rejecting `..`, absolute-elsewhere, and symlink
- *      escapes BEFORE the secret is ever resolved. The file is created 0o600 so
- *      a plaintext key is not left world/group readable.
+ *      escapes (including dangling/unverifiable links) BEFORE the secret is ever
+ *      resolved. The write opens the target with O_NOFOLLOW to close any TOCTOU
+ *      symlink swap, and the file is created 0o600 so a plaintext key is not
+ *      left world/group readable.
  *
  * Use-time resolution: resolveSecret is called on every invocation, so the
  * latest value is always written (owner key rotation takes effect with no
@@ -989,15 +1001,27 @@ async function handleWriteSecret(params: {
     if (dir && dir !== "." && dir !== absPath) {
       await mkdir(dir, { recursive: true });
     }
-    if (params.mode === "append") {
-      await appendFile(absPath, content, { encoding: "utf8", mode: SECRET_FILE_MODE });
-    } else {
-      await writeFile(absPath, content, { encoding: "utf8", mode: SECRET_FILE_MODE });
+    // 🔴 TOCTOU close-out: confineSecretPath() validated the path, but between
+    // that check and the write an attacker with filesystem access could swap the
+    // target for a symlink. We open the final component with O_NOFOLLOW so the
+    // kernel refuses to follow a symlink AT the target — the write either lands
+    // on the real in-jail file or fails (ELOOP), never on a redirected target.
+    // O_CREAT applies the 0o600 mode atomically on creation.
+    const flags =
+      (params.mode === "append"
+        ? fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_APPEND
+        : fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_TRUNC) |
+      fsConstants.O_NOFOLLOW;
+    const handle = await open(absPath, flags, SECRET_FILE_MODE);
+    try {
+      await handle.write(content, null, "utf8");
+      // writeFile/open's `mode` only applies when CREATING the file; a
+      // pre-existing target keeps its old perms. fchmod unconditionally so a
+      // plaintext key is always owner-only (0o600), never world-readable.
+      await handle.chmod(SECRET_FILE_MODE);
+    } finally {
+      await handle.close();
     }
-    // writeFile/appendFile's `mode` only applies when CREATING the file; a
-    // pre-existing target keeps its old perms. chmod unconditionally so a
-    // plaintext key is always owner-only (0o600), never world-readable.
-    await chmod(absPath, SECRET_FILE_MODE);
   } catch (err) {
     // A write error message can include the path but never the content.
     return makeError(

--- a/src/agent-tools.ts
+++ b/src/agent-tools.ts
@@ -41,8 +41,8 @@ import {
   resolveSecret,
 } from "./api-fetch.js";
 import { broadcastGroupMdUpdate, broadcastThreadMdUpdate } from "./group-md.js";
-import { mkdir, writeFile, appendFile } from "node:fs/promises";
-import { dirname } from "node:path";
+import { mkdir, writeFile, appendFile, chmod, realpath, lstat } from "node:fs/promises";
+import { dirname, resolve as resolvePath, isAbsolute, sep } from "node:path";
 
 import type { OpenClawConfig } from "openclaw/plugin-sdk";
 import { DEFAULT_ACCOUNT_ID } from "./sdk-compat.js";
@@ -55,6 +55,104 @@ import { DEFAULT_ACCOUNT_ID } from "./sdk-compat.js";
  * tool, never in the tool's arguments or return value.
  */
 const SECRET_PLACEHOLDER = "{{secret}}";
+
+/**
+ * Permissions for a freshly created secret file: owner read/write only (0o600).
+ * A file that now holds a plaintext API key must not be world/group readable.
+ */
+const SECRET_FILE_MODE = 0o600;
+
+/**
+ * Confine a caller-supplied write target to an operator-approved jail root.
+ *
+ * 🔴 SECURITY (P0): `filePath` comes from the LLM tool call, which is reachable
+ * via inbound group-chat messages — an untrusted, prompt-injectable surface.
+ * Without confinement, `write-secret` is an arbitrary-file-write of the owner's
+ * plaintext secret (e.g. "append my key to ~/.bashrc" / ".ssh/authorized_keys"
+ * / a web root). We therefore resolve the requested path against a fixed root
+ * (`secretsFileRoot` from config, else the plugin process CWD) and reject
+ * anything that escapes it — including `..` traversal, absolute paths pointing
+ * elsewhere, and symlink escapes.
+ *
+ * Returns the safe absolute path, or an error string describing the rejection
+ * (never echoing secret material — only the caller-typed path).
+ */
+async function confineSecretPath(
+  filePath: string,
+  rootInput: string | undefined,
+): Promise<{ ok: true; abs: string } | { ok: false; error: string }> {
+  // The jail root: operator config wins; otherwise the plugin's working dir.
+  // Resolve it to an absolute, symlink-free canonical form so containment
+  // checks compare apples to apples.
+  const rootRaw = rootInput && rootInput.trim() ? rootInput.trim() : process.cwd();
+  let root: string;
+  try {
+    root = await realpath(resolvePath(rootRaw));
+  } catch {
+    // Root doesn't exist yet (or isn't reachable): fall back to its lexical
+    // absolute form. We can still enforce containment lexically below.
+    root = resolvePath(rootRaw);
+  }
+
+  // Resolve the requested path against the root. resolvePath collapses any
+  // `..`/`.` segments; an absolute `filePath` replaces the root entirely, which
+  // the containment check below then rejects unless it still lands inside root.
+  const candidate = resolvePath(root, filePath);
+
+  // Lexical containment: candidate must be the root itself or sit strictly
+  // beneath it. This already defeats `..` traversal and absolute-elsewhere.
+  if (candidate !== root && !candidate.startsWith(root + sep)) {
+    return {
+      ok: false,
+      error: `Refusing to write the secret outside the allowed directory. "${filePath}" resolves outside the permitted root. Use a path inside the workspace.`,
+    };
+  }
+
+  // Symlink-escape guard: walk up to the nearest existing ancestor and
+  // canonicalize it. If a real path component is a symlink pointing out of the
+  // jail, the canonical form will fall outside root and we reject.
+  let probe = candidate;
+  // Find the deepest ancestor that exists on disk.
+  // (candidate itself may not exist yet for overwrite/append-create.)
+  // We stop at root because root is already canonical.
+  while (probe !== root && probe.startsWith(root + sep)) {
+    try {
+      const real = await realpath(probe);
+      if (real !== root && !real.startsWith(root + sep)) {
+        return {
+          ok: false,
+          error: `Refusing to write the secret: "${filePath}" resolves through a symlink that escapes the allowed directory.`,
+        };
+      }
+      break; // first existing ancestor is contained → safe
+    } catch {
+      // probe doesn't exist; step up one level and retry.
+      const parent = dirname(probe);
+      if (parent === probe) break;
+      probe = parent;
+    }
+  }
+
+  // If the final target already exists, make sure it isn't itself a symlink out
+  // of the jail (realpath above only canonicalizes existing ancestors; an
+  // existing target symlink is caught here for the overwrite/append case).
+  try {
+    const st = await lstat(candidate);
+    if (st.isSymbolicLink()) {
+      const real = await realpath(candidate);
+      if (real !== root && !real.startsWith(root + sep)) {
+        return {
+          ok: false,
+          error: `Refusing to write the secret: "${filePath}" is a symlink that escapes the allowed directory.`,
+        };
+      }
+    }
+  } catch {
+    // Target doesn't exist yet — fine, it will be created inside the jail.
+  }
+
+  return { ok: true, abs: candidate };
+}
 
 // ---------------------------------------------------------------------------
 // Types
@@ -202,8 +300,10 @@ export function createOctoManagementTools(params: {
         filePath: {
           type: "string",
           description:
-            "For write-secret only. Absolute or workspace-relative path of the local file to write the secret into. " +
-            "Choose the path based on the user's instruction (e.g. a .env file, a config file).",
+            "For write-secret only. Path of the local file to write the secret into, relative to the " +
+            "configured workspace root (e.g. \".env\" or \"config/keys.json\"). Choose the path based on the " +
+            "user's instruction. Writes are confined to the workspace root: paths that escape it (via '..', " +
+            "an absolute path elsewhere, or a symlink) are rejected.",
         },
         template: {
           type: "string",
@@ -546,6 +646,19 @@ export function createOctoManagementTools(params: {
               return makeError("filePath is required for write-secret");
             }
             const template = args.template as string | undefined;
+            // A provided, non-empty template MUST contain the placeholder.
+            // Otherwise we'd silently discard the caller's intended layout and
+            // write the bare secret — surprising, and prone to malformed config
+            // files. Whitespace-only is treated as "omitted" (write raw).
+            if (
+              template !== undefined &&
+              template.trim().length > 0 &&
+              !template.includes(SECRET_PLACEHOLDER)
+            ) {
+              return makeError(
+                `template was provided but does not contain the ${SECRET_PLACEHOLDER} placeholder. Include ${SECRET_PLACEHOLDER} where the secret should go, or omit template to write the raw value.`,
+              );
+            }
             const rawMode = args.mode as string | undefined;
             if (rawMode !== undefined && rawMode !== "overwrite" && rawMode !== "append") {
               return makeError(
@@ -559,6 +672,7 @@ export function createOctoManagementTools(params: {
               filePath,
               template,
               mode: rawMode === "append" ? "append" : "overwrite",
+              secretsFileRoot: account.config.secretsFileRoot,
             });
           }
 
@@ -788,16 +902,20 @@ async function handleVoiceContextDelete(params: {
  * Resolve a user-managed secret alias and write its current plaintext into a
  * local file.
  *
- * 🔴 RED LINE — plaintext containment:
- * The resolved secret value is read from resolveSecret(), substituted into the
- * (optional) caller template, and written to disk. It is consumed ENTIRELY
- * inside this function. The ToolResult returned to the LLM contains only:
- *   - success: { written: true, path, bytesWritten, display_name?, mode }
- *   - structured non-plaintext feedback for the not_found / ambiguous /
- *     resolve-failure cases.
- * The plaintext value, the rendered file content, and the template-with-secret
- * are NEVER placed in the return value, so they cannot reach the transcript /
- * Octo. `bytesWritten` is a length only — it carries no secret material.
+ * 🔴 RED LINE — plaintext containment (two channels, both closed):
+ *   1. Transcript: the resolved value is read from resolveSecret(), substituted
+ *      into the (optional) caller template, and written to disk. It is consumed
+ *      ENTIRELY inside this function. The ToolResult returned to the LLM
+ *      contains only { written, path, mode, display_name? } on success and
+ *      structured non-plaintext feedback otherwise — never the value, the
+ *      rendered content, or the template-with-secret, so nothing reaches the
+ *      transcript / Octo. (No length field either: a byte count is
+ *      secret-derived metadata, so we omit it.)
+ *   2. Filesystem: `filePath` is attacker-influenceable (the tool is reachable
+ *      from inbound chat). confineSecretPath() jails every write under an
+ *      operator-approved root, rejecting `..`, absolute-elsewhere, and symlink
+ *      escapes BEFORE the secret is ever resolved. The file is created 0o600 so
+ *      a plaintext key is not left world/group readable.
  *
  * Use-time resolution: resolveSecret is called on every invocation, so the
  * latest value is always written (owner key rotation takes effect with no
@@ -810,7 +928,16 @@ async function handleWriteSecret(params: {
   filePath: string;
   template?: string;
   mode: "overwrite" | "append";
+  secretsFileRoot?: string;
 }): Promise<ToolResult> {
+  // Confine the destination BEFORE resolving the secret. If the path is unsafe
+  // we never fetch the plaintext at all — minimizing its lifetime.
+  const confined = await confineSecretPath(params.filePath, params.secretsFileRoot);
+  if (!confined.ok) {
+    return makeError(confined.error);
+  }
+  const absPath = confined.abs;
+
   let resolved;
   try {
     resolved = await resolveSecret({
@@ -820,7 +947,8 @@ async function handleWriteSecret(params: {
     });
   } catch (err) {
     // resolve failure (5xx / malformed / transport). Surface a non-plaintext,
-    // actionable hint — never the underlying value (a failure has none).
+    // actionable hint. The underlying error carries only an HTTP status (the
+    // resolve client deliberately drops response bodies), never a value.
     return makeError(
       `Could not resolve secret "${params.alias}". The key service is unavailable or the secret may need to be re-set. Ask the user to re-add the key, then retry. (${
         err instanceof Error ? err.message : String(err)
@@ -848,24 +976,28 @@ async function handleWriteSecret(params: {
   }
 
   // resolved → substitute into template (or use raw value) and write to disk.
-  // From here the plaintext lives only in local variables and the file.
+  // From here the plaintext lives only in local variables and the file. A
+  // provided template without the placeholder was already rejected upstream, so
+  // here `includes` only gates the "template omitted → write raw" case.
   const content =
     params.template && params.template.includes(SECRET_PLACEHOLDER)
       ? params.template.split(SECRET_PLACEHOLDER).join(resolved.value)
       : resolved.value;
 
-  const bytesWritten = Buffer.byteLength(content, "utf8");
-
   try {
-    const dir = dirname(params.filePath);
-    if (dir && dir !== "." && dir !== params.filePath) {
+    const dir = dirname(absPath);
+    if (dir && dir !== "." && dir !== absPath) {
       await mkdir(dir, { recursive: true });
     }
     if (params.mode === "append") {
-      await appendFile(params.filePath, content, "utf8");
+      await appendFile(absPath, content, { encoding: "utf8", mode: SECRET_FILE_MODE });
     } else {
-      await writeFile(params.filePath, content, "utf8");
+      await writeFile(absPath, content, { encoding: "utf8", mode: SECRET_FILE_MODE });
     }
+    // writeFile/appendFile's `mode` only applies when CREATING the file; a
+    // pre-existing target keeps its old perms. chmod unconditionally so a
+    // plaintext key is always owner-only (0o600), never world-readable.
+    await chmod(absPath, SECRET_FILE_MODE);
   } catch (err) {
     // A write error message can include the path but never the content.
     return makeError(
@@ -875,12 +1007,12 @@ async function handleWriteSecret(params: {
     );
   }
 
-  // 🔴 Success payload is plaintext-free by construction.
+  // 🔴 Success payload is plaintext-free by construction (no value, no rendered
+  // content, no byte length).
   return makeSuccess({
     written: true,
-    path: params.filePath,
+    path: absPath,
     mode: params.mode,
-    bytesWritten,
     ...(resolved.display_name ? { display_name: resolved.display_name } : {}),
   });
 }

--- a/src/agent-tools.ts
+++ b/src/agent-tools.ts
@@ -38,11 +38,23 @@ import {
   deleteVoiceContext,
   getThreadMd,
   updateThreadMd,
+  resolveSecret,
 } from "./api-fetch.js";
 import { broadcastGroupMdUpdate, broadcastThreadMdUpdate } from "./group-md.js";
+import { mkdir, writeFile, appendFile } from "node:fs/promises";
+import { dirname } from "node:path";
 
 import type { OpenClawConfig } from "openclaw/plugin-sdk";
 import { DEFAULT_ACCOUNT_ID } from "./sdk-compat.js";
+
+/**
+ * Placeholder token replaced by the resolved plaintext secret inside the
+ * caller-supplied write template. Using an explicit token keeps the LLM in
+ * control of *how* the secret is laid out in the file (env line, JSON field,
+ * raw value, …) while the plaintext itself only ever materializes inside the
+ * tool, never in the tool's arguments or return value.
+ */
+const SECRET_PLACEHOLDER = "{{secret}}";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -88,7 +100,11 @@ export function createOctoManagementTools(params: {
     description:
       "Manage Octo groups and personal voice correction context: list groups, get group info/members, " +
       "read or update GROUP.md (group-level and thread-level), and manage personal voice correction context. " +
-      "Use this tool for any Octo management operations.",
+      "Use this tool for any Octo management operations. " +
+      "It also handles user-managed secrets (external API keys): when the user asks to write one of THEIR " +
+      "stored keys into a local file, call action 'write-secret' and pass the user's ALIAS for the key " +
+      "(the display name they used, e.g. \"my openai key\"), never a raw secret value. The tool fetches the " +
+      "current value internally and writes it to the file; the plaintext is NEVER returned to you.",
     parameters: {
       type: "object",
       properties: {
@@ -117,6 +133,7 @@ export function createOctoManagementTools(params: {
             "voice-context-read",
             "voice-context-update",
             "voice-context-delete",
+            "write-secret",
           ],
           description: "The management action to perform.",
         },
@@ -174,6 +191,34 @@ export function createOctoManagementTools(params: {
           type: "string",
           description:
             "Required when multiple Octo accounts are configured. Use the exact accountId from the current Octo context; casing is normalized when unambiguous. Omit when only one account is configured.",
+        },
+        alias: {
+          type: "string",
+          description:
+            "For write-secret only. The user's alias for one of THEIR stored secrets — the display name they " +
+            "referred to it by (e.g. \"openai key\"), or a secret_id returned by a previous ambiguous result. " +
+            "🔴 Pass the alias, NEVER a raw secret value: the tool resolves the current plaintext internally.",
+        },
+        filePath: {
+          type: "string",
+          description:
+            "For write-secret only. Absolute or workspace-relative path of the local file to write the secret into. " +
+            "Choose the path based on the user's instruction (e.g. a .env file, a config file).",
+        },
+        template: {
+          type: "string",
+          description:
+            "For write-secret only. Optional layout for what gets written, with the placeholder " +
+            "'{{secret}}' marking where the resolved value goes (e.g. \"OPENAI_API_KEY={{secret}}\\n\" " +
+            "or '{\"apiKey\":\"{{secret}}\"}'). If omitted, the raw secret value is written verbatim. " +
+            "🔴 Do NOT put the secret value here — only the '{{secret}}' placeholder.",
+        },
+        mode: {
+          type: "string",
+          enum: ["overwrite", "append"],
+          description:
+            "For write-secret only. 'overwrite' (default) replaces the file contents; 'append' adds to the end " +
+            "(useful for adding a line to an existing .env). Omit to overwrite.",
         },
       },
       required: ["action"],
@@ -491,6 +536,32 @@ export function createOctoManagementTools(params: {
           case "voice-context-delete":
             return await handleVoiceContextDelete({ apiUrl, botToken });
 
+          case "write-secret": {
+            const alias = (args.alias as string | undefined)?.trim();
+            if (!alias) {
+              return makeError("alias is required for write-secret");
+            }
+            const filePath = (args.filePath as string | undefined)?.trim();
+            if (!filePath) {
+              return makeError("filePath is required for write-secret");
+            }
+            const template = args.template as string | undefined;
+            const rawMode = args.mode as string | undefined;
+            if (rawMode !== undefined && rawMode !== "overwrite" && rawMode !== "append") {
+              return makeError(
+                `Invalid mode "${rawMode}" for write-secret; use "overwrite" or "append"`,
+              );
+            }
+            return await handleWriteSecret({
+              apiUrl,
+              botToken,
+              alias,
+              filePath,
+              template,
+              mode: rawMode === "append" ? "append" : "overwrite",
+            });
+          }
+
           default:
             return makeError(`Unknown action: ${action}`);
         }
@@ -707,6 +778,111 @@ async function handleVoiceContextDelete(params: {
     botToken: params.botToken,
   });
   return makeSuccess({ deleted: true });
+}
+
+// ---------------------------------------------------------------------------
+// Secret Write Handler
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve a user-managed secret alias and write its current plaintext into a
+ * local file.
+ *
+ * 🔴 RED LINE — plaintext containment:
+ * The resolved secret value is read from resolveSecret(), substituted into the
+ * (optional) caller template, and written to disk. It is consumed ENTIRELY
+ * inside this function. The ToolResult returned to the LLM contains only:
+ *   - success: { written: true, path, bytesWritten, display_name?, mode }
+ *   - structured non-plaintext feedback for the not_found / ambiguous /
+ *     resolve-failure cases.
+ * The plaintext value, the rendered file content, and the template-with-secret
+ * are NEVER placed in the return value, so they cannot reach the transcript /
+ * Octo. `bytesWritten` is a length only — it carries no secret material.
+ *
+ * Use-time resolution: resolveSecret is called on every invocation, so the
+ * latest value is always written (owner key rotation takes effect with no
+ * restart and no cache to invalidate).
+ */
+async function handleWriteSecret(params: {
+  apiUrl: string;
+  botToken: string;
+  alias: string;
+  filePath: string;
+  template?: string;
+  mode: "overwrite" | "append";
+}): Promise<ToolResult> {
+  let resolved;
+  try {
+    resolved = await resolveSecret({
+      apiUrl: params.apiUrl,
+      botToken: params.botToken,
+      alias: params.alias,
+    });
+  } catch (err) {
+    // resolve failure (5xx / malformed / transport). Surface a non-plaintext,
+    // actionable hint — never the underlying value (a failure has none).
+    return makeError(
+      `Could not resolve secret "${params.alias}". The key service is unavailable or the secret may need to be re-set. Ask the user to re-add the key, then retry. (${
+        err instanceof Error ? err.message : String(err)
+      })`,
+    );
+  }
+
+  // not_found → guide the user to add the secret first. Echo only the alias the
+  // user already typed (not sensitive).
+  if (resolved.status === "not_found") {
+    return makeError(
+      `No stored secret matches "${params.alias}". Ask the user to add this key first (e.g. via the Octo secrets settings), then try again.`,
+    );
+  }
+
+  // ambiguous → hand back ONLY the labels so the LLM can ask the user which one.
+  // 🔴 candidates carry display_name (+ secret_id) only, never the value.
+  if (resolved.status === "ambiguous") {
+    return makeSuccess({
+      written: false,
+      ambiguous: true,
+      message: `Multiple stored secrets match "${params.alias}". Ask the user which one, then retry write-secret with the chosen display_name (or its secret_id).`,
+      candidates: resolved.candidates,
+    });
+  }
+
+  // resolved → substitute into template (or use raw value) and write to disk.
+  // From here the plaintext lives only in local variables and the file.
+  const content =
+    params.template && params.template.includes(SECRET_PLACEHOLDER)
+      ? params.template.split(SECRET_PLACEHOLDER).join(resolved.value)
+      : resolved.value;
+
+  const bytesWritten = Buffer.byteLength(content, "utf8");
+
+  try {
+    const dir = dirname(params.filePath);
+    if (dir && dir !== "." && dir !== params.filePath) {
+      await mkdir(dir, { recursive: true });
+    }
+    if (params.mode === "append") {
+      await appendFile(params.filePath, content, "utf8");
+    } else {
+      await writeFile(params.filePath, content, "utf8");
+    }
+  } catch (err) {
+    // A write error message can include the path but never the content.
+    return makeError(
+      `Resolved the secret but failed to write it to "${params.filePath}": ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+  }
+
+  // 🔴 Success payload is plaintext-free by construction.
+  return makeSuccess({
+    written: true,
+    path: params.filePath,
+    mode: params.mode,
+    bytesWritten,
+    ...(resolved.display_name ? { display_name: resolved.display_name } : {}),
+  });
 }
 
 // ---------------------------------------------------------------------------

--- a/src/agent-tools.ts
+++ b/src/agent-tools.ts
@@ -43,7 +43,7 @@ import {
 import { broadcastGroupMdUpdate, broadcastThreadMdUpdate } from "./group-md.js";
 import { mkdir, realpath, lstat, open } from "node:fs/promises";
 import { constants as fsConstants } from "node:fs";
-import { dirname, resolve as resolvePath, sep } from "node:path";
+import { basename, dirname, relative, resolve as resolvePath, sep } from "node:path";
 
 import type { OpenClawConfig } from "openclaw/plugin-sdk";
 import { DEFAULT_ACCOUNT_ID } from "./sdk-compat.js";
@@ -83,7 +83,7 @@ const SECRET_FILE_MODE = 0o600;
 async function confineSecretPath(
   filePath: string,
   rootInput: string | undefined,
-): Promise<{ ok: true; abs: string } | { ok: false; error: string }> {
+): Promise<{ ok: true; abs: string; root: string } | { ok: false; error: string }> {
   // The jail root: operator config wins; otherwise the plugin's working dir.
   // Resolve it to an absolute, symlink-free canonical form so containment
   // checks compare apples to apples.
@@ -161,7 +161,7 @@ async function confineSecretPath(
     }
   }
 
-  return { ok: true, abs: candidate };
+  return { ok: true, abs: candidate, root };
 }
 
 // ---------------------------------------------------------------------------
@@ -949,6 +949,7 @@ async function handleWriteSecret(params: {
     return makeError(confined.error);
   }
   const absPath = confined.abs;
+  const root = confined.root;
 
   let resolved;
   try {
@@ -998,21 +999,37 @@ async function handleWriteSecret(params: {
 
   try {
     const dir = dirname(absPath);
+    let openTarget = absPath;
     if (dir && dir !== "." && dir !== absPath) {
       await mkdir(dir, { recursive: true });
+      // 🔴 TOCTOU close-out for INTERMEDIATE components. O_NOFOLLOW below only
+      // protects the final basename — the kernel still follows any symlink on
+      // the parent path. confineSecretPath() walked the path BEFORE mkdir, when
+      // the parent dirs did not yet exist, so a symlink swapped onto a parent
+      // AFTER mkdir creates it (and before open) would redirect the write out of
+      // the jail. Re-canonicalize the parent now that it is on disk and re-check
+      // containment, then open via the canonical parent + basename so every
+      // component is proven to stay inside the root.
+      const realDir = await realpath(dir);
+      if (realDir !== root && !realDir.startsWith(root + sep)) {
+        return makeError(
+          "Refusing to write the secret: the destination directory escaped the allowed root after creation.",
+        );
+      }
+      openTarget = resolvePath(realDir, basename(absPath));
     }
-    // 🔴 TOCTOU close-out: confineSecretPath() validated the path, but between
-    // that check and the write an attacker with filesystem access could swap the
-    // target for a symlink. We open the final component with O_NOFOLLOW so the
-    // kernel refuses to follow a symlink AT the target — the write either lands
-    // on the real in-jail file or fails (ELOOP), never on a redirected target.
-    // O_CREAT applies the 0o600 mode atomically on creation.
+    // 🔴 TOCTOU close-out for the LEAF: confineSecretPath() validated the path,
+    // but between that check and the write an attacker with filesystem access
+    // could swap the target for a symlink. We open the final component with
+    // O_NOFOLLOW so the kernel refuses to follow a symlink AT the target — the
+    // write either lands on the real in-jail file or fails (ELOOP), never on a
+    // redirected target. O_CREAT applies the 0o600 mode atomically on creation.
     const flags =
       (params.mode === "append"
         ? fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_APPEND
         : fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_TRUNC) |
       fsConstants.O_NOFOLLOW;
-    const handle = await open(absPath, flags, SECRET_FILE_MODE);
+    const handle = await open(openTarget, flags, SECRET_FILE_MODE);
     try {
       await handle.write(content, null, "utf8");
       // writeFile/open's `mode` only applies when CREATING the file; a
@@ -1023,19 +1040,22 @@ async function handleWriteSecret(params: {
       await handle.close();
     }
   } catch (err) {
-    // A write error message can include the path but never the content.
+    // A write error message can include the path but never the content. Echo the
+    // jail-relative path only — never the absolute path, which would leak the
+    // operator's jail root into the LLM-visible transcript.
     return makeError(
-      `Resolved the secret but failed to write it to "${params.filePath}": ${
+      `Resolved the secret but failed to write it to "${relative(root, absPath)}": ${
         err instanceof Error ? err.message : String(err)
       }`,
     );
   }
 
   // 🔴 Success payload is plaintext-free by construction (no value, no rendered
-  // content, no byte length).
+  // content, no byte length). The path is jail-relative so the absolute jail
+  // root is never disclosed to the LLM / transcript.
   return makeSuccess({
     written: true,
-    path: absPath,
+    path: relative(root, absPath),
     mode: params.mode,
     ...(resolved.display_name ? { display_name: resolved.display_name } : {}),
   });

--- a/src/agent-tools.ts
+++ b/src/agent-tools.ts
@@ -42,7 +42,7 @@ import {
 } from "./api-fetch.js";
 import { broadcastGroupMdUpdate, broadcastThreadMdUpdate } from "./group-md.js";
 import { mkdir, writeFile, appendFile, chmod, realpath, lstat } from "node:fs/promises";
-import { dirname, resolve as resolvePath, isAbsolute, sep } from "node:path";
+import { dirname, resolve as resolvePath, sep } from "node:path";
 
 import type { OpenClawConfig } from "openclaw/plugin-sdk";
 import { DEFAULT_ACCOUNT_ID } from "./sdk-compat.js";

--- a/src/api-fetch.test.ts
+++ b/src/api-fetch.test.ts
@@ -1612,18 +1612,32 @@ describe("resolveSecret", () => {
     }
   });
 
-  it("throws on a 5xx (resolve failure) without leaking a value", async () => {
+  it("throws on a 5xx (resolve failure) without leaking the response body", async () => {
+    // A resolve-endpoint error body could echo a secret-bearing diagnostic.
+    // The thrown error must carry ONLY the HTTP status, never this body.
+    const LEAK = "sk-live-LEAKED-IN-ERROR-BODY";
+    const textSpy = vi.fn().mockResolvedValue(`{"error":"${LEAK}"}`);
     global.fetch = vi.fn().mockResolvedValue({
       ok: false,
       status: 500,
       statusText: "Internal Server Error",
-      text: vi.fn().mockResolvedValue("boom"),
+      text: textSpy,
     }) as unknown as typeof fetch;
 
     const { resolveSecret } = await import("./api-fetch.js");
-    await expect(
-      resolveSecret({ apiUrl: "http://api.test", botToken: "t", alias: "x" }),
-    ).rejects.toThrow(/resolveSecret failed \(500\)/);
+    let caught: unknown;
+    await resolveSecret({ apiUrl: "http://api.test", botToken: "t", alias: "x" }).catch(
+      (e) => {
+        caught = e;
+      },
+    );
+    expect(caught).toBeInstanceOf(Error);
+    const message = (caught as Error).message;
+    expect(message).toMatch(/resolveSecret failed \(500\)/);
+    // 🔴 The body — and anything in it — must not appear in the error.
+    expect(message).not.toContain(LEAK);
+    // We don't even read the body, so it can't leak by accident.
+    expect(textSpy).not.toHaveBeenCalled();
   });
 
   it("throws when a resolved secret has no value", async () => {
@@ -1631,6 +1645,19 @@ describe("resolveSecret", () => {
       ok: true,
       status: 200,
       json: vi.fn().mockResolvedValue({ status: "resolved" }),
+    }) as unknown as typeof fetch;
+
+    const { resolveSecret } = await import("./api-fetch.js");
+    await expect(
+      resolveSecret({ apiUrl: "http://api.test", botToken: "t", alias: "x" }),
+    ).rejects.toThrow(/no value/);
+  });
+
+  it("throws when a resolved secret has an empty value", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: vi.fn().mockResolvedValue({ status: "resolved", value: "" }),
     }) as unknown as typeof fetch;
 
     const { resolveSecret } = await import("./api-fetch.js");

--- a/src/api-fetch.test.ts
+++ b/src/api-fetch.test.ts
@@ -1506,3 +1506,149 @@ describe("getMentionPref", () => {
     expect(seenSignal!.aborted).toBe(true);
   }, 10_000);
 });
+
+describe("resolveSecret", () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it("returns resolved value on a resolved response", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: vi.fn().mockResolvedValue({
+        status: "resolved",
+        value: "sk-live-PLAINTEXT",
+        secret_id: "sec_1",
+        display_name: "openai key",
+      }),
+    }) as unknown as typeof fetch;
+
+    const { resolveSecret } = await import("./api-fetch.js");
+    const result = await resolveSecret({
+      apiUrl: "http://api.test",
+      botToken: "bf_token",
+      alias: "openai key",
+    });
+
+    expect(result.status).toBe("resolved");
+    if (result.status === "resolved") {
+      expect(result.value).toBe("sk-live-PLAINTEXT");
+      expect(result.secret_id).toBe("sec_1");
+      expect(result.display_name).toBe("openai key");
+    }
+  });
+
+  it("POSTs the alias with a bearer bot token", async () => {
+    const spy = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: vi.fn().mockResolvedValue({ status: "not_found" }),
+    });
+    global.fetch = spy as unknown as typeof fetch;
+
+    const { resolveSecret } = await import("./api-fetch.js");
+    await resolveSecret({ apiUrl: "http://api.test/", botToken: "bf_token", alias: "k" });
+
+    const [url, init] = spy.mock.calls[0];
+    expect(url).toBe("http://api.test/v1/bot/secrets/resolve");
+    expect(init.method).toBe("POST");
+    expect(init.headers.Authorization).toBe("Bearer bf_token");
+    expect(JSON.parse(init.body)).toEqual({ alias: "k" });
+  });
+
+  it("normalizes status:not_found", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: vi.fn().mockResolvedValue({ status: "not_found" }),
+    }) as unknown as typeof fetch;
+
+    const { resolveSecret } = await import("./api-fetch.js");
+    const result = await resolveSecret({ apiUrl: "http://api.test", botToken: "t", alias: "x" });
+    expect(result.status).toBe("not_found");
+  });
+
+  it("normalizes a 404 to not_found (endpoint not deployed / unknown alias)", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 404,
+      text: vi.fn().mockResolvedValue("not found"),
+    }) as unknown as typeof fetch;
+
+    const { resolveSecret } = await import("./api-fetch.js");
+    const result = await resolveSecret({ apiUrl: "http://api.test", botToken: "t", alias: "x" });
+    expect(result.status).toBe("not_found");
+  });
+
+  it("returns label-only candidates for an ambiguous match (no value field)", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: vi.fn().mockResolvedValue({
+        status: "ambiguous",
+        candidates: [
+          { secret_id: "a", display_name: "openai prod" },
+          { secret_id: "b", display_name: "openai test" },
+          { display_name: "" }, // dropped: no label
+        ],
+      }),
+    }) as unknown as typeof fetch;
+
+    const { resolveSecret } = await import("./api-fetch.js");
+    const result = await resolveSecret({ apiUrl: "http://api.test", botToken: "t", alias: "openai" });
+    expect(result.status).toBe("ambiguous");
+    if (result.status === "ambiguous") {
+      expect(result.candidates).toHaveLength(2);
+      expect(result.candidates[0]).toEqual({ secret_id: "a", display_name: "openai prod" });
+      // No plaintext leaks into candidates.
+      expect(JSON.stringify(result.candidates)).not.toContain("value");
+    }
+  });
+
+  it("throws on a 5xx (resolve failure) without leaking a value", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: "Internal Server Error",
+      text: vi.fn().mockResolvedValue("boom"),
+    }) as unknown as typeof fetch;
+
+    const { resolveSecret } = await import("./api-fetch.js");
+    await expect(
+      resolveSecret({ apiUrl: "http://api.test", botToken: "t", alias: "x" }),
+    ).rejects.toThrow(/resolveSecret failed \(500\)/);
+  });
+
+  it("throws when a resolved secret has no value", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: vi.fn().mockResolvedValue({ status: "resolved" }),
+    }) as unknown as typeof fetch;
+
+    const { resolveSecret } = await import("./api-fetch.js");
+    await expect(
+      resolveSecret({ apiUrl: "http://api.test", botToken: "t", alias: "x" }),
+    ).rejects.toThrow(/no value/);
+  });
+
+  it("throws on an unknown status", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: vi.fn().mockResolvedValue({ status: "weird" }),
+    }) as unknown as typeof fetch;
+
+    const { resolveSecret } = await import("./api-fetch.js");
+    await expect(
+      resolveSecret({ apiUrl: "http://api.test", botToken: "t", alias: "x" }),
+    ).rejects.toThrow(/unknown status/);
+  });
+});

--- a/src/api-fetch.ts
+++ b/src/api-fetch.ts
@@ -936,10 +936,10 @@ export type ResolveSecretResult =
  *  - any other non-2xx → throws (caller surfaces a non-plaintext "resolve
  *    failed, please re-set" message)
  *
- * 🔴 SECURITY: on a non-2xx the thrown Error message contains only the HTTP
- * status and the (resolve-failure) response body — never a resolved value,
- * because a resolved value is only ever delivered inside a 2xx body that we
- * parse rather than throw.
+ * 🔴 SECURITY: on a non-2xx the thrown Error message contains ONLY the HTTP
+ * status — never the response body and never a resolved value. The body is
+ * deliberately dropped because this error reaches an LLM-visible tool result
+ * and a resolve-endpoint error body could carry secret-bearing diagnostics.
  */
 export async function resolveSecret(params: {
   apiUrl: string;
@@ -966,10 +966,11 @@ export async function resolveSecret(params: {
     return { status: "not_found" };
   }
   if (!resp.ok) {
-    const text = await resp.text().catch(() => "");
-    throw new Error(
-      `resolveSecret failed (${resp.status}): ${text || resp.statusText}`,
-    );
+    // 🔴 SECURITY: never fold the response body into the error. A resolve
+    // endpoint handles plaintext secrets; a 5xx/diagnostic body could echo a
+    // resolved value or other sensitive material. This error bubbles up to an
+    // LLM-visible tool result, so it must carry the HTTP status ONLY — no body.
+    throw new Error(`resolveSecret failed (${resp.status})`);
   }
 
   const raw = (await resp.json().catch(() => null)) as Record<string, unknown> | null;
@@ -998,7 +999,7 @@ export async function resolveSecret(params: {
   }
 
   if (status === "resolved") {
-    if (typeof raw.value !== "string") {
+    if (typeof raw.value !== "string" || raw.value.length === 0) {
       throw new Error("resolveSecret resolved a secret with no value");
     }
     return {

--- a/src/api-fetch.ts
+++ b/src/api-fetch.ts
@@ -879,6 +879,139 @@ export async function getBotOboGrant(params: {
   };
 }
 
+// ---- Secret Resolve API (user-managed external keys) ----
+
+/**
+ * One candidate when an alias matches more than one stored secret.
+ *
+ * 🔴 SECURITY: candidates carry ONLY non-sensitive identifiers
+ * (display_name + secret_id). The plaintext secret value is NEVER part of a
+ * candidate — disambiguation happens on labels alone so nothing sensitive is
+ * surfaced while the caller is still deciding which secret to use.
+ */
+export interface SecretCandidate {
+  /** Stable opaque id of the secret (safe to echo back for re-resolution). */
+  secret_id?: string;
+  /** Human-facing label the owner gave the secret. Safe to show. */
+  display_name: string;
+}
+
+/**
+ * Result of resolving a secret alias for the bot's owner.
+ *
+ * Discriminated on `status`:
+ *  - `resolved`   → exactly one match; `value` holds the plaintext secret.
+ *  - `not_found`  → no secret matches the alias; the owner must add it first.
+ *  - `ambiguous`  → multiple matches; `candidates` lists labels for the caller
+ *                   to re-resolve against (no plaintext).
+ *
+ * 🔴 RED LINE: the `value` field on the `resolved` variant is the ONLY place
+ * plaintext appears. Callers must consume it internally (e.g. write it to a
+ * local file) and MUST NOT propagate it into any LLM-visible return value,
+ * transcript, message, or log. See agent-tools.ts `write-secret`.
+ */
+export type ResolveSecretResult =
+  | { status: "resolved"; value: string; secret_id?: string; display_name?: string }
+  | { status: "not_found" }
+  | { status: "ambiguous"; candidates: SecretCandidate[] };
+
+/**
+ * Resolve a user-managed external-key alias to its current plaintext value.
+ *
+ * POST /v1/bot/secrets/resolve  (octo-server YUJ-3538)
+ *
+ * Auth & ownership: the request carries only the plugin's bot token
+ * (`bf_...`). The server authenticates the bot and resolves the alias against
+ * the secrets owned by THAT bot's owner — the plugin never sends, sees, or
+ * needs the owner's identity beyond the token it already holds.
+ *
+ * Use-time resolution: this is called on every write so the latest plaintext
+ * is always fetched. If the owner rotates the key, the next call picks it up
+ * with zero restart and zero cache invalidation.
+ *
+ * Contract:
+ *  - 200 `{ status: "resolved", value, secret_id?, display_name? }`
+ *  - 200 `{ status: "ambiguous", candidates: [{ secret_id?, display_name }] }`
+ *  - 200 `{ status: "not_found" }` OR 404 → normalized to `{ status: "not_found" }`
+ *  - any other non-2xx → throws (caller surfaces a non-plaintext "resolve
+ *    failed, please re-set" message)
+ *
+ * 🔴 SECURITY: on a non-2xx the thrown Error message contains only the HTTP
+ * status and the (resolve-failure) response body — never a resolved value,
+ * because a resolved value is only ever delivered inside a 2xx body that we
+ * parse rather than throw.
+ */
+export async function resolveSecret(params: {
+  apiUrl: string;
+  botToken: string;
+  /** Alias the owner referenced: a display_name or a secret_id. */
+  alias: string;
+  signal?: AbortSignal;
+}): Promise<ResolveSecretResult> {
+  const url = `${params.apiUrl.replace(/\/+$/, "")}/v1/bot/secrets/resolve`;
+  const resp = await fetch(url, {
+    method: "POST",
+    headers: {
+      ...DEFAULT_HEADERS,
+      Authorization: `Bearer ${params.botToken}`,
+    },
+    body: JSON.stringify({ alias: params.alias }),
+    signal: params.signal ?? AbortSignal.timeout(DEFAULT_TIMEOUT_MS),
+  });
+
+  // 404 = alias not found for this owner (or endpoint not deployed yet during
+  // rollout). Both degrade to a benign "not_found" so the caller can guide the
+  // user to add the secret rather than surfacing a hard error.
+  if (resp.status === 404) {
+    return { status: "not_found" };
+  }
+  if (!resp.ok) {
+    const text = await resp.text().catch(() => "");
+    throw new Error(
+      `resolveSecret failed (${resp.status}): ${text || resp.statusText}`,
+    );
+  }
+
+  const raw = (await resp.json().catch(() => null)) as Record<string, unknown> | null;
+  if (!raw || typeof raw !== "object") {
+    throw new Error("resolveSecret returned an unparseable response");
+  }
+
+  const status = raw.status;
+
+  if (status === "not_found") {
+    return { status: "not_found" };
+  }
+
+  if (status === "ambiguous") {
+    const rawCandidates = Array.isArray(raw.candidates) ? raw.candidates : [];
+    const candidates: SecretCandidate[] = rawCandidates
+      .map((c) => {
+        const obj = (c ?? {}) as Record<string, unknown>;
+        const displayName = typeof obj.display_name === "string" ? obj.display_name : "";
+        const secretId = typeof obj.secret_id === "string" ? obj.secret_id : undefined;
+        return { display_name: displayName, secret_id: secretId };
+      })
+      // Drop entries with no label — a candidate the caller can't show is useless.
+      .filter((c) => c.display_name.length > 0);
+    return { status: "ambiguous", candidates };
+  }
+
+  if (status === "resolved") {
+    if (typeof raw.value !== "string") {
+      throw new Error("resolveSecret resolved a secret with no value");
+    }
+    return {
+      status: "resolved",
+      value: raw.value,
+      secret_id: typeof raw.secret_id === "string" ? raw.secret_id : undefined,
+      display_name: typeof raw.display_name === "string" ? raw.display_name : undefined,
+    };
+  }
+
+  throw new Error(`resolveSecret returned an unknown status: ${String(status)}`);
+}
+
 /** Decoded payload from base64 message content */
 interface SyncMessagePayload {
   type?: number;

--- a/src/api-fetch.ts
+++ b/src/api-fetch.ts
@@ -1010,7 +1010,11 @@ export async function resolveSecret(params: {
     };
   }
 
-  throw new Error(`resolveSecret returned an unknown status: ${String(status)}`);
+  // 🔴 SECURITY: never fold the server-supplied status string into the error.
+  // This error bubbles up to an LLM-visible tool result; echoing a
+  // server-controlled value back into the transcript is an injection vector.
+  // Use a fixed message — the unexpected status is unusable to the caller anyway.
+  throw new Error("resolveSecret returned an unknown status");
 }
 
 /** Decoded payload from base64 message content */

--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -14,7 +14,7 @@ export interface OctoAccountConfig {
   historyLimit?: number;  // 群聊历史消息条数限制（默认20）
   historyPromptTemplate?: string;  // Template for group history context injection
   onBehalfOf?: string;  // Persona clone: grantor uid — bot acts on behalf of this human
-  secretsFileRoot?: string;  // Jail root for write-secret: secret files may only be written under this absolute path. REQUIRED for write-secret — if unset, write-secret fails closed (no process.cwd() fallback).
+  secretsFileRoot?: string;  // Jail root for write-secret: secret files may only be written under this path. When unset, defaults to the agent's workspace (agents.list[].workspace matched to the agent, else agents.defaults.workspace); if neither resolves, write-secret fails closed (no process.cwd() fallback).
 }
 
 export interface OctoConfig {
@@ -39,6 +39,12 @@ export interface OctoConfig {
 export const DEFAULT_HISTORY_PROMPT_TEMPLATE =
   "[Group Chat History] Below are messages from others since your last reply (sender is user ID, body is message content):\n```json\n{messages}\n```\nPlease respond to the current @mention based on this context.\n\n";
 
+// Shared description for secretsFileRoot, kept identical to the wording in
+// openclaw.plugin.json so the Control UI and the runtime schema never drift
+// (manifest-schema-sync.test.ts asserts this).
+export const SECRETS_FILE_ROOT_DESCRIPTION =
+  "Jail root for write-secret: secret files may only be written under this path. When unset, defaults to the agent's workspace (agents.list[].workspace matched to the agent, else agents.defaults.workspace). If neither resolves to a usable directory, write-secret is unavailable (fail-closed); there is no process working-directory fallback.";
+
 // JSON Schema for OpenClaw plugin config validation
 export const OctoConfigJsonSchema = {
   schema: {
@@ -57,7 +63,7 @@ export const OctoConfigJsonSchema = {
       historyLimit: { type: "number", minimum: 1, maximum: 100 },
       historyPromptTemplate: { type: "string" },
       onBehalfOf: { type: "string" },
-      secretsFileRoot: { type: "string" },
+      secretsFileRoot: { type: "string", description: SECRETS_FILE_ROOT_DESCRIPTION },
       accounts: {
         type: "object",
         additionalProperties: {
@@ -76,7 +82,7 @@ export const OctoConfigJsonSchema = {
             historyLimit: { type: "number", minimum: 1, maximum: 100 },
             historyPromptTemplate: { type: "string" },
             onBehalfOf: { type: "string" },
-            secretsFileRoot: { type: "string" },
+            secretsFileRoot: { type: "string", description: SECRETS_FILE_ROOT_DESCRIPTION },
           },
         },
       },

--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -14,7 +14,7 @@ export interface OctoAccountConfig {
   historyLimit?: number;  // 群聊历史消息条数限制（默认20）
   historyPromptTemplate?: string;  // Template for group history context injection
   onBehalfOf?: string;  // Persona clone: grantor uid — bot acts on behalf of this human
-  secretsFileRoot?: string;  // Jail root for write-secret: secret files may only be written under this absolute path (defaults to the plugin process CWD)
+  secretsFileRoot?: string;  // Jail root for write-secret: secret files may only be written under this absolute path. REQUIRED for write-secret — if unset, write-secret fails closed (no process.cwd() fallback).
 }
 
 export interface OctoConfig {

--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -14,6 +14,7 @@ export interface OctoAccountConfig {
   historyLimit?: number;  // 群聊历史消息条数限制（默认20）
   historyPromptTemplate?: string;  // Template for group history context injection
   onBehalfOf?: string;  // Persona clone: grantor uid — bot acts on behalf of this human
+  secretsFileRoot?: string;  // Jail root for write-secret: secret files may only be written under this absolute path (defaults to the plugin process CWD)
 }
 
 export interface OctoConfig {
@@ -30,6 +31,7 @@ export interface OctoConfig {
   historyLimit?: number;  // 群聊历史消息条数限制（默认20）
   historyPromptTemplate?: string;  // Template for group history context injection
   onBehalfOf?: string;  // Persona clone: grantor uid — bot acts on behalf of this human
+  secretsFileRoot?: string;  // Jail root for write-secret (see OctoAccountConfig)
   accounts?: Record<string, OctoAccountConfig | undefined>;
 }
 
@@ -55,6 +57,7 @@ export const OctoConfigJsonSchema = {
       historyLimit: { type: "number", minimum: 1, maximum: 100 },
       historyPromptTemplate: { type: "string" },
       onBehalfOf: { type: "string" },
+      secretsFileRoot: { type: "string" },
       accounts: {
         type: "object",
         additionalProperties: {
@@ -73,6 +76,7 @@ export const OctoConfigJsonSchema = {
             historyLimit: { type: "number", minimum: 1, maximum: 100 },
             historyPromptTemplate: { type: "string" },
             onBehalfOf: { type: "string" },
+            secretsFileRoot: { type: "string" },
           },
         },
       },

--- a/src/manifest-schema-sync.test.ts
+++ b/src/manifest-schema-sync.test.ts
@@ -33,4 +33,28 @@ describe("openclaw.plugin.json channelConfigs", () => {
       Object.keys(tsAccountProps).sort(),
     );
   });
+
+  // Description drift guard: secretsFileRoot carries operator-facing semantics
+  // (the write-secret jail default + fail-closed behavior). A stale manifest
+  // description here is what Jerry-Xin flagged on PR#92, so pin both copies to
+  // the single source of truth in OctoConfigJsonSchema.
+  it("secretsFileRoot description matches between manifest and OctoConfigJsonSchema", () => {
+    const tsDesc = (OctoConfigJsonSchema.schema.properties.secretsFileRoot as any)
+      .description as string;
+    expect(tsDesc).toBeDefined();
+    // Top-level copy.
+    expect(
+      manifest.channelConfigs.octo.schema.properties.secretsFileRoot.description,
+    ).toBe(tsDesc);
+    // Per-account copy.
+    expect(
+      manifest.channelConfigs.octo.schema.properties.accounts.additionalProperties
+        .properties.secretsFileRoot.description,
+    ).toBe(tsDesc);
+    // The new semantics must be reflected (not the old "process working
+    // directory" default).
+    expect(tsDesc).toMatch(/fail-closed/i);
+    expect(tsDesc).toMatch(/workspace/i);
+    expect(tsDesc).not.toMatch(/defaults to the plugin process working directory/i);
+  });
 });


### PR DESCRIPTION
Part of YUJ-3947. Experience-optimization follow-up on **PR#92** (`fix/write-secret-fail-closed-jail`, APPROVED). **Security model is unchanged** — this only relaxes "operator must hand-configure `secretsFileRoot`" into "default to the agent's workspace, still fail-closed if nothing usable resolves". Based on PR#92's branch.

## What changes

Jail-root resolution for `write-secret` (highest priority first):
1. explicit per-account/channel `secretsFileRoot` — **always wins** (operator can still lock to a narrower dir; existing behavior + tests preserved)
2. **default**: `cfg.agents.list[]` entry matched by `agentAccountId` → its `workspace`
3. that agent has no `workspace` → `cfg.agents.defaults.workspace`
4. none resolve to a usable non-root directory → **fail-closed** (PR#92's refuse behavior)

`createOctoManagementTools` already receives the full `cfg` + `agentAccountId`, so no new params are threaded through. A small `resolveAgentWorkspaceRoot(cfg, agentAccountId)` does the lookup; the call site computes `effectiveSecretsRoot = explicit || workspaceDefault` and hands it to `confineSecretPath`.

## 🔴 Security invariants preserved
- **Never** falls back to `process.cwd()` (the source of the `/`-degenerate self-lock + fail-open bugs).
- A workspace resolving to `/` is rejected as a degenerate root → fail-closed (a mis-set `defaults.workspace="/"` can't become a root-wide secret jail).
- `isInsideRoot` (path.relative) containment, symlink-escape walk, dangling-link denial, post-mkdir TOCTOU recheck, and `O_NOFOLLOW` all unchanged.
- Plaintext never reaches the tool return value (all `not.toContain(PLAINTEXT)` assertions intact); confine runs before `resolveSecret`.

## Manifest description fix (Jerry-Xin's PR#92 non-blocking)
`openclaw.plugin.json` `secretsFileRoot` no longer says "defaults to the plugin process working directory" — both copies now describe the workspace-default + fail-closed semantics. The wording lives in one `SECRETS_FILE_ROOT_DESCRIPTION` constant mirrored into the manifest, and `manifest-schema-sync.test.ts` now asserts the description stays in sync and reflects the new semantics.

## Tests
9 new cases under "jail root default = agent workspace": jail to matched agent workspace (in-jail accept / `..` reject), fall back to `defaults.workspace` (agent has none / no agent matches), explicit `secretsFileRoot` still wins, and fail-closed when nothing resolves / no `agents` block / `defaults.workspace="/"` / empty-whitespace workspace. All PR#71/PR#92 red-lines stay green.

Full suite: **952 passed**, `tsc --noEmit` clean.


---

## 🔁 Rework (YUJ-3990) — re-review requested

Addresses Jerry-Xin's 1 blocking + 2 owner P2s in one pass. No change to the security model; this hardens the workspace-default jail resolution.

### 🔴 Blocking fix — symlink→`/` fail-open (realpath-after-canon)
The degenerate-root rejection used to run on the **lexical** form (`resolvePath(workspace) === sep`), while `confineSecretPath` canonicalizes the root with `realpath()`. A workspace configured as a symlink whose real target is `/` (e.g. `/tmp/ws-root-link` → `/`) passed the lexical `!== "/"` check, then `realpath` collapsed it to `/` downstream → root-wide jail (fail-open). Also missed Windows drive roots (`resolvePath("C:\\") !== sep`).

Fix: `resolveAgentWorkspaceRoot` now home/env-expands the workspace, **realpath-canonicalizes it, and only then** rejects a degenerate root — using `path.parse(root).root === root` (covers POSIX `/` *and* Windows drive roots) instead of a bare `=== sep`. A symlink-to-`/` workspace now fails closed at resolution. The explicit operator `secretsFileRoot="/"` opt-in is unaffected (handled at the call site, not subject to the default-degeneracy guard).

Evidence: the new `…symlink to '/' (realpath-after-canon)` test **fails** when reverted to the old lexical check (asserts `not configured`, `resolveSecret` never called, no plaintext) and passes with the fix.

### P2#1 — match-key namespace (per-agent workspace could never hit)
`cfg.agents.list[]` is keyed by **OpenClaw agent id**, but the old code matched on `agentAccountId` (the channel/Octo account id). When the two differ (e.g. agent `main` ↔ octo account `default`), `list.find` missed and silently fell back to `defaults.workspace` — direction-safe but the per-agent jail never engaged.

Fix: prefer `ctx.agentId` (threaded through from `OpenClawPluginToolContext`), matched via the platform's `normalizeAgentId` semantics (lower/slug-normalized, both sides), falling back to `agentAccountId` only when `agentId` is unavailable.

### P2#2 — `~` / `$VAR` expansion (aligned with canonical resolver)
Raw workspace strings went straight into `resolvePath`, so `~/…` / `$VAR` were treated as literal segments. `resolveAgentWorkspaceDir` (platform) expands them. The SDK does **not** re-export `resolveAgentWorkspaceDir`/`resolveAgentConfig` through any `plugin-sdk` subpath (only `normalizeAgentId` is, via `plugin-sdk/routing`), so per the issue's stated fallback we expand locally: leading `~`→home (matches `expandHomePrefix`) and `$VAR`/`${VAR}`/`%VAR%`, then `realpath`.

### Non-blocking — fail-closed message
The "not configured" error now also points at `agents.list[].workspace` / `agents.defaults.workspace` as valid jail sources, not only `secretsFileRoot`.

### Invariants preserved
No `process.cwd()` fallback · degenerate effective root fails closed (except explicit `secretsFileRoot=/`) · `isInsideRoot`/symlink-walk/TOCTOU/`O_NOFOLLOW` untouched · confine before `resolveSecret` · all `not.toContain(PLAINTEXT)` intact.

### Tests
+8 cases: symlink→`/` fail-closed, Windows drive root (win32-gated), account-id≠agent-id hits per-agent workspace, agentId precedence over accountId, case-insensitive agent-id match, `~` expansion, `$VAR` expansion. **Full suite: 959 passing**, `tsc --noEmit` + `tsc` build clean.
