### PR TITLE
fix(write-secret): fail-closed jail + workspace default + resolve query contract (consolidates #92/#95/#96)

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -80,7 +80,11 @@ export default defineBundledChannelEntry({
       (ctx: OpenClawPluginToolContext) => {
         const cfg = ctx.getRuntimeConfig?.() ?? ctx.runtimeConfig ?? ctx.config;
         if (!cfg) return null;
-        return createOctoManagementTools({ cfg, agentAccountId: ctx.agentAccountId });
+        return createOctoManagementTools({
+          cfg,
+          agentAccountId: ctx.agentAccountId,
+          agentId: ctx.agentId,
+        });
       },
       { names: ['octo_management'] },
     );

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -126,7 +126,7 @@
                 },
                 "secretsFileRoot": {
                   "type": "string",
-                  "description": "Jail root for write-secret: secret files may only be written under this path (defaults to the plugin process working directory)"
+                  "description": "Jail root for write-secret: secret files may only be written under this path. When unset, defaults to the agent's workspace (agents.list[].workspace matched to the agent, else agents.defaults.workspace). If neither resolves to a usable directory, write-secret is unavailable (fail-closed); there is no process working-directory fallback."
                 }
               }
             }
@@ -137,7 +137,7 @@
           },
           "secretsFileRoot": {
             "type": "string",
-            "description": "Jail root for write-secret: secret files may only be written under this path (defaults to the plugin process working directory)"
+            "description": "Jail root for write-secret: secret files may only be written under this path. When unset, defaults to the agent's workspace (agents.list[].workspace matched to the agent, else agents.defaults.workspace). If neither resolves to a usable directory, write-secret is unavailable (fail-closed); there is no process working-directory fallback."
           }
         }
       }

--- a/src/agent-tools.test.ts
+++ b/src/agent-tools.test.ts
@@ -2095,41 +2095,135 @@ describe("createOctoManagementTools", () => {
         }
       });
 
-      // 🔴 必修2 (lml2468) — symlink-ANCESTOR first-write must NOT be
-      // false-rejected. When the jail root sits under a symlinked ancestor
-      // (macOS /tmp→/private/tmp, container bind-mounts, a symlinked $HOME) AND
+      // 🔴 必修2 / P1-A (lml2468) — symlink-ANCESTOR first-write must NOT be
+      // false-rejected. When the jail root sits under a symlinked ancestor AND
       // the workspace dir does not exist yet (the common first-write case), the
       // old code stored the root in its LEXICAL form but compared it post-mkdir
       // against realpath(dir). The two diverged through the symlink and the write
       // was wrongly refused as "escaped the allowed root after creation". The fix
-      // canonicalizes the root through its nearest existing ancestor, so both
-      // sides are symlink-free. Build a real symlinked-ancestor root and assert
-      // the first write succeeds and the file lands at the real target.
-      it("does not false-reject a first write when the jail root has a symlinked ancestor", async () => {
+      // canonicalizes BOTH the resolved workspace (resolveAgentWorkspaceRoot) and
+      // the jail root (confineSecretPath) through their nearest existing ancestor,
+      // so every comparison is symlink-free.
+      //
+      // lml2468 asked for coverage of three real-world ancestor-symlink shapes,
+      // not just one. Each case builds a genuine symlinked-ancestor root whose
+      // workspace leaf does not exist yet, then asserts the FIRST write succeeds
+      // and the file materializes at the REAL (symlink-resolved) target.
+      const symlinkAncestorCases: {
+        label: string;
+        build: () => Promise<{ workspace: string; realTarget: string; cleanup: () => Promise<void> }>;
+      }[] = [
+        {
+          // macOS-style: an intermediate path component is a symlink to its real
+          // dir (e.g. /tmp → /private/tmp). Workspace = <link>/ws.
+          label: "intermediate symlink (macOS /tmp→/private/tmp shape)",
+          build: async () => {
+            const realDir = await mkdtemp(join(tmpdir(), "octo-real-tmp-"));
+            const linkDir = join(tmpdir(), `octo-link-tmp-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+            await symlink(realDir, linkDir, "dir");
+            return {
+              workspace: join(linkDir, "ws"),
+              realTarget: join(realDir, "ws"),
+              cleanup: async () => {
+                await rm(linkDir, { force: true });
+                await rm(realDir, { recursive: true, force: true });
+              },
+            };
+          },
+        },
+        {
+          // Symlinked HOME shape: the home-like ancestor itself is a symlink and
+          // the workspace is nested several levels below it.
+          label: "symlinked HOME ancestor",
+          build: async () => {
+            const realHome = await mkdtemp(join(tmpdir(), "octo-real-home-"));
+            await mkdir(join(realHome, "agents"), { recursive: true });
+            const linkHome = join(tmpdir(), `octo-link-home-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+            await symlink(realHome, linkHome, "dir");
+            return {
+              workspace: join(linkHome, "agents", "ws", "secrets"),
+              realTarget: join(realHome, "agents", "ws", "secrets"),
+              cleanup: async () => {
+                await rm(linkHome, { force: true });
+                await rm(realHome, { recursive: true, force: true });
+              },
+            };
+          },
+        },
+        {
+          // Container bind-mount shape: a chain of symlinks (link→link→realdir),
+          // as a bind-mounted path indirected through more than one link can
+          // present. Workspace = <top-link>/data/ws.
+          label: "bind-mount-style symlink chain",
+          build: async () => {
+            const realDir = await mkdtemp(join(tmpdir(), "octo-real-bm-"));
+            const midLink = join(tmpdir(), `octo-bm-mid-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+            await symlink(realDir, midLink, "dir");
+            const topLink = join(tmpdir(), `octo-bm-top-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+            await symlink(midLink, topLink, "dir");
+            return {
+              workspace: join(topLink, "data", "ws"),
+              realTarget: join(realDir, "data", "ws"),
+              cleanup: async () => {
+                await rm(topLink, { force: true });
+                await rm(midLink, { force: true });
+                await rm(realDir, { recursive: true, force: true });
+              },
+            };
+          },
+        },
+      ];
+
+      for (const tc of symlinkAncestorCases) {
+        it(`does not false-reject a first write through a ${tc.label}`, async () => {
+          setupMocks();
+          vi.mocked(resolveSecret).mockResolvedValue({ status: "resolved", value: PLAINTEXT });
+          const { workspace, realTarget, cleanup } = await tc.build();
+          try {
+            const exec = executeWithAgents(
+              { list: [{ id: "bot-A", workspace }] },
+              "bot-A",
+            );
+
+            const result = await exec({ alias: "k", filePath: "first.env" });
+            expect(parseText(result).written).toBe(true);
+            // File lands at the REAL (symlink-resolved) target, first write.
+            expect(await readFile(join(realTarget, "first.env"), "utf8")).toBe(PLAINTEXT);
+            expect(JSON.stringify(result)).not.toContain(PLAINTEXT);
+          } finally {
+            await cleanup();
+          }
+        });
+      }
+
+      // 🔴 P1-B (Yu CR) — an UNDEFINED env var in the workspace path must FAIL
+      // CLOSED, not anchor the jail to process.cwd(). A literal, unexpanded
+      // `${UNDEF}` fed to path.resolve() silently roots the relative remainder at
+      // the current working directory, which would sail past both filesystem-root
+      // degeneracy guards and rebuild exactly the cwd-anchored jail this PR's
+      // fail-closed guarantee exists to prevent. Assert: refusal + no resolve()
+      // call + nothing written under cwd.
+      it("fails closed when the workspace references an UNDEFINED env var (no cwd anchor)", async () => {
         setupMocks();
         vi.mocked(resolveSecret).mockResolvedValue({ status: "resolved", value: PLAINTEXT });
-        // realDir is the genuine directory; linkDir is a symlink pointing at it.
-        // The workspace is configured UNDER the symlink, and its leaf subdir does
-        // NOT exist yet, so confineSecretPath falls into the not-yet-created path.
-        const realDir = await mkdtemp(join(tmpdir(), "octo-realtarget-"));
-        const linkDir = join(tmpdir(), `octo-symlink-${Date.now()}-${Math.random().toString(36).slice(2)}`);
-        await symlink(realDir, linkDir, "dir");
-        try {
-          const workspace = join(linkDir, "ws"); // under the symlink, not yet created
-          const exec = executeWithAgents(
-            { list: [{ id: "bot-A", workspace }] },
-            "bot-A",
-          );
+        const varName = `OCTO_UNSET_${Date.now()}`;
+        // Ensure the var is genuinely undefined.
+        delete process.env[varName];
+        const exec = executeWithAgents(
+          { list: [{ id: "bot-A", workspace: `\${${varName}}/octo-secrets` }] },
+          "bot-A",
+        );
 
-          const result = await exec({ alias: "k", filePath: "first.env" });
-          expect(parseText(result).written).toBe(true);
-          // The file lands at the REAL target the symlink points to.
-          expect(await readFile(join(realDir, "ws", "first.env"), "utf8")).toBe(PLAINTEXT);
-          expect(JSON.stringify(result)).not.toContain(PLAINTEXT);
-        } finally {
-          await rm(linkDir, { force: true });
-          await rm(realDir, { recursive: true, force: true });
-        }
+        const result = await exec({ alias: "k", filePath: "leak.env" });
+        expect(parseText(result).error).toMatch(/not configured/i);
+        // Never fetched the plaintext on the fail-closed path…
+        expect(resolveSecret).not.toHaveBeenCalled();
+        expect(JSON.stringify(result)).not.toContain(PLAINTEXT);
+        // …and crucially nothing was written under the literal "${UNDEF}" dir
+        // that a cwd-anchored resolve would have created.
+        await expect(
+          readFile(join(process.cwd(), `\${${varName}}`, "octo-secrets", "leak.env"), "utf8"),
+        ).rejects.toThrow();
       });
     });
   });

--- a/src/agent-tools.test.ts
+++ b/src/agent-tools.test.ts
@@ -1794,17 +1794,62 @@ describe("createOctoManagementTools", () => {
         expect(await readFile(join(root, "via-defaults.env"), "utf8")).toBe(PLAINTEXT);
       });
 
