### PR TITLE
fix(inbound): derive dispatch timeout from agents.defaults.timeoutSeconds instead of hardcoded 300s

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Configuration fields per account:
 - `cdnUrl` (optional): CDN base URL for media files
 - `requireMention` (optional): Only respond when @mentioned in groups
 - `historyLimit` (optional): Group chat history message limit (default: 20)
+- `dispatchTimeoutMs` (optional): Per-inbound dispatch timeout in milliseconds — an infrastructure backstop that releases the per-group message queue if an upstream dispatch hangs. When unset, it is derived from OpenClaw's `agents.defaults.timeoutSeconds` (600 if unset) as `timeoutSeconds * 1000 + 60000`, so it always fires *after* the agent-run timeout: the agent terminates gracefully first, and this timeout only catches genuinely hung dispatches. Set explicitly only if you need to decouple it from the agent timeout.
 
 ## What it does
 

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -127,6 +127,11 @@
                 "secretsFileRoot": {
                   "type": "string",
                   "description": "Jail root for write-secret: secret files may only be written under this path. When unset, defaults to the agent's workspace (agents.list[].workspace matched to the agent, else agents.defaults.workspace). If neither resolves to a usable directory, write-secret is unavailable (fail-closed); there is no process working-directory fallback."
+                },
+                "dispatchTimeoutMs": {
+                  "type": "number",
+                  "minimum": 1000,
+                  "description": "Per-inbound dispatch timeout in milliseconds (infrastructure backstop that releases the per-group queue when an upstream dispatch hangs). When unset, derived from agents.defaults.timeoutSeconds (default 600) as timeoutSeconds*1000 + 60000, so it always fires after the agent-run timeout. Set explicitly only when you need to decouple it from the agent timeout."
                 }
               }
             }
@@ -138,6 +143,11 @@
           "secretsFileRoot": {
             "type": "string",
             "description": "Jail root for write-secret: secret files may only be written under this path. When unset, defaults to the agent's workspace (agents.list[].workspace matched to the agent, else agents.defaults.workspace). If neither resolves to a usable directory, write-secret is unavailable (fail-closed); there is no process working-directory fallback."
+          },
+          "dispatchTimeoutMs": {
+            "type": "number",
+            "minimum": 1000,
+            "description": "Per-inbound dispatch timeout in milliseconds (infrastructure backstop that releases the per-group queue when an upstream dispatch hangs). When unset, derived from agents.defaults.timeoutSeconds (default 600) as timeoutSeconds*1000 + 60000, so it always fires after the agent-run timeout. Set explicitly only when you need to decouple it from the agent timeout."
           }
         }
       }

--- a/src/accounts.ts
+++ b/src/accounts.ts
@@ -20,6 +20,7 @@ export type ResolvedOctoAccount = {
     historyPromptTemplate?: string;  // Template for group history context injection
     onBehalfOf?: string;  // Persona clone: grantor uid
     secretsFileRoot?: string;  // Jail root for write-secret file writes
+    dispatchTimeoutMs?: number;  // Explicit dispatch-timeout override; unset = derive from agents.defaults.timeoutSeconds (issue #113)
   };
 };
 
@@ -102,6 +103,7 @@ export function resolveOctoAccount(params: {
       historyPromptTemplate: accountConfig.historyPromptTemplate ?? channel.historyPromptTemplate,
       onBehalfOf: accountConfig.onBehalfOf ?? channel.onBehalfOf,
       secretsFileRoot: accountConfig.secretsFileRoot ?? channel.secretsFileRoot,
+      dispatchTimeoutMs: accountConfig.dispatchTimeoutMs ?? channel.dispatchTimeoutMs,
     },
   };
 }

