### PR TITLE
feat(actions): resolve named target to group/thread candidates (#105)

### DIFF
--- a/src/agent-tools.test.ts
+++ b/src/agent-tools.test.ts
@@ -2544,5 +2544,49 @@ describe("createOctoManagementTools", () => {
       await execute("id", { action: "resolve", name: "Dup" });
       expect(resolveTargetsByName).toHaveBeenCalledTimes(2);
     });
+
+    // A limit:1 lookup returns a bounded page; a later wider (no-limit) lookup
+    // for the same name must NOT be served from that narrow cache entry — the
+    // limit is part of the cache key.
+    it("limit is part of the cache key — limit:1 then no-limit refetches", async () => {
+      vi.mocked(resolveTargetsByName).mockResolvedValue({
+        candidates: [
+          { kind: "group", channelId: "g1", channelType: 2, name: "Dup", groupNo: "g1" } as any,
+        ],
+        total: 1,
+        truncated: false,
+      });
+      const execute = getExecute();
+      await execute("id", { action: "resolve", name: "Dup", limit: 1 });
+      await execute("id", { action: "resolve", name: "Dup" });
+      expect(resolveTargetsByName).toHaveBeenCalledTimes(2);
+    });
+
+    // The positive-result cache only holds for RESOLVE_CACHE_TTL_MS (30s); once
+    // it expires the next identical resolve must hit fetch again.
+    it("cache expires after TTL — identical resolve refetches", async () => {
+      vi.useFakeTimers();
+      try {
+        vi.mocked(resolveTargetsByName).mockResolvedValue({
+          candidates: [
+            { kind: "group", channelId: "g1", channelType: 2, name: "Dup", groupNo: "g1" } as any,
+          ],
+          total: 1,
+          truncated: false,
+        });
+        const execute = getExecute();
+        await execute("id", { action: "resolve", name: "Dup" });
+        // Within TTL → served from cache, no refetch.
+        vi.advanceTimersByTime(29_999);
+        await execute("id", { action: "resolve", name: "Dup" });
+        expect(resolveTargetsByName).toHaveBeenCalledTimes(1);
+        // Past TTL → entry expired, refetch.
+        vi.advanceTimersByTime(2);
+        await execute("id", { action: "resolve", name: "Dup" });
+        expect(resolveTargetsByName).toHaveBeenCalledTimes(2);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
   });
 });

--- a/src/agent-tools.test.ts
+++ b/src/agent-tools.test.ts
@@ -18,11 +18,13 @@ vi.mock("./api-fetch.js", () => ({
   getThreadMd: vi.fn(),
   updateThreadMd: vi.fn(),
   resolveSecret: vi.fn(),
+  resolveTargetsByName: vi.fn(),
 }));
 
 vi.mock("./group-md.js", () => ({
   broadcastGroupMdUpdate: vi.fn(),
   broadcastThreadMdUpdate: vi.fn(),
+  getKnownGroupIds: vi.fn(() => new Set()),
 }));
 
 // NOTE: only mkdir from node:fs/promises is wrapped (see the vi.mock below); all
@@ -42,7 +44,7 @@ vi.mock("node:fs/promises", async (importOriginal) => {
   return { ...actual, mkdir: vi.fn(actual.mkdir) };
 });
 
