### PR TITLE
fix(write-secret): align resolve with octo-server PR#301 — request field alias→query (fix 400) + 422 ambiguous + 429 back-off

### DIFF
--- a/src/agent-tools.test.ts
+++ b/src/agent-tools.test.ts
@@ -1611,6 +1611,19 @@ describe("createOctoManagementTools", () => {
       await expect(readFile(join(root, ".env"), "utf8")).rejects.toThrow();
     });
 
+    it("rate_limited → back-off hint, no body in the error, no write", async () => {
+      vi.mocked(resolveSecret).mockResolvedValue({ status: "rate_limited" });
+
+      const result = await writeSecret({ alias: "openai key", filePath: ".env" });
+      const data = parseText(result);
+
+      expect(data.error).toMatch(/rate limited|busy/i);
+      expect(data.error).toContain("openai key");
+      // 🔴 The 429 path reads no body, so nothing server-controlled leaks here.
+      expect(JSON.stringify(result)).not.toContain(PLAINTEXT);
+      await expect(readFile(join(root, ".env"), "utf8")).rejects.toThrow();
+    });
+
     it("resolve failure → actionable re-set hint, no write", async () => {
       vi.mocked(resolveSecret).mockRejectedValue(
         new Error("resolveSecret failed (500)"),

--- a/src/agent-tools.ts
+++ b/src/agent-tools.ts
@@ -977,6 +977,15 @@ async function handleWriteSecret(params: {
     );
   }
 
+  // rate_limited → the resolve endpoint's per-IP limiter rejected the call.
+  // Surface a transient, actionable hint. 🔴 No body is read on a 429, so this
+  // message carries no server-controlled string — only a fixed back-off prompt.
+  if (resolved.status === "rate_limited") {
+    return makeError(
+      `The key service is busy right now (rate limited). Wait a moment and retry write-secret for "${params.alias}".`,
+    );
+  }
+
   // ambiguous → hand back ONLY the labels so the LLM can ask the user which one.
   // 🔴 candidates carry display_name (+ secret_id) only, never the value.
   if (resolved.status === "ambiguous") {

--- a/src/api-fetch.test.ts
+++ b/src/api-fetch.test.ts
@@ -1545,7 +1545,33 @@ describe("resolveSecret", () => {
     }
   });
 
-  it("POSTs the alias with a bearer bot token", async () => {
+  it("resolves a 200 body with no status field ({ secret_id, value }) per PR#301", async () => {
+    // The current server returns the resolved value via HTTP 200 with NO status
+    // discriminator: `{ "secret_id": "...", "value": "..." }`.
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: vi.fn().mockResolvedValue({
+        secret_id: "a1b2c3d4",
+        value: "sk-live-PLAINTEXT",
+      }),
+    }) as unknown as typeof fetch;
+
+    const { resolveSecret } = await import("./api-fetch.js");
+    const result = await resolveSecret({
+      apiUrl: "http://api.test",
+      botToken: "bf_token",
+      alias: "openai key",
+    });
+
+    expect(result.status).toBe("resolved");
+    if (result.status === "resolved") {
+      expect(result.value).toBe("sk-live-PLAINTEXT");
+      expect(result.secret_id).toBe("a1b2c3d4");
+    }
+  });
+
+  it("POSTs the alias as the `query` field with a bearer bot token", async () => {
     const spy = vi.fn().mockResolvedValue({
       ok: true,
       status: 200,
@@ -1560,7 +1586,11 @@ describe("resolveSecret", () => {
     expect(url).toBe("http://api.test/v1/bot/secrets/resolve");
     expect(init.method).toBe("POST");
     expect(init.headers.Authorization).toBe("Bearer bf_token");
-    expect(JSON.parse(init.body)).toEqual({ alias: "k" });
+    // 🔴 The server binds `query` (req.Query); sending `alias` leaves Query empty
+    // → 400 request_invalid. The wire field MUST be `query`, never `alias`.
+    const body = JSON.parse(init.body);
+    expect(body).toEqual({ query: "k" });
+    expect(body).not.toHaveProperty("alias");
   });
 
   it("normalizes status:not_found", async () => {
@@ -1610,6 +1640,98 @@ describe("resolveSecret", () => {
       // No plaintext leaks into candidates.
       expect(JSON.stringify(result.candidates)).not.toContain("value");
     }
+  });
+
+  it("parses 422 ambiguous candidates from error.details.candidates (PR#301 envelope)", async () => {
+    // The current server signals ambiguity with HTTP 422 and the i18n error
+    // envelope: error.details.candidates carries the masked candidate views.
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 422,
+      json: vi.fn().mockResolvedValue({
+        status: 422,
+        error: {
+          code: "err.server.usersecret.ambiguous",
+          message: "名称匹配到多个密钥，请进一步区分。",
+          http_status: 422,
+          details: {
+            candidates: [
+              {
+                secret_id: "a",
+                display_name: "我的密钥",
+                kind: "external",
+                masked: "****1111",
+              },
+              {
+                secret_id: "b",
+                display_name: "我的米要",
+                kind: "external",
+                masked: "****2222",
+              },
+            ],
+          },
+        },
+      }),
+    }) as unknown as typeof fetch;
+
+    const { resolveSecret } = await import("./api-fetch.js");
+    const result = await resolveSecret({ apiUrl: "http://api.test", botToken: "t", alias: "我的密钥" });
+    expect(result.status).toBe("ambiguous");
+    if (result.status === "ambiguous") {
+      expect(result.candidates).toHaveLength(2);
+      // Only label-only fields survive — masked/kind are dropped.
+      expect(result.candidates[0]).toEqual({ secret_id: "a", display_name: "我的密钥" });
+      expect(JSON.stringify(result.candidates)).not.toContain("value");
+      expect(JSON.stringify(result.candidates)).not.toContain("masked");
+    }
+  });
+
+  it("treats a 422 with exactly one candidate as ambiguous (fuzzy hit needs confirmation)", async () => {
+    // Per PR#301 a single fuzzy/pinyin candidate STILL returns 422 — it must be
+    // confirmed, never auto-used. The plugin must surface it as ambiguous.
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 422,
+      json: vi.fn().mockResolvedValue({
+        status: 422,
+        error: {
+          code: "err.server.usersecret.ambiguous",
+          http_status: 422,
+          details: {
+            candidates: [
+              { secret_id: "only", display_name: "我的密钥", kind: "external", masked: "****1111" },
+            ],
+          },
+        },
+      }),
+    }) as unknown as typeof fetch;
+
+    const { resolveSecret } = await import("./api-fetch.js");
+    const result = await resolveSecret({ apiUrl: "http://api.test", botToken: "t", alias: "我的米要" });
+    expect(result.status).toBe("ambiguous");
+    if (result.status === "ambiguous") {
+      expect(result.candidates).toHaveLength(1);
+      expect(result.candidates[0]).toEqual({ secret_id: "only", display_name: "我的密钥" });
+    }
+  });
+
+  it("normalizes 429 to rate_limited without reading the body", async () => {
+    // The per-IP resolve limiter returns 429. Surface a recognizable back-off
+    // outcome — and 🔴 never read the body (no-body-in-error invariant).
+    const jsonSpy = vi.fn();
+    const textSpy = vi.fn();
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 429,
+      json: jsonSpy,
+      text: textSpy,
+    }) as unknown as typeof fetch;
+
+    const { resolveSecret } = await import("./api-fetch.js");
+    const result = await resolveSecret({ apiUrl: "http://api.test", botToken: "t", alias: "x" });
+    expect(result.status).toBe("rate_limited");
+    expect(jsonSpy).not.toHaveBeenCalled();
+    expect(textSpy).not.toHaveBeenCalled();
   });
 
   it("throws on a 5xx (resolve failure) without leaking the response body", async () => {

--- a/src/api-fetch.ts
+++ b/src/api-fetch.ts
@@ -900,10 +900,15 @@ export interface SecretCandidate {
  * Result of resolving a secret alias for the bot's owner.
  *
  * Discriminated on `status`:
- *  - `resolved`   → exactly one match; `value` holds the plaintext secret.
- *  - `not_found`  → no secret matches the alias; the owner must add it first.
- *  - `ambiguous`  → multiple matches; `candidates` lists labels for the caller
- *                   to re-resolve against (no plaintext).
+ *  - `resolved`     → exactly one EXACT match; `value` holds the plaintext secret.
+ *  - `not_found`    → no secret matches the alias; the owner must add it first.
+ *  - `ambiguous`    → server needs confirmation; `candidates` lists labels for the
+ *                     caller to re-resolve against (no plaintext). Per octo-server
+ *                     PR#301 this covers BOTH "exact name hit >1" AND "any
+ *                     pinyin/fuzzy hit, even exactly one candidate" — a single
+ *                     fuzzy candidate must still be confirmed, never auto-used.
+ *  - `rate_limited` → the per-IP resolve limiter rejected this call (HTTP 429);
+ *                     the caller should back off and retry.
  *
  * 🔴 RED LINE: the `value` field on the `resolved` variant is the ONLY place
  * plaintext appears. Callers must consume it internally (e.g. write it to a
@@ -913,7 +918,8 @@ export interface SecretCandidate {
 export type ResolveSecretResult =
   | { status: "resolved"; value: string; secret_id?: string; display_name?: string }
   | { status: "not_found" }
-  | { status: "ambiguous"; candidates: SecretCandidate[] };
+  | { status: "ambiguous"; candidates: SecretCandidate[] }
+  | { status: "rate_limited" };
 
 /**
  * Resolve a user-managed external-key alias to its current plaintext value.
@@ -929,14 +935,22 @@ export type ResolveSecretResult =
  * is always fetched. If the owner rotates the key, the next call picks it up
  * with zero restart and zero cache invalidation.
  *
- * Contract:
- *  - 200 `{ status: "resolved", value, secret_id?, display_name? }`
- *  - 200 `{ status: "ambiguous", candidates: [{ secret_id?, display_name }] }`
- *  - 200 `{ status: "not_found" }` OR 404 → normalized to `{ status: "not_found" }`
+ * Contract (octo-server PR#301, docs/user-secret-alias-api.md):
+ *  - 200 `{ secret_id?, value }` → exact unique hit; `value` is the plaintext.
+ *  - 422 → ambiguous: the i18n error envelope carries the (masked) candidates at
+ *    `error.details.candidates`. Triggered by an exact name hit on >1 row OR ANY
+ *    pinyin/fuzzy hit (even a single candidate). Normalized to
+ *    `{ status: "ambiguous", candidates }`.
+ *  - 404 → not_found (also covers "endpoint not deployed yet during rollout").
+ *  - 429 → the per-IP resolve limiter rejected this call. Normalized to
+ *    `{ status: "rate_limited" }` so the caller can surface a back-off hint.
  *  - any other non-2xx → throws (caller surfaces a non-plaintext "resolve
- *    failed, please re-set" message)
+ *    failed, please re-set" message).
  *
- * 🔴 SECURITY: on a non-2xx the thrown Error message contains ONLY the HTTP
+ * For backward compatibility a 200 body still carrying `status:"ambiguous"` /
+ * `status:"not_found"` is honored, but the HTTP status is authoritative.
+ *
+ * 🔴 SECURITY: on a thrown non-2xx the Error message contains ONLY the HTTP
  * status — never the response body and never a resolved value. The body is
  * deliberately dropped because this error reaches an LLM-visible tool result
  * and a resolve-endpoint error body could carry secret-bearing diagnostics.
@@ -955,7 +969,11 @@ export async function resolveSecret(params: {
       ...DEFAULT_HEADERS,
       Authorization: `Bearer ${params.botToken}`,
     },
-    body: JSON.stringify({ alias: params.alias }),
+    // 🔴 The server binds the request field `query` (BindJSON → req.Query) and
+    // 400s when it is empty. The function input is still named `alias` for
+    // callers, but the wire field MUST be `query` — `query` accepts either a
+    // secret_id or a display_name, matching the `alias` semantics.
+    body: JSON.stringify({ query: params.alias }),
     signal: params.signal ?? AbortSignal.timeout(DEFAULT_TIMEOUT_MS),
   });
 
@@ -965,6 +983,31 @@ export async function resolveSecret(params: {
   if (resp.status === 404) {
     return { status: "not_found" };
   }
+
+  // 422 = ambiguous. The server returns the i18n error envelope; the masked
+  // candidate list lives at `error.details.candidates`. This is NOT an HTTP
+  // failure to surface — it is a normal "needs confirmation" outcome, so we
+  // parse it here instead of letting it fall into the throw branch below.
+  // 🔴 SECURITY: candidates carry ONLY masked identifiers (display_name,
+  // secret_id, kind, masked) — never the plaintext value — so reading this
+  // specific body is safe. We still read NOTHING from any other error body.
+  if (resp.status === 422) {
+    const raw = (await resp.json().catch(() => null)) as Record<string, unknown> | null;
+    const error = (raw?.error ?? {}) as Record<string, unknown>;
+    const details = (error.details ?? {}) as Record<string, unknown>;
+    const rawCandidates = Array.isArray(details.candidates) ? details.candidates : [];
+    return { status: "ambiguous", candidates: parseCandidates(rawCandidates) };
+  }
+
+  // 429 = the per-IP resolve limiter (StrictIPRateLimitMiddleware,
+  // tag=usersecret_resolve) rejected this call. Surface a recognizable
+  // back-off outcome rather than a generic error.
+  // 🔴 SECURITY: do NOT read the body — a rate-limit response is not expected to
+  // carry a value, and the no-body-in-error invariant for this endpoint stands.
+  if (resp.status === 429) {
+    return { status: "rate_limited" };
+  }
+
   if (!resp.ok) {
     // 🔴 SECURITY: never fold the response body into the error. A resolve
     // endpoint handles plaintext secrets; a 5xx/diagnostic body could echo a
@@ -980,25 +1023,23 @@ export async function resolveSecret(params: {
 
   const status = raw.status;
 
+  // Backward-compat: honor a legacy 200 body that still carries an explicit
+  // status discriminator. The current server (PR#301) instead signals these via
+  // HTTP status (404/422), handled above; a 200 body simply carries the value.
   if (status === "not_found") {
     return { status: "not_found" };
   }
 
   if (status === "ambiguous") {
     const rawCandidates = Array.isArray(raw.candidates) ? raw.candidates : [];
-    const candidates: SecretCandidate[] = rawCandidates
-      .map((c) => {
-        const obj = (c ?? {}) as Record<string, unknown>;
-        const displayName = typeof obj.display_name === "string" ? obj.display_name : "";
-        const secretId = typeof obj.secret_id === "string" ? obj.secret_id : undefined;
-        return { display_name: displayName, secret_id: secretId };
-      })
-      // Drop entries with no label — a candidate the caller can't show is useless.
-      .filter((c) => c.display_name.length > 0);
-    return { status: "ambiguous", candidates };
+    return { status: "ambiguous", candidates: parseCandidates(rawCandidates) };
   }
 
-  if (status === "resolved") {
+  // Resolved: the current server returns 200 `{ secret_id?, value }` WITHOUT a
+  // status field, so a 200 carrying a non-empty `value` is the resolved case.
+  // A legacy `status:"resolved"` body is also accepted. Anything else is treated
+  // as a malformed resolved response (missing value) and rejected.
+  if (status === "resolved" || (status === undefined && "value" in raw)) {
     if (typeof raw.value !== "string" || raw.value.length === 0) {
       throw new Error("resolveSecret resolved a secret with no value");
     }
@@ -1015,6 +1056,26 @@ export async function resolveSecret(params: {
   // server-controlled value back into the transcript is an injection vector.
   // Use a fixed message — the unexpected status is unusable to the caller anyway.
   throw new Error("resolveSecret returned an unknown status");
+}
+
+/**
+ * Map a raw candidate array (from a 422 `error.details.candidates` envelope or a
+ * legacy 200 ambiguous body) into label-only SecretCandidate entries.
+ *
+ * 🔴 SECURITY: deliberately copies ONLY `display_name` + `secret_id` — never any
+ * `value`/`masked`/other server field — so nothing sensitive leaks into the
+ * disambiguation surface the LLM eventually sees. Entries with no label are
+ * dropped: a candidate the caller can't show the user is useless.
+ */
+function parseCandidates(rawCandidates: unknown[]): SecretCandidate[] {
+  return rawCandidates
+    .map((c) => {
+      const obj = (c ?? {}) as Record<string, unknown>;
+      const displayName = typeof obj.display_name === "string" ? obj.display_name : "";
+      const secretId = typeof obj.secret_id === "string" ? obj.secret_id : undefined;
+      return { display_name: displayName, secret_id: secretId };
+    })
+    .filter((c) => c.display_name.length > 0);
 }
 
 /** Decoded payload from base64 message content */


### PR DESCRIPTION
## What

Resolve end-to-end contract alignment with octo-server PR#301 (`feat/user-secret-alias`, merged + deployed im-test). Owner Yu hit a hard blocker: `write-secret` passed the jail then stalled at `resolveSecret`, server returning 400 `err.server.usersecret.request_invalid` for any alias.

Contract reference: octo-server `docs/user-secret-alias-api.md` + `modules/usersecret/api.go` (`resolve` handler, `req.Query` bind; 200 `{secret_id,value}` / 404 / 422 `error.details.candidates` / 429 / 500).

## Fixes

1. **Request field `alias` → `query` (the actual 400 cause).** Server binds `req.Query` (`BindJSON`) and 400s when empty; the plugin sent `{ alias }`, so `Query` was always empty and lookup logic was never reached — every alias 400'd regardless of existence. Now sends `{ query: params.alias }`. Function input stays named `alias`; only the wire field changes (`query` = secret_id or display_name).

2. **Ambiguous via HTTP 422 (was unhandled).** The plugin only read `status:"ambiguous"` from a 200 body and let 422 fall into the generic error throw, so the "fuzzy name → candidates" state always failed. Now 422 is parsed explicitly from `error.details.candidates` (i18n envelope). Covers exact-name >1 **and any pinyin/fuzzy hit including exactly one candidate** — a single fuzzy candidate must still be confirmed, never auto-used. Also adapted to the canonical 200 shape `{ secret_id, value }` (no `status` field) → resolved; legacy `status`-bearing 200 bodies still honored.

3. **429 rate limit (was unhandled).** resolve carries per-IP `StrictIPRateLimitMiddleware` (tag `usersecret_resolve`, 50rps/burst200). 429 now normalizes to a `rate_limited` result and surfaces a back-off hint instead of a generic error.

## Security invariants (unchanged)

- Thrown resolve errors carry **only the HTTP status**, never the response body (SECURITY note preserved). The 429 path reads no body at all.
- Candidates reduced to label-only fields (`display_name` + `secret_id`); `masked`/`kind`/`value` dropped.
- Plaintext never enters the LLM-visible transcript; all `not.toContain(PLAINTEXT)` assertions retained.

## Tests

- Body asserts `query`, not `alias`.
- 200 `{ secret_id, value }` → resolved.
- 422 → ambiguous candidates, incl. the **exactly-one-candidate** case.
- 429 → `rate_limited`, body never read.
- write-secret `rate_limited` → back-off hint, no write, no plaintext.

Full vitest (945 tests) + type-check green.

## Stack

Base: `feat/agent-tool-write-secret` (same stack as #71/#92/#95).

Part of #4015
