### PR TITLE
fix(inbound): use idle inactivity detection for dispatch timeout (#113)

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -127,6 +127,10 @@
                 "secretsFileRoot": {
                   "type": "string",
                   "description": "Jail root for write-secret: secret files may only be written under this path. When unset, defaults to the agent's workspace (agents.list[].workspace matched to the agent, else agents.defaults.workspace). If neither resolves to a usable directory, write-secret is unavailable (fail-closed); there is no process working-directory fallback."
+                },
+                "dispatchIdleTimeoutMs": {
+                  "type": "number",
+                  "minimum": 1000
                 }
               }
             }
@@ -138,6 +142,10 @@
           "secretsFileRoot": {
             "type": "string",
             "description": "Jail root for write-secret: secret files may only be written under this path. When unset, defaults to the agent's workspace (agents.list[].workspace matched to the agent, else agents.defaults.workspace). If neither resolves to a usable directory, write-secret is unavailable (fail-closed); there is no process working-directory fallback."
+          },
+          "dispatchIdleTimeoutMs": {
+            "type": "number",
+            "minimum": 1000
           }
         }
       }

--- a/src/accounts.ts
+++ b/src/accounts.ts
@@ -20,6 +20,7 @@ export type ResolvedOctoAccount = {
     historyPromptTemplate?: string;  // Template for group history context injection
     onBehalfOf?: string;  // Persona clone: grantor uid
     secretsFileRoot?: string;  // Jail root for write-secret file writes
+    dispatchIdleTimeoutMs?: number;  // Idle window (ms) before a silent dispatch is treated as hung (issue #113)
   };
 };
 
@@ -102,6 +103,7 @@ export function resolveOctoAccount(params: {
       historyPromptTemplate: accountConfig.historyPromptTemplate ?? channel.historyPromptTemplate,
       onBehalfOf: accountConfig.onBehalfOf ?? channel.onBehalfOf,
       secretsFileRoot: accountConfig.secretsFileRoot ?? channel.secretsFileRoot,
+      dispatchIdleTimeoutMs: accountConfig.dispatchIdleTimeoutMs ?? channel.dispatchIdleTimeoutMs,
     },
   };
 }