--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -15,6 +15,7 @@ export interface OctoAccountConfig {
   historyPromptTemplate?: string;  // Template for group history context injection
   onBehalfOf?: string;  // Persona clone: grantor uid — bot acts on behalf of this human
   secretsFileRoot?: string;  // Jail root for write-secret: secret files may only be written under this path. When unset, defaults to the agent's workspace (agents.list[].workspace matched to the agent, else agents.defaults.workspace); if neither resolves, write-secret fails closed (no process.cwd() fallback).
+  dispatchTimeoutMs?: number;  // Explicit per-inbound dispatch timeout override (ms). Unset = derived from agents.defaults.timeoutSeconds + 60s buffer (issue #113).
 }
 
 export interface OctoConfig {
@@ -32,6 +33,7 @@ export interface OctoConfig {
   historyPromptTemplate?: string;  // Template for group history context injection
   onBehalfOf?: string;  // Persona clone: grantor uid — bot acts on behalf of this human
   secretsFileRoot?: string;  // Jail root for write-secret (see OctoAccountConfig)
+  dispatchTimeoutMs?: number;  // Explicit per-inbound dispatch timeout override (ms); see OctoAccountConfig
   accounts?: Record<string, OctoAccountConfig | undefined>;
 }
 
@@ -44,6 +46,15 @@ export const DEFAULT_HISTORY_PROMPT_TEMPLATE =
 // (manifest-schema-sync.test.ts asserts this).
 export const SECRETS_FILE_ROOT_DESCRIPTION =
   "Jail root for write-secret: secret files may only be written under this path. When unset, defaults to the agent's workspace (agents.list[].workspace matched to the agent, else agents.defaults.workspace). If neither resolves to a usable directory, write-secret is unavailable (fail-closed); there is no process working-directory fallback.";
+
+// Shared description for dispatchTimeoutMs, kept identical to the wording in
+// openclaw.plugin.json (manifest-schema-sync.test.ts asserts key-level sync).
+// Semantics (issue #113): this timeout is the per-group-queue infrastructure
+// backstop from issue #75, NOT an agent-run timeout. When unset it is DERIVED
+// as (agents.defaults.timeoutSeconds ?? 600) * 1000 + 60000, so it always
+// fires strictly after OpenClaw core's own agent-run timeout.
+export const DISPATCH_TIMEOUT_MS_DESCRIPTION =
+  "Per-inbound dispatch timeout in milliseconds (infrastructure backstop that releases the per-group queue when an upstream dispatch hangs). When unset, derived from agents.defaults.timeoutSeconds (default 600) as timeoutSeconds*1000 + 60000, so it always fires after the agent-run timeout. Set explicitly only when you need to decouple it from the agent timeout.";
 
 // JSON Schema for OpenClaw plugin config validation
 export const OctoConfigJsonSchema = {
@@ -64,6 +75,7 @@ export const OctoConfigJsonSchema = {
       historyPromptTemplate: { type: "string" },
       onBehalfOf: { type: "string" },
       secretsFileRoot: { type: "string", description: SECRETS_FILE_ROOT_DESCRIPTION },
+      dispatchTimeoutMs: { type: "number", minimum: 1000, description: DISPATCH_TIMEOUT_MS_DESCRIPTION },
       accounts: {
         type: "object",
         additionalProperties: {
@@ -83,6 +95,7 @@ export const OctoConfigJsonSchema = {
             historyPromptTemplate: { type: "string" },
             onBehalfOf: { type: "string" },
             secretsFileRoot: { type: "string", description: SECRETS_FILE_ROOT_DESCRIPTION },
+            dispatchTimeoutMs: { type: "number", minimum: 1000, description: DISPATCH_TIMEOUT_MS_DESCRIPTION },
           },
         },
       },

--- a/src/inbound-dispatch-timeout.test.ts
+++ b/src/inbound-dispatch-timeout.test.ts
@@ -2,11 +2,13 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { ChannelType, MessageType } from "./types.js";
 import {
   handleInboundMessage,
+  resolveDispatchTimeoutMs,
   _setDispatchTimeoutForTests,
   _setDispatchApologyTimeoutForTests,
 } from "./inbound.js";
 import { setOctoRuntime } from "./runtime.js";
 import { _clearKnownBots } from "./bot-registry.js";
+import { resolveOctoAccount } from "./accounts.js";
 import type { ResolvedOctoAccount } from "./accounts.js";
 
 /**
@@ -193,14 +195,17 @@ function installHangingRuntime(): { dispatch: ReturnType<typeof vi.fn> } {
   return { dispatch };
 }
 
-function installImmediateRuntime(deliverArgs?: { text?: string; kind?: string }) {
+function installImmediateRuntime(
+  deliverArgs?: { text?: string; kind?: string },
+  opts?: { config?: Record<string, unknown> },
+) {
   const dispatch = vi.fn(async (args: any) => {
     if (deliverArgs) {
       await args.dispatcherOptions.deliver({ text: deliverArgs.text ?? "hi" }, { kind: deliverArgs.kind ?? "final" });
     }
   });
   setOctoRuntime({
-    config: { loadConfig: () => ({}) },
+    config: { loadConfig: () => opts?.config ?? {} },
     channel: {
       reply: {
         dispatchReplyWithBufferedBlockDispatcher: dispatch,
@@ -354,5 +359,91 @@ describe("dispatch timeout guard (issue #75)", () => {
     const finalFlush = sends.find((s) => s.content === "buffered-final");
     expect(finalFlush, "final flush sendMessage must reach fetch").toBeDefined();
     expect(finalFlush!.abortedBeforeResolve, "final flush must be aborted by its own AbortSignal.timeout").toBe(true);
+  });
+});
+
+describe("dispatch timeout derivation from config (issue #113)", () => {
+  // These tests exercise the real resolution chain, so clear the test
+  // override that the outer beforeEach installs.
+  beforeEach(() => {
+    _setDispatchTimeoutForTests(null);
+  });
+
+  it("derives from agents.defaults.timeoutSeconds + 60s buffer (1000s → 1060s)", () => {
+    const cfg = { agents: { defaults: { timeoutSeconds: 1000 } } } as any;
+    expect(resolveDispatchTimeoutMs(cfg, makeAccount())).toBe(1_060_000);
+  });
+
+  it("falls back to 600s agent timeout when cfg omits timeoutSeconds → 660s", () => {
+    expect(resolveDispatchTimeoutMs({} as any, makeAccount())).toBe(660_000);
+    expect(resolveDispatchTimeoutMs({ agents: {} } as any, makeAccount())).toBe(660_000);
+    expect(resolveDispatchTimeoutMs({ agents: { defaults: {} } } as any, makeAccount())).toBe(660_000);
+  });
+
+  it("explicit dispatchTimeoutMs config wins over the derived value", () => {
+    const account = makeAccount();
+    account.config.dispatchTimeoutMs = 1_234_000;
+    const cfg = { agents: { defaults: { timeoutSeconds: 1000 } } } as any;
+    expect(resolveDispatchTimeoutMs(cfg, account)).toBe(1_234_000);
+  });
+
+  it("invalid explicit values (0, negative, NaN, Infinity) fall through to derivation", () => {
+    for (const bad of [0, -5, NaN, Infinity]) {
+      const account = makeAccount();
+      (account.config as any).dispatchTimeoutMs = bad;
+      expect(resolveDispatchTimeoutMs({} as any, account), `bad value: ${bad}`).toBe(660_000);
+    }
+  });
+
+  it("invalid agents.defaults.timeoutSeconds falls back to the 600s default", () => {
+    for (const bad of [0, -1, NaN, "1000"]) {
+      const cfg = { agents: { defaults: { timeoutSeconds: bad } } } as any;
+      expect(resolveDispatchTimeoutMs(cfg, makeAccount()), `bad value: ${bad}`).toBe(660_000);
+    }
+  });
+
+  it("_setDispatchTimeoutForTests override beats both explicit config and derivation", () => {
+    _setDispatchTimeoutForTests(123);
+    const account = makeAccount();
+    account.config.dispatchTimeoutMs = 999_999;
+    const cfg = { agents: { defaults: { timeoutSeconds: 1000 } } } as any;
+    expect(resolveDispatchTimeoutMs(cfg, account)).toBe(123);
+  });
+
+  it("resolveOctoAccount plumbs dispatchTimeoutMs: account-level overrides channel-level", () => {
+    const cfg = {
+      channels: {
+        octo: {
+          botToken: "tok",
+          apiUrl: API,
+          dispatchTimeoutMs: 700_000,
+          accounts: {
+            a1: { botToken: "tok1", dispatchTimeoutMs: 900_000 },
+            a2: { botToken: "tok2" },
+          },
+        },
+      },
+    } as any;
+    expect(resolveOctoAccount({ cfg, accountId: "a1" }).config.dispatchTimeoutMs).toBe(900_000);
+    // a2 sets nothing → inherits the channel-level value
+    expect(resolveOctoAccount({ cfg, accountId: "a2" }).config.dispatchTimeoutMs).toBe(700_000);
+    // neither set → undefined (handleInboundMessage derives from agent timeout)
+    const bare = { channels: { octo: { botToken: "tok", apiUrl: API } } } as any;
+    expect(resolveOctoAccount({ cfg: bare, accountId: null }).config.dispatchTimeoutMs).toBeUndefined();
+  });
+
+  it("wiring: handleInboundMessage arms the dispatch timer with the derived value", async () => {
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout") as any;
+
+    installImmediateRuntime(
+      { text: "hi", kind: "final" },
+      { config: { agents: { defaults: { timeoutSeconds: 1000 } } } },
+    );
+    installFetchStub();
+
+    await runInbound({ log: { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} } });
+
+    const armed = setTimeoutSpy.mock.calls.some((call: any[]) => call[1] === 1_060_000);
+    expect(armed, "dispatch timer must be armed with timeoutSeconds*1000 + 60s").toBe(true);
   });
 });

--- a/src/inbound.ts
+++ b/src/inbound.ts
@@ -32,7 +32,8 @@ import { mkdir, unlink, readdir, stat } from "node:fs/promises";
 import { join, basename } from "node:path";
 import { randomUUID } from "node:crypto";
 
-// Per-inbound dispatch timeout (issue #75). The upstream OpenClaw runtime call
+// Per-inbound dispatch timeout (issue #75; config derivation: issue #113).
+// The upstream OpenClaw runtime call
 // `core.channel.reply.dispatchReplyWithBufferedBlockDispatcher` is observed to
 // occasionally hang indefinitely (no resolve, no reject, no onError) — likely
 // in agent/runtime layers, not in this plugin. Combined with the per-group
@@ -41,11 +42,21 @@ import { randomUUID } from "node:crypto";
 // restarts. This wrapper turns "silent permanent block" into "single-message
 // timeout with a warn log + user-facing apology + queue advances".
 //
-// 5 minutes is intentionally generous — longer than any normal LLM round-trip,
-// short enough that a stuck group recovers within one user attention span.
+// This timeout is a pure infrastructure backstop — it must NOT double as an
+// agent-run timeout (OpenClaw core already bounds agent runs via
+// `agents.defaults.timeoutSeconds`). Issue #113: the old hardcoded 5-minute
+// value killed healthy long-running dispatches whenever operators raised
+// `timeoutSeconds` above 300s. The effective value is therefore resolved
+// per-inbound by `resolveDispatchTimeoutMs` (see below): an explicit
+// `dispatchTimeoutMs` channel/account config wins, otherwise the value is
+// DERIVED as `agents.defaults.timeoutSeconds (default 600) * 1000 + 60s`.
+// The 60s buffer guarantees by construction that this guard fires strictly
+// AFTER the agent-run timeout — core terminates the run gracefully first,
+// and the dispatch guard only catches genuinely hung infrastructure.
 // Tests override via `_setDispatchTimeoutForTests` to keep the suite fast.
-const DISPATCH_TIMEOUT_DEFAULT_MS = 5 * 60 * 1000;
-let DISPATCH_TIMEOUT_MS = DISPATCH_TIMEOUT_DEFAULT_MS;
+const DISPATCH_TIMEOUT_BUFFER_MS = 60_000;
+const DEFAULT_AGENT_TIMEOUT_SECONDS = 600;
+let dispatchTimeoutTestOverrideMs: number | null = null;
 // How long we wait for the user-facing "处理超时" apology to post, AND for the
 // happy-path buffered-text final flush, before giving up. The whole point of
 // issue #75 is that an Octo API call can hang; these recovery/flush calls hit
@@ -57,7 +68,38 @@ const DISPATCH_TIMEOUT_APOLOGY_DEFAULT_MS = 10_000;
 let DISPATCH_TIMEOUT_APOLOGY_MS = DISPATCH_TIMEOUT_APOLOGY_DEFAULT_MS;
 
 export function _setDispatchTimeoutForTests(ms: number | null): void {
-  DISPATCH_TIMEOUT_MS = ms === null ? DISPATCH_TIMEOUT_DEFAULT_MS : ms;
+  dispatchTimeoutTestOverrideMs = ms;
+}
+
+/**
+ * Resolve the effective per-inbound dispatch timeout (issue #113).
+ *
+ * Precedence:
+ *   1. `_setDispatchTimeoutForTests` override (tests only).
+ *   2. Explicit `dispatchTimeoutMs` from channel/account config
+ *      (`channels.octo.dispatchTimeoutMs`, overridable per account) —
+ *      ignored unless a finite positive number.
+ *   3. Derived from the agent-run timeout: `(agents.defaults.timeoutSeconds
+ *      ?? 600) * 1000 + 60_000`. Single source of truth — raising
+ *      `timeoutSeconds` automatically moves this guard with it, and the 60s
+ *      buffer keeps it strictly behind the agent timeout so a healthy run is
+ *      never killed by its own infrastructure backstop.
+ */
+export function resolveDispatchTimeoutMs(
+  cfg: OpenClawConfig,
+  account: ResolvedOctoAccount,
+): number {
+  if (dispatchTimeoutTestOverrideMs !== null) return dispatchTimeoutTestOverrideMs;
+  const explicit = account.config.dispatchTimeoutMs;
+  if (typeof explicit === "number" && Number.isFinite(explicit) && explicit > 0) {
+    return explicit;
+  }
+  const configured = cfg.agents?.defaults?.timeoutSeconds;
+  const agentTimeoutSeconds =
+    typeof configured === "number" && Number.isFinite(configured) && configured > 0
+      ? configured
+      : DEFAULT_AGENT_TIMEOUT_SECONDS;
+  return agentTimeoutSeconds * 1000 + DISPATCH_TIMEOUT_BUFFER_MS;
 }
 
 export function _setDispatchApologyTimeoutForTests(ms: number | null): void {
@@ -2487,8 +2529,8 @@ export async function handleInboundMessage(params: {
 
   let replySucceeded = false;
 
-  // Timeout guard: see DISPATCH_TIMEOUT_MS at top of file. Without this, an
-  // upstream dispatch hang would leave the per-group queue's Promise chain
+  // Timeout guard: see resolveDispatchTimeoutMs at top of file. Without this,
+  // an upstream dispatch hang would leave the per-group queue's Promise chain
   // unresolved forever — see issue #75.
   //
   // Scope note: we intentionally do NOT try to cancel an already-in-flight
@@ -2503,13 +2545,14 @@ export async function handleInboundMessage(params: {
   // is OUR timeout" by reference equality, never by string comparison —
   // protects against a same-text upstream error being misclassified.
   let dispatchTimeoutHandle: ReturnType<typeof setTimeout> | undefined;
+  const dispatchTimeoutMs = resolveDispatchTimeoutMs(config, account);
   const timeoutError = new Error(
-    `octo: dispatch timed out after ${DISPATCH_TIMEOUT_MS}ms`,
+    `octo: dispatch timed out after ${dispatchTimeoutMs}ms`,
   );
   const dispatchTimeoutPromise = new Promise<never>((_, reject) => {
     dispatchTimeoutHandle = setTimeout(() => {
       reject(timeoutError);
-    }, DISPATCH_TIMEOUT_MS);
+    }, dispatchTimeoutMs);
   });
 
   try {
@@ -2589,7 +2632,7 @@ export async function handleInboundMessage(params: {
               // Same bounded signal as the timeout-path apology: if upstream
               // signals an error AND the Octo API is also sick, this recovery
               // sendMessage would otherwise hold the per-group queue until
-              // the outer dispatch timeout kicks in (5min). PR #83 review.
+              // the outer dispatch timeout kicks in. PR #83 review.
               signal: AbortSignal.timeout(DISPATCH_TIMEOUT_APOLOGY_MS),
             });
           } catch (sendErr) {
@@ -2601,7 +2644,7 @@ export async function handleInboundMessage(params: {
       dispatchTimeoutPromise,
     ]);
   } catch (err) {
-    // Timeout: dispatch never returned within DISPATCH_TIMEOUT_MS. Tell the
+    // Timeout: dispatch never returned within dispatchTimeoutMs. Tell the
     // user, suppress any stale buffered text (so the finally-flush branch
     // does not double-send), then rethrow so the per-group queue's outer
     // .catch() (channel.ts#enqueueInbound) can advance to the next message
@@ -2613,7 +2656,7 @@ export async function handleInboundMessage(params: {
     if (err === timeoutError) {
       clearInterval(typingInterval);
       log?.warn?.(
-        `octo: dispatch hung past ${DISPATCH_TIMEOUT_MS}ms, aborting to unblock per-group queue (session=${route?.sessionKey ?? "?"})`,
+        `octo: dispatch hung past ${dispatchTimeoutMs}ms, aborting to unblock per-group queue (session=${route?.sessionKey ?? "?"})`,
       );
       deliverBuffer.lastText = null;
       deliverBuffer.textSent = true;


### PR DESCRIPTION
Fixes #113

## Problem

The per-inbound dispatch timeout (from #75) was hardcoded at `5 * 60 * 1000` ms in `src/inbound.ts` with no production config entry — the only setter was the test-only `_setDispatchTimeoutForTests`. With `agents.defaults.timeoutSeconds: 1000` on the OpenClaw side, an agent is allowed to run 16+ minutes, but octo killed the dispatch at exactly 300s (`Promise.race`), sending「处理超时」while the agent run was still healthy.

## Approach: derive, don't invent another number

This timeout's job (per the #75 scope) is purely infrastructural — turn a silently hung dispatch into a bounded failure that releases the per-group queue. It must not double as an agent-run timeout; core already owns that via `timeoutSeconds`. So the effective value is now resolved per-inbound by `resolveDispatchTimeoutMs`:

1. **`_setDispatchTimeoutForTests` override** (tests only) — retained, existing #75 suite unchanged.
2. **Explicit `dispatchTimeoutMs`** — new optional channel config (`channels.octo.dispatchTimeoutMs`, per-account overridable), plumbed through `resolveOctoAccount` like the other account fields. Wins when set to a finite positive number.
3. **Derived default**: `(agents.defaults.timeoutSeconds ?? 600) * 1000 + 60_000`.

The 60s buffer guarantees by construction that the dispatch guard fires strictly *after* the agent-run timeout — core terminates the run gracefully first, the guard only catches genuinely hung infrastructure. Single source of truth: raising `timeoutSeconds` moves the guard automatically. A truly hung dispatch is still bounded and the per-group queue still advances.

## Out of scope (unchanged)

- Per-group serial queue semantics, no activity watchdog, no early release (#75 scope note)
- Apology timeout (`DISPATCH_TIMEOUT_APOLOGY_MS` = 10s)
- `timeoutError` reference-equality identification

## Changes

- `src/inbound.ts` — `resolveDispatchTimeoutMs` (override → explicit config → derived); race/log/error sites use the resolved value
- `src/accounts.ts` — plumb `dispatchTimeoutMs` (account-level overrides channel-level)
- `src/config-schema.ts` + `openclaw.plugin.json` — `dispatchTimeoutMs` schema field (both levels, kept in sync for manifest-schema-sync test)
- `README.md` — document the field and its relationship to `agents.defaults.timeoutSeconds`
- `src/inbound-dispatch-timeout.test.ts` — new derivation suite

## Tests

New cases (issue #113):
- `timeoutSeconds=1000` → dispatch timeout `1_060_000` ms (1060s)
- cfg missing/empty → `660_000` ms (660s)
- explicit `dispatchTimeoutMs` wins over derivation; invalid values (0/negative/NaN/Infinity) fall through
- invalid `timeoutSeconds` falls back to 600s default
- test override beats everything
- account-level config overrides channel-level; unset stays `undefined`
- wiring test: `handleInboundMessage` arms the real timer with the derived value

Existing #75 regression suite (hang → apology → buffer drop → rethrow releases queue, timer cleanup, bounded apology/final-flush) passes unmodified.

Full suite: **26 files, 1109 tests, all green**; `tsc --noEmit` clean.
<!-- sprint-retrigger 2026-06-11T11:58Z -->