-      it("falls back to defaults.workspace when no agent matches agentAccountId", async () => {
+      // 🔴 P0 (Jerry-Xin + yujiawei) — NON-DEFAULT agent jail = per-agent
+      // SUBDIRECTORY of defaults.workspace, NEVER the bare shared parent. Here
+      // bot-A is not the default agent (someone-else is), so the platform's
+      // canonical resolveAgentWorkspaceDir derives <defaults.workspace>/<agentId>.
+      // The previous hand-rolled resolver wrongly jailed every non-default agent
+      // to the WHOLE defaults.workspace, letting one agent write into another's
+      // tree. Assert the secret lands under the per-agent subdir, not the parent.
+      it("jails a non-default agent to defaults.workspace/<agentId> (per-agent subdir)", async () => {
         setupMocks();
         vi.mocked(resolveSecret).mockResolvedValue({ status: "resolved", value: PLAINTEXT });
         const exec = executeWithAgents(
           { defaults: { workspace: root }, list: [{ id: "someone-else", workspace: "/x" }] },
-          "bot-A",
+          undefined,
+          "bot-A", // non-default agent (default is someone-else)
         );
 
         const result = await exec({ alias: "k", filePath: "no-match.env" });
         expect(parseText(result).written).toBe(true);
-        expect(await readFile(join(root, "no-match.env"), "utf8")).toBe(PLAINTEXT);
+        // Under the per-agent subdir…
+        expect(await readFile(join(root, "bot-a", "no-match.env"), "utf8")).toBe(PLAINTEXT);
+        // …NOT the bare shared parent.
+        await expect(
+          readFile(join(root, "no-match.env"), "utf8"),
+        ).rejects.toThrow();
+      });
+
+      // 🔴 P0 (Jerry-Xin + yujiawei) — a non-default agent must NOT be able to
+      // climb out of its per-agent subdir into a SIBLING agent's directory and
+      // write the owner's plaintext there. This is the concrete cross-agent
+      // secret-write escape the bare-defaults jail allowed: a `worker` writing
+      // `main/.env`. With the per-agent subdir jail, `../main/.env` resolves
+      // outside the jail and is refused before any plaintext is fetched.
+      it("rejects a non-default agent writing into a sibling agent's dir (worker→main/.env)", async () => {
+        setupMocks();
+        vi.mocked(resolveSecret).mockResolvedValue({ status: "resolved", value: PLAINTEXT });
+        // Pre-create a sibling "main" dir so a successful escape would actually
+        // land a file there — making the assertion that nothing escaped real.
+        await mkdir(join(root, "main"), { recursive: true });
+        const exec = executeWithAgents(
+          {
+            defaults: { workspace: root },
+            list: [
+              { id: "main", default: true },
+              { id: "worker" },
+            ],
+          },
+          undefined,
+          "worker", // non-default agent → jailed to <root>/worker
+        );
+
+        const result = await exec({ alias: "k", filePath: "../main/.env" });
+        expect(parseText(result).error).toMatch(/outside the allowed|permitted root/i);
+        // Plaintext never fetched on a confinement reject; nothing written to main/.
+        expect(resolveSecret).not.toHaveBeenCalled();
+        await expect(readFile(join(root, "main", ".env"), "utf8")).rejects.toThrow();
+        expect(JSON.stringify(result)).not.toContain(PLAINTEXT);
       });
 
       it("explicit secretsFileRoot still wins over the agent-workspace default", async () => {
@@ -2047,6 +2092,43 @@ describe("createOctoManagementTools", () => {
         } finally {
           if (prev === undefined) delete process.env.OCTO_TEST_WS;
           else process.env.OCTO_TEST_WS = prev;
+        }
+      });
+
+      // 🔴 必修2 (lml2468) — symlink-ANCESTOR first-write must NOT be
+      // false-rejected. When the jail root sits under a symlinked ancestor
+      // (macOS /tmp→/private/tmp, container bind-mounts, a symlinked $HOME) AND
+      // the workspace dir does not exist yet (the common first-write case), the
+      // old code stored the root in its LEXICAL form but compared it post-mkdir
+      // against realpath(dir). The two diverged through the symlink and the write
+      // was wrongly refused as "escaped the allowed root after creation". The fix
+      // canonicalizes the root through its nearest existing ancestor, so both
+      // sides are symlink-free. Build a real symlinked-ancestor root and assert
+      // the first write succeeds and the file lands at the real target.
+      it("does not false-reject a first write when the jail root has a symlinked ancestor", async () => {
+        setupMocks();
+        vi.mocked(resolveSecret).mockResolvedValue({ status: "resolved", value: PLAINTEXT });
+        // realDir is the genuine directory; linkDir is a symlink pointing at it.
+        // The workspace is configured UNDER the symlink, and its leaf subdir does
+        // NOT exist yet, so confineSecretPath falls into the not-yet-created path.
+        const realDir = await mkdtemp(join(tmpdir(), "octo-realtarget-"));
+        const linkDir = join(tmpdir(), `octo-symlink-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+        await symlink(realDir, linkDir, "dir");
+        try {
+          const workspace = join(linkDir, "ws"); // under the symlink, not yet created
+          const exec = executeWithAgents(
+            { list: [{ id: "bot-A", workspace }] },
+            "bot-A",
+          );
+
+          const result = await exec({ alias: "k", filePath: "first.env" });
+          expect(parseText(result).written).toBe(true);
+          // The file lands at the REAL target the symlink points to.
+          expect(await readFile(join(realDir, "ws", "first.env"), "utf8")).toBe(PLAINTEXT);
+          expect(JSON.stringify(result)).not.toContain(PLAINTEXT);
+        } finally {
+          await rm(linkDir, { force: true });
+          await rm(realDir, { recursive: true, force: true });
         }
       });
     });

--- a/src/agent-tools.test.ts
+++ b/src/agent-tools.test.ts
@@ -71,8 +71,8 @@ import {
   symlink,
   writeFile as fsWriteFile,
 } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { tmpdir, homedir } from "node:os";
+import { join, relative } from "node:path";
 
 // Minimal config stub — mocked account functions don't inspect it
 const mockCfg = { channels: { octo: { botToken: "tok-secret" } } } as any;
@@ -1570,13 +1570,52 @@ describe("createOctoManagementTools", () => {
       expect(await readFile(join(root, "atroot.txt"), "utf8")).toBe(PLAINTEXT);
     });
 
-    it("defaults the jail root to process.cwd() when secretsFileRoot is unset", async () => {
-      // No secretsFileRoot configured → CWD is the root. A path that escapes
-      // CWD must still be rejected.
+    // 🔴 FAIL-CLOSED (P0): no secretsFileRoot configured → refuse every write.
+    // There is deliberately NO process.cwd() fallback (that fallback was the
+    // root cause of the `/`-degenerate self-lock + fail-open bugs).
+    it("fails closed when secretsFileRoot is unset — no resolve, no write", async () => {
       setupMocks(); // no secretsFileRoot
-      const result = await writeSecret({ alias: "k", filePath: "../../../../etc/passwd" });
-      expect(parseText(result).error).toMatch(/outside the allowed directory/i);
+      vi.mocked(resolveSecret).mockResolvedValue({ status: "resolved", value: PLAINTEXT });
+      const result = await writeSecret({ alias: "k", filePath: "key.txt" });
+      const data = parseText(result);
+      // Explicit, operator-actionable message about the missing config.
+      expect(data.error).toMatch(/not configured/i);
+      expect(data.error).toMatch(/secretsFileRoot/);
+      // Plaintext is never fetched and never leaks into the error.
       expect(resolveSecret).not.toHaveBeenCalled();
+      expect(JSON.stringify(result)).not.toContain(PLAINTEXT);
+    });
+
+    it("fails closed for ANY filePath when secretsFileRoot is unset (even a plain name)", async () => {
+      setupMocks(); // no secretsFileRoot
+      for (const filePath of [".env", "secrets/.env", "/etc/passwd", "../x"]) {
+        const result = await writeSecret({ alias: "k", filePath });
+        expect(parseText(result).error).toMatch(/not configured/i);
+      }
+      expect(resolveSecret).not.toHaveBeenCalled();
+    });
+
+    // 🔴 REGRESSION: the old `root + sep` containment self-locked when root="/"
+    // (`//` prefix matched nothing → reject everything) and a later patch made
+    // root="/" fail-open. The path.relative containment has neither pathology.
+    // The fail-closed default means a degenerate root="/" can never arise from
+    // an unset config, but an operator could still set it explicitly, so pin the
+    // behavior: a path inside "/" is contained, an absolute-elsewhere is not
+    // (here everything is under "/", so it is accepted — the point is the jail
+    // does NOT self-lock and does NOT crash).
+    it("does not self-lock when secretsFileRoot is explicitly '/'", async () => {
+      setupMocks({ secretsFileRoot: "/" });
+      vi.mocked(resolveSecret).mockResolvedValue({ status: "resolved", value: PLAINTEXT });
+      const target = join(root, "explicit-root-slash.txt");
+      // Use the real temp path (which is under "/") as the relative target so we
+      // do not actually write to a sensitive location.
+      const rel = relative("/", target);
+      const result = await writeSecret({ alias: "k", filePath: rel });
+      const data = parseText(result);
+      expect(data.written).toBe(true);
+      expect(await readFile(target, "utf8")).toBe(PLAINTEXT);
+      // jail-relative path never leaks the absolute root layout.
+      expect(JSON.stringify(result)).not.toContain(PLAINTEXT);
     });
 
     it("not_found → guides the user to add the key, no plaintext, no write", async () => {
@@ -1607,6 +1646,19 @@ describe("createOctoManagementTools", () => {
       expect(data.ambiguous).toBe(true);
       expect(data.candidates).toHaveLength(2);
       expect(data.candidates[0].display_name).toBe("openai prod");
+      expect(JSON.stringify(result)).not.toContain(PLAINTEXT);
+      await expect(readFile(join(root, ".env"), "utf8")).rejects.toThrow();
+    });
+
+    it("rate_limited → back-off hint, no body in the error, no write", async () => {
+      vi.mocked(resolveSecret).mockResolvedValue({ status: "rate_limited" });
+
+      const result = await writeSecret({ alias: "openai key", filePath: ".env" });
+      const data = parseText(result);
+
+      expect(data.error).toMatch(/rate limited|busy/i);
+      expect(data.error).toContain("openai key");
+      // 🔴 The 429 path reads no body, so nothing server-controlled leaks here.
       expect(JSON.stringify(result)).not.toContain(PLAINTEXT);
       await expect(readFile(join(root, ".env"), "utf8")).rejects.toThrow();
     });
@@ -1666,6 +1718,337 @@ describe("createOctoManagementTools", () => {
       expect(resolveSecret).toHaveBeenCalledTimes(2);
       // overwrite mode → file ends up with the latest value.
       expect(await readFile(join(root, ".env"), "utf8")).toBe("rotated-value");
+    });
+
+    // -----------------------------------------------------------------------
+    // Jail root DEFAULT = agent workspace (YUJ-3947)
+    //
+    // When no explicit secretsFileRoot is configured, the jail root falls back
+    // to the agent's workspace (cfg.agents.list[].workspace matched by
+    // agentAccountId, else cfg.agents.defaults.workspace). This removes the
+    // "operator must hand-configure secretsFileRoot" step from PR#92 WITHOUT
+    // weakening the security model: if no usable (non-root) workspace resolves,
+    // the write still FAILS CLOSED — there is NO process.cwd() fallback.
+    // -----------------------------------------------------------------------
+    describe("jail root default = agent workspace", () => {
+      // Build an execute() bound to a cfg with agents config + an agentAccountId,
+      // so the workspace-default resolution path is exercised. setupMocks (run in
+      // the parent beforeEach) controls the account-level secretsFileRoot.
+      const executeWithAgents = (
+        agents: unknown,
+        agentAccountId: string | undefined,
+        agentId?: string,
+      ) => {
+        const cfg = { ...mockCfg, agents } as any;
+        const tools = createOctoManagementTools({ cfg, agentAccountId, agentId });
+        expect(tools).toHaveLength(1);
+        return (args: Record<string, unknown>) =>
+          (tools[0].execute as any)("tc", { action: "write-secret", ...args });
+      };
+
+      it("jails to the matched agent's workspace when secretsFileRoot is unset", async () => {
+        setupMocks(); // no secretsFileRoot → falls back to workspace
+        vi.mocked(resolveSecret).mockResolvedValue({ status: "resolved", value: PLAINTEXT });
+        const exec = executeWithAgents(
+          { defaults: { workspace: "/nope" }, list: [{ id: "bot-A", workspace: root }] },
+          "bot-A",
+        );
+
+        const result = await exec({ alias: "k", filePath: "in-jail.env" });
+        const data = parseText(result);
+
+        expect(data.written).toBe(true);
+        expect(await readFile(join(root, "in-jail.env"), "utf8")).toBe(PLAINTEXT);
+        expect(JSON.stringify(result)).not.toContain(PLAINTEXT);
+      });
+
+      it("rejects an out-of-jail path under the agent-workspace default", async () => {
+        setupMocks();
+        vi.mocked(resolveSecret).mockResolvedValue({ status: "resolved", value: PLAINTEXT });
+        const exec = executeWithAgents(
+          { list: [{ id: "bot-A", workspace: root }] },
+          "bot-A",
+        );
+
+        const result = await exec({ alias: "k", filePath: "../escape.env" });
+        const data = parseText(result);
+
+        expect(data.error).toMatch(/outside the allowed|permitted root/i);
+        // Plaintext never fetched / leaked on a confinement reject.
+        expect(resolveSecret).not.toHaveBeenCalled();
+        expect(JSON.stringify(result)).not.toContain(PLAINTEXT);
+      });
+
+      it("falls back to defaults.workspace when the agent has no own workspace", async () => {
+        setupMocks();
+        vi.mocked(resolveSecret).mockResolvedValue({ status: "resolved", value: PLAINTEXT });
+        const exec = executeWithAgents(
+          { defaults: { workspace: root }, list: [{ id: "bot-A" }] },
+          "bot-A",
+        );
+
+        const result = await exec({ alias: "k", filePath: "via-defaults.env" });
+        const data = parseText(result);
+
+        expect(data.written).toBe(true);
+        expect(await readFile(join(root, "via-defaults.env"), "utf8")).toBe(PLAINTEXT);
+      });
+
+      it("falls back to defaults.workspace when no agent matches agentAccountId", async () => {
+        setupMocks();
+        vi.mocked(resolveSecret).mockResolvedValue({ status: "resolved", value: PLAINTEXT });
+        const exec = executeWithAgents(
+          { defaults: { workspace: root }, list: [{ id: "someone-else", workspace: "/x" }] },
+          "bot-A",
+        );
+
+        const result = await exec({ alias: "k", filePath: "no-match.env" });
+        expect(parseText(result).written).toBe(true);
+        expect(await readFile(join(root, "no-match.env"), "utf8")).toBe(PLAINTEXT);
+      });
+
+      it("explicit secretsFileRoot still wins over the agent-workspace default", async () => {
+        // Operator wants a NARROWER jail than the workspace: secretsFileRoot must
+        // take precedence. Point the workspace at a sibling temp dir and assert
+        // the file lands under secretsFileRoot (root), not the workspace.
+        const otherWorkspace = await mkdtemp(join(tmpdir(), "octo-ws-"));
+        try {
+          setupMocks({ secretsFileRoot: root });
+          vi.mocked(resolveSecret).mockResolvedValue({ status: "resolved", value: PLAINTEXT });
+          const exec = executeWithAgents(
+            { list: [{ id: "bot-A", workspace: otherWorkspace }] },
+            "bot-A",
+          );
+
+          const result = await exec({ alias: "k", filePath: "explicit.env" });
+          expect(parseText(result).written).toBe(true);
+          // Written under the explicit root…
+          expect(await readFile(join(root, "explicit.env"), "utf8")).toBe(PLAINTEXT);
+          // …NOT under the workspace.
+          await expect(
+            readFile(join(otherWorkspace, "explicit.env"), "utf8"),
+          ).rejects.toThrow();
+        } finally {
+          await rm(otherWorkspace, { recursive: true, force: true });
+        }
+      });
+
+      it("fails closed when neither secretsFileRoot nor any workspace is set", async () => {
+        setupMocks(); // no secretsFileRoot
+        vi.mocked(resolveSecret).mockResolvedValue({ status: "resolved", value: PLAINTEXT });
+        const exec = executeWithAgents({ list: [{ id: "bot-A" }] }, "bot-A");
+
+        const result = await exec({ alias: "k", filePath: "key.env" });
+        const data = parseText(result);
+
+        expect(data.error).toMatch(/not configured/i);
+        expect(resolveSecret).not.toHaveBeenCalled();
+        expect(JSON.stringify(result)).not.toContain(PLAINTEXT);
+      });
+
+      it("fails closed when cfg has no agents block at all", async () => {
+        setupMocks();
+        vi.mocked(resolveSecret).mockResolvedValue({ status: "resolved", value: PLAINTEXT });
+        const exec = executeWithAgents(undefined, "bot-A");
+
+        const result = await exec({ alias: "k", filePath: "key.env" });
+        expect(parseText(result).error).toMatch(/not configured/i);
+        expect(resolveSecret).not.toHaveBeenCalled();
+      });
+
+      it("fails closed when defaults.workspace resolves to '/' (degenerate root)", async () => {
+        // A defaults.workspace mistakenly set to "/" must NOT become a root-wide
+        // secret jail — treat it as no usable default and fail closed.
+        setupMocks();
+        vi.mocked(resolveSecret).mockResolvedValue({ status: "resolved", value: PLAINTEXT });
+        const exec = executeWithAgents({ defaults: { workspace: "/" } }, "bot-A");
+
+        const result = await exec({ alias: "k", filePath: "key.env" });
+        expect(parseText(result).error).toMatch(/not configured/i);
+        expect(resolveSecret).not.toHaveBeenCalled();
+      });
+
+      it("fails closed when the agent workspace is an empty/whitespace string", async () => {
+        setupMocks();
+        vi.mocked(resolveSecret).mockResolvedValue({ status: "resolved", value: PLAINTEXT });
+        const exec = executeWithAgents(
+          { defaults: { workspace: "   " }, list: [{ id: "bot-A", workspace: "" }] },
+          "bot-A",
+        );
+
+        const result = await exec({ alias: "k", filePath: "key.env" });
+        expect(parseText(result).error).toMatch(/not configured/i);
+        expect(resolveSecret).not.toHaveBeenCalled();
+      });
+
+      // 🔴 BLOCKING REGRESSION (Jerry-Xin) — symlink-to-`/` fail-open.
+      // The old guard checked the LEXICAL form (`resolvePath(workspace) === sep`),
+      // so a workspace configured as a symlink whose REAL target is "/" slipped
+      // past it (the lexical path is the link, ≠ "/") and only degenerated into a
+      // root-wide jail later inside confineSecretPath's realpath(). The fix moves
+      // the degenerate-root check to AFTER realpath canonicalization, so a
+      // workspace that resolves to "/" now fails closed here.
+      it("fails closed when the agent workspace is a symlink to '/' (realpath-after-canon)", async () => {
+        setupMocks();
+        vi.mocked(resolveSecret).mockResolvedValue({ status: "resolved", value: PLAINTEXT });
+        const linkToRoot = join(root, "ws-root-link");
+        await symlink("/", linkToRoot, "dir");
+        // Sanity: lexically the workspace is NOT "/", so the old guard would pass it.
+        expect(linkToRoot).not.toBe("/");
+
+        const exec = executeWithAgents(
+          { list: [{ id: "bot-A", workspace: linkToRoot }] },
+          "bot-A",
+        );
+
+        const result = await exec({ alias: "k", filePath: "key.env" });
+        expect(parseText(result).error).toMatch(/not configured/i);
+        // Plaintext never fetched / leaked on the fail-closed path.
+        expect(resolveSecret).not.toHaveBeenCalled();
+        expect(JSON.stringify(result)).not.toContain(PLAINTEXT);
+      });
+
+      // 🔴 BLOCKING (Jerry-Xin) — Windows drive root must fail closed too. The old
+      // `=== sep` compare never matched "C:\\" (resolvePath("C:\\") !== "/"), so a
+      // drive-root workspace would have degenerated into a root-wide jail. The
+      // path.parse(p).root === p check covers POSIX and Windows roots alike.
+      // Drive roots only exist on win32, so this assertion is platform-gated.
+      it("fails closed when the agent workspace is a Windows drive root", async () => {
+        if (process.platform !== "win32") return; // drive roots are win32-only
+        setupMocks();
+        vi.mocked(resolveSecret).mockResolvedValue({ status: "resolved", value: PLAINTEXT });
+        const exec = executeWithAgents(
+          { list: [{ id: "bot-A", workspace: "C:\\" }] },
+          "bot-A",
+        );
+
+        const result = await exec({ alias: "k", filePath: "key.env" });
+        expect(parseText(result).error).toMatch(/not configured/i);
+        expect(resolveSecret).not.toHaveBeenCalled();
+      });
+
+      // 必修2 — match key namespace. The workspace is indexed by OpenClaw AGENT
+      // id, not the channel/Octo account id. When the two differ (e.g. agent
+      // `main` ↔ octo account `default`), keying on the account id silently misses
+      // the per-agent workspace and falls back to defaults. Assert that passing a
+      // distinct agentId hits the per-agent workspace even though agentAccountId
+      // points at a different entry.
+      it("matches the per-agent workspace by agentId when account id ≠ agent id", async () => {
+        setupMocks(); // no secretsFileRoot → workspace default
+        vi.mocked(resolveSecret).mockResolvedValue({ status: "resolved", value: PLAINTEXT });
+        const exec = executeWithAgents(
+          {
+            defaults: { workspace: "/nope" },
+            // The agent we want is keyed by agent id "main"; the octo account id
+            // is the unrelated "default".
+            list: [{ id: "main", workspace: root }],
+          },
+          "default", // agentAccountId (octo account) — does NOT match list[].id
+          "main", // agentId (OpenClaw agent) — DOES match
+        );
+
+        const result = await exec({ alias: "k", filePath: "by-agent-id.env" });
+        const data = parseText(result);
+
+        expect(data.written).toBe(true);
+        expect(await readFile(join(root, "by-agent-id.env"), "utf8")).toBe(PLAINTEXT);
+        expect(JSON.stringify(result)).not.toContain(PLAINTEXT);
+      });
+
+      // 必修2 — agentId takes precedence over agentAccountId when both match
+      // different entries. The correct (per-agent-id) workspace must win.
+      it("prefers agentId over agentAccountId when both match different entries", async () => {
+        setupMocks();
+        vi.mocked(resolveSecret).mockResolvedValue({ status: "resolved", value: PLAINTEXT });
+        const wrongWorkspace = await mkdtemp(join(tmpdir(), "octo-ws-wrong-"));
+        try {
+          const exec = executeWithAgents(
+            {
+              list: [
+                { id: "main", workspace: root }, // matched by agentId
+                { id: "default", workspace: wrongWorkspace }, // matched by accountId
+              ],
+            },
+            "default", // agentAccountId
+            "main", // agentId — should win
+          );
+
+          const result = await exec({ alias: "k", filePath: "pref.env" });
+          expect(parseText(result).written).toBe(true);
+          // Written under the agentId-matched workspace…
+          expect(await readFile(join(root, "pref.env"), "utf8")).toBe(PLAINTEXT);
+          // …NOT under the accountId-matched one.
+          await expect(
+            readFile(join(wrongWorkspace, "pref.env"), "utf8"),
+          ).rejects.toThrow();
+        } finally {
+          await rm(wrongWorkspace, { recursive: true, force: true });
+        }
+      });
+
+      // 必修2 — agent id matching is namespace-normalized (lower/slug), matching
+      // the platform's normalizeAgentId. A config entry id with different casing
+      // must still match the runtime agent id.
+      it("matches the agent workspace case-insensitively (normalizeAgentId)", async () => {
+        setupMocks();
+        vi.mocked(resolveSecret).mockResolvedValue({ status: "resolved", value: PLAINTEXT });
+        const exec = executeWithAgents(
+          { list: [{ id: "Bot-A", workspace: root }] },
+          undefined,
+          "bot-a", // differs only in casing
+        );
+
+        const result = await exec({ alias: "k", filePath: "case.env" });
+        expect(parseText(result).written).toBe(true);
+        expect(await readFile(join(root, "case.env"), "utf8")).toBe(PLAINTEXT);
+      });
+
+      // 必修3 — `~` expansion. A workspace configured as "~/<subdir>" must expand
+      // to $HOME, matching the platform's canonical resolveAgentWorkspaceDir,
+      // rather than being treated as a literal "./~" segment.
+      it("expands a leading ~ in the workspace to the home directory", async () => {
+        setupMocks();
+        vi.mocked(resolveSecret).mockResolvedValue({ status: "resolved", value: PLAINTEXT });
+        // Carve a real workspace under HOME so realpath canonicalization succeeds.
+        const home = homedir();
+        const wsName = `octo-tilde-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+        const wsAbs = join(home, wsName);
+        await mkdir(wsAbs, { recursive: true });
+        try {
+          const exec = executeWithAgents(
+            { list: [{ id: "bot-A", workspace: `~/${wsName}` }] },
+            "bot-A",
+          );
+
+          const result = await exec({ alias: "k", filePath: "tilde.env" });
+          expect(parseText(result).written).toBe(true);
+          expect(await readFile(join(wsAbs, "tilde.env"), "utf8")).toBe(PLAINTEXT);
+        } finally {
+          await rm(wsAbs, { recursive: true, force: true });
+        }
+      });
+
+      // 必修3 — $VAR / ${VAR} expansion. A workspace parameterized by an env var
+      // must expand before the path is used as the jail root.
+      it("expands $VAR / ${VAR} in the workspace path", async () => {
+        setupMocks();
+        vi.mocked(resolveSecret).mockResolvedValue({ status: "resolved", value: PLAINTEXT });
+        const prev = process.env.OCTO_TEST_WS;
+        process.env.OCTO_TEST_WS = root;
+        try {
+          const exec = executeWithAgents(
+            { list: [{ id: "bot-A", workspace: "${OCTO_TEST_WS}/sub" }] },
+            "bot-A",
+          );
+
+          const result = await exec({ alias: "k", filePath: "envvar.env" });
+          expect(parseText(result).written).toBe(true);
+          expect(await readFile(join(root, "sub", "envvar.env"), "utf8")).toBe(PLAINTEXT);
+        } finally {
+          if (prev === undefined) delete process.env.OCTO_TEST_WS;
+          else process.env.OCTO_TEST_WS = prev;
+        }
+      });
     });
   });
 });

--- a/src/agent-tools.ts
+++ b/src/agent-tools.ts
@@ -43,7 +43,6 @@ import {
 import { broadcastGroupMdUpdate, broadcastThreadMdUpdate } from "./group-md.js";
 import { mkdir, realpath, lstat, open } from "node:fs/promises";
 import { constants as fsConstants } from "node:fs";
-import { homedir } from "node:os";
 import {
   basename,
   dirname,
@@ -55,6 +54,16 @@ import {
 } from "node:path";
 
 import type { OpenClawConfig } from "openclaw/plugin-sdk";
+// 🔴 Canonical, platform-owned agent-workspace resolver. This is the SAME logic
+// the OpenClaw host uses to decide where an agent's workspace lives, so the
+// write-secret jail default stays in lock-step with the platform instead of a
+// hand-rolled re-derivation that drifts (the source of the non-default-agent
+// jail-escape + symlink-normalization bugs this rework fixes). It encodes:
+//   • default agent  → agents.defaults.workspace (or the agent's own workspace);
+//   • non-default    → agents.defaults.workspace/<normalizedAgentId> (per-agent
+//                      subdir — never the bare shared parent);
+//   • `~` home expansion via resolveUserPath.
+import { resolveAgentWorkspaceDir } from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
 import { DEFAULT_ACCOUNT_ID } from "./sdk-compat.js";
 
 /**
@@ -141,15 +150,16 @@ async function confineSecretPath(
   }
 
   // Resolve the configured root to an absolute, symlink-free canonical form so
-  // containment checks compare apples to apples.
-  let root: string;
-  try {
-    root = await realpath(resolvePath(rootRaw));
-  } catch {
-    // Root doesn't exist yet (or isn't reachable): fall back to its lexical
-    // absolute form. We can still enforce containment lexically below.
-    root = resolvePath(rootRaw);
-  }
+  // containment checks compare apples to apples. 🔴 We canonicalize through the
+  // NEAREST EXISTING ANCESTOR rather than `realpath(root)` outright: on a
+  // workspace-default jail's first write the root directory often doesn't exist
+  // yet, and a plain realpath() would throw ENOENT and leave us with the LEXICAL
+  // (un-canonicalized) form. That lexical root later diverges from the
+  // post-mkdir `realpath(dir)` whenever any ancestor is a symlink (macOS
+  // `/tmp`→`/private/tmp`, container bind-mounts, a symlinked `$HOME`),
+  // false-rejecting a legitimate write as "escaped the allowed root after
+  // creation". Canonicalizing the existing prefix makes both sides symlink-free.
+  const root = await canonicalizeThroughExisting(rootRaw);
 
   // Resolve the requested path against the root. resolvePath collapses any
   // `..`/`.` segments; an absolute `filePath` replaces the root entirely, which
@@ -243,39 +253,30 @@ function normalizeAgentId(value: string | undefined | null): string {
 }
 
 /**
- * Expand a configured workspace string the same way the platform's canonical
- * `resolveAgentWorkspaceDir` does before it is used as a path:
- *   • leading `~` / `~/…` → the user's home directory (matches the platform's
- *     `resolveUserPath` / `expandHomePrefix`);
- *   • `$VAR` and `${VAR}` (and Windows `%VAR%`) → the matching environment
- *     variable, so an operator can parameterize the jail root.
- * A raw config string fed straight into `resolvePath` (the previous behavior)
- * would treat `~`/`$VAR` as literal path segments, jailing secrets under a
- * bogus `./~/…` directory instead of the intended workspace.
+ * Expand `$VAR` / `${VAR}` (POSIX) and `%VAR%` (Windows) against the process
+ * environment.
+ *
+ * The platform's canonical `resolveAgentWorkspaceDir` (via `resolveUserPath`)
+ * expands a leading `~` but does NOT substitute environment variables, so an
+ * operator who parameterizes a workspace as `${SECRETS_BASE}/octo` would
+ * otherwise get a literal `./${SECRETS_BASE}` directory. We pre-expand env vars
+ * on the configured workspace string BEFORE handing it to the platform resolver,
+ * which then performs the `~`-expansion and the per-agent path derivation. An
+ * undefined variable is left untouched (so the resulting non-root path still
+ * fails the existence/degeneracy checks safely rather than silently collapsing).
  */
-function expandWorkspacePath(input: string): string {
-  let out = input;
-  // $VAR / ${VAR}
-  out = out.replace(/\$\{([A-Za-z_][A-Za-z0-9_]*)\}|\$([A-Za-z_][A-Za-z0-9_]*)/g, (m, a, b) => {
-    const name = a ?? b;
-    const val = process.env[name];
-    return val !== undefined ? val : m;
-  });
-  // Windows %VAR%
+function expandEnvVars(input: string): string {
+  let out = input.replace(
+    /\$\{([A-Za-z_][A-Za-z0-9_]*)\}|\$([A-Za-z_][A-Za-z0-9_]*)/g,
+    (m, a, b) => {
+      const val = process.env[a ?? b];
+      return val !== undefined ? val : m;
+    },
+  );
   out = out.replace(/%([A-Za-z_][A-Za-z0-9_]*)%/g, (m, name) => {
     const val = process.env[name];
     return val !== undefined ? val : m;
   });
-  // Leading ~ → home
-  if (out === "~" || out.startsWith("~/") || out.startsWith("~\\")) {
-    try {
-      const home = homedir();
-      if (home) out = out.replace(/^~(?=$|[\\/])/, home);
-    } catch {
-      // homedir() unavailable — leave the literal "~", resolvePath will treat it
-      // as a relative segment and the (non-root) result still fails safe.
-    }
-  }
   return out;
 }
 
@@ -294,35 +295,95 @@ function isFilesystemRoot(p: string): boolean {
 }
 
 /**
+ * Canonicalize an absolute path through its NEAREST EXISTING ANCESTOR.
+ *
+ * `realpath(p)` throws ENOENT the moment any component of `p` does not yet exist
+ * — which is the common case for a workspace-default jail on its very first
+ * write (the workspace dir hasn't been created). The old code fell back to the
+ * LEXICAL (un-canonicalized) form in that case. That produced a subtle but
+ * security-relevant inconsistency: the jail root was stored lexically, but the
+ * post-mkdir guard later compared it against `realpath(dir)` of the now-created
+ * directory. If ANY ancestor was a symlink (macOS `/tmp`→`/private/tmp`, a
+ * container bind-mount, a symlinked `$HOME`/workspace), the two diverged and a
+ * perfectly legitimate first write was rejected with "destination directory
+ * escaped the allowed root after creation".
+ *
+ * The fix: canonicalize the deepest ancestor that DOES exist, then re-append the
+ * still-missing tail. The result is symlink-free for every component that could
+ * possibly be a symlink (a not-yet-existing component cannot be one), so a later
+ * `realpath` of the created directory compares apples to apples. This neither
+ * loosens nor tightens containment — it only makes the root's canonical form
+ * consistent with how every downstream check canonicalizes paths.
+ */
+async function canonicalizeThroughExisting(absInput: string): Promise<string> {
+  const abs = resolvePath(absInput);
+  let dir = abs;
+  const tail: string[] = [];
+  // Walk up until we find an ancestor that exists (and can be realpath'd).
+  // Stop at the filesystem root regardless.
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    try {
+      const real = await realpath(dir);
+      return tail.length ? resolvePath(real, ...tail.reverse()) : real;
+    } catch {
+      const parent = dirname(dir);
+      if (parent === dir) {
+        // Reached the filesystem root and even it didn't resolve — fall back to
+        // the lexical absolute form (no symlink can hide above the root).
+        return abs;
+      }
+      tail.push(basename(dir));
+      dir = parent;
+    }
+  }
+}
+
+/**
  * Resolve the DEFAULT jail root for write-secret from the agent's workspace.
  *
  * This is the fallback used when no explicit per-account `secretsFileRoot` is
  * configured (the explicit value is handled by the caller and ALWAYS wins over
  * this default, so an operator can still lock writes to a narrower directory).
  *
- * Resolution order (matched against the OpenClaw **agent id**, the namespace
- * `cfg.agents.list[]` is keyed by — see normalizeAgentId):
- *   1. The matched `cfg.agents.list[]` entry → its `workspace`.
- *   2. `cfg.agents.defaults.workspace` (when the matched agent has no own
- *      workspace, or no agent matched).
- * The OpenClaw agent id (`agentId`) is preferred; the channel/Octo account id
- * (`agentAccountId`) is only a fallback, because account id ≠ agent id in
- * multi-agent deployments (e.g. agent `main` ↔ octo account `default`) and
- * keying on the account id would silently miss the per-agent workspace.
+ * 🔴 We delegate the actual path derivation to the platform-canonical
+ * `resolveAgentWorkspaceDir`, the SAME function the OpenClaw host uses, instead
+ * of re-deriving it here. That resolver encodes the per-agent semantics a
+ * hand-rolled version kept getting wrong:
+ *   • DEFAULT agent → `agents.defaults.workspace` (or its own `workspace`);
+ *   • NON-DEFAULT agent with no own workspace → `agents.defaults.workspace/<id>`
+ *     — a per-agent SUBDIRECTORY, never the bare shared parent. (The previous
+ *     hand-rolled code jailed every non-default agent to the WHOLE
+ *     `defaults.workspace`, letting e.g. a `worker` agent write into a sibling
+ *     `main/.env` — a cross-agent secret-write escape.)
+ * It also applies `~` expansion via `resolveUserPath`.
  *
- * 🔴 SECURITY — realpath-after-canon degenerate guard: this NEVER falls back to
- * `process.cwd()` (the source of the historical `/`-degenerate self-lock +
- * fail-open bugs). The configured workspace is home/env-expanded, then
- * **realpath-canonicalized**, and ONLY THEN checked for the filesystem-root
- * degeneracy. Doing the check after canonicalization closes the symlink-to-`/`
- * fail-open: a workspace pointed at a symlink whose real target is `/` (or a
- * drive root) now resolves to that root and is rejected here, instead of
- * slipping through a lexical `!== "/"` test and degenerating into a root-wide
- * jail downstream. If no workspace is configured, the value is empty, or it
- * canonicalizes to a filesystem root, we return `undefined` so the caller FAILS
- * CLOSED. (An operator who *explicitly* sets secretsFileRoot="/" is a separate,
- * deliberate opt-in handled by the caller and is intentionally NOT subject to
- * this default-degeneracy guard.)
+ * The OpenClaw agent id (`agentId`) is the namespace `cfg.agents.list[]` is
+ * keyed by; the channel/Octo account id (`agentAccountId`) is only a fallback
+ * for deployments where the two coincide, because account id ≠ agent id in
+ * multi-agent setups (e.g. agent `main` ↔ octo account `default`).
+ *
+ * Two things the platform resolver intentionally does NOT do, which this wrapper
+ * adds because a SECRET jail has stricter requirements than a general workspace:
+ *   1. ENV-VAR EXPANSION. The resolver expands `~` but not `$VAR`/`${VAR}`, so we
+ *      pre-expand env vars on the configured workspace strings first.
+ *   2. FAIL-CLOSED. The resolver always SYNTHESIZES a path (e.g.
+ *      `~/.openclaw/workspace`) even when nothing is configured. Silently
+ *      writing the owner's plaintext secret under a synthesized default the
+ *      operator never opted into is unsafe, so we return `undefined` (→ caller
+ *      fails closed) unless a workspace is ACTUALLY configured for this agent.
+ *
+ * 🔴 SECURITY — realpath-after-canon degenerate guard: NEVER falls back to
+ * `process.cwd()`. The resolved workspace is realpath-canonicalized and ONLY
+ * THEN checked for filesystem-root degeneracy, so a workspace pointing (directly
+ * or via symlink) at `/` or a drive root resolves to that root and is rejected
+ * here instead of degenerating into a root-wide jail downstream. We also reject
+ * when the CONFIGURED BASE is itself a filesystem root, because the platform
+ * resolver would turn `defaults.workspace="/"` into `"/<agentId>"` for a
+ * non-default agent — a per-agent subdir of `/` is still a root-adjacent jail
+ * the operator plainly did not intend. (An operator who *explicitly* sets
+ * secretsFileRoot="/" is a separate, deliberate opt-in handled by the caller and
+ * is intentionally NOT subject to this default-degeneracy guard.)
  */
 async function resolveAgentWorkspaceRoot(
   cfg: OpenClawConfig,
@@ -332,41 +393,80 @@ async function resolveAgentWorkspaceRoot(
   const agents = cfg.agents;
   if (!agents) return undefined;
 
-  // Match on the OpenClaw agent id first (the namespace list[] is keyed by),
-  // then fall back to the channel/Octo account id for deployments where the two
-  // coincide. Normalize both sides so casing/punctuation can't cause a miss.
+  // Effective agent id: prefer the OpenClaw agent id, fall back to the Octo
+  // account id only when the agent id is absent. The platform resolver
+  // normalizes this internally, so we pass it through as-is.
+  const effectiveId = (agentId ?? agentAccountId)?.trim();
+  if (!effectiveId) return undefined;
+  const normId = normalizeAgentId(effectiveId);
+
+  // Find this agent's OWN configured workspace (if any) and the shared default,
+  // matching the platform's id namespace (lower/slug-normalized).
   const list = agents.list;
-  let matched: { workspace?: string } | undefined;
-  for (const candidate of [agentId, agentAccountId]) {
-    if (!candidate) continue;
-    const norm = normalizeAgentId(candidate);
-    matched = list?.find(
-      (a) => a.id != null && normalizeAgentId(a.id) === norm,
-    );
-    if (matched) break;
+  const matched = list?.find(
+    (a) => a.id != null && normalizeAgentId(a.id) === normId,
+  );
+  const ownWorkspaceRaw = matched?.workspace?.trim();
+  const defaultWorkspaceRaw = agents.defaults?.workspace?.trim();
+
+  // 🔴 FAIL-CLOSED: only proceed when a workspace is ACTUALLY configured for
+  // this agent (its own, or a shared default it can inherit). Without this the
+  // platform resolver would synthesize `~/.openclaw/workspace` and we'd silently
+  // jail secrets under a directory the operator never opted into.
+  const configuredBaseRaw = ownWorkspaceRaw || defaultWorkspaceRaw;
+  if (!configuredBaseRaw) return undefined;
+
+  // 🔴 Reject a configured BASE that is a filesystem root up-front: for a
+  // non-default agent the platform would append `/<agentId>` and produce a
+  // root-adjacent jail (`/<agentId>`), which is just as unintended as a
+  // root-wide one. resolveUserPath('~') etc. can't yield a root from a non-root
+  // input, so this only catches an explicit `/` / drive-root base.
+  if (isFilesystemRoot(resolvePath(expandEnvVars(configuredBaseRaw)))) {
+    return undefined;
   }
 
-  const workspace = (matched?.workspace ?? agents.defaults?.workspace)?.trim();
-  if (!workspace) return undefined;
+  // Hand the platform resolver an env-EXPANDED view of this agent's config so
+  // its `~`-expansion + per-agent derivation operate on real path segments. We
+  // only override the two workspace fields it reads, preserving the rest of cfg.
+  const resolverCfg: OpenClawConfig = {
+    ...cfg,
+    agents: {
+      ...agents,
+      defaults: {
+        ...agents.defaults,
+        ...(defaultWorkspaceRaw
+          ? { workspace: expandEnvVars(defaultWorkspaceRaw) }
+          : {}),
+      },
+      ...(Array.isArray(list)
+        ? {
+            list: list.map((a) =>
+              a.id != null && normalizeAgentId(a.id) === normId && ownWorkspaceRaw
+                ? { ...a, workspace: expandEnvVars(ownWorkspaceRaw) }
+                : a,
+            ),
+          }
+        : {}),
+    },
+  } as OpenClawConfig;
 
-  // Home/env-expand to align with the platform's canonical workspace resolver,
-  // then realpath-canonicalize so the degenerate-root check below runs on the
-  // REAL target (defeats a symlink-to-`/` fail-open).
-  const expanded = resolvePath(expandWorkspacePath(workspace));
-  let canonical: string;
+  let derived: string;
   try {
-    canonical = await realpath(expanded);
+    derived = resolveAgentWorkspaceDir(resolverCfg, effectiveId);
   } catch {
-    // Workspace doesn't exist yet (or is unreachable): a non-existent path can't
-    // be a symlink, so its lexical absolute form is its effective target. We can
-    // still apply the degenerate-root guard against it.
-    canonical = expanded;
+    return undefined;
   }
+  if (!derived?.trim()) return undefined;
+
+  // Canonicalize through the nearest existing ancestor so the jail root is
+  // symlink-free and consistent with the post-mkdir `realpath(dir)` comparison
+  // (defeats the symlink-ancestor false-reject) AND so a symlink-to-`/` is
+  // caught by the degenerate-root guard below.
+  const canonical = await canonicalizeThroughExisting(derived);
 
   // 🔴 Degenerate-root guard, AFTER canonicalization: a workspace that resolves
-  // to a filesystem root (POSIX "/" or a Windows drive root) must NOT become a
-  // root-wide secret jail. Treat it as "no usable default" so the caller fails
-  // closed.
+  // to a filesystem root must NOT become a root-wide secret jail. Treat it as
+  // "no usable default" so the caller fails closed.
   if (isFilesystemRoot(canonical)) return undefined;
   return canonical;
 }

--- a/src/agent-tools.ts
+++ b/src/agent-tools.ts
@@ -254,30 +254,46 @@ function normalizeAgentId(value: string | undefined | null): string {
 
 /**
  * Expand `$VAR` / `${VAR}` (POSIX) and `%VAR%` (Windows) against the process
- * environment.
+ * environment, returning `undefined` if ANY referenced variable is undefined.
  *
  * The platform's canonical `resolveAgentWorkspaceDir` (via `resolveUserPath`)
  * expands a leading `~` but does NOT substitute environment variables, so an
  * operator who parameterizes a workspace as `${SECRETS_BASE}/octo` would
  * otherwise get a literal `./${SECRETS_BASE}` directory. We pre-expand env vars
- * on the configured workspace string BEFORE handing it to the platform resolver,
- * which then performs the `~`-expansion and the per-agent path derivation. An
- * undefined variable is left untouched (so the resulting non-root path still
- * fails the existence/degeneracy checks safely rather than silently collapsing).
+ * on the configured workspace string BEFORE handing it to the platform resolver.
+ *
+ * 🔴 FAIL-CLOSED on an UNDEFINED variable. Leaving an unresolved `${UNDEF}` as a
+ * literal segment is NOT safe: `path.resolve("${UNDEF}/octo")` silently anchors
+ * the relative remainder to `process.cwd()`, which would sail past the
+ * filesystem-root degeneracy guards and rebuild exactly the cwd-anchored jail
+ * this PR's fail-closed guarantee exists to prevent. So a reference to a variable
+ * the operator never set collapses the whole resolution to `undefined`, and the
+ * caller fails closed (refuses the write) rather than guessing a jail root from
+ * the process working directory. A string with no variable references at all is
+ * returned unchanged.
  */
-function expandEnvVars(input: string): string {
+function expandEnvVars(input: string): string | undefined {
+  let missing = false;
   let out = input.replace(
     /\$\{([A-Za-z_][A-Za-z0-9_]*)\}|\$([A-Za-z_][A-Za-z0-9_]*)/g,
     (m, a, b) => {
       const val = process.env[a ?? b];
-      return val !== undefined ? val : m;
+      if (val === undefined) {
+        missing = true;
+        return m;
+      }
+      return val;
     },
   );
   out = out.replace(/%([A-Za-z_][A-Za-z0-9_]*)%/g, (m, name) => {
     const val = process.env[name];
-    return val !== undefined ? val : m;
+    if (val === undefined) {
+      missing = true;
+      return m;
+    }
+    return val;
   });
-  return out;
+  return missing ? undefined : out;
 }
 
 /**
@@ -409,44 +425,61 @@ async function resolveAgentWorkspaceRoot(
   const ownWorkspaceRaw = matched?.workspace?.trim();
   const defaultWorkspaceRaw = agents.defaults?.workspace?.trim();
 
+  // Determine the EFFECTIVE base the platform resolver will use for this agent,
+  // mirroring its precedence: an agent's own workspace wins; otherwise the shared
+  // default (which the resolver uses verbatim for the default agent, or appends
+  // `/<agentId>` to for a non-default agent).
+  const usingOwnWorkspace = Boolean(ownWorkspaceRaw);
+  const configuredBaseRaw = ownWorkspaceRaw || defaultWorkspaceRaw;
+
   // 🔴 FAIL-CLOSED: only proceed when a workspace is ACTUALLY configured for
   // this agent (its own, or a shared default it can inherit). Without this the
   // platform resolver would synthesize `~/.openclaw/workspace` and we'd silently
   // jail secrets under a directory the operator never opted into.
-  const configuredBaseRaw = ownWorkspaceRaw || defaultWorkspaceRaw;
   if (!configuredBaseRaw) return undefined;
+
+  // Env-expand the EFFECTIVE base BEFORE handing it to the platform resolver.
+  // 🔴 expandEnvVars FAILS CLOSED on an undefined variable (returns undefined)
+  // rather than leaving a literal `${UNDEF}` that `path.resolve` would anchor to
+  // process.cwd() and slip past the filesystem-root guards below — so an operator
+  // typo / unset var refuses the write instead of silently rebuilding a
+  // cwd-anchored jail.
+  const configuredBaseExpanded = expandEnvVars(configuredBaseRaw);
+  if (configuredBaseExpanded === undefined) return undefined;
 
   // 🔴 Reject a configured BASE that is a filesystem root up-front: for a
   // non-default agent the platform would append `/<agentId>` and produce a
   // root-adjacent jail (`/<agentId>`), which is just as unintended as a
   // root-wide one. resolveUserPath('~') etc. can't yield a root from a non-root
   // input, so this only catches an explicit `/` / drive-root base.
-  if (isFilesystemRoot(resolvePath(expandEnvVars(configuredBaseRaw)))) {
+  if (isFilesystemRoot(resolvePath(configuredBaseExpanded))) {
     return undefined;
   }
 
   // Hand the platform resolver an env-EXPANDED view of this agent's config so
   // its `~`-expansion + per-agent derivation operate on real path segments. We
-  // only override the two workspace fields it reads, preserving the rest of cfg.
+  // override ONLY the single workspace field the resolver will actually read for
+  // this agent (its own entry, or the shared default), preserving the rest of cfg.
   const resolverCfg: OpenClawConfig = {
     ...cfg,
     agents: {
       ...agents,
-      defaults: {
-        ...agents.defaults,
-        ...(defaultWorkspaceRaw
-          ? { workspace: expandEnvVars(defaultWorkspaceRaw) }
-          : {}),
-      },
-      ...(Array.isArray(list)
+      ...(usingOwnWorkspace
         ? {
-            list: list.map((a) =>
-              a.id != null && normalizeAgentId(a.id) === normId && ownWorkspaceRaw
-                ? { ...a, workspace: expandEnvVars(ownWorkspaceRaw) }
-                : a,
-            ),
+            list: Array.isArray(list)
+              ? list.map((a) =>
+                  a.id != null && normalizeAgentId(a.id) === normId
+                    ? { ...a, workspace: configuredBaseExpanded }
+                    : a,
+                )
+              : list,
           }
-        : {}),
+        : {
+            defaults: {
+              ...agents.defaults,
+              workspace: configuredBaseExpanded,
+            },
+          }),
     },
   } as OpenClawConfig;
 

--- a/src/agent-tools.ts
+++ b/src/agent-tools.ts
@@ -43,7 +43,16 @@ import {
 import { broadcastGroupMdUpdate, broadcastThreadMdUpdate } from "./group-md.js";
 import { mkdir, realpath, lstat, open } from "node:fs/promises";
 import { constants as fsConstants } from "node:fs";
-import { basename, dirname, relative, resolve as resolvePath, sep } from "node:path";
+import { homedir } from "node:os";
+import {
+  basename,
+  dirname,
+  isAbsolute,
+  parse as parsePath,
+  relative,
+  resolve as resolvePath,
+  sep,
+} from "node:path";
 
 import type { OpenClawConfig } from "openclaw/plugin-sdk";
 import { DEFAULT_ACCOUNT_ID } from "./sdk-compat.js";
@@ -64,18 +73,54 @@ const SECRET_PLACEHOLDER = "{{secret}}";
 const SECRET_FILE_MODE = 0o600;
 
 /**
+ * Containment test: is `candidate` the jail `root` itself or a path strictly
+ * beneath it?
+ *
+ * We use `path.relative(root, candidate)` rather than string-prefix matching on
+ * `root + sep`. The prefix form has two failure modes that BOTH bit us in
+ * production:
+ *   • `root === "/"` makes `root + sep === "//"`, so `candidate.startsWith("//")`
+ *     is false for every real path → the jail rejects everything (self-lock).
+ *   • Patching that special-case the other way (treating `/` as "always inside")
+ *     turns the jail into a no-op fail-open.
+ * `path.relative` has neither pathology: the candidate is inside the root iff
+ * the relative path is empty (candidate === root), does not start with `..`
+ * (would climb out), and is not itself absolute (different root / drive on
+ * Windows). The same predicate is reused at every containment site (lexical
+ * check, symlink walk, post-mkdir re-check) so they cannot drift apart.
+ */
+function isInsideRoot(root: string, candidate: string): boolean {
+  if (candidate === root) return true;
+  const rel = relative(root, candidate);
+  return rel !== "" && !rel.startsWith(`..${sep}`) && rel !== ".." && !isAbsolute(rel);
+}
+
+/**
  * Confine a caller-supplied write target to an operator-approved jail root.
  *
  * 🔴 SECURITY (P0): `filePath` comes from the LLM tool call, which is reachable
  * via inbound group-chat messages — an untrusted, prompt-injectable surface.
  * Without confinement, `write-secret` is an arbitrary-file-write of the owner's
  * plaintext secret (e.g. "append my key to ~/.bashrc" / ".ssh/authorized_keys"
- * / a web root). We therefore resolve the requested path against a fixed root
- * (`secretsFileRoot` from config, else the plugin process CWD) and reject
- * anything that escapes it — including `..` traversal, absolute paths pointing
- * elsewhere, and symlink escapes (resolved, dangling, or otherwise
- * unverifiable). The actual write additionally uses O_NOFOLLOW to defeat a
- * TOCTOU swap between this check and the write.
+ * / a web root). The OWNER may have triggered the conversation, but the caller
+ * that actually picks `filePath`/`template` is a prompt-injectable LLM driven by
+ * arbitrary group-chat members, so OS-level "owner can write anyway" reasoning
+ * does NOT make the jail redundant — it is the only boundary between an injected
+ * instruction and an arbitrary owner-writable file.
+ *
+ * 🔴 FAIL-CLOSED: the jail root is resolved by the caller — an explicit
+ * `secretsFileRoot` if configured, otherwise the agent's workspace (see
+ * resolveAgentWorkspaceRoot). There is deliberately NO fallback to
+ * `process.cwd()`: a CWD of `/` is exactly what produced the historical
+ * self-lock and fail-open bugs, and silently writing owner secrets under
+ * whatever directory the process happens to run in is itself unsafe. If neither
+ * an explicit root nor a workspace resolves to a usable (non-root) directory,
+ * we refuse the write outright rather than guess one.
+ *
+ * When a root IS configured, we reject anything that escapes it — `..`
+ * traversal, absolute paths pointing elsewhere, and symlink escapes (resolved,
+ * dangling, or otherwise unverifiable). The actual write additionally uses
+ * O_NOFOLLOW to defeat a TOCTOU swap between this check and the write.
  *
  * Returns the safe absolute path, or an error string describing the rejection
  * (never echoing secret material — only the caller-typed path).
@@ -84,10 +129,19 @@ async function confineSecretPath(
   filePath: string,
   rootInput: string | undefined,
 ): Promise<{ ok: true; abs: string; root: string } | { ok: false; error: string }> {
-  // The jail root: operator config wins; otherwise the plugin's working dir.
-  // Resolve it to an absolute, symlink-free canonical form so containment
-  // checks compare apples to apples.
-  const rootRaw = rootInput && rootInput.trim() ? rootInput.trim() : process.cwd();
+  // 🔴 FAIL-CLOSED: no operator-configured root → refuse. Never fall back to
+  // process.cwd() (the source of the `/`-degenerate self-lock + fail-open bugs).
+  const rootRaw = rootInput?.trim();
+  if (!rootRaw) {
+    return {
+      ok: false,
+      error:
+        "write-secret is not configured: no jail root could be resolved. Set an explicit secretsFileRoot (the directory secrets may be written under), or configure the agent's workspace via agents.list[].workspace or agents.defaults.workspace, before this action can be used.",
+    };
+  }
+
+  // Resolve the configured root to an absolute, symlink-free canonical form so
+  // containment checks compare apples to apples.
   let root: string;
   try {
     root = await realpath(resolvePath(rootRaw));
@@ -102,9 +156,10 @@ async function confineSecretPath(
   // the containment check below then rejects unless it still lands inside root.
   const candidate = resolvePath(root, filePath);
 
-  // Lexical containment: candidate must be the root itself or sit strictly
-  // beneath it. This already defeats `..` traversal and absolute-elsewhere.
-  if (candidate !== root && !candidate.startsWith(root + sep)) {
+  // Lexical containment (path.relative form): candidate must be the root itself
+  // or sit strictly beneath it. This defeats `..` traversal and
+  // absolute-elsewhere without the `root + sep` self-lock/fail-open pitfalls.
+  if (!isInsideRoot(root, candidate)) {
     return {
       ok: false,
       error: `Refusing to write the secret outside the allowed directory. "${filePath}" resolves outside the permitted root. Use a path inside the workspace.`,
@@ -125,7 +180,7 @@ async function confineSecretPath(
   //   • a component that simply does not exist (ENOENT on lstat itself, not a
   //     symlink) → it and everything below it will be freshly created as plain
   //     entries inside the already-validated jail, so we can stop walking.
-  const rel = candidate === root ? "" : candidate.slice(root.length + sep.length);
+  const rel = candidate === root ? "" : relative(root, candidate);
   const segments = rel ? rel.split(sep) : [];
   let current = root;
   for (const seg of segments) {
@@ -149,7 +204,7 @@ async function confineSecretPath(
           error: `Refusing to write the secret: "${filePath}" passes through a symlink that cannot be verified to stay inside the allowed directory.`,
         };
       }
-      if (real !== root && !real.startsWith(root + sep)) {
+      if (!isInsideRoot(root, real)) {
         return {
           ok: false,
           error: `Refusing to write the secret: "${filePath}" resolves through a symlink that escapes the allowed directory.`,
@@ -162,6 +217,158 @@ async function confineSecretPath(
   }
 
   return { ok: true, abs: candidate, root };
+}
+
+/**
+ * Canonical agent-id matcher, aligned with the platform's `normalizeAgentId`
+ * (openclaw/plugin-sdk/routing). Agent entries in `cfg.agents.list[]` are keyed
+ * by OpenClaw agent id, which is lower-cased and slug-normalized; comparing raw
+ * strings (the previous `a.id === agentAccountId`) misses legitimate matches
+ * whenever casing or punctuation differs. We normalize BOTH sides before
+ * comparison so the match key lives in the same namespace as the platform.
+ */
+const VALID_AGENT_ID_RE = /^[a-z0-9][a-z0-9_-]{0,63}$/i;
+function normalizeAgentId(value: string | undefined | null): string {
+  const trimmed = (value ?? "").trim();
+  if (!trimmed) return "main";
+  const lower = trimmed.toLowerCase();
+  if (VALID_AGENT_ID_RE.test(trimmed)) return lower;
+  return (
+    lower
+      .replace(/[^a-z0-9_-]+/g, "-")
+      .replace(/^-+/, "")
+      .replace(/-+$/, "")
+      .slice(0, 64) || "main"
+  );
+}
+
+/**
+ * Expand a configured workspace string the same way the platform's canonical
+ * `resolveAgentWorkspaceDir` does before it is used as a path:
+ *   • leading `~` / `~/…` → the user's home directory (matches the platform's
+ *     `resolveUserPath` / `expandHomePrefix`);
+ *   • `$VAR` and `${VAR}` (and Windows `%VAR%`) → the matching environment
+ *     variable, so an operator can parameterize the jail root.
+ * A raw config string fed straight into `resolvePath` (the previous behavior)
+ * would treat `~`/`$VAR` as literal path segments, jailing secrets under a
+ * bogus `./~/…` directory instead of the intended workspace.
+ */
+function expandWorkspacePath(input: string): string {
+  let out = input;
+  // $VAR / ${VAR}
+  out = out.replace(/\$\{([A-Za-z_][A-Za-z0-9_]*)\}|\$([A-Za-z_][A-Za-z0-9_]*)/g, (m, a, b) => {
+    const name = a ?? b;
+    const val = process.env[name];
+    return val !== undefined ? val : m;
+  });
+  // Windows %VAR%
+  out = out.replace(/%([A-Za-z_][A-Za-z0-9_]*)%/g, (m, name) => {
+    const val = process.env[name];
+    return val !== undefined ? val : m;
+  });
+  // Leading ~ → home
+  if (out === "~" || out.startsWith("~/") || out.startsWith("~\\")) {
+    try {
+      const home = homedir();
+      if (home) out = out.replace(/^~(?=$|[\\/])/, home);
+    } catch {
+      // homedir() unavailable — leave the literal "~", resolvePath will treat it
+      // as a relative segment and the (non-root) result still fails safe.
+    }
+  }
+  return out;
+}
+
+/**
+ * Is `p` a filesystem root — POSIX `/` or a Windows drive root like `C:\`?
+ *
+ * `path.parse(p).root === p` is true exactly for those roots and nothing else,
+ * which is why we use it instead of a bare `=== sep` compare: the old check
+ * missed Windows drive roots (`resolvePath("C:\\") !== "/"`), and — crucially —
+ * it ran on the LEXICAL form, so a workspace configured as a symlink TO `/`
+ * (e.g. `/tmp/ws-link` → `/`) sailed past it and only degenerated into a
+ * root-wide jail later, inside confineSecretPath's realpath().
+ */
+function isFilesystemRoot(p: string): boolean {
+  return parsePath(p).root === p;
+}
+
+/**
+ * Resolve the DEFAULT jail root for write-secret from the agent's workspace.
+ *
+ * This is the fallback used when no explicit per-account `secretsFileRoot` is
+ * configured (the explicit value is handled by the caller and ALWAYS wins over
+ * this default, so an operator can still lock writes to a narrower directory).
+ *
+ * Resolution order (matched against the OpenClaw **agent id**, the namespace
+ * `cfg.agents.list[]` is keyed by — see normalizeAgentId):
+ *   1. The matched `cfg.agents.list[]` entry → its `workspace`.
+ *   2. `cfg.agents.defaults.workspace` (when the matched agent has no own
+ *      workspace, or no agent matched).
+ * The OpenClaw agent id (`agentId`) is preferred; the channel/Octo account id
+ * (`agentAccountId`) is only a fallback, because account id ≠ agent id in
+ * multi-agent deployments (e.g. agent `main` ↔ octo account `default`) and
+ * keying on the account id would silently miss the per-agent workspace.
+ *
+ * 🔴 SECURITY — realpath-after-canon degenerate guard: this NEVER falls back to
+ * `process.cwd()` (the source of the historical `/`-degenerate self-lock +
+ * fail-open bugs). The configured workspace is home/env-expanded, then
+ * **realpath-canonicalized**, and ONLY THEN checked for the filesystem-root
+ * degeneracy. Doing the check after canonicalization closes the symlink-to-`/`
+ * fail-open: a workspace pointed at a symlink whose real target is `/` (or a
+ * drive root) now resolves to that root and is rejected here, instead of
+ * slipping through a lexical `!== "/"` test and degenerating into a root-wide
+ * jail downstream. If no workspace is configured, the value is empty, or it
+ * canonicalizes to a filesystem root, we return `undefined` so the caller FAILS
+ * CLOSED. (An operator who *explicitly* sets secretsFileRoot="/" is a separate,
+ * deliberate opt-in handled by the caller and is intentionally NOT subject to
+ * this default-degeneracy guard.)
+ */
+async function resolveAgentWorkspaceRoot(
+  cfg: OpenClawConfig,
+  agentId: string | undefined,
+  agentAccountId: string | undefined,
+): Promise<string | undefined> {
+  const agents = cfg.agents;
+  if (!agents) return undefined;
+
+  // Match on the OpenClaw agent id first (the namespace list[] is keyed by),
+  // then fall back to the channel/Octo account id for deployments where the two
+  // coincide. Normalize both sides so casing/punctuation can't cause a miss.
+  const list = agents.list;
+  let matched: { workspace?: string } | undefined;
+  for (const candidate of [agentId, agentAccountId]) {
+    if (!candidate) continue;
+    const norm = normalizeAgentId(candidate);
+    matched = list?.find(
+      (a) => a.id != null && normalizeAgentId(a.id) === norm,
+    );
+    if (matched) break;
+  }
+
+  const workspace = (matched?.workspace ?? agents.defaults?.workspace)?.trim();
+  if (!workspace) return undefined;
+
+  // Home/env-expand to align with the platform's canonical workspace resolver,
+  // then realpath-canonicalize so the degenerate-root check below runs on the
+  // REAL target (defeats a symlink-to-`/` fail-open).
+  const expanded = resolvePath(expandWorkspacePath(workspace));
+  let canonical: string;
+  try {
+    canonical = await realpath(expanded);
+  } catch {
+    // Workspace doesn't exist yet (or is unreachable): a non-existent path can't
+    // be a symlink, so its lexical absolute form is its effective target. We can
+    // still apply the degenerate-root guard against it.
+    canonical = expanded;
+  }
+
+  // 🔴 Degenerate-root guard, AFTER canonicalization: a workspace that resolves
+  // to a filesystem root (POSIX "/" or a Windows drive root) must NOT become a
+  // root-wide secret jail. Treat it as "no usable default" so the caller fails
+  // closed.
+  if (isFilesystemRoot(canonical)) return undefined;
+  return canonical;
 }
 
 // ---------------------------------------------------------------------------
@@ -185,9 +392,11 @@ type LogSink = {
 export function createOctoManagementTools(params: {
   cfg?: OpenClawConfig;
   agentAccountId?: string;
+  agentId?: string;
 }): any[] {
   const cfg = params.cfg;
   const agentAccountId = params.agentAccountId;
+  const agentId = params.agentId;
   if (!cfg) return [];
 
   // Check if any account is configured
@@ -675,6 +884,17 @@ export function createOctoManagementTools(params: {
                 `Invalid mode "${rawMode}" for write-secret; use "overwrite" or "append"`,
               );
             }
+            // Jail root resolution (highest priority first):
+            //   1. explicit per-account/channel secretsFileRoot (operator can
+            //      lock writes to a narrower directory — this always wins).
+            //   2. DEFAULT: the agent's workspace, matched by OpenClaw agent id
+            //      (cfg.agents.list[].workspace, else cfg.agents.defaults.workspace),
+            //      home/env-expanded + realpath-canonicalized.
+            // If neither yields a usable non-root directory, confineSecretPath
+            // fails closed — there is NO process.cwd() fallback.
+            const effectiveSecretsRoot =
+              account.config.secretsFileRoot?.trim() ||
+              (await resolveAgentWorkspaceRoot(cfg, agentId, agentAccountId));
             return await handleWriteSecret({
               apiUrl,
               botToken,
@@ -682,7 +902,7 @@ export function createOctoManagementTools(params: {
               filePath,
               template,
               mode: rawMode === "append" ? "append" : "overwrite",
-              secretsFileRoot: account.config.secretsFileRoot,
+              secretsFileRoot: effectiveSecretsRoot,
             });
           }
 
@@ -977,6 +1197,15 @@ async function handleWriteSecret(params: {
     );
   }
 
+  // rate_limited → the resolve endpoint's per-IP limiter rejected the call.
+  // Surface a transient, actionable hint. 🔴 No body is read on a 429, so this
+  // message carries no server-controlled string — only a fixed back-off prompt.
+  if (resolved.status === "rate_limited") {
+    return makeError(
+      `The key service is busy right now (rate limited). Wait a moment and retry write-secret for "${params.alias}".`,
+    );
+  }
+
   // ambiguous → hand back ONLY the labels so the LLM can ask the user which one.
   // 🔴 candidates carry display_name (+ secret_id) only, never the value.
   if (resolved.status === "ambiguous") {
@@ -1011,7 +1240,7 @@ async function handleWriteSecret(params: {
       // containment, then open via the canonical parent + basename so every
       // component is proven to stay inside the root.
       const realDir = await realpath(dir);
-      if (realDir !== root && !realDir.startsWith(root + sep)) {
+      if (!isInsideRoot(root, realDir)) {
         return makeError(
           "Refusing to write the secret: the destination directory escaped the allowed root after creation.",
         );

--- a/src/api-fetch.test.ts
+++ b/src/api-fetch.test.ts
@@ -1545,7 +1545,33 @@ describe("resolveSecret", () => {
     }
   });
 
-  it("POSTs the alias with a bearer bot token", async () => {
+  it("resolves a 200 body with no status field ({ secret_id, value }) per PR#301", async () => {
+    // The current server returns the resolved value via HTTP 200 with NO status
+    // discriminator: `{ "secret_id": "...", "value": "..." }`.
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: vi.fn().mockResolvedValue({
+        secret_id: "a1b2c3d4",
+        value: "sk-live-PLAINTEXT",
+      }),
+    }) as unknown as typeof fetch;
+
+    const { resolveSecret } = await import("./api-fetch.js");
+    const result = await resolveSecret({
+      apiUrl: "http://api.test",
+      botToken: "bf_token",
+      alias: "openai key",
+    });
+
+    expect(result.status).toBe("resolved");
+    if (result.status === "resolved") {
+      expect(result.value).toBe("sk-live-PLAINTEXT");
+      expect(result.secret_id).toBe("a1b2c3d4");
+    }
+  });
+
+  it("POSTs the alias as the `query` field with a bearer bot token", async () => {
     const spy = vi.fn().mockResolvedValue({
       ok: true,
       status: 200,
@@ -1560,7 +1586,11 @@ describe("resolveSecret", () => {
     expect(url).toBe("http://api.test/v1/bot/secrets/resolve");
     expect(init.method).toBe("POST");
     expect(init.headers.Authorization).toBe("Bearer bf_token");
-    expect(JSON.parse(init.body)).toEqual({ alias: "k" });
+    // 🔴 The server binds `query` (req.Query); sending `alias` leaves Query empty
+    // → 400 request_invalid. The wire field MUST be `query`, never `alias`.
+    const body = JSON.parse(init.body);
+    expect(body).toEqual({ query: "k" });
+    expect(body).not.toHaveProperty("alias");
   });
 
   it("normalizes status:not_found", async () => {
@@ -1610,6 +1640,98 @@ describe("resolveSecret", () => {
       // No plaintext leaks into candidates.
       expect(JSON.stringify(result.candidates)).not.toContain("value");
     }
+  });
+
+  it("parses 422 ambiguous candidates from error.details.candidates (PR#301 envelope)", async () => {
+    // The current server signals ambiguity with HTTP 422 and the i18n error
+    // envelope: error.details.candidates carries the masked candidate views.
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 422,
+      json: vi.fn().mockResolvedValue({
+        status: 422,
+        error: {
+          code: "err.server.usersecret.ambiguous",
+          message: "名称匹配到多个密钥，请进一步区分。",
+          http_status: 422,
+          details: {
+            candidates: [
+              {
+                secret_id: "a",
+                display_name: "我的密钥",
+                kind: "external",
+                masked: "****1111",
+              },
+              {
+                secret_id: "b",
+                display_name: "我的米要",
+                kind: "external",
+                masked: "****2222",
+              },
+            ],
+          },
+        },
+      }),
+    }) as unknown as typeof fetch;
+
+    const { resolveSecret } = await import("./api-fetch.js");
+    const result = await resolveSecret({ apiUrl: "http://api.test", botToken: "t", alias: "我的密钥" });
+    expect(result.status).toBe("ambiguous");
+    if (result.status === "ambiguous") {
+      expect(result.candidates).toHaveLength(2);
+      // Only label-only fields survive — masked/kind are dropped.
+      expect(result.candidates[0]).toEqual({ secret_id: "a", display_name: "我的密钥" });
+      expect(JSON.stringify(result.candidates)).not.toContain("value");
+      expect(JSON.stringify(result.candidates)).not.toContain("masked");
+    }
+  });
+
+  it("treats a 422 with exactly one candidate as ambiguous (fuzzy hit needs confirmation)", async () => {
+    // Per PR#301 a single fuzzy/pinyin candidate STILL returns 422 — it must be
+    // confirmed, never auto-used. The plugin must surface it as ambiguous.
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 422,
+      json: vi.fn().mockResolvedValue({
+        status: 422,
+        error: {
+          code: "err.server.usersecret.ambiguous",
+          http_status: 422,
+          details: {
+            candidates: [
+              { secret_id: "only", display_name: "我的密钥", kind: "external", masked: "****1111" },
+            ],
+          },
+        },
+      }),
+    }) as unknown as typeof fetch;
+
+    const { resolveSecret } = await import("./api-fetch.js");
+    const result = await resolveSecret({ apiUrl: "http://api.test", botToken: "t", alias: "我的米要" });
+    expect(result.status).toBe("ambiguous");
+    if (result.status === "ambiguous") {
+      expect(result.candidates).toHaveLength(1);
+      expect(result.candidates[0]).toEqual({ secret_id: "only", display_name: "我的密钥" });
+    }
+  });
+
+  it("normalizes 429 to rate_limited without reading the body", async () => {
+    // The per-IP resolve limiter returns 429. Surface a recognizable back-off
+    // outcome — and 🔴 never read the body (no-body-in-error invariant).
+    const jsonSpy = vi.fn();
+    const textSpy = vi.fn();
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 429,
+      json: jsonSpy,
+      text: textSpy,
+    }) as unknown as typeof fetch;
+
+    const { resolveSecret } = await import("./api-fetch.js");
+    const result = await resolveSecret({ apiUrl: "http://api.test", botToken: "t", alias: "x" });
+    expect(result.status).toBe("rate_limited");
+    expect(jsonSpy).not.toHaveBeenCalled();
+    expect(textSpy).not.toHaveBeenCalled();
   });
 
   it("throws on a 5xx (resolve failure) without leaking the response body", async () => {

--- a/src/api-fetch.ts
+++ b/src/api-fetch.ts
@@ -900,10 +900,15 @@ export interface SecretCandidate {
  * Result of resolving a secret alias for the bot's owner.
  *
  * Discriminated on `status`:
- *  - `resolved`   → exactly one match; `value` holds the plaintext secret.
- *  - `not_found`  → no secret matches the alias; the owner must add it first.
- *  - `ambiguous`  → multiple matches; `candidates` lists labels for the caller
- *                   to re-resolve against (no plaintext).
+ *  - `resolved`     → exactly one EXACT match; `value` holds the plaintext secret.
+ *  - `not_found`    → no secret matches the alias; the owner must add it first.
+ *  - `ambiguous`    → server needs confirmation; `candidates` lists labels for the
+ *                     caller to re-resolve against (no plaintext). Per octo-server
+ *                     PR#301 this covers BOTH "exact name hit >1" AND "any
+ *                     pinyin/fuzzy hit, even exactly one candidate" — a single
+ *                     fuzzy candidate must still be confirmed, never auto-used.
+ *  - `rate_limited` → the per-IP resolve limiter rejected this call (HTTP 429);
+ *                     the caller should back off and retry.
  *
  * 🔴 RED LINE: the `value` field on the `resolved` variant is the ONLY place
  * plaintext appears. Callers must consume it internally (e.g. write it to a
@@ -913,7 +918,8 @@ export interface SecretCandidate {
 export type ResolveSecretResult =
   | { status: "resolved"; value: string; secret_id?: string; display_name?: string }
   | { status: "not_found" }
-  | { status: "ambiguous"; candidates: SecretCandidate[] };
+  | { status: "ambiguous"; candidates: SecretCandidate[] }
+  | { status: "rate_limited" };
 
 /**
  * Resolve a user-managed external-key alias to its current plaintext value.
@@ -929,14 +935,22 @@ export type ResolveSecretResult =
  * is always fetched. If the owner rotates the key, the next call picks it up
  * with zero restart and zero cache invalidation.
  *
- * Contract:
- *  - 200 `{ status: "resolved", value, secret_id?, display_name? }`
- *  - 200 `{ status: "ambiguous", candidates: [{ secret_id?, display_name }] }`
- *  - 200 `{ status: "not_found" }` OR 404 → normalized to `{ status: "not_found" }`
+ * Contract (octo-server PR#301, docs/user-secret-alias-api.md):
+ *  - 200 `{ secret_id?, value }` → exact unique hit; `value` is the plaintext.
+ *  - 422 → ambiguous: the i18n error envelope carries the (masked) candidates at
+ *    `error.details.candidates`. Triggered by an exact name hit on >1 row OR ANY
+ *    pinyin/fuzzy hit (even a single candidate). Normalized to
+ *    `{ status: "ambiguous", candidates }`.
+ *  - 404 → not_found (also covers "endpoint not deployed yet during rollout").
+ *  - 429 → the per-IP resolve limiter rejected this call. Normalized to
+ *    `{ status: "rate_limited" }` so the caller can surface a back-off hint.
  *  - any other non-2xx → throws (caller surfaces a non-plaintext "resolve
- *    failed, please re-set" message)
+ *    failed, please re-set" message).
  *
- * 🔴 SECURITY: on a non-2xx the thrown Error message contains ONLY the HTTP
+ * For backward compatibility a 200 body still carrying `status:"ambiguous"` /
+ * `status:"not_found"` is honored, but the HTTP status is authoritative.
+ *
+ * 🔴 SECURITY: on a thrown non-2xx the Error message contains ONLY the HTTP
  * status — never the response body and never a resolved value. The body is
  * deliberately dropped because this error reaches an LLM-visible tool result
  * and a resolve-endpoint error body could carry secret-bearing diagnostics.
@@ -955,7 +969,11 @@ export async function resolveSecret(params: {
       ...DEFAULT_HEADERS,
       Authorization: `Bearer ${params.botToken}`,
     },
-    body: JSON.stringify({ alias: params.alias }),
+    // 🔴 The server binds the request field `query` (BindJSON → req.Query) and
+    // 400s when it is empty. The function input is still named `alias` for
+    // callers, but the wire field MUST be `query` — `query` accepts either a
+    // secret_id or a display_name, matching the `alias` semantics.
+    body: JSON.stringify({ query: params.alias }),
     signal: params.signal ?? AbortSignal.timeout(DEFAULT_TIMEOUT_MS),
   });
 
@@ -965,6 +983,31 @@ export async function resolveSecret(params: {
   if (resp.status === 404) {
     return { status: "not_found" };
   }
+
+  // 422 = ambiguous. The server returns the i18n error envelope; the masked
+  // candidate list lives at `error.details.candidates`. This is NOT an HTTP
+  // failure to surface — it is a normal "needs confirmation" outcome, so we
+  // parse it here instead of letting it fall into the throw branch below.
+  // 🔴 SECURITY: candidates carry ONLY masked identifiers (display_name,
+  // secret_id, kind, masked) — never the plaintext value — so reading this
+  // specific body is safe. We still read NOTHING from any other error body.
+  if (resp.status === 422) {
+    const raw = (await resp.json().catch(() => null)) as Record<string, unknown> | null;
+    const error = (raw?.error ?? {}) as Record<string, unknown>;
+    const details = (error.details ?? {}) as Record<string, unknown>;
+    const rawCandidates = Array.isArray(details.candidates) ? details.candidates : [];
+    return { status: "ambiguous", candidates: parseCandidates(rawCandidates) };
+  }
+
+  // 429 = the per-IP resolve limiter (StrictIPRateLimitMiddleware,
+  // tag=usersecret_resolve) rejected this call. Surface a recognizable
+  // back-off outcome rather than a generic error.
+  // 🔴 SECURITY: do NOT read the body — a rate-limit response is not expected to
+  // carry a value, and the no-body-in-error invariant for this endpoint stands.
+  if (resp.status === 429) {
+    return { status: "rate_limited" };
+  }
+
   if (!resp.ok) {
     // 🔴 SECURITY: never fold the response body into the error. A resolve
     // endpoint handles plaintext secrets; a 5xx/diagnostic body could echo a
@@ -980,25 +1023,23 @@ export async function resolveSecret(params: {
 
   const status = raw.status;
 
+  // Backward-compat: honor a legacy 200 body that still carries an explicit
+  // status discriminator. The current server (PR#301) instead signals these via
+  // HTTP status (404/422), handled above; a 200 body simply carries the value.
   if (status === "not_found") {
     return { status: "not_found" };
   }
 
   if (status === "ambiguous") {
     const rawCandidates = Array.isArray(raw.candidates) ? raw.candidates : [];
-    const candidates: SecretCandidate[] = rawCandidates
-      .map((c) => {
-        const obj = (c ?? {}) as Record<string, unknown>;
-        const displayName = typeof obj.display_name === "string" ? obj.display_name : "";
-        const secretId = typeof obj.secret_id === "string" ? obj.secret_id : undefined;
-        return { display_name: displayName, secret_id: secretId };
-      })
-      // Drop entries with no label — a candidate the caller can't show is useless.
-      .filter((c) => c.display_name.length > 0);
-    return { status: "ambiguous", candidates };
+    return { status: "ambiguous", candidates: parseCandidates(rawCandidates) };
   }
 
-  if (status === "resolved") {
+  // Resolved: the current server returns 200 `{ secret_id?, value }` WITHOUT a
+  // status field, so a 200 carrying a non-empty `value` is the resolved case.
+  // A legacy `status:"resolved"` body is also accepted. Anything else is treated
+  // as a malformed resolved response (missing value) and rejected.
+  if (status === "resolved" || (status === undefined && "value" in raw)) {
     if (typeof raw.value !== "string" || raw.value.length === 0) {
       throw new Error("resolveSecret resolved a secret with no value");
     }
@@ -1015,6 +1056,26 @@ export async function resolveSecret(params: {
   // server-controlled value back into the transcript is an injection vector.
   // Use a fixed message — the unexpected status is unusable to the caller anyway.
   throw new Error("resolveSecret returned an unknown status");
+}
+
+/**
+ * Map a raw candidate array (from a 422 `error.details.candidates` envelope or a
+ * legacy 200 ambiguous body) into label-only SecretCandidate entries.
+ *
+ * 🔴 SECURITY: deliberately copies ONLY `display_name` + `secret_id` — never any
+ * `value`/`masked`/other server field — so nothing sensitive leaks into the
+ * disambiguation surface the LLM eventually sees. Entries with no label are
+ * dropped: a candidate the caller can't show the user is useless.
+ */
+function parseCandidates(rawCandidates: unknown[]): SecretCandidate[] {
+  return rawCandidates
+    .map((c) => {
+      const obj = (c ?? {}) as Record<string, unknown>;
+      const displayName = typeof obj.display_name === "string" ? obj.display_name : "";
+      const secretId = typeof obj.secret_id === "string" ? obj.secret_id : undefined;
+      return { display_name: displayName, secret_id: secretId };
+    })
+    .filter((c) => c.display_name.length > 0);
 }
 
 /** Decoded payload from base64 message content */

--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -14,7 +14,7 @@ export interface OctoAccountConfig {
   historyLimit?: number;  // 群聊历史消息条数限制（默认20）
   historyPromptTemplate?: string;  // Template for group history context injection
   onBehalfOf?: string;  // Persona clone: grantor uid — bot acts on behalf of this human
-  secretsFileRoot?: string;  // Jail root for write-secret: secret files may only be written under this absolute path (defaults to the plugin process CWD)
+  secretsFileRoot?: string;  // Jail root for write-secret: secret files may only be written under this path. When unset, defaults to the agent's workspace (agents.list[].workspace matched to the agent, else agents.defaults.workspace); if neither resolves, write-secret fails closed (no process.cwd() fallback).
 }
 
 export interface OctoConfig {
@@ -39,6 +39,12 @@ export interface OctoConfig {
 export const DEFAULT_HISTORY_PROMPT_TEMPLATE =
   "[Group Chat History] Below are messages from others since your last reply (sender is user ID, body is message content):\n```json\n{messages}\n```\nPlease respond to the current @mention based on this context.\n\n";
 
+// Shared description for secretsFileRoot, kept identical to the wording in
+// openclaw.plugin.json so the Control UI and the runtime schema never drift
+// (manifest-schema-sync.test.ts asserts this).
+export const SECRETS_FILE_ROOT_DESCRIPTION =
+  "Jail root for write-secret: secret files may only be written under this path. When unset, defaults to the agent's workspace (agents.list[].workspace matched to the agent, else agents.defaults.workspace). If neither resolves to a usable directory, write-secret is unavailable (fail-closed); there is no process working-directory fallback.";
+
 // JSON Schema for OpenClaw plugin config validation
 export const OctoConfigJsonSchema = {
   schema: {
@@ -57,7 +63,7 @@ export const OctoConfigJsonSchema = {
       historyLimit: { type: "number", minimum: 1, maximum: 100 },
       historyPromptTemplate: { type: "string" },
       onBehalfOf: { type: "string" },
-      secretsFileRoot: { type: "string" },
+      secretsFileRoot: { type: "string", description: SECRETS_FILE_ROOT_DESCRIPTION },
       accounts: {
         type: "object",
         additionalProperties: {
@@ -76,7 +82,7 @@ export const OctoConfigJsonSchema = {
             historyLimit: { type: "number", minimum: 1, maximum: 100 },
             historyPromptTemplate: { type: "string" },
             onBehalfOf: { type: "string" },
-            secretsFileRoot: { type: "string" },
+            secretsFileRoot: { type: "string", description: SECRETS_FILE_ROOT_DESCRIPTION },
           },
         },
       },

--- a/src/manifest-schema-sync.test.ts
+++ b/src/manifest-schema-sync.test.ts
@@ -33,4 +33,28 @@ describe("openclaw.plugin.json channelConfigs", () => {
       Object.keys(tsAccountProps).sort(),
     );
   });
+
+  // Description drift guard: secretsFileRoot carries operator-facing semantics
+  // (the write-secret jail default + fail-closed behavior). A stale manifest
+  // description here is what Jerry-Xin flagged on PR#92, so pin both copies to
+  // the single source of truth in OctoConfigJsonSchema.
+  it("secretsFileRoot description matches between manifest and OctoConfigJsonSchema", () => {
+    const tsDesc = (OctoConfigJsonSchema.schema.properties.secretsFileRoot as any)
+      .description as string;
+    expect(tsDesc).toBeDefined();
+    // Top-level copy.
+    expect(
+      manifest.channelConfigs.octo.schema.properties.secretsFileRoot.description,
+    ).toBe(tsDesc);
+    // Per-account copy.
+    expect(
+      manifest.channelConfigs.octo.schema.properties.accounts.additionalProperties
+        .properties.secretsFileRoot.description,
+    ).toBe(tsDesc);
+    // The new semantics must be reflected (not the old "process working
+    // directory" default).
+    expect(tsDesc).toMatch(/fail-closed/i);
+    expect(tsDesc).toMatch(/workspace/i);
+    expect(tsDesc).not.toMatch(/defaults to the plugin process working directory/i);
+  });
 });


### PR DESCRIPTION
## What
Consolidates the `write-secret` hardening that was split across **PR#92 / #95 / #96** (all APPROVED) into a single PR on top of `main`. After PR#71 squash-merged, the stacked branches collapsed (deleting `feat/agent-tool-write-secret` auto-closed PR#92 and rebased the rest into conflict). This re-lands the exact reviewed delta cleanly.

## Squashed content (all previously APPROVED)
- **fail-closed jail** (was PR#92): no `process.cwd()` fallback; an unset root refuses the write. Kills the `root="/"` self-lock and the fail-open regression at the source.
- **default jail = agent workspace** (was PR#95 + rework): realpath-after-canon degenerate-root guard (covers symlink→`/` and Windows drive roots), agent-id namespace matching, `~`/`$VAR` expansion. Zero-config for the common case; still fail-closed when no usable root resolves.
- **resolve contract aligned to octo-server PR#301** (was PR#96): request field `alias`→`query` (fixes the `400 request_invalid`), HTTP `422` ambiguous candidate handling (incl. single-candidate fuzzy hits), `429` back-off.

## Red line preserved
Plaintext secret never returned to the LLM / never in transcript. All `not.toContain(PLAINTEXT)` assertions intact.

## Verification
- `tsc --noEmit` clean
- **1001/1001 tests pass**
- End-to-end verified live against im-test: wangmazi write-secret resolves "测试密钥" (exact, 200) and writes a `0600` file inside its workspace jail.

Supersedes #92 #95 #96.
