### PR TITLE
fix(inbound): prevent tool warning from overwriting final reply in deliver buffer

### DIFF
--- a/src/__tests__/deliver-buffer.test.ts
+++ b/src/__tests__/deliver-buffer.test.ts
@@ -18,6 +18,11 @@ import { describe, it, expect, vi } from "vitest";
 
 // ---- helpers that mirror the production logic in inbound.ts ----
 
+// Bounded signal used by the production sends (DISPATCH_TIMEOUT_APOLOGY_MS).
+// Mirror sends pass AbortSignal.timeout(...) so a sick Octo API can't strand
+// the per-group queue; tests assert the signal is forwarded.
+const DISPATCH_TIMEOUT_APOLOGY_MS = 10_000;
+
 function createDeliverBuffer() {
   return {
     lastText: null as string | null,
@@ -46,7 +51,7 @@ function makeDeliver(
   state: DeliverState,
   sentMediaUrls: Set<string>,
   sendMediaFn: (url: string) => Promise<void>,
-  sendTextFn: (text: string) => Promise<void>,
+  sendTextFn: (text: string, signal?: AbortSignal) => Promise<void>,
   isToolWarningFn: (payload: any) => boolean,
 ) {
   return async (
@@ -57,12 +62,12 @@ function makeDeliver(
       isReasoning?: boolean;
       isError?: boolean;
     },
-    info?: { kind?: string },
+    info: { kind: string },
   ) => {
     // Skip reasoning blocks
     if (payload.isReasoning) return;
 
-    const kind = info?.kind ?? "final";
+    const kind = info.kind;
 
     // Media: send immediately with dedup
     const outboundMediaUrls = [
@@ -82,7 +87,7 @@ function makeDeliver(
 
     // Text handling based on kind
     const content = payload.text?.trim() ?? "";
-    if (!content && outboundMediaUrls.length > 0) {
+    if (!content && sentMediaUrls.size > 0) {
       state.replySucceeded = true;
       return;
     }
@@ -90,7 +95,7 @@ function makeDeliver(
 
     if (kind === "tool") {
       // Verbose tool call output: send immediately
-      await sendTextFn(content);
+      await sendTextFn(content, AbortSignal.timeout(DISPATCH_TIMEOUT_APOLOGY_MS));
       state.replySucceeded = true;
       return;
     }
@@ -103,7 +108,7 @@ function makeDeliver(
         return;
       }
 
-      await sendTextFn(content);
+      await sendTextFn(content, AbortSignal.timeout(DISPATCH_TIMEOUT_APOLOGY_MS));
       state.replySucceeded = true;
       state.userFacingFinalDelivered = true;
       state.pendingToolWarningFinal = undefined;
@@ -131,17 +136,24 @@ function makeOnError(
 }
 
 function makeOnFreshSettledDelivery(
+  deliverBuffer: ReturnType<typeof createDeliverBuffer>,
   state: DeliverState,
-  sendTextFn: (text: string) => Promise<void>,
+  sendTextFn: (text: string, signal?: AbortSignal) => Promise<void>,
 ) {
   return async () => {
     if (!state.pendingToolWarningFinal || state.userFacingFinalDelivered || state.deliveryErrorOccurred) {
       return undefined;
     }
+    // Buffered block text is the real user-facing reply; let the finally
+    // flush deliver it and drop the warning fallback (single message).
+    if (deliverBuffer.lastText && !deliverBuffer.textSent) {
+      state.pendingToolWarningFinal = undefined;
+      return undefined;
+    }
     const pending = state.pendingToolWarningFinal;
     state.pendingToolWarningFinal = undefined;
     try {
-      await sendTextFn(pending.text);
+      await sendTextFn(pending.text, AbortSignal.timeout(DISPATCH_TIMEOUT_APOLOGY_MS));
       state.replySucceeded = true;
       return { visibleReplySent: true };
     } catch {
@@ -152,12 +164,12 @@ function makeOnFreshSettledDelivery(
 
 async function runFinally(
   deliverBuffer: ReturnType<typeof createDeliverBuffer>,
-  sendTextFn: (text: string) => Promise<void>,
+  sendTextFn: (text: string, signal?: AbortSignal) => Promise<void>,
   state?: DeliverState,
 ) {
   if (deliverBuffer.lastText && !deliverBuffer.textSent) {
     deliverBuffer.textSent = true;
-    await sendTextFn(deliverBuffer.lastText);
+    await sendTextFn(deliverBuffer.lastText, AbortSignal.timeout(DISPATCH_TIMEOUT_APOLOGY_MS));
     if (state) state.replySucceeded = true;
   }
 }
@@ -199,7 +211,7 @@ describe("deliver buffer pattern", () => {
     // finally block sends the buffered text
     await runFinally(deliverBuffer, sendText, state);
     expect(sendText).toHaveBeenCalledTimes(1);
-    expect(sendText).toHaveBeenCalledWith("Hello, how are you? I'm here to help.");
+    expect(sendText).toHaveBeenCalledWith("Hello, how are you? I'm here to help.", expect.any(AbortSignal));
     expect(deliverBuffer.textSent).toBe(true);
   });
 
@@ -215,7 +227,7 @@ describe("deliver buffer pattern", () => {
 
     // final is sent immediately
     expect(sendText).toHaveBeenCalledTimes(1);
-    expect(sendText).toHaveBeenCalledWith("Final answer");
+    expect(sendText).toHaveBeenCalledWith("Final answer", expect.any(AbortSignal));
     expect(state.userFacingFinalDelivered).toBe(true);
     // Buffer is cleared to prevent finally from re-sending
     expect(deliverBuffer.textSent).toBe(true);
@@ -237,7 +249,7 @@ describe("deliver buffer pattern", () => {
     await deliver({ text: "Tool output: file listing..." }, { kind: "tool" });
 
     expect(sendText).toHaveBeenCalledTimes(1);
-    expect(sendText).toHaveBeenCalledWith("Tool output: file listing...");
+    expect(sendText).toHaveBeenCalledWith("Tool output: file listing...", expect.any(AbortSignal));
     // tool does NOT set textSent — final text should still be sent via finally
     expect(deliverBuffer.textSent).toBe(false);
     expect(deliverBuffer.lastText).toBeNull();
@@ -262,27 +274,11 @@ describe("deliver buffer pattern", () => {
     // Final sent immediately
     await deliver(textPayload("Here are your files: ..."), { kind: "final" });
     expect(sendText).toHaveBeenCalledTimes(2);
-    expect(sendText).toHaveBeenLastCalledWith("Here are your files: ...");
+    expect(sendText).toHaveBeenLastCalledWith("Here are your files: ...", expect.any(AbortSignal));
 
     // finally should not send again
     await runFinally(deliverBuffer, sendText, state);
     expect(sendText).toHaveBeenCalledTimes(2);
-  });
-
-  it("undefined kind defaults to final: sends text immediately", async () => {
-    const deliverBuffer = createDeliverBuffer();
-    const state = createDeliverState();
-    const sentMediaUrls = new Set<string>();
-    const sendMedia = vi.fn().mockResolvedValue(undefined);
-    const sendText = vi.fn().mockResolvedValue(undefined);
-    const deliver = makeDeliver(deliverBuffer, state, sentMediaUrls, sendMedia, sendText, defaultIsToolWarning);
-
-    // No info parameter at all
-    await deliver({ text: "Fallback text" });
-
-    // undefined kind defaults to "final" → sent immediately (not a tool warning)
-    expect(sendText).toHaveBeenCalledTimes(1);
-    expect(sendText).toHaveBeenCalledWith("Fallback text");
   });
 
   it("isReasoning: skips entirely", async () => {
@@ -320,7 +316,7 @@ describe("deliver buffer pattern", () => {
     // Final arrives — sent immediately, clears buffer
     await deliver(textPayload("Complete response"), { kind: "final" });
     expect(sendText).toHaveBeenCalledTimes(1);
-    expect(sendText).toHaveBeenCalledWith("Complete response");
+    expect(sendText).toHaveBeenCalledWith("Complete response", expect.any(AbortSignal));
     expect(deliverBuffer.lastText).toBeNull();
 
     // finally block should not send again
@@ -410,12 +406,12 @@ describe("tool warning deferral", () => {
     const sendMedia = vi.fn().mockResolvedValue(undefined);
     const sendText = vi.fn().mockResolvedValue(undefined);
     const deliver = makeDeliver(deliverBuffer, state, sentMediaUrls, sendMedia, sendText, defaultIsToolWarning);
-    const onSettled = makeOnFreshSettledDelivery(state, sendText);
+    const onSettled = makeOnFreshSettledDelivery(deliverBuffer, state, sendText);
 
     // Normal final sent immediately
     await deliver(textPayload("Here is your answer with 173 chars of content..."), { kind: "final" });
     expect(sendText).toHaveBeenCalledTimes(1);
-    expect(sendText).toHaveBeenCalledWith("Here is your answer with 173 chars of content...");
+    expect(sendText).toHaveBeenCalledWith("Here is your answer with 173 chars of content...", expect.any(AbortSignal));
     expect(state.userFacingFinalDelivered).toBe(true);
 
     // Tool warning final arrives — discarded (userFacingFinalDelivered=true, not stored)
@@ -436,7 +432,7 @@ describe("tool warning deferral", () => {
     const sendMedia = vi.fn().mockResolvedValue(undefined);
     const sendText = vi.fn().mockResolvedValue(undefined);
     const deliver = makeDeliver(deliverBuffer, state, sentMediaUrls, sendMedia, sendText, defaultIsToolWarning);
-    const onSettled = makeOnFreshSettledDelivery(state, sendText);
+    const onSettled = makeOnFreshSettledDelivery(deliverBuffer, state, sendText);
 
     // Tool warning arrives first — deferred
     await deliver(toolWarningPayload("write_file failed"), { kind: "final" });
@@ -446,7 +442,7 @@ describe("tool warning deferral", () => {
     // Normal final arrives — sent immediately, clears pending warning
     await deliver(textPayload("Here is your answer"), { kind: "final" });
     expect(sendText).toHaveBeenCalledTimes(1);
-    expect(sendText).toHaveBeenCalledWith("Here is your answer");
+    expect(sendText).toHaveBeenCalledWith("Here is your answer", expect.any(AbortSignal));
     expect(state.userFacingFinalDelivered).toBe(true);
     expect(state.pendingToolWarningFinal).toBeUndefined();
 
@@ -463,7 +459,7 @@ describe("tool warning deferral", () => {
     const sendMedia = vi.fn().mockResolvedValue(undefined);
     const sendText = vi.fn().mockResolvedValue(undefined);
     const deliver = makeDeliver(deliverBuffer, state, sentMediaUrls, sendMedia, sendText, defaultIsToolWarning);
-    const onSettled = makeOnFreshSettledDelivery(state, sendText);
+    const onSettled = makeOnFreshSettledDelivery(deliverBuffer, state, sendText);
 
     // Only tool warning final — deferred
     await deliver(toolWarningPayload("write_file failed"), { kind: "final" });
@@ -475,7 +471,7 @@ describe("tool warning deferral", () => {
     const result = await onSettled();
     expect(result).toEqual({ visibleReplySent: true });
     expect(sendText).toHaveBeenCalledTimes(1);
-    expect(sendText).toHaveBeenCalledWith("write_file failed");
+    expect(sendText).toHaveBeenCalledWith("write_file failed", expect.any(AbortSignal));
     expect(state.pendingToolWarningFinal).toBeUndefined();
   });
 
@@ -486,7 +482,7 @@ describe("tool warning deferral", () => {
     const sendMedia = vi.fn().mockResolvedValue(undefined);
     const sendText = vi.fn().mockResolvedValue(undefined);
     const deliver = makeDeliver(deliverBuffer, state, sentMediaUrls, sendMedia, sendText, defaultIsToolWarning);
-    const onSettled = makeOnFreshSettledDelivery(state, sendText);
+    const onSettled = makeOnFreshSettledDelivery(deliverBuffer, state, sendText);
 
     // Normal final — sent immediately
     await deliver(textPayload("Complete answer"), { kind: "final" });
@@ -506,7 +502,7 @@ describe("tool warning deferral", () => {
     const sendMedia = vi.fn().mockResolvedValue(undefined);
     const sendText = vi.fn().mockResolvedValue(undefined);
     const deliver = makeDeliver(deliverBuffer, state, sentMediaUrls, sendMedia, sendText, defaultIsToolWarning);
-    const onSettled = makeOnFreshSettledDelivery(state, sendText);
+    const onSettled = makeOnFreshSettledDelivery(deliverBuffer, state, sendText);
 
     // Tool text sent immediately — replySucceeded=true
     await deliver({ text: "Tool: ls output" }, { kind: "tool" });
@@ -526,7 +522,7 @@ describe("tool warning deferral", () => {
     const result = await onSettled();
     expect(result).toEqual({ visibleReplySent: true });
     expect(sendText).toHaveBeenCalledTimes(2);
-    expect(sendText).toHaveBeenLastCalledWith("write_file failed");
+    expect(sendText).toHaveBeenLastCalledWith("write_file failed", expect.any(AbortSignal));
   });
 
   it("onError prevents warning fallback delivery", async () => {
@@ -538,7 +534,7 @@ describe("tool warning deferral", () => {
     const sendError = vi.fn().mockResolvedValue(undefined);
     const deliver = makeDeliver(deliverBuffer, state, sentMediaUrls, sendMedia, sendText, defaultIsToolWarning);
     const onError = makeOnError(deliverBuffer, state, sendError);
-    const onSettled = makeOnFreshSettledDelivery(state, sendText);
+    const onSettled = makeOnFreshSettledDelivery(deliverBuffer, state, sendText);
 
     // Warning deferred
     await deliver(toolWarningPayload("write_file failed"), { kind: "final" });
@@ -553,5 +549,70 @@ describe("tool warning deferral", () => {
     const result = await onSettled();
     expect(result).toBeUndefined();
     expect(sendText).not.toHaveBeenCalled();
+  });
+
+  it("bounded immediate-final send: normal final and fallback send pass an AbortSignal", async () => {
+    const deliverBuffer = createDeliverBuffer();
+    const state = createDeliverState();
+    const sentMediaUrls = new Set<string>();
+    const sendMedia = vi.fn().mockResolvedValue(undefined);
+    const sendText = vi.fn().mockResolvedValue(undefined);
+    const deliver = makeDeliver(deliverBuffer, state, sentMediaUrls, sendMedia, sendText, defaultIsToolWarning);
+    const onSettled = makeOnFreshSettledDelivery(deliverBuffer, state, sendText);
+
+    // Normal final immediate send — must be bounded by a signal so a hung
+    // Octo sendMessage can't stall the per-group queue for the full dispatch
+    // timeout.
+    await deliver(textPayload("Final answer"), { kind: "final" });
+    expect(sendText).toHaveBeenCalledTimes(1);
+    const [, finalSignal] = sendText.mock.calls[0];
+    expect(finalSignal).toBeInstanceOf(AbortSignal);
+
+    // Fresh state: only a tool warning, delivered via onFreshSettledDelivery
+    // fallback — that send must also be bounded.
+    const deliverBuffer2 = createDeliverBuffer();
+    const state2 = createDeliverState();
+    const sendText2 = vi.fn().mockResolvedValue(undefined);
+    const deliver2 = makeDeliver(deliverBuffer2, state2, new Set<string>(), sendMedia, sendText2, defaultIsToolWarning);
+    const onSettled2 = makeOnFreshSettledDelivery(deliverBuffer2, state2, sendText2);
+
+    await deliver2(toolWarningPayload("write_file failed"), { kind: "final" });
+    expect(sendText2).not.toHaveBeenCalled();
+
+    await onSettled2();
+    expect(sendText2).toHaveBeenCalledTimes(1);
+    const [, fallbackSignal] = sendText2.mock.calls[0];
+    expect(fallbackSignal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("block then warning-only final → single send: block delivered, warning dropped", async () => {
+    const deliverBuffer = createDeliverBuffer();
+    const state = createDeliverState();
+    const sentMediaUrls = new Set<string>();
+    const sendMedia = vi.fn().mockResolvedValue(undefined);
+    const sendText = vi.fn().mockResolvedValue(undefined);
+    const deliver = makeDeliver(deliverBuffer, state, sentMediaUrls, sendMedia, sendText, defaultIsToolWarning);
+    const onSettled = makeOnFreshSettledDelivery(deliverBuffer, state, sendText);
+
+    // Block buffers the real user-facing reply
+    await deliver({ text: "Here is the buffered block reply" }, { kind: "block" });
+    expect(sendText).not.toHaveBeenCalled();
+    expect(deliverBuffer.lastText).toBe("Here is the buffered block reply");
+
+    // Fallback-only tool-warning final — deferred
+    await deliver(toolWarningPayload("write_file failed"), { kind: "final" });
+    expect(state.pendingToolWarningFinal).toEqual({ text: "write_file failed" });
+
+    // onFreshSettledDelivery: buffered block is pending → drop the warning,
+    // do NOT send it, and clear pendingToolWarningFinal
+    const result = await onSettled();
+    expect(result).toBeUndefined();
+    expect(sendText).not.toHaveBeenCalled();
+    expect(state.pendingToolWarningFinal).toBeUndefined();
+
+    // finally flush delivers the block text — exactly one message overall
+    await runFinally(deliverBuffer, sendText, state);
+    expect(sendText).toHaveBeenCalledTimes(1);
+    expect(sendText).toHaveBeenCalledWith("Here is the buffered block reply", expect.any(AbortSignal));
   });
 });

--- a/src/__tests__/deliver-buffer.test.ts
+++ b/src/__tests__/deliver-buffer.test.ts
@@ -5,12 +5,15 @@ import { describe, it, expect, vi } from "vitest";
  *
  * The deliver callback uses info.kind to decide behavior:
  * - "tool"  → send immediately via resolveAndSendText (verbose output)
- * - "block" / "final" / other → buffer text (overwrite), send once in finally
+ * - "final" (normal) → send immediately, mark userFacingFinalDelivered
+ * - "final" (tool warning) → defer to pendingToolWarningFinal
+ * - "block" / other → buffer text (overwrite), send once in finally
  *
  * - isReasoning payloads are skipped entirely
  * - Media payloads are always sent immediately with dedup
  * - The finally block sends the last buffered text after dispatcher finishes
  * - onError clears the buffer to prevent stale text
+ * - onFreshSettledDelivery sends pending tool warning as fallback
  */
 
 // ---- helpers that mirror the production logic in inbound.ts ----
@@ -22,11 +25,29 @@ function createDeliverBuffer() {
   };
 }
 
+interface DeliverState {
+  userFacingFinalDelivered: boolean;
+  pendingToolWarningFinal: { text: string } | undefined;
+  deliveryErrorOccurred: boolean;
+  replySucceeded: boolean;
+}
+
+function createDeliverState(): DeliverState {
+  return {
+    userFacingFinalDelivered: false,
+    pendingToolWarningFinal: undefined,
+    deliveryErrorOccurred: false,
+    replySucceeded: false,
+  };
+}
+
 function makeDeliver(
   deliverBuffer: ReturnType<typeof createDeliverBuffer>,
+  state: DeliverState,
   sentMediaUrls: Set<string>,
   sendMediaFn: (url: string) => Promise<void>,
   sendTextFn: (text: string) => Promise<void>,
+  isToolWarningFn: (payload: any) => boolean,
 ) {
   return async (
     payload: {
@@ -34,6 +55,7 @@ function makeDeliver(
       mediaUrls?: string[];
       mediaUrl?: string;
       isReasoning?: boolean;
+      isError?: boolean;
     },
     info?: { kind?: string },
   ) => {
@@ -60,50 +82,109 @@ function makeDeliver(
 
     // Text handling based on kind
     const content = payload.text?.trim() ?? "";
-    if (!content && outboundMediaUrls.length > 0) return;
+    if (!content && outboundMediaUrls.length > 0) {
+      state.replySucceeded = true;
+      return;
+    }
     if (!content) return;
 
     if (kind === "tool") {
       // Verbose tool call output: send immediately
       await sendTextFn(content);
+      state.replySucceeded = true;
       return;
     }
 
-    // kind === "block" / "final" / anything else: buffer, send once after dispatcher finishes
+    if (kind === "final") {
+      if (isToolWarningFn(payload)) {
+        if (!state.userFacingFinalDelivered) {
+          state.pendingToolWarningFinal = { text: content };
+        }
+        return;
+      }
+
+      await sendTextFn(content);
+      state.replySucceeded = true;
+      state.userFacingFinalDelivered = true;
+      state.pendingToolWarningFinal = undefined;
+      deliverBuffer.lastText = null;
+      deliverBuffer.textSent = true;
+      return;
+    }
+
+    // kind === "block" / anything else: buffer, send once after dispatcher finishes
     deliverBuffer.lastText = content;
   };
 }
 
 function makeOnError(
   deliverBuffer: ReturnType<typeof createDeliverBuffer>,
+  state: DeliverState,
   sendErrorFn: () => Promise<void>,
 ) {
   return async (_err: unknown) => {
     deliverBuffer.lastText = null;
     deliverBuffer.textSent = true;
+    state.deliveryErrorOccurred = true;
     await sendErrorFn();
+  };
+}
+
+function makeOnFreshSettledDelivery(
+  state: DeliverState,
+  sendTextFn: (text: string) => Promise<void>,
+) {
+  return async () => {
+    if (!state.pendingToolWarningFinal || state.userFacingFinalDelivered || state.deliveryErrorOccurred) {
+      return undefined;
+    }
+    const pending = state.pendingToolWarningFinal;
+    state.pendingToolWarningFinal = undefined;
+    try {
+      await sendTextFn(pending.text);
+      state.replySucceeded = true;
+      return { visibleReplySent: true };
+    } catch {
+      return { visibleReplySent: false };
+    }
   };
 }
 
 async function runFinally(
   deliverBuffer: ReturnType<typeof createDeliverBuffer>,
   sendTextFn: (text: string) => Promise<void>,
+  state?: DeliverState,
 ) {
   if (deliverBuffer.lastText && !deliverBuffer.textSent) {
     deliverBuffer.textSent = true;
     await sendTextFn(deliverBuffer.lastText);
+    if (state) state.replySucceeded = true;
   }
 }
+
+// Standard non-warning payload
+function textPayload(text: string) {
+  return { text };
+}
+
+// Tool warning payload (isError=true, simulates nonTerminalToolErrorWarning)
+function toolWarningPayload(text: string) {
+  return { text, isError: true as const };
+}
+
+// Default isToolWarning checker: treats any payload with isError=true as a tool warning
+const defaultIsToolWarning = (payload: any) => payload.isError === true;
 
 // ---- tests ----
 
 describe("deliver buffer pattern", () => {
   it("block kind: buffers text without sending", async () => {
     const deliverBuffer = createDeliverBuffer();
+    const state = createDeliverState();
     const sentMediaUrls = new Set<string>();
     const sendMedia = vi.fn().mockResolvedValue(undefined);
     const sendText = vi.fn().mockResolvedValue(undefined);
-    const deliver = makeDeliver(deliverBuffer, sentMediaUrls, sendMedia, sendText);
+    const deliver = makeDeliver(deliverBuffer, state, sentMediaUrls, sendMedia, sendText, defaultIsToolWarning);
 
     await deliver({ text: "Hello" }, { kind: "block" });
     await deliver({ text: "Hello, how are you" }, { kind: "block" });
@@ -116,37 +197,42 @@ describe("deliver buffer pattern", () => {
     expect(deliverBuffer.textSent).toBe(false);
 
     // finally block sends the buffered text
-    await runFinally(deliverBuffer, sendText);
+    await runFinally(deliverBuffer, sendText, state);
     expect(sendText).toHaveBeenCalledTimes(1);
     expect(sendText).toHaveBeenCalledWith("Hello, how are you? I'm here to help.");
     expect(deliverBuffer.textSent).toBe(true);
   });
 
-  it("final kind: buffers text, sends via finally", async () => {
+  it("final kind: sends text immediately", async () => {
     const deliverBuffer = createDeliverBuffer();
+    const state = createDeliverState();
     const sentMediaUrls = new Set<string>();
     const sendMedia = vi.fn().mockResolvedValue(undefined);
     const sendText = vi.fn().mockResolvedValue(undefined);
-    const deliver = makeDeliver(deliverBuffer, sentMediaUrls, sendMedia, sendText);
+    const deliver = makeDeliver(deliverBuffer, state, sentMediaUrls, sendMedia, sendText, defaultIsToolWarning);
 
-    await deliver({ text: "Final answer" }, { kind: "final" });
+    await deliver(textPayload("Final answer"), { kind: "final" });
 
-    // final is buffered, NOT sent immediately
-    expect(sendText).not.toHaveBeenCalled();
-    expect(deliverBuffer.lastText).toBe("Final answer");
-
-    // finally block sends it
-    await runFinally(deliverBuffer, sendText);
+    // final is sent immediately
     expect(sendText).toHaveBeenCalledTimes(1);
     expect(sendText).toHaveBeenCalledWith("Final answer");
+    expect(state.userFacingFinalDelivered).toBe(true);
+    // Buffer is cleared to prevent finally from re-sending
+    expect(deliverBuffer.textSent).toBe(true);
+    expect(deliverBuffer.lastText).toBeNull();
+
+    // finally block should NOT send again
+    await runFinally(deliverBuffer, sendText, state);
+    expect(sendText).toHaveBeenCalledTimes(1);
   });
 
   it("tool kind: sends text immediately, does not affect buffer", async () => {
     const deliverBuffer = createDeliverBuffer();
+    const state = createDeliverState();
     const sentMediaUrls = new Set<string>();
     const sendMedia = vi.fn().mockResolvedValue(undefined);
     const sendText = vi.fn().mockResolvedValue(undefined);
-    const deliver = makeDeliver(deliverBuffer, sentMediaUrls, sendMedia, sendText);
+    const deliver = makeDeliver(deliverBuffer, state, sentMediaUrls, sendMedia, sendText, defaultIsToolWarning);
 
     await deliver({ text: "Tool output: file listing..." }, { kind: "tool" });
 
@@ -157,52 +243,55 @@ describe("deliver buffer pattern", () => {
     expect(deliverBuffer.lastText).toBeNull();
   });
 
-  it("tool then final: tool sent immediately, final sent via finally", async () => {
+  it("tool then final: tool sent immediately, final sent immediately", async () => {
     const deliverBuffer = createDeliverBuffer();
+    const state = createDeliverState();
     const sentMediaUrls = new Set<string>();
     const sendMedia = vi.fn().mockResolvedValue(undefined);
     const sendText = vi.fn().mockResolvedValue(undefined);
-    const deliver = makeDeliver(deliverBuffer, sentMediaUrls, sendMedia, sendText);
+    const deliver = makeDeliver(deliverBuffer, state, sentMediaUrls, sendMedia, sendText, defaultIsToolWarning);
 
     // Tool output sent immediately
-    await deliver({ text: "🔧 exec: ls" }, { kind: "tool" });
+    await deliver({ text: "exec: ls" }, { kind: "tool" });
     expect(sendText).toHaveBeenCalledTimes(1);
 
-    // Block and final buffered
+    // Block buffered
     await deliver({ text: "Checking files..." }, { kind: "block" });
-    await deliver({ text: "Here are your files: ..." }, { kind: "final" });
-    expect(sendText).toHaveBeenCalledTimes(1); // still 1, final buffered
+    expect(sendText).toHaveBeenCalledTimes(1);
 
-    // finally sends the last buffered text
-    await runFinally(deliverBuffer, sendText);
+    // Final sent immediately
+    await deliver(textPayload("Here are your files: ..."), { kind: "final" });
     expect(sendText).toHaveBeenCalledTimes(2);
     expect(sendText).toHaveBeenLastCalledWith("Here are your files: ...");
+
+    // finally should not send again
+    await runFinally(deliverBuffer, sendText, state);
+    expect(sendText).toHaveBeenCalledTimes(2);
   });
 
-  it("undefined kind falls back to buffer (sends via finally)", async () => {
+  it("undefined kind defaults to final: sends text immediately", async () => {
     const deliverBuffer = createDeliverBuffer();
+    const state = createDeliverState();
     const sentMediaUrls = new Set<string>();
     const sendMedia = vi.fn().mockResolvedValue(undefined);
     const sendText = vi.fn().mockResolvedValue(undefined);
-    const deliver = makeDeliver(deliverBuffer, sentMediaUrls, sendMedia, sendText);
+    const deliver = makeDeliver(deliverBuffer, state, sentMediaUrls, sendMedia, sendText, defaultIsToolWarning);
 
     // No info parameter at all
     await deliver({ text: "Fallback text" });
 
-    expect(sendText).not.toHaveBeenCalled();
-    expect(deliverBuffer.lastText).toBe("Fallback text");
-
-    await runFinally(deliverBuffer, sendText);
+    // undefined kind defaults to "final" → sent immediately (not a tool warning)
     expect(sendText).toHaveBeenCalledTimes(1);
     expect(sendText).toHaveBeenCalledWith("Fallback text");
   });
 
   it("isReasoning: skips entirely", async () => {
     const deliverBuffer = createDeliverBuffer();
+    const state = createDeliverState();
     const sentMediaUrls = new Set<string>();
     const sendMedia = vi.fn().mockResolvedValue(undefined);
     const sendText = vi.fn().mockResolvedValue(undefined);
-    const deliver = makeDeliver(deliverBuffer, sentMediaUrls, sendMedia, sendText);
+    const deliver = makeDeliver(deliverBuffer, state, sentMediaUrls, sendMedia, sendText, defaultIsToolWarning);
 
     await deliver({ text: "Internal reasoning...", isReasoning: true }, { kind: "block" });
     await deliver({ text: "More reasoning", isReasoning: true }, { kind: "final" });
@@ -210,16 +299,17 @@ describe("deliver buffer pattern", () => {
     expect(sendText).not.toHaveBeenCalled();
     expect(deliverBuffer.lastText).toBeNull();
 
-    await runFinally(deliverBuffer, sendText);
+    await runFinally(deliverBuffer, sendText, state);
     expect(sendText).not.toHaveBeenCalled();
   });
 
-  it("blocks then final: all buffered, finally sends last final", async () => {
+  it("blocks then final: blocks buffered, final sent immediately", async () => {
     const deliverBuffer = createDeliverBuffer();
+    const state = createDeliverState();
     const sentMediaUrls = new Set<string>();
     const sendMedia = vi.fn().mockResolvedValue(undefined);
     const sendText = vi.fn().mockResolvedValue(undefined);
-    const deliver = makeDeliver(deliverBuffer, sentMediaUrls, sendMedia, sendText);
+    const deliver = makeDeliver(deliverBuffer, state, sentMediaUrls, sendMedia, sendText, defaultIsToolWarning);
 
     // Streaming blocks
     await deliver({ text: "Part 1" }, { kind: "block" });
@@ -227,25 +317,26 @@ describe("deliver buffer pattern", () => {
     expect(sendText).not.toHaveBeenCalled();
     expect(deliverBuffer.lastText).toBe("Part 1 Part 2");
 
-    // Final arrives — also buffered (overwrites block buffer)
-    await deliver({ text: "Complete response" }, { kind: "final" });
-    expect(sendText).not.toHaveBeenCalled();
-    expect(deliverBuffer.lastText).toBe("Complete response");
-
-    // finally block sends the last buffered text
-    await runFinally(deliverBuffer, sendText);
+    // Final arrives — sent immediately, clears buffer
+    await deliver(textPayload("Complete response"), { kind: "final" });
     expect(sendText).toHaveBeenCalledTimes(1);
     expect(sendText).toHaveBeenCalledWith("Complete response");
+    expect(deliverBuffer.lastText).toBeNull();
+
+    // finally block should not send again
+    await runFinally(deliverBuffer, sendText, state);
+    expect(sendText).toHaveBeenCalledTimes(1);
   });
 
   it("onError clears buffer so finally does not send stale text", async () => {
     const deliverBuffer = createDeliverBuffer();
+    const state = createDeliverState();
     const sentMediaUrls = new Set<string>();
     const sendMedia = vi.fn().mockResolvedValue(undefined);
     const sendText = vi.fn().mockResolvedValue(undefined);
     const sendError = vi.fn().mockResolvedValue(undefined);
-    const deliver = makeDeliver(deliverBuffer, sentMediaUrls, sendMedia, sendText);
-    const onError = makeOnError(deliverBuffer, sendError);
+    const deliver = makeDeliver(deliverBuffer, state, sentMediaUrls, sendMedia, sendText, defaultIsToolWarning);
+    const onError = makeOnError(deliverBuffer, state, sendError);
 
     // Partial text buffered before error
     await deliver({ text: "Partial response from AI..." }, { kind: "block" });
@@ -256,19 +347,21 @@ describe("deliver buffer pattern", () => {
 
     expect(deliverBuffer.lastText).toBeNull();
     expect(deliverBuffer.textSent).toBe(true);
+    expect(state.deliveryErrorOccurred).toBe(true);
     expect(sendError).toHaveBeenCalledTimes(1);
 
     // finally block — should NOT send anything
-    await runFinally(deliverBuffer, sendText);
+    await runFinally(deliverBuffer, sendText, state);
     expect(sendText).not.toHaveBeenCalled();
   });
 
   it("media is sent immediately via deliver, not buffered", async () => {
     const deliverBuffer = createDeliverBuffer();
+    const state = createDeliverState();
     const sentMediaUrls = new Set<string>();
     const sendMedia = vi.fn().mockResolvedValue(undefined);
     const sendText = vi.fn().mockResolvedValue(undefined);
-    const deliver = makeDeliver(deliverBuffer, sentMediaUrls, sendMedia, sendText);
+    const deliver = makeDeliver(deliverBuffer, state, sentMediaUrls, sendMedia, sendText, defaultIsToolWarning);
 
     await deliver({ mediaUrl: "https://example.com/img1.png" }, { kind: "final" });
     await deliver({
@@ -288,16 +381,17 @@ describe("deliver buffer pattern", () => {
     expect(deliverBuffer.lastText).toBeNull();
 
     // finally should not send text
-    await runFinally(deliverBuffer, sendText);
+    await runFinally(deliverBuffer, sendText, state);
     expect(sendText).not.toHaveBeenCalled();
   });
 
   it("sentMediaUrls dedup: same URL is not sent twice", async () => {
     const deliverBuffer = createDeliverBuffer();
+    const state = createDeliverState();
     const sentMediaUrls = new Set<string>();
     const sendMedia = vi.fn().mockResolvedValue(undefined);
     const sendText = vi.fn().mockResolvedValue(undefined);
-    const deliver = makeDeliver(deliverBuffer, sentMediaUrls, sendMedia, sendText);
+    const deliver = makeDeliver(deliverBuffer, state, sentMediaUrls, sendMedia, sendText, defaultIsToolWarning);
 
     await deliver({ mediaUrl: "https://example.com/img.png" }, { kind: "block" });
     await deliver({ mediaUrl: "https://example.com/img.png" }, { kind: "final" });
@@ -305,5 +399,159 @@ describe("deliver buffer pattern", () => {
     // Only one call — second was deduped
     expect(sendMedia).toHaveBeenCalledTimes(1);
     expect(sentMediaUrls.size).toBe(1);
+  });
+});
+
+describe("tool warning deferral", () => {
+  it("normal final first + warning final second: normal sent, warning discarded", async () => {
+    const deliverBuffer = createDeliverBuffer();
+    const state = createDeliverState();
+    const sentMediaUrls = new Set<string>();
+    const sendMedia = vi.fn().mockResolvedValue(undefined);
+    const sendText = vi.fn().mockResolvedValue(undefined);
+    const deliver = makeDeliver(deliverBuffer, state, sentMediaUrls, sendMedia, sendText, defaultIsToolWarning);
+    const onSettled = makeOnFreshSettledDelivery(state, sendText);
+
+    // Normal final sent immediately
+    await deliver(textPayload("Here is your answer with 173 chars of content..."), { kind: "final" });
+    expect(sendText).toHaveBeenCalledTimes(1);
+    expect(sendText).toHaveBeenCalledWith("Here is your answer with 173 chars of content...");
+    expect(state.userFacingFinalDelivered).toBe(true);
+
+    // Tool warning final arrives — discarded (userFacingFinalDelivered=true, not stored)
+    await deliver(toolWarningPayload("write_file failed"), { kind: "final" });
+    expect(sendText).toHaveBeenCalledTimes(1);
+    expect(state.pendingToolWarningFinal).toBeUndefined();
+
+    // onFreshSettledDelivery: skips (userFacingFinalDelivered=true)
+    const result = await onSettled();
+    expect(result).toBeUndefined();
+    expect(sendText).toHaveBeenCalledTimes(1);
+  });
+
+  it("warning final first + normal final second: warning deferred then cleared", async () => {
+    const deliverBuffer = createDeliverBuffer();
+    const state = createDeliverState();
+    const sentMediaUrls = new Set<string>();
+    const sendMedia = vi.fn().mockResolvedValue(undefined);
+    const sendText = vi.fn().mockResolvedValue(undefined);
+    const deliver = makeDeliver(deliverBuffer, state, sentMediaUrls, sendMedia, sendText, defaultIsToolWarning);
+    const onSettled = makeOnFreshSettledDelivery(state, sendText);
+
+    // Tool warning arrives first — deferred
+    await deliver(toolWarningPayload("write_file failed"), { kind: "final" });
+    expect(sendText).not.toHaveBeenCalled();
+    expect(state.pendingToolWarningFinal).toEqual({ text: "write_file failed" });
+
+    // Normal final arrives — sent immediately, clears pending warning
+    await deliver(textPayload("Here is your answer"), { kind: "final" });
+    expect(sendText).toHaveBeenCalledTimes(1);
+    expect(sendText).toHaveBeenCalledWith("Here is your answer");
+    expect(state.userFacingFinalDelivered).toBe(true);
+    expect(state.pendingToolWarningFinal).toBeUndefined();
+
+    // onFreshSettledDelivery: skips (warning already cleared)
+    const result = await onSettled();
+    expect(result).toBeUndefined();
+    expect(sendText).toHaveBeenCalledTimes(1);
+  });
+
+  it("only warning final, no normal final: warning sent as fallback via onFreshSettledDelivery", async () => {
+    const deliverBuffer = createDeliverBuffer();
+    const state = createDeliverState();
+    const sentMediaUrls = new Set<string>();
+    const sendMedia = vi.fn().mockResolvedValue(undefined);
+    const sendText = vi.fn().mockResolvedValue(undefined);
+    const deliver = makeDeliver(deliverBuffer, state, sentMediaUrls, sendMedia, sendText, defaultIsToolWarning);
+    const onSettled = makeOnFreshSettledDelivery(state, sendText);
+
+    // Only tool warning final — deferred
+    await deliver(toolWarningPayload("write_file failed"), { kind: "final" });
+    expect(sendText).not.toHaveBeenCalled();
+    expect(state.pendingToolWarningFinal).toEqual({ text: "write_file failed" });
+    expect(state.userFacingFinalDelivered).toBe(false);
+
+    // onFreshSettledDelivery: sends the warning as fallback
+    const result = await onSettled();
+    expect(result).toEqual({ visibleReplySent: true });
+    expect(sendText).toHaveBeenCalledTimes(1);
+    expect(sendText).toHaveBeenCalledWith("write_file failed");
+    expect(state.pendingToolWarningFinal).toBeUndefined();
+  });
+
+  it("only normal final, no warning: normal sent immediately, onFreshSettledDelivery skips", async () => {
+    const deliverBuffer = createDeliverBuffer();
+    const state = createDeliverState();
+    const sentMediaUrls = new Set<string>();
+    const sendMedia = vi.fn().mockResolvedValue(undefined);
+    const sendText = vi.fn().mockResolvedValue(undefined);
+    const deliver = makeDeliver(deliverBuffer, state, sentMediaUrls, sendMedia, sendText, defaultIsToolWarning);
+    const onSettled = makeOnFreshSettledDelivery(state, sendText);
+
+    // Normal final — sent immediately
+    await deliver(textPayload("Complete answer"), { kind: "final" });
+    expect(sendText).toHaveBeenCalledTimes(1);
+    expect(state.userFacingFinalDelivered).toBe(true);
+
+    // onFreshSettledDelivery: skips (no pending warning)
+    const result = await onSettled();
+    expect(result).toBeUndefined();
+    expect(sendText).toHaveBeenCalledTimes(1);
+  });
+
+  it("tool text or media success does not affect warning fallback judgment", async () => {
+    const deliverBuffer = createDeliverBuffer();
+    const state = createDeliverState();
+    const sentMediaUrls = new Set<string>();
+    const sendMedia = vi.fn().mockResolvedValue(undefined);
+    const sendText = vi.fn().mockResolvedValue(undefined);
+    const deliver = makeDeliver(deliverBuffer, state, sentMediaUrls, sendMedia, sendText, defaultIsToolWarning);
+    const onSettled = makeOnFreshSettledDelivery(state, sendText);
+
+    // Tool text sent immediately — replySucceeded=true
+    await deliver({ text: "Tool: ls output" }, { kind: "tool" });
+    expect(sendText).toHaveBeenCalledTimes(1);
+    expect(state.replySucceeded).toBe(true);
+
+    // Media sent immediately — replySucceeded stays true
+    await deliver({ mediaUrl: "https://example.com/img.png" }, { kind: "final" });
+    expect(sendMedia).toHaveBeenCalledTimes(1);
+
+    // Warning final arrives — deferred (userFacingFinalDelivered is still false)
+    await deliver(toolWarningPayload("write_file failed"), { kind: "final" });
+    expect(state.userFacingFinalDelivered).toBe(false);
+    expect(state.pendingToolWarningFinal).toEqual({ text: "write_file failed" });
+
+    // onFreshSettledDelivery: sends warning (replySucceeded is irrelevant)
+    const result = await onSettled();
+    expect(result).toEqual({ visibleReplySent: true });
+    expect(sendText).toHaveBeenCalledTimes(2);
+    expect(sendText).toHaveBeenLastCalledWith("write_file failed");
+  });
+
+  it("onError prevents warning fallback delivery", async () => {
+    const deliverBuffer = createDeliverBuffer();
+    const state = createDeliverState();
+    const sentMediaUrls = new Set<string>();
+    const sendMedia = vi.fn().mockResolvedValue(undefined);
+    const sendText = vi.fn().mockResolvedValue(undefined);
+    const sendError = vi.fn().mockResolvedValue(undefined);
+    const deliver = makeDeliver(deliverBuffer, state, sentMediaUrls, sendMedia, sendText, defaultIsToolWarning);
+    const onError = makeOnError(deliverBuffer, state, sendError);
+    const onSettled = makeOnFreshSettledDelivery(state, sendText);
+
+    // Warning deferred
+    await deliver(toolWarningPayload("write_file failed"), { kind: "final" });
+    expect(state.pendingToolWarningFinal).toEqual({ text: "write_file failed" });
+
+    // Error occurs — deliveryErrorOccurred=true
+    await onError(new Error("dispatch failed"));
+    expect(state.deliveryErrorOccurred).toBe(true);
+    expect(sendError).toHaveBeenCalledTimes(1);
+
+    // onFreshSettledDelivery: skips (deliveryErrorOccurred guard)
+    const result = await onSettled();
+    expect(result).toBeUndefined();
+    expect(sendText).not.toHaveBeenCalled();
   });
 });

--- a/src/inbound.ts
+++ b/src/inbound.ts
@@ -1,6 +1,25 @@
 import type { OpenClawConfig } from "openclaw/plugin-sdk";
 import type { ChannelLogSink } from "openclaw/plugin-sdk/channel-contract";
+import type { ReplyPayload, ReplyDispatchKind } from "openclaw/plugin-sdk/reply-runtime";
+import type { ReplyDispatcherWithTypingOptions } from "openclaw/plugin-sdk/reply-runtime";
 import { DEFAULT_GROUP_HISTORY_LIMIT } from "openclaw/plugin-sdk/reply-history";
+// Namespace import + runtime feature detection so the deliver-buffer fix
+// degrades gracefully across SDK versions:
+//   - isReplyPayloadNonTerminalToolErrorWarning lands in newer SDK (>=5.27);
+//     on older SDK (e.g. 5.22) it is undefined, so we cannot classify a final
+//     as a tool-warning fallback and treat it as a normal final (sent
+//     immediately), which still preserves the real user-facing reply.
+//   - resolveSendableOutboundReplyParts is present across these versions.
+import * as replyPayloadSdk from "openclaw/plugin-sdk/reply-payload";
+
+const replyPayloadCompat = replyPayloadSdk as typeof replyPayloadSdk & {
+  isReplyPayloadNonTerminalToolErrorWarning?: (payload: ReplyPayload) => boolean;
+};
+const isReplyPayloadNonTerminalToolErrorWarning =
+  typeof replyPayloadCompat.isReplyPayloadNonTerminalToolErrorWarning === "function"
+    ? replyPayloadCompat.isReplyPayloadNonTerminalToolErrorWarning
+    : undefined;
+const resolveSendableOutboundReplyParts = replyPayloadSdk.resolveSendableOutboundReplyParts;
 import { sendMessage, sendReadReceipt, sendTyping, getChannelMessages, getGroupMembers, getGroupMd, postJson, sendMediaMessage, inferContentType, ensureTextCharset, parseImageDimensions, parseImageDimensionsFromFile, getUploadPresign, uploadFileToPresignedUrl, fetchUserInfo } from "./api-fetch.js";
 import { getMentionPrefFromCache, invalidateMentionPref } from "./mention-prefs.js";
 import { normalizeAccountId } from "./account-id.js";
@@ -137,6 +156,22 @@ function resolveOutboundMediaUrls(payload: { mediaUrl?: string; mediaUrls?: stri
     ...(payload.mediaUrls ?? []),
     ...(payload.mediaUrl ? [payload.mediaUrl] : []),
   ].filter(Boolean);
+}
+
+// Tool warning final: a kind=final payload that carries a non-terminal tool
+// error warning and no media.  These should be deferred (not sent immediately)
+// so they don't overwrite the real user-facing answer in the single-slot
+// deliver buffer.  Mirrors Discord's isFallbackOnlyToolWarningFinal.
+function isFallbackOnlyToolWarningFinal(payload: ReplyPayload): boolean {
+  // Older SDK lacks the tool-warning classifier: never defer, so the final is
+  // sent immediately and the real reply is never lost.
+  if (!isReplyPayloadNonTerminalToolErrorWarning) {
+    return false;
+  }
+  if (payload.isError !== true || !isReplyPayloadNonTerminalToolErrorWarning(payload)) {
+    return false;
+  }
+  return !resolveSendableOutboundReplyParts(payload).hasMedia;
 }
 
 /**
@@ -2369,6 +2404,9 @@ export async function handleInboundMessage(params: {
     textSent: false,
   };
   const sentMediaUrls = new Set<string>();
+  let userFacingFinalDelivered = false;
+  let pendingToolWarningFinal: { text: string } | undefined;
+  let deliveryErrorOccurred = false;
 
   // --- Shared helper: resolve mentions and send text ---
   const resolveAndSendText = async (content: string, signal?: AbortSignal): Promise<SendMessageResult | undefined> => {
@@ -2518,18 +2556,16 @@ export async function handleInboundMessage(params: {
       ctx: ctxPayload,
       cfg: config,
       replyOptions: {},
-      dispatcherOptions: {
-        deliver: async (payload: {
-          text?: string;
-          mediaUrls?: string[];
-          mediaUrl?: string;
-          replyToId?: string | null;
-          isReasoning?: boolean;
-        }, info?: { kind?: string }) => {
+      // onFreshSettledDelivery is only present on newer SDK dispatcher options.
+      // On older SDK the property is ignored (and never invoked, since
+      // pendingToolWarningFinal is only set when the tool-warning classifier
+      // exists), so the cast keeps both versions type-correct.
+      dispatcherOptions: ({
+        deliver: async (payload: ReplyPayload, info: { kind: ReplyDispatchKind }) => {
           // Skip reasoning blocks
           if (payload.isReasoning) return;
 
-          const kind = info?.kind ?? "final";
+          const kind = info.kind;
 
           // --- Media: send immediately (no edit/forward issue) with dedup ---
           const outboundMediaUrls = resolveOutboundMediaUrls(payload);
@@ -2568,7 +2604,28 @@ export async function handleInboundMessage(params: {
             return;
           }
 
-          // kind === "block" / "final" / anything else: buffer, send only once after dispatcher finishes
+          if (kind === "final") {
+            if (isFallbackOnlyToolWarningFinal(payload)) {
+              if (!userFacingFinalDelivered) {
+                pendingToolWarningFinal = { text: content };
+              }
+              log?.debug?.(
+                `octo: [deliver-buffer] tool warning final deferred (${content.length} chars)`,
+              );
+              return;
+            }
+
+            await resolveAndSendText(content);
+            replySucceeded = true;
+            userFacingFinalDelivered = true;
+            pendingToolWarningFinal = undefined;
+            deliverBuffer.lastText = null;
+            deliverBuffer.textSent = true;
+            log?.info?.(`octo: [deliver] final text sent immediately (${content.length} chars)`);
+            return;
+          }
+
+          // kind === "block" / anything else: buffer, send only once after dispatcher finishes
           deliverBuffer.lastText = content;
           log?.debug?.(`octo: [deliver-buffer] ${kind} text buffered (${content.length} chars)`);
         },
@@ -2578,6 +2635,7 @@ export async function handleInboundMessage(params: {
           // Prevent finally block from sending stale buffered text after error
           deliverBuffer.lastText = null;
           deliverBuffer.textSent = true;
+          deliveryErrorOccurred = true;
           try {
             await sendMessage({
               apiUrl,
@@ -2596,7 +2654,29 @@ export async function handleInboundMessage(params: {
             log?.error?.(`octo: failed to send error message: ${String(sendErr)}`);
           }
         },
-      },
+        onFreshSettledDelivery: async () => {
+          if (!pendingToolWarningFinal || userFacingFinalDelivered || deliveryErrorOccurred) {
+            return undefined;
+          }
+          const pending = pendingToolWarningFinal;
+          pendingToolWarningFinal = undefined;
+          try {
+            await resolveAndSendText(pending.text);
+            replySucceeded = true;
+            log?.info?.(
+              `octo: [deliver] pending tool warning sent as fallback (${pending.text.length} chars)`,
+            );
+            return { visibleReplySent: true };
+          } catch (err) {
+            log?.error?.(
+              `octo: [deliver] tool warning fallback send failed: ${String(err)}`,
+            );
+            return { visibleReplySent: false };
+          }
+        },
+      } as ReplyDispatcherWithTypingOptions & {
+        onFreshSettledDelivery?: () => Promise<{ visibleReplySent: boolean } | undefined>;
+      }),
       }),
       dispatchTimeoutPromise,
     ]);
@@ -2638,7 +2718,7 @@ export async function handleInboundMessage(params: {
   } finally {
     if (dispatchTimeoutHandle) clearTimeout(dispatchTimeoutHandle);
     // --- Debug: log dispatch outcome ---
-    log?.debug?.(`octo: [dispatch-result] replySucceeded=${replySucceeded} bufferedText=${deliverBuffer.lastText?.length ?? 0} textSent=${deliverBuffer.textSent} effectiveOBO=${effectiveOnBehalfOf ?? 'none'}`);
+    log?.debug?.(`octo: [dispatch-result] replySucceeded=${replySucceeded} bufferedText=${deliverBuffer.lastText?.length ?? 0} textSent=${deliverBuffer.textSent} userFacingFinalDelivered=${userFacingFinalDelivered} effectiveOBO=${effectiveOnBehalfOf ?? 'none'}`);
 
     // --- Final send: deliver buffered text if only blocks arrived (no final/tool) ---
     if (deliverBuffer.lastText && !deliverBuffer.textSent) {

--- a/src/inbound.ts
+++ b/src/inbound.ts
@@ -2598,7 +2598,7 @@ export async function handleInboundMessage(params: {
 
           if (kind === "tool") {
             // Verbose tool call output: send immediately
-            await resolveAndSendText(content);
+            await resolveAndSendText(content, AbortSignal.timeout(DISPATCH_TIMEOUT_APOLOGY_MS));
             replySucceeded = true;
             log?.info?.(`octo: [deliver] tool text sent (${content.length} chars)`);
             return;
@@ -2615,7 +2615,7 @@ export async function handleInboundMessage(params: {
               return;
             }
 
-            await resolveAndSendText(content);
+            await resolveAndSendText(content, AbortSignal.timeout(DISPATCH_TIMEOUT_APOLOGY_MS));
             replySucceeded = true;
             userFacingFinalDelivered = true;
             pendingToolWarningFinal = undefined;
@@ -2658,10 +2658,16 @@ export async function handleInboundMessage(params: {
           if (!pendingToolWarningFinal || userFacingFinalDelivered || deliveryErrorOccurred) {
             return undefined;
           }
+          // Buffered block text is the real user-facing reply; let the finally
+          // flush deliver it and drop the warning fallback (single message).
+          if (deliverBuffer.lastText && !deliverBuffer.textSent) {
+            pendingToolWarningFinal = undefined;
+            return undefined;
+          }
           const pending = pendingToolWarningFinal;
           pendingToolWarningFinal = undefined;
           try {
-            await resolveAndSendText(pending.text);
+            await resolveAndSendText(pending.text, AbortSignal.timeout(DISPATCH_TIMEOUT_APOLOGY_MS));
             replySucceeded = true;
             log?.info?.(
               `octo: [deliver] pending tool warning sent as fallback (${pending.text.length} chars)`,


### PR DESCRIPTION
Closes #117

## Problem

When Core produces both a normal final reply and a tool-error warning in the same turn (both `kind=final`), the single-slot deliver buffer (`deliverBuffer.lastText`) gets overwritten by the shorter warning text. The user ends up seeing only the `⚠️ ... failed` warning and the actual response is lost.

Reproduced live on octo thread delivery: an `@`-mention reply collapsed to a ~20-char tool warning while the real multi-paragraph answer was dropped.

## Root cause

Two interacting layers:
1. Plugin: the `deliver` callback unconditionally wrote every `kind=final` payload to `deliverBuffer.lastText`, so a trailing tool-warning final clobbered the already-buffered real reply.
2. Core: `shouldDropFinalPayloads` latches on `didStream`, so on the recovery turn the restored final text could be dropped — leaving only the warning.

## Fix

Adopt the same deferred tool-warning pattern Discord already uses:
- Tool-warning finals (classified via `isReplyPayloadNonTerminalToolErrorWarning`) are held in `pendingToolWarningFinal` instead of being written to the buffer.
- Normal final replies are sent immediately via `resolveAndSendText()` and mark `userFacingFinalDelivered`.
- `onFreshSettledDelivery` flushes the pending warning **only** when no normal final was delivered (true only-warning case).
- `deliveryErrorOccurred` guard prevents warning delivery after `onError`.
- Block payloads keep existing buffer behavior; tool payloads keep sending immediately (unchanged).

### Cross-SDK compatibility

Uses namespace import + runtime feature-detection so it degrades gracefully:
- On newer SDK (exports `isReplyPayloadNonTerminalToolErrorWarning` + `onFreshSettledDelivery`): full fix path is active.
- On older SDK lacking the classifier: `isFallbackOnlyToolWarningFinal` returns false, so the final is sent immediately and the real reply is never lost (no regression).

`peerDependencies` stays at `>=2026.4.15` — no dependency bump required.

## Tests

- New `deliver-buffer.test.ts` "tool warning deferral" cases: normal+warning (both orders), only-warning fallback via `onFreshSettledDelivery`, `onError` blocks fallback, media/tool don't affect warning judgment.
- Full suite green: 1107 tests pass, type-check clean, build OK.
- Rebased onto latest `main`; resolved conflicts with the #66 upload refactor and the #75/#83 dispatch-timeout block.