-import { createOctoManagementTools } from "./agent-tools.js";
+import { createOctoManagementTools, _clearResolveCache } from "./agent-tools.js";
 import {
   listOctoAccountIds,
   resolveOctoAccount,
@@ -60,8 +62,9 @@ import {
   getThreadMd,
   updateThreadMd,
   resolveSecret,
+  resolveTargetsByName,
 } from "./api-fetch.js";
-import { broadcastGroupMdUpdate, broadcastThreadMdUpdate } from "./group-md.js";
+import { broadcastGroupMdUpdate, broadcastThreadMdUpdate, getKnownGroupIds } from "./group-md.js";
 import {
   mkdir,
   mkdtemp,
@@ -2225,6 +2228,321 @@ describe("createOctoManagementTools", () => {
           readFile(join(process.cwd(), `\${${varName}}`, "octo-secrets", "leak.env"), "utf8"),
         ).rejects.toThrow();
       });
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // resolve action (name → target candidates)
+  // -----------------------------------------------------------------------
+  describe("resolve action", () => {
+    beforeEach(() => {
+      _clearResolveCache();
+      vi.mocked(getKnownGroupIds).mockReturnValue(new Set());
+    });
+
+    it("enum contains 'resolve'", () => {
+      const tools = createOctoManagementTools({ cfg: mockCfg });
+      expect(tools[0].parameters.properties.action.enum).toContain("resolve");
+      // resolve-only params are present
+      expect(tools[0].parameters.properties.kind).toBeDefined();
+      expect(tools[0].parameters.properties.limit).toBeDefined();
+    });
+
+    it("requires a non-empty name", async () => {
+      const execute = getExecute();
+      const res = await execute("id", { action: "resolve" });
+      const data = res.details as any;
+      expect(data.error).toContain("name is required");
+      expect(resolveTargetsByName).not.toHaveBeenCalled();
+    });
+
+    it("rejects an invalid kind", async () => {
+      const execute = getExecute();
+      const res = await execute("id", { action: "resolve", name: "X", kind: "bogus" });
+      const data = res.details as any;
+      expect(data.error).toContain("Invalid kind");
+      expect(resolveTargetsByName).not.toHaveBeenCalled();
+    });
+
+    it("0 candidates → not-found result with fuzzy suggestions", async () => {
+      vi.mocked(getKnownGroupIds).mockReturnValue(new Set(["Sales Team", "Random"]));
+      vi.mocked(resolveTargetsByName).mockResolvedValue({
+        candidates: [],
+        total: 0,
+        truncated: false,
+      });
+      const execute = getExecute();
+      const res = await execute("id", { action: "resolve", name: "sales" });
+      const data = res.details as any;
+      expect(data.resolved).toBeNull();
+      expect(data.candidates).toEqual([]);
+      expect(data.total).toBe(0);
+      expect(data.error).toContain('No target named "sales" found');
+      expect(data.suggestions).toContain("Sales Team");
+      expect(data.suggestions).not.toContain("Random");
+    });
+
+    it("0 candidates with no matching known names → empty suggestions", async () => {
+      vi.mocked(getKnownGroupIds).mockReturnValue(new Set(["grp123"]));
+      vi.mocked(resolveTargetsByName).mockResolvedValue({
+        candidates: [],
+        total: 0,
+        truncated: false,
+      });
+      const execute = getExecute();
+      const res = await execute("id", { action: "resolve", name: "nonexistent" });
+      const data = res.details as any;
+      expect(data.suggestions).toEqual([]);
+    });
+
+    it("exactly 1 candidate → resolved echoes kind, does not send", async () => {
+      const candidate: any = {
+        kind: "group",
+        channelId: "grp1",
+        channelType: 2,
+        name: "Sales",
+        groupNo: "grp1",
+      };
+      vi.mocked(resolveTargetsByName).mockResolvedValue({
+        candidates: [candidate],
+        total: 1,
+        truncated: false,
+      });
+      const execute = getExecute();
+      const res = await execute("id", { action: "resolve", name: "Sales" });
+      const data = res.details as any;
+      expect(data.resolved).toEqual(candidate);
+      expect(data.resolved.kind).toBe("group");
+      // No candidates list on the single-resolve shape; nothing auto-sent.
+      expect(data.candidates).toBeUndefined();
+    });
+
+    // 🔴 BLOCKER: a single RETURNED candidate that is NOT the whole match set
+    // (total>1 and/or truncated) must NOT auto-resolve — otherwise a limit:1
+    // request over 5 matches would silently treat a partial result as a
+    // confident pick. It must fall through to the candidates branch so the agent
+    // asks the user.
+    it("1 returned but total>1 → returns candidates, NOT resolved (no silent send)", async () => {
+      const candidate: any = {
+        kind: "group",
+        channelId: "grp1",
+        channelType: 2,
+        name: "Sales",
+        groupNo: "grp1",
+      };
+      vi.mocked(resolveTargetsByName).mockResolvedValue({
+        candidates: [candidate],
+        total: 5,
+        truncated: false,
+      });
+      const execute = getExecute();
+      const res = await execute("id", { action: "resolve", name: "Sales", limit: 1 });
+      const data = res.details as any;
+      // Must NOT auto-resolve a truncated/partial result.
+      expect(data.resolved).toBeUndefined();
+      expect(data.candidates).toHaveLength(1);
+      expect(data.total).toBe(5);
+    });
+
+    it("1 returned but truncated:true → returns candidates, NOT resolved", async () => {
+      const candidate: any = {
+        kind: "group",
+        channelId: "grp1",
+        channelType: 2,
+        name: "Sales",
+        groupNo: "grp1",
+      };
+      vi.mocked(resolveTargetsByName).mockResolvedValue({
+        candidates: [candidate],
+        total: 1,
+        truncated: true,
+      });
+      const execute = getExecute();
+      const res = await execute("id", { action: "resolve", name: "Sales" });
+      const data = res.details as any;
+      expect(data.resolved).toBeUndefined();
+      expect(data.candidates).toHaveLength(1);
+      expect(data.truncated).toBe(true);
+    });
+
+    it("multiple candidates (same-name group + thread) → returns candidates, no send", async () => {
+      const candidates: any[] = [
+        { kind: "group", channelId: "grp1", channelType: 2, name: "Ops", groupNo: "grp1" },
+        {
+          kind: "thread",
+          channelId: "grp1____tp01",
+          channelType: 5,
+          name: "Ops",
+          groupNo: "grp1",
+          shortId: "tp01",
+          parentName: "Parent",
+        },
+      ];
+      vi.mocked(resolveTargetsByName).mockResolvedValue({
+        candidates,
+        total: 2,
+        truncated: false,
+      });
+      const execute = getExecute();
+      const res = await execute("id", { action: "resolve", name: "Ops" });
+      const data = res.details as any;
+      expect(data.candidates).toHaveLength(2);
+      expect(data.total).toBe(2);
+      expect(data.resolved).toBeUndefined();
+    });
+
+    it("multiple same-name threads → returns candidates", async () => {
+      const candidates: any[] = [
+        { kind: "thread", channelId: "grp1____a", channelType: 5, name: "Bugs", groupNo: "grp1", shortId: "a", parentName: "P1" },
+        { kind: "thread", channelId: "grp2____b", channelType: 5, name: "Bugs", groupNo: "grp2", shortId: "b", parentName: "P2" },
+      ];
+      vi.mocked(resolveTargetsByName).mockResolvedValue({
+        candidates,
+        total: 2,
+        truncated: false,
+      });
+      const execute = getExecute();
+      const res = await execute("id", { action: "resolve", name: "Bugs" });
+      const data = res.details as any;
+      expect(data.candidates).toHaveLength(2);
+    });
+
+    it("truncated:true is passed through", async () => {
+      vi.mocked(resolveTargetsByName).mockResolvedValue({
+        candidates: [
+          { kind: "group", channelId: "g1", channelType: 2, name: "A", groupNo: "g1" } as any,
+          { kind: "group", channelId: "g2", channelType: 2, name: "A", groupNo: "g2" } as any,
+        ],
+        total: 2,
+        truncated: true,
+      });
+      const execute = getExecute();
+      const res = await execute("id", { action: "resolve", name: "A" });
+      const data = res.details as any;
+      expect(data.truncated).toBe(true);
+    });
+
+    it("forwards kind and limit into the request", async () => {
+      vi.mocked(resolveTargetsByName).mockResolvedValue({
+        candidates: [],
+        total: 0,
+        truncated: false,
+      });
+      const execute = getExecute();
+      await execute("id", { action: "resolve", name: "X", kind: "thread", limit: 5 });
+      expect(resolveTargetsByName).toHaveBeenCalledWith(
+        expect.objectContaining({ name: "X", kind: "thread", limit: 5 }),
+      );
+    });
+
+    // MINOR: an invalid limit (<=0, NaN, non-integer) must be dropped so the
+    // backend default applies — never forwarded as 0 / negative into the query.
+    it("does not forward an invalid limit (<=0 / NaN / non-integer)", async () => {
+      vi.mocked(resolveTargetsByName).mockResolvedValue({
+        candidates: [],
+        total: 0,
+        truncated: false,
+      });
+      const execute = getExecute();
+
+      for (const bad of [0, -3, Number.NaN]) {
+        vi.mocked(resolveTargetsByName).mockClear();
+        _clearResolveCache();
+        await execute("id", { action: "resolve", name: "X", limit: bad });
+        const call = vi.mocked(resolveTargetsByName).mock.calls[0][0] as any;
+        expect(call.limit).toBeUndefined();
+      }
+
+      // A non-integer is floored only when it stays positive; <1 fractional drops.
+      vi.mocked(resolveTargetsByName).mockClear();
+      _clearResolveCache();
+      await execute("id", { action: "resolve", name: "X", limit: 0.5 });
+      expect((vi.mocked(resolveTargetsByName).mock.calls[0][0] as any).limit).toBeUndefined();
+    });
+
+    it("floors a positive non-integer limit and forwards it", async () => {
+      vi.mocked(resolveTargetsByName).mockResolvedValue({
+        candidates: [],
+        total: 0,
+        truncated: false,
+      });
+      const execute = getExecute();
+      await execute("id", { action: "resolve", name: "X", limit: 7.9 });
+      expect(resolveTargetsByName).toHaveBeenCalledWith(
+        expect.objectContaining({ limit: 7 }),
+      );
+    });
+
+    // MAJOR: a 0-candidate (not-found) result must NOT be cached, so a target
+    // freshly created/renamed seconds later is not masked by a stale miss. A
+    // second resolve after an initial 0-result must hit fetch again.
+    it("does not cache a 0-candidate result — second resolve refetches", async () => {
+      vi.mocked(resolveTargetsByName).mockResolvedValue({
+        candidates: [],
+        total: 0,
+        truncated: false,
+      });
+      const execute = getExecute();
+      await execute("id", { action: "resolve", name: "Fresh" });
+      await execute("id", { action: "resolve", name: "Fresh" });
+      expect(resolveTargetsByName).toHaveBeenCalledTimes(2);
+    });
+
+    it("caches a POSITIVE result — second identical resolve refetches only once", async () => {
+      vi.mocked(resolveTargetsByName).mockResolvedValue({
+        candidates: [
+          { kind: "group", channelId: "g1", channelType: 2, name: "Hit", groupNo: "g1" } as any,
+        ],
+        total: 1,
+        truncated: false,
+      });
+      const execute = getExecute();
+      await execute("id", { action: "resolve", name: "Hit" });
+      await execute("id", { action: "resolve", name: "Hit" });
+      expect(resolveTargetsByName).toHaveBeenCalledTimes(1);
+    });
+
+    it("caches within TTL — second identical resolve does not refetch", async () => {
+      vi.mocked(resolveTargetsByName).mockResolvedValue({
+        candidates: [
+          { kind: "group", channelId: "g1", channelType: 2, name: "Dup", groupNo: "g1" } as any,
+        ],
+        total: 1,
+        truncated: false,
+      });
+      const execute = getExecute();
+      await execute("id", { action: "resolve", name: "Dup" });
+      await execute("id", { action: "resolve", name: "Dup" });
+      expect(resolveTargetsByName).toHaveBeenCalledTimes(1);
+    });
+
+    it("different kind is a distinct cache key", async () => {
+      vi.mocked(resolveTargetsByName).mockResolvedValue({
+        candidates: [
+          { kind: "group", channelId: "g1", channelType: 2, name: "Dup", groupNo: "g1" } as any,
+        ],
+        total: 1,
+        truncated: false,
+      });
+      const execute = getExecute();
+      await execute("id", { action: "resolve", name: "Dup", kind: "group" });
+      await execute("id", { action: "resolve", name: "Dup", kind: "thread" });
+      expect(resolveTargetsByName).toHaveBeenCalledTimes(2);
+    });
+
+    it("cache clear hook resets the cache", async () => {
+      vi.mocked(resolveTargetsByName).mockResolvedValue({
+        candidates: [
+          { kind: "group", channelId: "g1", channelType: 2, name: "Dup", groupNo: "g1" } as any,
+        ],
+        total: 1,
+        truncated: false,
+      });
+      const execute = getExecute();
+      await execute("id", { action: "resolve", name: "Dup" });
+      _clearResolveCache();
+      await execute("id", { action: "resolve", name: "Dup" });
+      expect(resolveTargetsByName).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/src/agent-tools.ts
+++ b/src/agent-tools.ts
@@ -39,8 +39,10 @@ import {
   getThreadMd,
   updateThreadMd,
   resolveSecret,
+  resolveTargetsByName,
 } from "./api-fetch.js";
-import { broadcastGroupMdUpdate, broadcastThreadMdUpdate } from "./group-md.js";
+import { broadcastGroupMdUpdate, broadcastThreadMdUpdate, getKnownGroupIds } from "./group-md.js";
+import type { TargetCandidate } from "./types.js";
 import { mkdir, realpath, lstat, open } from "node:fs/promises";
 import { constants as fsConstants } from "node:fs";
 import {
@@ -519,6 +521,31 @@ type LogSink = {
 };
 
 // ---------------------------------------------------------------------------
+// Resolve-targets short-TTL cache
+// ---------------------------------------------------------------------------
+
+/**
+ * Short-TTL in-process cache for resolveTargetsByName results. The agent often
+ * resolves the same name several times within one conversation turn (read it,
+ * ask the user, resolve again); a 30s TTL collapses those into a single backend
+ * fetch without risking a stale view across turns. Mirrors the reset-hook style
+ * of member-cache (`_clearMemberCache`) / owner-registry (`_clearOwnerRegistry`).
+ */
+const RESOLVE_CACHE_TTL_MS = 30_000;
+
+interface ResolveCacheEntry {
+  result: { candidates: TargetCandidate[]; total: number; truncated: boolean };
+  expiry: number;
+}
+
+const _resolveCache = new Map<string, ResolveCacheEntry>();
+
+/** Visible for testing — clears the resolve-targets cache. */
+export function _clearResolveCache(): void {
+  _resolveCache.clear();
+}
+
+// ---------------------------------------------------------------------------
 // Tool factory
 // ---------------------------------------------------------------------------
 
@@ -567,6 +594,7 @@ export function createOctoManagementTools(params: {
             "group-md-read",
             "group-md-update",
             "search-members",
+            "resolve",
             "create-group",
             "update-group",
             "add-members",
@@ -616,7 +644,17 @@ export function createOctoManagementTools(params: {
         name: {
           type: "string",
           description:
-            "Group name. Optional for create-group, update-group.",
+            "Group name. Optional for create-group, update-group; for action=resolve it is the target name to search for.",
+        },
+        kind: {
+          type: "string",
+          enum: ["group", "thread", "all"],
+          description: "For resolve only. Filter candidate kind. Default all.",
+        },
+        limit: {
+          type: "number",
+          description:
+            "For resolve only. Max candidates (default 20, capped 50 by the server).",
         },
         notice: {
           type: "string",
@@ -802,6 +840,41 @@ export function createOctoManagementTools(params: {
               keyword: keyword || undefined,
             });
             return makeSuccess({ members: results });
+          }
+
+          case "resolve": {
+            const name = (args.name as string | undefined)?.trim();
+            if (!name) {
+              return makeError("name is required for resolve");
+            }
+            const rawKind = args.kind as string | undefined;
+            if (
+              rawKind !== undefined &&
+              rawKind !== "group" &&
+              rawKind !== "thread" &&
+              rawKind !== "all"
+            ) {
+              return makeError(
+                `Invalid kind "${rawKind}" for resolve; use "group", "thread", or "all"`,
+              );
+            }
+            const kind = rawKind as "group" | "thread" | "all" | undefined;
+            // Validate limit: accept only a positive integer. Anything else
+            // (<=0, NaN, non-integer) is dropped so the backend default applies
+            // — never forward a 0 / negative limit into the query.
+            let limit: number | undefined;
+            if (typeof args.limit === "number" && Number.isFinite(args.limit)) {
+              const floored = Math.floor(args.limit);
+              if (floored > 0) limit = floored;
+            }
+            return await handleResolveTargets({
+              apiUrl,
+              botToken,
+              accountId,
+              name,
+              kind,
+              limit,
+            });
           }
 
           case "create-group": {
@@ -1068,6 +1141,108 @@ async function handleListGroups(params: {
     botToken: params.botToken,
   });
   return makeSuccess({ groups });
+}
+
+/**
+ * Resolve a NAMED target into concrete channel candidates.
+ *
+ * Disambiguation is mandatory — this NEVER auto-sends and NEVER silently picks
+ * when more than one candidate matches:
+ *   • 0 candidates  → not-found result carrying fuzzy name suggestions (so the
+ *                     agent can offer "did you mean …?"), nothing sent.
+ *   • genuinely unique (1 candidate AND total === 1 AND not truncated)
+ *                   → { resolved } echoing kind; the agent must then call send
+ *                     with candidate.channelId. Still not sent here.
+ *   • anything else (>1 candidates, OR 1 returned but total>1 / truncated)
+ *                   → { candidates, total, truncated }; the agent must ask the
+ *                     user which one. Not sent here. A single returned candidate
+ *                     over a larger match set is NOT treated as unambiguous, so
+ *                     a truncated/partial result can never silently auto-resolve.
+ *
+ * Results are cached for RESOLVE_CACHE_TTL_MS keyed by accountId|name|kind to
+ * avoid repeat fetches within one conversation turn.
+ */
+async function handleResolveTargets(params: {
+  apiUrl: string;
+  botToken: string;
+  accountId: string;
+  name: string;
+  kind?: "group" | "thread" | "all";
+  limit?: number;
+}): Promise<ToolResult> {
+  const cacheKey = `${params.accountId}|${params.name}|${params.kind ?? "all"}`;
+  const cached = _resolveCache.get(cacheKey);
+  let result: { candidates: TargetCandidate[]; total: number; truncated: boolean };
+  if (cached && cached.expiry > Date.now()) {
+    result = cached.result;
+  } else {
+    result = await resolveTargetsByName({
+      apiUrl: params.apiUrl,
+      botToken: params.botToken,
+      name: params.name,
+      kind: params.kind,
+      limit: params.limit,
+    });
+    // Only cache POSITIVE (>=1 candidate) results. A 0-candidate miss must NOT
+    // be cached: a target freshly created/renamed seconds ago would otherwise be
+    // masked by the stale not-found entry for the rest of the 30s TTL.
+    if (result.candidates.length > 0) {
+      _resolveCache.set(cacheKey, {
+        result,
+        expiry: Date.now() + RESOLVE_CACHE_TTL_MS,
+      });
+    }
+  }
+
+  const { candidates, total, truncated } = result;
+
+  // 0 candidates → not found. Offer fuzzy suggestions from known group NAMES so
+  // the agent can ask "did you mean …?" instead of guessing a group: address.
+  if (candidates.length === 0) {
+    const suggestions = fuzzyGroupNameSuggestions(params.name);
+    return makeSuccess({
+      resolved: null,
+      candidates: [],
+      total: 0,
+      error: `No target named "${params.name}" found`,
+      suggestions,
+    });
+  }
+
+  // Genuinely unique → resolved. Require candidates.length === 1 AND total === 1
+  // AND not truncated: a single RETURNED candidate over a larger match set (e.g.
+  // the agent passed limit:1, or the server truncated) is NOT unambiguous, and
+  // auto-resolving it would silently treat a partial result as a confident pick.
+  // Echo kind so the agent knows group vs thread. Do NOT auto-send; the agent
+  // must call send with candidate.channelId next.
+  if (candidates.length === 1 && total === 1 && truncated !== true) {
+    return makeSuccess({ resolved: candidates[0] });
+  }
+
+  // Otherwise (>1 candidates, OR 1 returned but total>1 / truncated) → return the
+  // list; the agent must ask the user which one. Pass truncated through so the
+  // agent can suggest refining the name.
+  return makeSuccess({ candidates, total, truncated });
+}
+
+/**
+ * Fuzzy-match a name against the known group NAMES for "did you mean …?"
+ * suggestions on a not-found resolve. Intentionally simple: case-insensitive
+ * substring match in either direction. getKnownGroupIds() exposes group IDs;
+ * when those happen to be human names they match here, otherwise suggestions are
+ * empty — which is an acceptable degrade (the agent just gets no hints).
+ */
+function fuzzyGroupNameSuggestions(name: string): string[] {
+  const needle = name.trim().toLowerCase();
+  if (!needle) return [];
+  const out: string[] = [];
+  for (const known of getKnownGroupIds()) {
+    const hay = known.toLowerCase();
+    if (hay.includes(needle) || needle.includes(hay)) {
+      out.push(known);
+    }
+  }
+  return out;
 }
 
 async function handleGroupInfo(params: {

--- a/src/agent-tools.ts
+++ b/src/agent-tools.ts
@@ -1159,8 +1159,8 @@ async function handleListGroups(params: {
  *                     over a larger match set is NOT treated as unambiguous, so
  *                     a truncated/partial result can never silently auto-resolve.
  *
- * Results are cached for RESOLVE_CACHE_TTL_MS keyed by accountId|name|kind to
- * avoid repeat fetches within one conversation turn.
+ * Results are cached for RESOLVE_CACHE_TTL_MS keyed by accountId|name|kind|limit
+ * to avoid repeat fetches within one conversation turn.
  */
 async function handleResolveTargets(params: {
   apiUrl: string;
@@ -1170,7 +1170,12 @@ async function handleResolveTargets(params: {
   kind?: "group" | "thread" | "all";
   limit?: number;
 }): Promise<ToolResult> {
-  const cacheKey = `${params.accountId}|${params.name}|${params.kind ?? "all"}`;
+  // Include the normalized limit in the cache key: a limit:1 lookup returns a
+  // bounded page, which must NOT satisfy a later wider (no-limit) lookup for the
+  // same name — otherwise the narrow, possibly-truncated result would poison the
+  // broader request.
+  const limitKey = params.limit == null ? "default" : String(params.limit);
+  const cacheKey = `${params.accountId}|${params.name}|${params.kind ?? "all"}|${limitKey}`;
   const cached = _resolveCache.get(cacheKey);
   let result: { candidates: TargetCandidate[]; total: number; truncated: boolean };
   if (cached && cached.expiry > Date.now()) {

--- a/src/api-fetch.test.ts
+++ b/src/api-fetch.test.ts
@@ -2041,4 +2041,46 @@ describe("resolveTargetsByName", () => {
       resolveTargetsByName({ apiUrl: "http://api.test", botToken: "t", name: "X" }),
     ).rejects.toThrow(/resolveTargetsByName failed \(500\): boom/);
   });
+
+  it("falls back total to candidates.length when total is omitted (no limit)", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: vi.fn().mockResolvedValue({
+        candidates: [
+          { kind: "group", channel_id: "g1", channel_type: 2, name: "n1", group_no: "g1" },
+          { kind: "group", channel_id: "g2", channel_type: 2, name: "n2", group_no: "g2" },
+        ],
+        // total + truncated omitted by the server
+      }),
+    }) as unknown as typeof fetch;
+
+    const { resolveTargetsByName } = await import("./api-fetch.js");
+    const result = await resolveTargetsByName({ apiUrl: "http://api.test", botToken: "t", name: "X" });
+    expect(result.total).toBe(2);
+    // No limit requested → cannot have hit a bound → not forced truncated.
+    expect(result.truncated).toBe(false);
+  });
+
+  it("fail-closed: total omitted AND candidates fill the limit → truncated:true", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: vi.fn().mockResolvedValue({
+        candidates: [{ kind: "group", channel_id: "g1", channel_type: 2, name: "n1", group_no: "g1" }],
+        // total + truncated omitted: a limit:1 page that fills the bound must
+        // be treated as possibly-partial, never as a confident total of 1.
+      }),
+    }) as unknown as typeof fetch;
+
+    const { resolveTargetsByName } = await import("./api-fetch.js");
+    const result = await resolveTargetsByName({
+      apiUrl: "http://api.test",
+      botToken: "t",
+      name: "X",
+      limit: 1,
+    });
+    expect(result.total).toBe(1);
+    expect(result.truncated).toBe(true);
+  });
 });

--- a/src/api-fetch.test.ts
+++ b/src/api-fetch.test.ts
@@ -1891,3 +1891,154 @@ describe("resolveSecret", () => {
     ).rejects.toThrow(/unknown status/);
   });
 });
+
+describe("resolveTargetsByName", () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it("maps snake_case → camelCase for group and thread candidates", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: vi.fn().mockResolvedValue({
+        candidates: [
+          { kind: "group", channel_id: "grp1", channel_type: 2, name: "G", group_no: "grp1" },
+          {
+            kind: "thread",
+            channel_id: "grp1____tp01",
+            channel_type: 5,
+            name: "T",
+            group_no: "grp1",
+            short_id: "tp01",
+            parent_name: "G",
+          },
+        ],
+        total: 2,
+        truncated: false,
+      }),
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const { resolveTargetsByName } = await import("./api-fetch.js");
+    const result = await resolveTargetsByName({
+      apiUrl: "http://api.test",
+      botToken: "t",
+      name: "X",
+    });
+
+    expect(result.total).toBe(2);
+    expect(result.truncated).toBe(false);
+
+    const [group, thread] = result.candidates;
+    expect(group).toEqual({
+      kind: "group",
+      channelId: "grp1",
+      channelType: 2,
+      name: "G",
+      groupNo: "grp1",
+    });
+    // group candidate must NOT carry thread-only fields
+    expect(group.shortId).toBeUndefined();
+    expect(group.parentName).toBeUndefined();
+
+    expect(thread).toEqual({
+      kind: "thread",
+      channelId: "grp1____tp01",
+      channelType: 5,
+      name: "T",
+      groupNo: "grp1",
+      shortId: "tp01",
+      parentName: "G",
+    });
+  });
+
+  it("always sets name; sets kind/limit only when provided", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: vi.fn().mockResolvedValue({ candidates: [], total: 0, truncated: false }),
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const { resolveTargetsByName } = await import("./api-fetch.js");
+    await resolveTargetsByName({
+      apiUrl: "http://api.test",
+      botToken: "t",
+      name: "Hello World",
+      kind: "thread",
+      limit: 7,
+    });
+
+    const calledUrl = fetchMock.mock.calls[0][0] as string;
+    const qs = new URL(calledUrl).searchParams;
+    expect(qs.get("name")).toBe("Hello World");
+    expect(qs.get("kind")).toBe("thread");
+    expect(qs.get("limit")).toBe("7");
+  });
+
+  it("omits kind/limit from the query when not provided", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: vi.fn().mockResolvedValue({ candidates: [], total: 0, truncated: false }),
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const { resolveTargetsByName } = await import("./api-fetch.js");
+    await resolveTargetsByName({ apiUrl: "http://api.test", botToken: "t", name: "X" });
+
+    const qs = new URL(fetchMock.mock.calls[0][0] as string).searchParams;
+    expect(qs.has("kind")).toBe(false);
+    expect(qs.has("limit")).toBe(false);
+  });
+
+  it("passes through truncated:true", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: vi.fn().mockResolvedValue({
+        candidates: [{ kind: "group", channel_id: "g", channel_type: 2, name: "n", group_no: "g" }],
+        total: 1,
+        truncated: true,
+      }),
+    }) as unknown as typeof fetch;
+
+    const { resolveTargetsByName } = await import("./api-fetch.js");
+    const result = await resolveTargetsByName({ apiUrl: "http://api.test", botToken: "t", name: "X" });
+    expect(result.truncated).toBe(true);
+  });
+
+  it("empty result (App Bot / no match) → empty candidates, total 0", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: vi.fn().mockResolvedValue({ candidates: [], total: 0, truncated: false }),
+    }) as unknown as typeof fetch;
+
+    const { resolveTargetsByName } = await import("./api-fetch.js");
+    const result = await resolveTargetsByName({ apiUrl: "http://api.test", botToken: "t", name: "X" });
+    expect(result.candidates).toEqual([]);
+    expect(result.total).toBe(0);
+  });
+
+  it("throws on non-2xx with status and body", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: "Internal Server Error",
+      text: vi.fn().mockResolvedValue("boom"),
+    }) as unknown as typeof fetch;
+
+    const { resolveTargetsByName } = await import("./api-fetch.js");
+    await expect(
+      resolveTargetsByName({ apiUrl: "http://api.test", botToken: "t", name: "X" }),
+    ).rejects.toThrow(/resolveTargetsByName failed \(500\): boom/);
+  });
+});

