### PR TITLE
fix(actions): rewrite bare parent-group target to current thread

### DIFF
--- a/src/actions.test.ts
+++ b/src/actions.test.ts
@@ -528,37 +528,173 @@ describe("handleOctoMessageAction", () => {
     });
   });
 
-  // Foot-gun UX guard (#232 review): when the agent explicitly passes a bare
-  // parent-group target while the session's currentChannelId is inside a
-  // thread, log a warning. This doesn't reroute and doesn't reject (the
-  // parent-group reply may be intentional), it just surfaces the ambiguity
-  // so operators can notice model misuse.
+  // Context-aware rewrite (#104, reverses #232's warn-only decision): when the
+  // agent passes a bare parent-group target while the session's currentChannelId
+  // is inside a thread, the send is rewritten to the current thread (the most
+  // likely intent). `scope:"parent"` is the explicit escape hatch to reach the
+  // parent group. A paper-trail warning is still logged on rewrite.
 
-  describe("send — thread-context foot-gun warning", () => {
-    it("warns (via log.warn) when target is the thread's parent group", async () => {
+  describe("send — thread-context rewrite", () => {
+    it("rewrites a bare parent-group target to the current thread (no scope)", async () => {
       registerBotGroupIds(["grp1"]);
+      let sentPayload: any = null;
       globalThis.fetch = mockFetch({
-        "/v1/bot/sendMessage": async () => jsonResponse({ message_id: 1, message_seq: 1 }),
+        "/v1/bot/sendMessage": async (_url, init) => {
+          sentPayload = JSON.parse(init?.body as string);
+          return jsonResponse({ message_id: 1, message_seq: 1 });
+        },
       });
       const logWarn = vi.fn();
-      const logInfo = vi.fn();
       const { handleOctoMessageAction } = await import("./actions.js");
-      await handleOctoMessageAction({
+      const result = await handleOctoMessageAction({
         action: "send",
         args: { target: "group:grp1", message: "hi" },
         apiUrl: "http://localhost:8090",
         botToken: "test-token",
         currentChannelId: "grp1____topicA",
-        log: { warn: logWarn, info: logInfo } as any,
+        log: { warn: logWarn } as any,
       });
+      expect(result.ok).toBe(true);
+      expect(sentPayload.channel_id).toBe("grp1____topicA");
+      expect(sentPayload.channel_type).toBe(ChannelType.CommunityTopic);
+      expect((result.data as any).rewritten).toBe(true);
+      expect((result.data as any).resolutionReason).toBe("thread-context-rewrite");
+      expect((result.data as any).resolvedTarget).toBe("group:grp1____topicA");
+      // Paper trail preserved on rewrite.
       expect(logWarn).toHaveBeenCalledTimes(1);
-      expect(logInfo).not.toHaveBeenCalled();
-      const msg = logWarn.mock.calls[0][0] as string;
-      expect(msg).toContain("target=\"group:grp1\"");
-      expect(msg).toContain("grp1____topicA");
     });
 
-    it("falls back to log.info when log.warn is not provided", async () => {
+    it("scope:\"parent\" delivers to the parent group and never rewrites", async () => {
+      registerBotGroupIds(["grp1"]);
+      let sentPayload: any = null;
+      globalThis.fetch = mockFetch({
+        "/v1/bot/sendMessage": async (_url, init) => {
+          sentPayload = JSON.parse(init?.body as string);
+          return jsonResponse({ message_id: 1, message_seq: 1 });
+        },
+      });
+      const { handleOctoMessageAction } = await import("./actions.js");
+      const result = await handleOctoMessageAction({
+        action: "send",
+        args: { target: "group:grp1", message: "hi", scope: "parent" },
+        apiUrl: "http://localhost:8090",
+        botToken: "test-token",
+        currentChannelId: "grp1____topicA",
+      });
+      expect(result.ok).toBe(true);
+      expect(sentPayload.channel_id).toBe("grp1");
+      expect(sentPayload.channel_type).toBe(ChannelType.Group);
+      expect((result.data as any).rewritten).toBe(false);
+      expect((result.data as any).resolutionReason).toBe("explicit-parent-scope");
+    });
+
+    it("scope:\"parent\" clears an ambient threadId (no thread synthesis)", async () => {
+      registerBotGroupIds(["grp1"]);
+      let sentPayload: any = null;
+      globalThis.fetch = mockFetch({
+        "/v1/bot/sendMessage": async (_url, init) => {
+          sentPayload = JSON.parse(init?.body as string);
+          return jsonResponse({ message_id: 1, message_seq: 1 });
+        },
+      });
+      const { handleOctoMessageAction } = await import("./actions.js");
+      const result = await handleOctoMessageAction({
+        action: "send",
+        args: { target: "group:grp1", message: "hi", scope: "parent" },
+        apiUrl: "http://localhost:8090",
+        botToken: "test-token",
+        currentChannelId: "grp1____topicA",
+        threadId: "topicA",
+      });
+      expect(result.ok).toBe(true);
+      // Even with threadId present, scope:"parent" prevents synthesis to the thread.
+      expect(sentPayload.channel_id).toBe("grp1");
+      expect(sentPayload.channel_type).toBe(ChannelType.Group);
+      expect((result.data as any).rewritten).toBe(false);
+      expect((result.data as any).resolutionReason).toBe("explicit-parent-scope");
+    });
+
+    it("does NOT rewrite when target is a DIFFERENT group (legitimate cross-channel send)", async () => {
+      registerBotGroupIds(["grp1", "otherGroup"]);
+      let sentPayload: any = null;
+      globalThis.fetch = mockFetch({
+        "/v1/bot/sendMessage": async (_url, init) => {
+          sentPayload = JSON.parse(init?.body as string);
+          return jsonResponse({ message_id: 1, message_seq: 1 });
+        },
+      });
+      const logWarn = vi.fn();
+      const { handleOctoMessageAction } = await import("./actions.js");
+      const result = await handleOctoMessageAction({
+        action: "send",
+        args: { target: "group:otherGroup", message: "hi" },
+        apiUrl: "http://localhost:8090",
+        botToken: "test-token",
+        currentChannelId: "grp1____topicA", // in thread of grp1, but sending to otherGroup
+        log: { warn: logWarn } as any,
+      });
+      expect(result.ok).toBe(true);
+      expect(sentPayload.channel_id).toBe("otherGroup");
+      expect(sentPayload.channel_type).toBe(ChannelType.Group);
+      expect((result.data as any).rewritten).toBe(false);
+      expect((result.data as any).resolutionReason).toBe("passthrough");
+      expect(logWarn).not.toHaveBeenCalled();
+    });
+
+    it("does NOT rewrite when target already carries the thread short id", async () => {
+      registerBotGroupIds(["grp1"]);
+      let sentPayload: any = null;
+      globalThis.fetch = mockFetch({
+        "/v1/bot/sendMessage": async (_url, init) => {
+          sentPayload = JSON.parse(init?.body as string);
+          return jsonResponse({ message_id: 1, message_seq: 1 });
+        },
+      });
+      const logWarn = vi.fn();
+      const { handleOctoMessageAction } = await import("./actions.js");
+      const result = await handleOctoMessageAction({
+        action: "send",
+        args: { target: "group:grp1____topicA", message: "hi" },
+        apiUrl: "http://localhost:8090",
+        botToken: "test-token",
+        currentChannelId: "grp1____topicA",
+        log: { warn: logWarn } as any,
+      });
+      expect(result.ok).toBe(true);
+      expect(sentPayload.channel_id).toBe("grp1____topicA");
+      expect((result.data as any).rewritten).toBe(false);
+      expect((result.data as any).resolutionReason).toBe("explicit-target");
+      expect(logWarn).not.toHaveBeenCalled();
+    });
+
+    it("does NOT rewrite when session is NOT in a thread (plain group chat)", async () => {
+      registerBotGroupIds(["grp1"]);
+      let sentPayload: any = null;
+      globalThis.fetch = mockFetch({
+        "/v1/bot/sendMessage": async (_url, init) => {
+          sentPayload = JSON.parse(init?.body as string);
+          return jsonResponse({ message_id: 1, message_seq: 1 });
+        },
+      });
+      const logWarn = vi.fn();
+      const { handleOctoMessageAction } = await import("./actions.js");
+      const result = await handleOctoMessageAction({
+        action: "send",
+        args: { target: "group:grp1", message: "hi" },
+        apiUrl: "http://localhost:8090",
+        botToken: "test-token",
+        currentChannelId: "grp1",
+        log: { warn: logWarn } as any,
+      });
+      expect(result.ok).toBe(true);
+      expect(sentPayload.channel_id).toBe("grp1");
+      expect(sentPayload.channel_type).toBe(ChannelType.Group);
+      expect((result.data as any).rewritten).toBe(false);
+      expect((result.data as any).resolutionReason).toBe("passthrough");
+      expect(logWarn).not.toHaveBeenCalled();
+    });
+
+    it("falls back to log.info for the paper trail when log.warn is absent", async () => {
       registerBotGroupIds(["grp1"]);
       globalThis.fetch = mockFetch({
         "/v1/bot/sendMessage": async () => jsonResponse({ message_id: 1, message_seq: 1 }),
@@ -576,82 +712,30 @@ describe("handleOctoMessageAction", () => {
       expect(logInfo).toHaveBeenCalledTimes(1);
     });
 
-    it("does NOT warn when target is a DIFFERENT group (legitimate cross-channel send)", async () => {
-      registerBotGroupIds(["grp1", "otherGroup"]);
-      globalThis.fetch = mockFetch({
-        "/v1/bot/sendMessage": async () => jsonResponse({ message_id: 1, message_seq: 1 }),
-      });
-      const logWarn = vi.fn();
-      const logInfo = vi.fn();
-      const { handleOctoMessageAction } = await import("./actions.js");
-      await handleOctoMessageAction({
-        action: "send",
-        args: { target: "group:otherGroup", message: "hi" },
-        apiUrl: "http://localhost:8090",
-        botToken: "test-token",
-        currentChannelId: "grp1____topicA", // in thread of grp1, but sending to otherGroup
-        log: { warn: logWarn, info: logInfo } as any,
-      });
-      expect(logWarn).not.toHaveBeenCalled();
-      expect(logInfo).not.toHaveBeenCalled();
-    });
-
-    it("does NOT warn when target already carries the thread short id", async () => {
+    it("exposes receipt fields on the RichText success path", async () => {
       registerBotGroupIds(["grp1"]);
       globalThis.fetch = mockFetch({
         "/v1/bot/sendMessage": async () => jsonResponse({ message_id: 1, message_seq: 1 }),
-      });
-      const logWarn = vi.fn();
-      const { handleOctoMessageAction } = await import("./actions.js");
-      await handleOctoMessageAction({
-        action: "send",
-        args: { target: "group:grp1____topicA", message: "hi" },
-        apiUrl: "http://localhost:8090",
-        botToken: "test-token",
-        currentChannelId: "grp1____topicA",
-        log: { warn: logWarn } as any,
-      });
-      expect(logWarn).not.toHaveBeenCalled();
-    });
-
-    it("does NOT warn when session is NOT in a thread (plain group chat)", async () => {
-      registerBotGroupIds(["grp1"]);
-      globalThis.fetch = mockFetch({
-        "/v1/bot/sendMessage": async () => jsonResponse({ message_id: 1, message_seq: 1 }),
-      });
-      const logWarn = vi.fn();
-      const { handleOctoMessageAction } = await import("./actions.js");
-      await handleOctoMessageAction({
-        action: "send",
-        args: { target: "group:grp1", message: "hi" },
-        apiUrl: "http://localhost:8090",
-        botToken: "test-token",
-        currentChannelId: "grp1",
-        log: { warn: logWarn } as any,
-      });
-      expect(logWarn).not.toHaveBeenCalled();
-    });
-
-    it("still sends the message when the warning fires (warn, not reject)", async () => {
-      registerBotGroupIds(["grp1"]);
-      let sent = false;
-      globalThis.fetch = mockFetch({
-        "/v1/bot/sendMessage": async () => {
-          sent = true;
-          return jsonResponse({ message_id: 1, message_seq: 1 });
-        },
+        "/v1/bot/sendRichText": async () => jsonResponse({ message_id: 2, message_seq: 2 }),
+        "/v1/bot/sendMedia": async () => jsonResponse({ message_id: 3, message_seq: 3 }),
       });
       const { handleOctoMessageAction } = await import("./actions.js");
       const result = await handleOctoMessageAction({
         action: "send",
-        args: { target: "group:grp1", message: "hi" },
+        args: {
+          target: "group:grp1",
+          message: "look",
+          mediaUrl: "https://example.com/image.png",
+          richText: true,
+        },
         apiUrl: "http://localhost:8090",
         botToken: "test-token",
         currentChannelId: "grp1____topicA",
-        log: { warn: vi.fn() } as any,
       });
-      expect(sent).toBe(true);
       expect(result.ok).toBe(true);
+      expect((result.data as any).resolvedTarget).toBe("group:grp1____topicA");
+      expect((result.data as any).resolutionReason).toBe("thread-context-rewrite");
+      expect((result.data as any).rewritten).toBe(true);
     });
   });
 

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -187,6 +187,97 @@ export function resolveOutboundOctoTarget(
   return parsed;
 }
 
+/** Resolution outcome of {@link applyThreadScope}. */
+export type ThreadScopeResolution = {
+  channelId: string;
+  channelType: ChannelType;
+  rewritten: boolean;
+  resolutionReason: "thread-context-rewrite" | "explicit-parent-scope" | "explicit-target" | "passthrough";
+};
+
+/**
+ * Decide the final delivery target for a `send` once the raw target has been
+ * resolved (via resolveOutboundOctoTarget) into a concrete {channelId, channelType}.
+ *
+ * Background (#104, reverses the warn-only decision from #232): when the agent
+ * is replying inside a sub-topic (session's currentChannelId carries `____`)
+ * but passes a bare parent-group target matching the current thread's parent,
+ * it's almost always a phrasing slip ("send to this group" really means the
+ * current thread). Rather than silently delivering to the parent group and only
+ * logging, rewrite the target to the current thread so the reply lands where the
+ * conversation is happening.
+ *
+ * Priority (highest first):
+ *  - scope === "parent"  → explicit escape hatch, never rewrite (caller already
+ *    cleared effectiveThreadId before resolveOutboundOctoTarget so the target
+ *    stays the parent group). resolutionReason="explicit-parent-scope".
+ *  - target carries `____` → caller named a thread explicitly, respect it.
+ *    resolutionReason="explicit-target".
+ *  - bare parent-group target inside a thread context → rewrite to the current
+ *    thread. resolutionReason="thread-context-rewrite", rewritten=true. This only
+ *    fires when the resolved type is still Group, i.e. threadId was absent and
+ *    nothing got synthesised onto a sub-topic.
+ *  - otherwise → passthrough.
+ *
+ * Pure function: takes only the already-resolved target plus context, returns
+ * the (possibly rewritten) target. The `scope==="parent"` effectiveThreadId reset
+ * MUST happen at the call site before resolveOutboundOctoTarget — it cannot be
+ * expressed here because by the time we run, the target is already resolved.
+ */
+export function applyThreadScope(input: {
+  resolvedChannelId: string;
+  resolvedChannelType: ChannelType;
+  target: string;
+  currentChannelId?: string;
+  scope?: "parent" | "thread";
+}): ThreadScopeResolution {
+  const THREAD_SEP = "____";
+  const { resolvedChannelId, resolvedChannelType, target, currentChannelId, scope } = input;
+
+  // Explicit parent-group escape hatch always wins — never rewrite.
+  if (scope === "parent") {
+    return {
+      channelId: resolvedChannelId,
+      channelType: resolvedChannelType,
+      rewritten: false,
+      resolutionReason: "explicit-parent-scope",
+    };
+  }
+
+  // Target already names a sub-topic explicitly (carries `____`) → respect it.
+  if (target.includes(THREAD_SEP)) {
+    return {
+      channelId: resolvedChannelId,
+      channelType: resolvedChannelType,
+      rewritten: false,
+      resolutionReason: "explicit-target",
+    };
+  }
+
+  // Context-aware rewrite: bare parent-group target while the session is inside
+  // a sub-topic of that same parent, and no threadId was synthesised (resolved
+  // type is still Group). Redirect to the current thread.
+  if (
+    resolvedChannelType === ChannelType.Group &&
+    currentChannelId?.includes(THREAD_SEP) &&
+    resolvedChannelId === currentChannelId.slice(0, currentChannelId.indexOf(THREAD_SEP))
+  ) {
+    return {
+      channelId: currentChannelId,
+      channelType: ChannelType.CommunityTopic,
+      rewritten: true,
+      resolutionReason: "thread-context-rewrite",
+    };
+  }
+
+  return {
+    channelId: resolvedChannelId,
+    channelType: resolvedChannelType,
+    rewritten: false,
+    resolutionReason: "passthrough",
+  };
+}
+
 /**
  * Resolve the group ID from args, falling back to currentChannelId.
  * Accepts: args.groupId, args.target (with group: prefix), or bare currentChannelId.
@@ -471,8 +562,18 @@ async function handleSend(params: {
     };
   }
 
+  // Explicit parent-group escape hatch (#104): `scope:"parent"` means "I really
+  // do want the parent group, even from a thread context". It must take effect
+  // BEFORE resolveOutboundOctoTarget so an ambient threadId can't be synthesised
+  // onto a sub-topic — once that synthesis happens the target is already a
+  // CommunityTopic and the parent-group intent is lost. So clear effectiveThreadId
+  // up front when scope is "parent".
+  const scope = args.scope === "parent" || args.scope === "thread" ? args.scope : undefined;
+
   let effectiveThreadId: typeof threadId = threadId;
-  if (effectiveThreadId != null && currentChannelId) {
+  if (scope === "parent") {
+    effectiveThreadId = undefined;
+  } else if (effectiveThreadId != null && currentChannelId) {
     const SEP = "____";
     const currentParent = currentChannelId.includes(SEP)
       ? currentChannelId.slice(0, currentChannelId.indexOf(SEP))
@@ -486,35 +587,42 @@ async function handleSend(params: {
     }
   }
 
-  const { channelId, channelType } = resolveOutboundOctoTarget(target, effectiveThreadId);
+  const resolved = resolveOutboundOctoTarget(target, effectiveThreadId);
 
-  // UX warning for a specific foot-gun on the message-tool path (#232 review):
-  // the agent is replying inside a sub-topic (session's currentChannelId carries
-  // `____`) but explicitly passed a bare parent-group target matching the
-  // current thread's parent group. That's semantically valid (parent-group
-  // reply from a thread context) but almost always a model mistake — the
-  // reply will land in the parent group where other members see it rather
-  // than in the thread where the conversation is happening. Don't silently
-  // reroute to the thread and don't hard-reject (breaks the legitimate case),
-  // just log so operators have a paper trail. Scoped to same-group cross-room
-  // to avoid false positives on legitimate cross-channel sends (e.g. the
-  // agent explicitly shipping results to a different group entirely).
-  const THREAD_SEP = "____";
-  if (
-    channelType === ChannelType.Group &&
-    currentChannelId?.includes(THREAD_SEP) &&
-    !target.includes(THREAD_SEP)
-  ) {
-    const currentThreadParent = currentChannelId.slice(0, currentChannelId.indexOf(THREAD_SEP));
-    if (channelId === currentThreadParent) {
-      const warn = log?.warn ?? log?.info;
-      warn?.(
-        `octo: send action: target="${target}" is the parent group of the current thread session ` +
-        `(${currentChannelId}). Reply will land in the parent group, not the thread. If the agent ` +
-        `meant to reply to the thread, pass the full target "group:${currentChannelId}".`,
-      );
-    }
+  // Context-aware routing (#104, reverses #232's warn-only decision): inside a
+  // sub-topic, a bare parent-group target matching the current thread's parent
+  // is almost always a phrasing slip ("send to this group" → the current
+  // thread). Rewrite it to the current thread instead of silently delivering to
+  // the parent group. `scope:"parent"` is the explicit escape hatch (handled
+  // above + here), and an explicit `____` target is respected as-is.
+  const { channelId, channelType, rewritten, resolutionReason } = applyThreadScope({
+    resolvedChannelId: resolved.channelId,
+    resolvedChannelType: resolved.channelType,
+    target,
+    currentChannelId,
+    scope,
+  });
+
+  // Keep a paper trail when we rewrite (operators still need to notice the
+  // ambiguity) and when the explicit parent-group escape hatch is taken.
+  if (rewritten) {
+    const warn = log?.warn ?? log?.info;
+    warn?.(
+      `octo: send action: target="${target}" is the parent group of the current thread session ` +
+      `(${currentChannelId}). Rewriting delivery to the current thread "group:${channelId}". ` +
+      `Pass scope:"parent" to deliver to the parent group instead.`,
+    );
+  } else if (resolutionReason === "explicit-parent-scope" && currentChannelId?.includes("____")) {
+    log?.info?.(
+      `octo: send action: scope:"parent" → delivering target="${target}" to the parent group ` +
+      `from thread context (${currentChannelId}).`,
+    );
   }
+
+  // Receipt prefix for the actually-delivered address, so the agent can see
+  // exactly where the message landed (e.g. "group:grp1____topicA" vs "group:grp1").
+  const kindPrefix = channelType === ChannelType.DM ? "user:" : "group:";
+  const resolvedTarget = `${kindPrefix}${channelId}`;
 
   // Resolve mentions + @all once; reused by both the legacy text path and the
   // RichText(=14) 图文混排 path so mention semantics stay identical.
@@ -590,6 +698,9 @@ async function handleSend(params: {
         target,
         channelId,
         channelType,
+        resolvedTarget,
+        resolutionReason,
+        rewritten,
         // richText is true only when a type-14 payload was actually sent (≥1
         // image block); a text-only / file-only send reports richText:false.
         ...(richResult.richText ? { richText: true } : {}),
@@ -663,6 +774,9 @@ async function handleSend(params: {
       target,
       channelId,
       channelType,
+      resolvedTarget,
+      resolutionReason,
+      rewritten,
       mediaCount: sentMedia.length,
       // messageId fields added for issue #51 — let the LLM reference the
       // sent message(s) for downstream edit/pin/delete operations.

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -699,7 +699,7 @@ export const octoPlugin: ChannelPlugin<ResolvedOctoAccount> = {
       return [
         `IMPORTANT: Your Octo accountId is "${accountId}". You MUST always pass accountId: "${accountId}" when using the octo_management tool. Do NOT use any other accountId.`,
         `For sending messages: if the target is a group, use target="group:<groupId>". If the target is a specific user (1v1 direct message), use target="user:<userId>". If sending to the current conversation, no prefix is needed.`,
-        `For threads/sub-topics: if you are explicitly targeting a thread, the target MUST be the full "group:<group_no>____<short_id>" (four underscores) — do not send just the parent "group:<group_no>" or the reply will land in the parent group instead of the thread. The same rule applies to file uploads.`,
+        `Terminology: "group" (群) means the parent group, visible to all members; "thread"/sub-topic (子区) means the current conversation thread. When you are inside a thread session and the user says "send to this group/the current chat", that defaults to the CURRENT THREAD — do NOT send to the parent group. To deliberately post to the parent group from a thread, pass scope:"parent". To explicitly target a specific thread, the target MUST be the full "group:<group_no>____<short_id>" (four underscores). The same rules apply to file uploads.`,
         `For reading message history: use action="read" with target="user:<uid>" to read DM history, or target="group:<groupId>" to read group message history. Cross-channel queries require the requester to be a participant of the target channel.`,
         `For searching: use action="search" with query="shared-groups" to find groups that the bot and the current user both belong to.`,
       ];


### PR DESCRIPTION
## Summary

When sending from inside a sub-topic (thread), a bare parent-group target that matches the current thread's parent is almost always a phrasing slip — "send to this group" usually means the current thread. Previously the code detected this foot-gun but only logged a warning and still posted to the parent group. This PR rewrites the delivery to the current thread instead, and adds an explicit escape hatch for the genuine "broadcast to the parent group" case.

Closes #104.

## Changes

- Rewrite a bare `group:<group_no>` target to the current thread when (and only when) the conversation is a thread context whose parent matches that bare group. Cross-group targets and targets already carrying a thread suffix are passed through untouched.
- Add `scope:"parent"` as the explicit escape hatch: it clears the ambient `threadId` before target resolution so delivery stays on the parent group and is never rewritten. `scope` always takes priority over the context rewrite.
- Surface `resolvedTarget` / `resolutionReason` / `rewritten` on both the plain and RichText send success paths, so a misroute (or a deliberate rewrite) is visible in the receipt rather than discovered after the fact.
- Update the message tool hints with the group-vs-thread terminology rules ("current / here / this group" inside a thread defaults to the current thread; only "parent group" routes to the parent).

## Testing

- `pnpm run type-check` passes.
- `pnpm test` — full suite green, including the new scenario-1 tests covering the rewrite gating, the `scope:"parent"` escape hatch, cross-group pass-through, and receipt fields.