--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -15,6 +15,7 @@ export interface OctoAccountConfig {
   historyPromptTemplate?: string;  // Template for group history context injection
   onBehalfOf?: string;  // Persona clone: grantor uid — bot acts on behalf of this human
   secretsFileRoot?: string;  // Jail root for write-secret: secret files may only be written under this path. When unset, defaults to the agent's workspace (agents.list[].workspace matched to the agent, else agents.defaults.workspace); if neither resolves, write-secret fails closed (no process.cwd() fallback).
+  dispatchIdleTimeoutMs?: number;  // Idle window (ms) of zero deliver events before a silent dispatch is treated as hung (issue #113)
 }
 
 export interface OctoConfig {
@@ -32,6 +33,7 @@ export interface OctoConfig {
   historyPromptTemplate?: string;  // Template for group history context injection
   onBehalfOf?: string;  // Persona clone: grantor uid — bot acts on behalf of this human
   secretsFileRoot?: string;  // Jail root for write-secret (see OctoAccountConfig)
+  dispatchIdleTimeoutMs?: number;  // Idle window (ms) of zero deliver events before a silent dispatch is treated as hung (issue #113)
   accounts?: Record<string, OctoAccountConfig | undefined>;
 }
 
@@ -64,6 +66,7 @@ export const OctoConfigJsonSchema = {
       historyPromptTemplate: { type: "string" },
       onBehalfOf: { type: "string" },
       secretsFileRoot: { type: "string", description: SECRETS_FILE_ROOT_DESCRIPTION },
+      dispatchIdleTimeoutMs: { type: "number", minimum: 1000 },
       accounts: {
         type: "object",
         additionalProperties: {
@@ -83,6 +86,7 @@ export const OctoConfigJsonSchema = {
             historyPromptTemplate: { type: "string" },
             onBehalfOf: { type: "string" },
             secretsFileRoot: { type: "string", description: SECRETS_FILE_ROOT_DESCRIPTION },
+            dispatchIdleTimeoutMs: { type: "number", minimum: 1000 },
           },
         },
       },

--- a/src/inbound-dispatch-timeout.test.ts
+++ b/src/inbound-dispatch-timeout.test.ts
@@ -498,6 +498,52 @@ describe("dispatch idle timeout (issue #113)", () => {
     expect(elapsed, "must time out at the small account window, not the 10s default").toBeLessThan(2000);
   });
 
+  // Suggestion #1 — runtime finite-positive guard for dispatchIdleTimeoutMs.
+  // The schema's minimum:1000 is host metadata and is not enforced at runtime;
+  // a dirty config can smuggle NaN/0/negative/Infinity past it. setTimeout
+  // clamps any of those to a 1ms delay, and since the idle timer arms ONCE
+  // before the first deliver, a 1ms window would fire before any delivery and
+  // mark every message timed out — bricking the whole account/channel. The
+  // guard must fall back to the DEFAULT (not the 1000 floor, which would break
+  // the legitimate 80ms override above).
+  //
+  // Each case sets the default to a controllable small window (IDLE_WINDOW_MS)
+  // and runs the streaming runtime: 12 chunks 20ms apart (240ms total) survive
+  // the 200ms window only via idle resets. If the invalid value were honored,
+  // setTimeout's 1ms clamp would fire before the first chunk → 处理超时. So a
+  // clean stream + a warn log proves the fallback, distinguishing it from an
+  // instant timeout.
+  for (const { label, value } of [
+    { label: "NaN", value: NaN },
+    { label: "0", value: 0 },
+    { label: "negative", value: -5 },
+    { label: "Infinity", value: Infinity },
+  ]) {
+    it(`config: invalid dispatchIdleTimeoutMs=${label} falls back to default (no instant timeout)`, async () => {
+      _setDispatchTimeoutForTests(IDLE_WINDOW_MS);
+      installStreamingRuntime({
+        deliveries: Array.from({ length: DELIVER_COUNT }, (_, i) => ({ text: `chunk ${i}` })),
+        intervalMs: DELIVER_INTERVAL_MS,
+        finalText: "fallback answer",
+      });
+      const { sends } = installFetchStub();
+      const warnSpy = vi.fn();
+
+      const account = makeAccount({ dispatchIdleTimeoutMs: value as number });
+      await runInbound({ account, log: { debug: () => {}, info: () => {}, warn: warnSpy, error: () => {} } });
+
+      // Fell back to the default window: the long-but-active stream was NOT
+      // killed (no 处理超时), and the real buffered reply was flushed.
+      expect(pickTimeoutSends(sends)).toHaveLength(0);
+      expect(sends.find((s) => s?.payload?.content === "fallback answer")).toBeDefined();
+      // And the invalid value was reported.
+      expect(
+        warnSpy.mock.calls.some((c) => String(c[0]).includes("ignoring invalid dispatchIdleTimeoutMs")),
+        "an invalid dispatchIdleTimeoutMs must be logged",
+      ).toBe(true);
+    });
+  }
+
   it("config: resolveOctoAccount picks account > channel-top-level > undefined", () => {
     // account value wins over channel top-level
     const both = resolveOctoAccount({

--- a/src/inbound-dispatch-timeout.test.ts
+++ b/src/inbound-dispatch-timeout.test.ts
@@ -8,6 +8,7 @@ import {
 import { setOctoRuntime } from "./runtime.js";
 import { _clearKnownBots } from "./bot-registry.js";
 import type { ResolvedOctoAccount } from "./accounts.js";
+import { resolveOctoAccount } from "./accounts.js";
 
 /**
  * Regression tests for issue #75 — upstream
@@ -50,7 +51,7 @@ const originalClearTimeout = globalThis.clearTimeout;
 const TIMEOUT_MS_FOR_TESTS = 100;
 const APOLOGY_TIMEOUT_MS_FOR_TESTS = 150;
 
-function makeAccount(): ResolvedOctoAccount {
+function makeAccount(configOverrides?: Partial<ResolvedOctoAccount["config"]>): ResolvedOctoAccount {
   return {
     accountId: "acct1",
     enabled: true,
@@ -61,9 +62,14 @@ function makeAccount(): ResolvedOctoAccount {
       pollIntervalMs: 1000,
       heartbeatIntervalMs: 1000,
       requireMention: false,
+      ...configOverrides,
     },
   };
 }
+
+// Real-timer sleep that bypasses any setTimeout spy installed in a test, so
+// streaming-delivery pacing never pollutes the spy's call records.
+const sleep = (ms: number) => new Promise<void>((resolve) => originalSetTimeout(resolve, ms));
 
 function makeAtBotMessage() {
   return {
@@ -227,9 +233,56 @@ function pickTimeoutSends(sends: any[]) {
   );
 }
 
-function runInbound(opts: { log?: any } = {}) {
+/**
+ * Runtime that streams a series of deliver() calls spaced `intervalMs` apart,
+ * optionally finishing with a non-reasoning "final" block. Used to exercise the
+ * idle-reset path: each delivery resets the idle timer, so a total stream
+ * longer than the idle window must NOT time out as long as every gap is shorter
+ * than the window.
+ */
+function installStreamingRuntime(opts: {
+  deliveries: Array<{ text?: string; isReasoning?: boolean; kind?: string }>;
+  intervalMs: number;
+  finalText?: string;
+}) {
+  const dispatch = vi.fn(async (args: any) => {
+    for (const d of opts.deliveries) {
+      await sleep(opts.intervalMs);
+      await args.dispatcherOptions.deliver(
+        { text: d.text, isReasoning: d.isReasoning },
+        { kind: d.kind ?? "block" },
+      );
+    }
+    if (opts.finalText !== undefined) {
+      await sleep(opts.intervalMs);
+      await args.dispatcherOptions.deliver({ text: opts.finalText }, { kind: "block" });
+    }
+  });
+  setOctoRuntime({
+    config: { loadConfig: () => ({}) },
+    channel: {
+      reply: {
+        dispatchReplyWithBufferedBlockDispatcher: dispatch,
+        resolveEnvelopeFormatOptions: () => ({}),
+        formatAgentEnvelope: ({ body }: any) => body,
+        finalizeInboundContext: (ctx: any) => ctx,
+      },
+      routing: {
+        resolveAgentRoute: () => ({ agentId: "agent1", sessionKey: "sk1", accountId: "acct1" }),
+      },
+      session: {
+        resolveStorePath: () => "/tmp/store",
+        readSessionUpdatedAt: () => undefined,
+        recordInboundSession: async () => {},
+      },
+    },
+  } as any);
+  return { dispatch };
+}
+
+function runInbound(opts: { log?: any; account?: ResolvedOctoAccount } = {}) {
   return handleInboundMessage({
-    account: makeAccount(),
+    account: opts.account ?? makeAccount(),
     message: makeAtBotMessage() as any,
     botUid: BOT_UID,
     groupHistories: new Map(),
@@ -267,7 +320,7 @@ describe("dispatch timeout guard (issue #75)", () => {
 
     expect(dispatch).toHaveBeenCalledTimes(1);
     expect(pickTimeoutSends(sends)).toHaveLength(1);
-    expect(warnSpy.mock.calls.some((c) => String(c[0]).includes("dispatch hung"))).toBe(true);
+    expect(warnSpy.mock.calls.some((c) => String(c[0]).includes("dispatch idle"))).toBe(true);
   });
 
   it("happy path: dispatchTimeoutHandle is cleared (no leaked timer)", async () => {
@@ -354,5 +407,228 @@ describe("dispatch timeout guard (issue #75)", () => {
     const finalFlush = sends.find((s) => s.content === "buffered-final");
     expect(finalFlush, "final flush sendMessage must reach fetch").toBeDefined();
     expect(finalFlush!.abortedBeforeResolve, "final flush must be aborted by its own AbortSignal.timeout").toBe(true);
+  });
+});
+
+/**
+ * Regression tests for issue #113 — the dispatch timeout used to be a single
+ * non-resetting setTimeout measuring TOTAL turn wall-clock, which killed long
+ * but actively-streaming turns. It is now an IDLE timer: every deliver event
+ * resets it, so only a genuinely silent dispatch (zero events for a full
+ * window) is treated as hung.
+ */
+describe("dispatch idle timeout (issue #113)", () => {
+  // Window comfortably larger than each delivery gap, but smaller than the
+  // total stream duration — so a correct idle reset survives while a stale
+  // "total wall-clock" timer would fire mid-stream.
+  const IDLE_WINDOW_MS = 200;
+  const DELIVER_INTERVAL_MS = 20;
+  const DELIVER_COUNT = 12; // 12 * 20ms = 240ms total > 200ms window
+
+  it("idle reset: repeated deliver within the window outlasts it without timing out", async () => {
+    _setDispatchTimeoutForTests(IDLE_WINDOW_MS);
+    installStreamingRuntime({
+      deliveries: Array.from({ length: DELIVER_COUNT }, (_, i) => ({ text: `chunk ${i}` })),
+      intervalMs: DELIVER_INTERVAL_MS,
+      finalText: "the real answer",
+    });
+    const { sends } = installFetchStub();
+
+    await runInbound({ log: { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} } });
+
+    // No timeout apology, and the real buffered reply was flushed.
+    expect(pickTimeoutSends(sends)).toHaveLength(0);
+    const realReply = sends.find((s) => s?.payload?.content === "the real answer");
+    expect(realReply, "real reply must be sent after a long but active stream").toBeDefined();
+  });
+
+  it("reasoning-only stream resets the idle timer (reset runs before isReasoning return)", async () => {
+    // This locks the ordering constraint: resetIdleTimer() MUST be called
+    // before `if (payload.isReasoning) return;`. A turn that streams only
+    // reasoning blocks for longer than the window must NOT be killed. Moving
+    // the reset after the early return makes this test fail (idle timer fires
+    // mid-reasoning → 处理超时).
+    _setDispatchTimeoutForTests(IDLE_WINDOW_MS);
+    installStreamingRuntime({
+      deliveries: Array.from({ length: DELIVER_COUNT }, () => ({ isReasoning: true })),
+      intervalMs: DELIVER_INTERVAL_MS,
+      finalText: "answer after thinking",
+    });
+    const { sends } = installFetchStub();
+
+    await runInbound({ log: { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} } });
+
+    expect(pickTimeoutSends(sends)).toHaveLength(0);
+    const realReply = sends.find((s) => s?.payload?.content === "answer after thinking");
+    expect(realReply, "reply must follow a long reasoning-only phase without timing out").toBeDefined();
+  });
+
+  it("true idle: a dispatch that never delivers rejects, posts 处理超时, advances the queue", async () => {
+    // Same semantics as the issue #75 hang test — zero deliver events ever, so
+    // the idle timer (armed once before the race) fires.
+    const { dispatch } = installHangingRuntime();
+    const { sends } = installFetchStub();
+    const warnSpy = vi.fn();
+
+    await expect(runInbound({ log: { debug: () => {}, info: () => {}, warn: warnSpy, error: () => {} } }))
+      .rejects.toThrow();
+
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    expect(pickTimeoutSends(sends)).toHaveLength(1);
+    expect(warnSpy.mock.calls.some((c) => String(c[0]).includes("dispatch idle"))).toBe(true);
+  });
+
+  it("config: account.config.dispatchIdleTimeoutMs overrides the default window", async () => {
+    // Default window is set deliberately large; the per-account override is
+    // small. The hanging runtime never delivers, so it must time out at the
+    // SMALL account value — proving the account override is honored, not the
+    // large default.
+    _setDispatchTimeoutForTests(10_000);
+    installHangingRuntime();
+    const { sends } = installFetchStub();
+
+    const account = makeAccount({ dispatchIdleTimeoutMs: 80 });
+    const start = Date.now();
+    await expect(
+      runInbound({ account, log: { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} } }),
+    ).rejects.toThrow();
+    const elapsed = Date.now() - start;
+
+    expect(pickTimeoutSends(sends)).toHaveLength(1);
+    expect(elapsed, "must time out at the small account window, not the 10s default").toBeLessThan(2000);
+  });
+
+  it("config: resolveOctoAccount picks account > channel-top-level > undefined", () => {
+    // account value wins over channel top-level
+    const both = resolveOctoAccount({
+      cfg: {
+        channels: {
+          octo: {
+            dispatchIdleTimeoutMs: 5000,
+            accounts: { acctA: { dispatchIdleTimeoutMs: 1234 } },
+          },
+        },
+      } as any,
+      accountId: "acctA",
+    });
+    expect(both.config.dispatchIdleTimeoutMs).toBe(1234);
+
+    // only channel top-level set → channel value used
+    const channelOnly = resolveOctoAccount({
+      cfg: {
+        channels: {
+          octo: {
+            dispatchIdleTimeoutMs: 5000,
+            accounts: { acctA: {} },
+          },
+        },
+      } as any,
+      accountId: "acctA",
+    });
+    expect(channelOnly.config.dispatchIdleTimeoutMs).toBe(5000);
+
+    // neither set → undefined (inbound.ts then falls back to the default)
+    const neither = resolveOctoAccount({
+      cfg: { channels: { octo: { accounts: { acctA: {} } } } } as any,
+      accountId: "acctA",
+    });
+    expect(neither.config.dispatchIdleTimeoutMs).toBeUndefined();
+  });
+
+  it("timer cleanup: every idle-timer setTimeout handle is eventually cleared (reset + finally)", async () => {
+    // resetIdleTimer arms a fresh setTimeout on each delivery and clears the
+    // prior one; the finally block clears the last. Net: zero leaked timers.
+    // Filter by delay === IDLE_WINDOW_MS, which is unique vs the apology timers
+    // (APOLOGY_TIMEOUT_MS_FOR_TESTS) and the streaming sleeps (which bypass the
+    // spy via originalSetTimeout).
+    _setDispatchTimeoutForTests(IDLE_WINDOW_MS);
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout") as any;
+    const clearTimeoutSpy = vi.spyOn(globalThis, "clearTimeout") as any;
+
+    installStreamingRuntime({
+      deliveries: Array.from({ length: 4 }, (_, i) => ({ text: `chunk ${i}` })),
+      intervalMs: DELIVER_INTERVAL_MS,
+      finalText: "done",
+    });
+    installFetchStub();
+
+    await runInbound({ log: { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} } });
+
+    const idleTimerCalls = setTimeoutSpy.mock.calls
+      .map((call: any[], idx: number) => ({ delay: call[1], idx }))
+      .filter((x: any) => x.delay === IDLE_WINDOW_MS);
+    // arm-once + one reset per delivery (4 chunks + 1 final) = several timers
+    expect(idleTimerCalls.length).toBeGreaterThan(1);
+
+    for (const c of idleTimerCalls) {
+      const handle = setTimeoutSpy.mock.results[c.idx]?.value;
+      expect(handle).toBeDefined();
+      const cleared = clearTimeoutSpy.mock.calls.some((call: any[]) => call[0] === handle);
+      expect(cleared, `idle-timer handle from setTimeout call ${c.idx} was not cleared`).toBe(true);
+    }
+  });
+
+  it("late deliver after idle timeout does not arm a new (uncleared) idle timer", async () => {
+    // The Promise.race settles on idle timeout, but the upstream dispatch may
+    // keep running and call deliver() afterwards. resetIdleTimer() must NOT arm
+    // a fresh setTimeout once the race has settled — the finally block already
+    // ran its clearTimeout and would never clear a newly-armed handle, leaking
+    // one timer ref for up to a full idle window. The `settled` guard gates
+    // ONLY the timer re-arm; the late reply content is still delivered.
+    _setDispatchTimeoutForTests(IDLE_WINDOW_MS);
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout") as any;
+    const clearTimeoutSpy = vi.spyOn(globalThis, "clearTimeout") as any;
+
+    // Dispatch captures the deliver callback then never resolves, forcing the
+    // idle timeout to fire while the dispatch is still "running".
+    let capturedDeliver: ((payload: any, info?: any) => Promise<void>) | undefined;
+    const dispatch = vi.fn(async (args: any) => {
+      capturedDeliver = args.dispatcherOptions.deliver;
+      await new Promise<void>(() => {}); // never resolves, never rejects
+    });
+    setOctoRuntime({
+      config: { loadConfig: () => ({}) },
+      channel: {
+        reply: {
+          dispatchReplyWithBufferedBlockDispatcher: dispatch,
+          resolveEnvelopeFormatOptions: () => ({}),
+          formatAgentEnvelope: ({ body }: any) => body,
+          finalizeInboundContext: (ctx: any) => ctx,
+        },
+        routing: {
+          resolveAgentRoute: () => ({ agentId: "agent1", sessionKey: "sk1", accountId: "acct1" }),
+        },
+        session: {
+          resolveStorePath: () => "/tmp/store",
+          readSessionUpdatedAt: () => undefined,
+          recordInboundSession: async () => {},
+        },
+      },
+    } as any);
+    installFetchStub();
+
+    await expect(runInbound({ log: { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} } }))
+      .rejects.toThrow();
+
+    const idleCallsBefore = setTimeoutSpy.mock.calls.filter((c: any[]) => c[1] === IDLE_WINDOW_MS).length;
+
+    // Simulate the still-running upstream dispatch delivering a late reply.
+    expect(capturedDeliver).toBeDefined();
+    await capturedDeliver!({ text: "late reply" }, { kind: "final" });
+
+    // No new idle timer was armed by the late deliver...
+    const idleCallsAfter = setTimeoutSpy.mock.calls.filter((c: any[]) => c[1] === IDLE_WINDOW_MS).length;
+    expect(idleCallsAfter, "late deliver must not arm a new idle timer").toBe(idleCallsBefore);
+
+    // ...and every idle-timer handle ever armed has a matching clearTimeout.
+    const idleTimerCalls = setTimeoutSpy.mock.calls
+      .map((call: any[], idx: number) => ({ delay: call[1], idx }))
+      .filter((x: any) => x.delay === IDLE_WINDOW_MS);
+    for (const c of idleTimerCalls) {
+      const handle = setTimeoutSpy.mock.results[c.idx]?.value;
+      expect(handle).toBeDefined();
+      const cleared = clearTimeoutSpy.mock.calls.some((call: any[]) => call[0] === handle);
+      expect(cleared, `idle-timer handle from setTimeout call ${c.idx} leaked (not cleared)`).toBe(true);
+    }
   });
 });

--- a/src/inbound.ts
+++ b/src/inbound.ts
@@ -2519,7 +2519,29 @@ export async function handleInboundMessage(params: {
   // Idle window resolution mirrors account.config.historyLimit: account value
   // wins, else channel top-level (already merged into account.config by
   // resolveOctoAccount), else the (test-overridable) default.
-  const idleTimeoutMs = account.config.dispatchIdleTimeoutMs ?? DISPATCH_IDLE_TIMEOUT_MS;
+  //
+  // Runtime finite-positive guard: the schema's minimum:1000 is host metadata
+  // and is NOT enforced at runtime. A dirty config that bypasses the schema can
+  // smuggle in NaN/0/negative/Infinity. Any of those would make setTimeout clamp
+  // the delay to 1ms, and because the idle timer is armed ONCE before the race
+  // (before the first deliver), a 1ms window fires almost certainly before the
+  // first deliver event — so EVERY message would be judged instantly timed out
+  // and the whole account/channel would become unusable. We therefore accept
+  // only a finite positive number and otherwise fall back to the default.
+  //
+  // The fallback is the default (DISPATCH_IDLE_TIMEOUT_MS), deliberately NOT the
+  // schema's 1000 floor — clamping to 1000 would silently break legitimate
+  // small per-account overrides (e.g. dispatchIdleTimeoutMs: 80).
+  const configured = account.config.dispatchIdleTimeoutMs;
+  const idleTimeoutMs =
+    typeof configured === "number" && Number.isFinite(configured) && configured > 0
+      ? configured
+      : DISPATCH_IDLE_TIMEOUT_MS;
+  if (configured !== undefined && idleTimeoutMs !== configured) {
+    log?.warn?.(
+      `octo: ignoring invalid dispatchIdleTimeoutMs=${configured}, falling back to default ${DISPATCH_IDLE_TIMEOUT_MS}ms`,
+    );
+  }
   let dispatchTimeoutHandle: ReturnType<typeof setTimeout> | undefined;
   // True once the race has settled (timeout OR normal completion) and the
   // finally block has run its clearTimeout. A still-running upstream dispatch

--- a/src/inbound.ts
+++ b/src/inbound.ts
@@ -32,20 +32,31 @@ import { mkdir, unlink, readdir, stat } from "node:fs/promises";
 import { join, basename } from "node:path";
 import { randomUUID } from "node:crypto";
 
-// Per-inbound dispatch timeout (issue #75). The upstream OpenClaw runtime call
-// `core.channel.reply.dispatchReplyWithBufferedBlockDispatcher` is observed to
-// occasionally hang indefinitely (no resolve, no reject, no onError) — likely
-// in agent/runtime layers, not in this plugin. Combined with the per-group
-// serial inbound queue (`enqueueInbound` in channel.ts), a single hang locks
-// the entire group: no further messages get processed until the gateway
-// restarts. This wrapper turns "silent permanent block" into "single-message
-// timeout with a warn log + user-facing apology + queue advances".
+// Per-inbound dispatcher idle timeout (issues #75, #113). The upstream
+// OpenClaw runtime call `core.channel.reply.dispatchReplyWithBufferedBlockDispatcher`
+// is observed to occasionally hang indefinitely (no resolve, no reject, no
+// onError) — likely in agent/runtime layers, not in this plugin. Combined with
+// the per-group serial inbound queue (`enqueueInbound` in channel.ts), a single
+// hang locks the entire group: no further messages get processed until the
+// gateway restarts. This wrapper turns "silent permanent block" into "single-
+// message timeout with a warn log + user-facing apology + queue advances".
 //
-// 5 minutes is intentionally generous — longer than any normal LLM round-trip,
-// short enough that a stuck group recovers within one user attention span.
-// Tests override via `_setDispatchTimeoutForTests` to keep the suite fast.
-const DISPATCH_TIMEOUT_DEFAULT_MS = 5 * 60 * 1000;
-let DISPATCH_TIMEOUT_MS = DISPATCH_TIMEOUT_DEFAULT_MS;
+// The timeout is measured as IDLE time, not total wall-clock turn time: each
+// `deliver` event from the dispatcher resets the timer, so we only give up
+// after N consecutive seconds with ZERO deliver activity (issue #113 — a long
+// but actively-streaming turn must never be killed mid-flight). A genuinely
+// stuck dispatch produces no events at all, so the idle timer still fires.
+//
+// Default idle window = LLM_REQUEST_TIMEOUT_MS + IDLE_GRACE_MS: long enough to
+// outlast one stalled LLM/HTTP round-trip plus slack, short enough that a truly
+// stuck group recovers within one user attention span. Both are tunable
+// constants; the window is also configurable per account / per channel via
+// `dispatchIdleTimeoutMs`. Tests override the default via
+// `_setDispatchTimeoutForTests` to keep the suite fast.
+const LLM_REQUEST_TIMEOUT_MS = 300_000; // single LLM/HTTP request timeout, matches AbortSignal.timeout(300_000) elsewhere
+const IDLE_GRACE_MS = 120_000; // idle grace on top of one stalled request
+const DISPATCH_IDLE_TIMEOUT_DEFAULT_MS = LLM_REQUEST_TIMEOUT_MS + IDLE_GRACE_MS; // 420_000ms
+let DISPATCH_IDLE_TIMEOUT_MS = DISPATCH_IDLE_TIMEOUT_DEFAULT_MS;
 // How long we wait for the user-facing "处理超时" apology to post, AND for the
 // happy-path buffered-text final flush, before giving up. The whole point of
 // issue #75 is that an Octo API call can hang; these recovery/flush calls hit
@@ -57,7 +68,7 @@ const DISPATCH_TIMEOUT_APOLOGY_DEFAULT_MS = 10_000;
 let DISPATCH_TIMEOUT_APOLOGY_MS = DISPATCH_TIMEOUT_APOLOGY_DEFAULT_MS;
 
 export function _setDispatchTimeoutForTests(ms: number | null): void {
-  DISPATCH_TIMEOUT_MS = ms === null ? DISPATCH_TIMEOUT_DEFAULT_MS : ms;
+  DISPATCH_IDLE_TIMEOUT_MS = ms === null ? DISPATCH_IDLE_TIMEOUT_DEFAULT_MS : ms;
 }
 
 export function _setDispatchApologyTimeoutForTests(ms: number | null): void {
@@ -2487,9 +2498,11 @@ export async function handleInboundMessage(params: {
 
   let replySucceeded = false;
 
-  // Timeout guard: see DISPATCH_TIMEOUT_MS at top of file. Without this, an
-  // upstream dispatch hang would leave the per-group queue's Promise chain
-  // unresolved forever — see issue #75.
+  // Idle-timeout guard: see DISPATCH_IDLE_TIMEOUT_MS at top of file. Without
+  // this, an upstream dispatch hang would leave the per-group queue's Promise
+  // chain unresolved forever — see issue #75. We measure idle (inter-event)
+  // time, not total turn time, so a long but actively-streaming turn is never
+  // killed mid-flight — see issue #113.
   //
   // Scope note: we intentionally do NOT try to cancel an already-in-flight
   // dispatch or gate late deliver/onError callbacks from a "woken up" old
@@ -2502,15 +2515,40 @@ export async function handleInboundMessage(params: {
   // timeoutError: a per-invocation Error so the outer catch identifies "this
   // is OUR timeout" by reference equality, never by string comparison —
   // protects against a same-text upstream error being misclassified.
+  //
+  // Idle window resolution mirrors account.config.historyLimit: account value
+  // wins, else channel top-level (already merged into account.config by
+  // resolveOctoAccount), else the (test-overridable) default.
+  const idleTimeoutMs = account.config.dispatchIdleTimeoutMs ?? DISPATCH_IDLE_TIMEOUT_MS;
   let dispatchTimeoutHandle: ReturnType<typeof setTimeout> | undefined;
+  // True once the race has settled (timeout OR normal completion) and the
+  // finally block has run its clearTimeout. A still-running upstream dispatch
+  // can call deliver() AFTER we've settled — without this guard, resetIdleTimer
+  // would arm a fresh handle that the (already-executed) finally never clears,
+  // leaking one timer ref for up to a full idle window (issue #113 review).
+  // Note: this gates ONLY timer re-arming. Late deliver content is still sent
+  // as before — we do not adopt the timedOut-style "drop late replies" guard.
+  let settled = false;
   const timeoutError = new Error(
-    `octo: dispatch timed out after ${DISPATCH_TIMEOUT_MS}ms`,
+    `octo: dispatch idle for ${idleTimeoutMs}ms with no deliver activity`,
   );
-  const dispatchTimeoutPromise = new Promise<never>((_, reject) => {
+  // Resettable idle timer: each call clears the prior handle and arms a fresh
+  // one. Every deliver event calls this, so the timer only fires after a full
+  // idle window with no dispatcher activity at all.
+  let rejectTimeout: (err: unknown) => void = () => {};
+  const resetIdleTimer = () => {
+    if (settled) return;
+    if (dispatchTimeoutHandle) clearTimeout(dispatchTimeoutHandle);
     dispatchTimeoutHandle = setTimeout(() => {
-      reject(timeoutError);
-    }, DISPATCH_TIMEOUT_MS);
+      rejectTimeout(timeoutError);
+    }, idleTimeoutMs);
+  };
+  const dispatchTimeoutPromise = new Promise<never>((_, reject) => {
+    rejectTimeout = reject;
   });
+  // Arm once before the race so the original "zero events ever" hang is still
+  // covered even if deliver is never called.
+  resetIdleTimer();
 
   try {
     await Promise.race([
@@ -2526,6 +2564,13 @@ export async function handleInboundMessage(params: {
           replyToId?: string | null;
           isReasoning?: boolean;
         }, info?: { kind?: string }) => {
+          // Any deliver event — including reasoning-only blocks — proves the
+          // dispatcher is alive, so reset the idle timer FIRST. This MUST run
+          // before the `if (payload.isReasoning) return;` below: a turn that
+          // streams only reasoning blocks for a while would otherwise look
+          // idle and get killed mid-thought (issue #113).
+          resetIdleTimer();
+
           // Skip reasoning blocks
           if (payload.isReasoning) return;
 
@@ -2601,9 +2646,9 @@ export async function handleInboundMessage(params: {
       dispatchTimeoutPromise,
     ]);
   } catch (err) {
-    // Timeout: dispatch never returned within DISPATCH_TIMEOUT_MS. Tell the
-    // user, suppress any stale buffered text (so the finally-flush branch
-    // does not double-send), then rethrow so the per-group queue's outer
+    // Timeout: dispatch produced no deliver activity for a full idle window.
+    // Tell the user, suppress any stale buffered text (so the finally-flush
+    // branch does not double-send), then rethrow so the per-group queue's outer
     // .catch() (channel.ts#enqueueInbound) can advance to the next message
     // — otherwise this group stays stuck forever, see issue #75.
     //
@@ -2613,7 +2658,7 @@ export async function handleInboundMessage(params: {
     if (err === timeoutError) {
       clearInterval(typingInterval);
       log?.warn?.(
-        `octo: dispatch hung past ${DISPATCH_TIMEOUT_MS}ms, aborting to unblock per-group queue (session=${route?.sessionKey ?? "?"})`,
+        `octo: dispatch idle past ${idleTimeoutMs}ms with no deliver activity, aborting to unblock per-group queue (session=${route?.sessionKey ?? "?"})`,
       );
       deliverBuffer.lastText = null;
       deliverBuffer.textSent = true;
@@ -2636,6 +2681,11 @@ export async function handleInboundMessage(params: {
     }
     throw err;
   } finally {
+    // Mark settled BEFORE clearing the handle so any late deliver() from a
+    // still-running upstream dispatch can't re-arm a new idle timer that this
+    // finally would never clear (issue #113 review). Late reply CONTENT is
+    // unaffected — settled gates only resetIdleTimer, not the send path.
+    settled = true;
     if (dispatchTimeoutHandle) clearTimeout(dispatchTimeoutHandle);
     // --- Debug: log dispatch outcome ---
     log?.debug?.(`octo: [dispatch-result] replySucceeded=${replySucceeded} bufferedText=${deliverBuffer.lastText?.length ?? 0} textSent=${deliverBuffer.textSent} effectiveOBO=${effectiveOnBehalfOf ?? 'none'}`);


### PR DESCRIPTION
Fixes #113. Alternative to #114 (same bug, different model — see comparison below).

## Problem

The per-inbound dispatch timeout (from #75) was a one-shot wall-clock `setTimeout(reject, 5*60*1000)` in `src/inbound.ts` that never resets. It measures **total turn duration**, so it cannot tell a genuinely hung dispatch (zero events) apart from a healthy long turn that keeps streaming `deliver`/tool/block events. A turn that legitimately runs past the window (e.g. ~7 minutes of continuous research + polling) gets rejected mid-flight: the group sees「⚠️ 处理超时，请稍后重试。」, the buffered text is dropped, and the real reply arrives late as a ghost reply.

## Approach: measure inactivity, not total time

This guard's only job (per the #75 scope) is infrastructural — turn a *silently hung* dispatch into a bounded failure that releases the per-group serial queue. The right signal for "hung" is **inactivity**, not elapsed time.

- The one-shot timer is replaced with a resettable **idle timer**: every `deliver` event calls `resetIdleTimer()`, so the timer only fires after a full window of *zero* dispatcher activity. A healthy turn that keeps emitting events never times out, regardless of total duration.
- `resetIdleTimer()` is called at the very top of the `deliver` callback, **before** the `if (payload.isReasoning) return;` early-return — so a pure-reasoning streaming phase still keeps the dispatch marked alive. (Locked by a dedicated regression test.)
- A `settled` flag prevents a late `deliver()` from a still-running upstream dispatch from re-arming a timer the `finally` block already cleared (no timer leak). It gates only timer re-arming — late reply content is still delivered as before.

## Configurable window

New optional `dispatchIdleTimeoutMs` (channel-level and per-account, plumbed via `resolveOctoAccount` like other fields; account wins). Default = `LLM_REQUEST_TIMEOUT_MS (300_000) + IDLE_GRACE_MS (120_000) = 420_000 ms`. The value is validated as a **finite positive number** at the read site; `NaN`/`0`/negative/`Infinity` fall back to the default with a warning (a raw invalid value would otherwise be clamped by Node to a 1 ms delay and instantly time out every message).

## How this differs from #114

Both fix the same #113 symptom but choose fundamentally different models — they are mutually exclusive (they touch the same timer in `inbound.ts` and add a same-purpose but differently-named config field), so only one should land.

- **#114 keeps the one-shot wall-clock total-duration timer** and only raises the threshold, deriving it from `agents.defaults.timeoutSeconds * 1000 + 60s` (field `dispatchTimeoutMs`). It is a *threshold mitigation*: a healthy turn that runs past the derived window is still killed, and the guard is coupled to the agent-run budget. With `timeoutSeconds` set high (e.g. 3600s — common for long agents), the infrastructural guard becomes ~61 minutes, so a genuinely hung dispatch (zero events) can lock the whole group for an hour — contrary to #75's "recover within one attention span" intent.
- **This PR changes the semantics**: idle/inactivity detection (field `dispatchIdleTimeoutMs`), fully decoupled from total turn length. A healthy long turn never times out as long as it keeps emitting events; a real hang (continuous zero events) is caught within ~420s regardless of how high `timeoutSeconds` is. This is the more complete fix for the reported "healthy long turn killed" problem.

## Out of scope (unchanged)

- Per-group serial queue semantics; no early release of an in-flight dispatch (#75 scope).
- Suppressing late ghost replies after timeout — intentionally not adopted; a late real reply still posts as before. Truly cancelling an in-flight dispatch needs an `AbortSignal` in the upstream SDK dispatch params (not currently available) and is tracked separately.
- Apology timeout (`DISPATCH_TIMEOUT_APOLOGY_MS` = 10s) and `timeoutError` reference-equality identification.

## Changes

- `src/inbound.ts` — resettable idle timer + `settled` guard; finite-positive validation of `dispatchIdleTimeoutMs`; race/log/error sites use the resolved value; comments updated from "5-minute wall clock" to "N seconds of zero deliver events".
- `src/accounts.ts` — plumb `dispatchIdleTimeoutMs` (account-level overrides channel-level).
- `src/config-schema.ts` + `openclaw.plugin.json` — `dispatchIdleTimeoutMs` schema field at both levels, kept in sync for the manifest-schema-sync test.
- `src/inbound-dispatch-timeout.test.ts` — idle-reset survival, reasoning-only reset (ordering lock), true idle timeout, account>channel precedence, timer-leak-free cleanup, and finite-positive fallback (NaN/0/negative/Infinity).

## Tests

Full suite: **26 files, 1112 tests, all green**; `tsc --noEmit` clean. The existing #75 regression suite (hang → apology → buffer drop → rethrow releases queue, timer cleanup, bounded apology/final-flush) passes with only the warn-string updated for the rename.