--- a/src/api-fetch.ts
+++ b/src/api-fetch.ts
@@ -1615,9 +1615,19 @@ export async function resolveTargetsByName(params: {
     if (c.parent_name != null) mapped.parentName = c.parent_name as string;
     return mapped;
   });
+  // When the server omits `total`, fall back to candidates.length — but that
+  // fallback is unsafe if we asked for a bounded page (limit) and got a full
+  // page back: total would collapse to the page size and a truncated result
+  // could masquerade as genuinely unique. Fail closed: if total is missing AND
+  // we hit the limit, force truncated=true so the caller never auto-resolves.
+  const hasTotal = typeof data?.total === "number";
+  const total = hasTotal ? (data.total as number) : candidates.length;
+  const limitReached =
+    typeof params.limit === "number" && params.limit > 0 && candidates.length >= params.limit;
+  const truncated = data?.truncated === true || (!hasTotal && limitReached);
   return {
     candidates,
-    total: typeof data?.total === "number" ? data.total : candidates.length,
-    truncated: data?.truncated === true,
+    total,
+    truncated,
   };
 }

--- a/src/api-fetch.ts
+++ b/src/api-fetch.ts
@@ -3,7 +3,7 @@
  * These are used by inbound/outbound where the full OctoAPI class is not available.
  */
 
-import { ChannelType, MessageType, type MentionEntity, type RichTextBlock, type SendMessageResult } from "./types.js";
+import { ChannelType, MessageType, type MentionEntity, type RichTextBlock, type SendMessageResult, type TargetCandidate } from "./types.js";
 import path from "path";
 import { open } from "node:fs/promises";
 import { randomUUID } from "node:crypto";
@@ -1560,4 +1560,64 @@ export async function leaveThread(params: {
     const text = await resp.text().catch(() => "");
     throw new Error(`leaveThread failed (${resp.status}): ${text || resp.statusText}`);
   }
+}
+
+// ========== Target Resolve API ==========
+
+/**
+ * Resolve a NAMED target ("forward to 'XXX'") into concrete channel candidates.
+ *
+ * GET /v1/bot/resolve/targets?name=...&kind=...&limit=... (octo-server PR #337).
+ *
+ * Returns candidates the agent can disambiguate against — it must NEVER
+ * hand-build a `group:` address from a name. An empty result (App Bot, or no
+ * match) comes back as candidates:[] / total:0 with HTTP 200, not an error.
+ *
+ * The server response is snake_case; this does EXPLICIT field mapping into the
+ * camelCase TargetCandidate shape rather than casting the raw JSON, so a backend
+ * field rename surfaces as a typed gap here instead of silently propagating.
+ */
+export async function resolveTargetsByName(params: {
+  apiUrl: string;
+  botToken: string;
+  name: string;
+  kind?: "group" | "thread" | "all";
+  limit?: number;
+}): Promise<{ candidates: TargetCandidate[]; total: number; truncated: boolean }> {
+  const query = new URLSearchParams();
+  query.set("name", params.name);
+  if (params.kind) query.set("kind", params.kind);
+  if (params.limit != null) query.set("limit", String(params.limit));
+  const url = `${params.apiUrl.replace(/\/+$/, "")}/v1/bot/resolve/targets?${query}`;
+  const resp = await fetch(url, {
+    headers: { Authorization: `Bearer ${params.botToken}` },
+    signal: AbortSignal.timeout(DEFAULT_TIMEOUT_MS),
+  });
+  if (!resp.ok) {
+    const text = await resp.text().catch(() => "");
+    throw new Error(`resolveTargetsByName failed (${resp.status}): ${text || resp.statusText}`);
+  }
+  const data = (await resp.json()) as {
+    candidates?: Array<Record<string, unknown>>;
+    total?: number;
+    truncated?: boolean;
+  };
+  const rawCandidates = Array.isArray(data?.candidates) ? data.candidates : [];
+  const candidates: TargetCandidate[] = rawCandidates.map((c) => {
+    const mapped: TargetCandidate = {
+      kind: c.kind as "group" | "thread",
+      channelId: c.channel_id as string,
+      channelType: c.channel_type as ChannelType,
+      name: c.name as string,
+      groupNo: c.group_no as string,
+    };
+    if (c.short_id != null) mapped.shortId = c.short_id as string;
+    if (c.parent_name != null) mapped.parentName = c.parent_name as string;
+    return mapped;
+  });
+  return {
+    candidates,
+    total: typeof data?.total === "number" ? data.total : candidates.length,
+    truncated: data?.truncated === true,
+  };
 }

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -743,6 +743,7 @@ export const octoPlugin: ChannelPlugin<ResolvedOctoAccount> = {
         `For reading message history: use action="read" with target="user:<uid>" to read DM history, or target="group:<groupId>" to read group message history. Cross-channel queries require the requester to be a participant of the target channel.`,
         `For searching: use action="search" with query="shared-groups" to find groups that the bot and the current user both belong to.`,
         `For @mentions in a group: FIRST look up the target member's real uid + display name with octo_management action="group-members" (target="group:<groupId>"). ${MENTION_FORMAT_HINT}`,
+        `When the user names a target by NAME (not id), e.g. "forward to 'XXX' group/chat", FIRST call octo_management action="resolve" with name:"XXX" to resolve it. If multiple candidates are returned, ask the user which group/thread; if exactly one, use its channelId to send. Never hand-build a "group:" address from a name.`,
       ];
     },
   },

--- a/src/types.ts
+++ b/src/types.ts
@@ -190,6 +190,28 @@ export interface RichTextPayload {
   plain?: string;
 }
 
+/**
+ * A single candidate returned by the name → target resolver
+ * (GET /v1/bot/resolve/targets, octo-server PR #337).
+ *
+ * Group candidates carry only the group identity; thread candidates additionally
+ * carry `shortId` + `parentName`. There is no `parentGroupNo` — `groupNo` already
+ * holds the parent group for a thread.
+ */
+export interface TargetCandidate {
+  kind: "group" | "thread";
+  /** group: group_no ; thread: group_no____short_id (four underscores). */
+  channelId: string;
+  /** 2 = group, 5 = thread (CommunityTopic). */
+  channelType: ChannelType;
+  name: string;
+  groupNo: string;
+  /** Thread only. */
+  shortId?: string;
+  /** Thread only. */
+  parentName?: string;
+}
+
 /** Minimal logger interface used across modules. */
 export type LogSink = {
   info?: (msg: string) => void;


### PR DESCRIPTION
Closes #105.

Scenario 2 plugin integration of the group/thread routing disambiguation work (umbrella #98). Adds a `resolve` action to the `octo_management` tool so the agent can turn a named target ("forward to 'XXX'") into concrete group/thread candidates instead of hand-building a `group:` address and guessing.

### Depends on
- octo-server #337 (`GET /v1/bot/resolve/targets`). This PR codes strictly against that endpoint's response contract. The action only works at runtime once #337 is merged and deployed; until then the backend returns 404 and the action surfaces a clean "resolve unavailable" error. Tests mock the endpoint, so they are independent of #337.

### What it does
- New `resolve` action: `name` (required), optional `kind` (`group`|`thread`|`all`, default `all`), optional `limit` (positive integer; invalid values are dropped so the server default applies).
- Calls `GET /v1/bot/resolve/targets` (Bearer bot token) and maps the snake_case response to camelCase explicitly (`channel_id`→`channelId`, `short_id`→`shortId`, `parent_name`→`parentName`, etc.). Thread-only fields are set only when present.
- Disambiguation never auto-sends:
  - 0 candidates → not-found result with best-effort name suggestions.
  - genuinely unique (1 candidate AND `total === 1` AND not truncated) → `{ resolved }`; the agent then sends with the resolved `channelId`.
  - any ambiguous or truncated result (incl. 1 returned but `total > 1`) → returns the full candidate list for the user to choose.
- 30s in-process cache (positive matches only — misses are not cached so freshly created/renamed targets aren't masked), with a `_clearResolveCache()` test hook.
- `messageToolHints` updated to steer the agent to `resolve` for name-based targets.

### Tests
- snake→camel mapping (group omits thread fields; thread carries both), query forwarding (name always; kind/limit conditional + invalid-limit dropped), `truncated` passthrough, empty result, non-2xx throw.
- enum/params presence, name-required, invalid-kind, 0/1/multiple candidates, single-returned-but-truncated → candidates (no silent send), cache hit, negative result re-fetches, distinct key per kind, cache-clear hook.
- Full suite: 1108 passing, no regressions. type-check + build green.