### PR TITLE
fix(inbound): clamp dispatch timeout to setTimeout ceiling to prevent overflow (#121)

### DIFF
--- a/src/inbound-dispatch-timeout.test.ts
+++ b/src/inbound-dispatch-timeout.test.ts
@@ -380,6 +380,50 @@ describe("dispatch timeout derivation from config (issue #113)", () => {
     expect(resolveDispatchTimeoutMs({ agents: { defaults: {} } } as any, makeAccount())).toBe(660_000);
   });
 
+  describe("clamp to setTimeout ceiling (issue #121)", () => {
+    const CEIL = 2 ** 31 - 1; // 2_147_483_647, Node setTimeout 32-bit delay 上限
+
+    it("clamps absurd timeoutSeconds (MAX_SAFE_INTEGER) to 2^31-1 instead of overflowing setTimeout", () => {
+      const cfg = { agents: { defaults: { timeoutSeconds: Number.MAX_SAFE_INTEGER } } } as any;
+      const ms = resolveDispatchTimeoutMs(cfg, makeAccount());
+      expect(ms).toBe(CEIL);
+      expect(ms).toBeLessThanOrEqual(CEIL);
+    });
+
+    it("clamps a large-but-finite timeoutSeconds (30d → > 2^31 ms) to 2^31-1", () => {
+      const cfg = { agents: { defaults: { timeoutSeconds: 2_592_000 } } } as any; // 30 天
+      expect(resolveDispatchTimeoutMs(cfg, makeAccount())).toBe(CEIL);
+    });
+
+    it("clamps absurd explicit dispatchTimeoutMs (MAX_SAFE_INTEGER) to 2^31-1", () => {
+      const account = makeAccount();
+      (account.config as any).dispatchTimeoutMs = Number.MAX_SAFE_INTEGER;
+      const ms = resolveDispatchTimeoutMs({} as any, account);
+      expect(ms).toBe(CEIL);
+      expect(ms).toBeLessThanOrEqual(CEIL);
+    });
+
+    it("derived-path boundary: 2_147_423s (≤ ceil) not clamped, 2_147_424s (> ceil) clamped", () => {
+      // 2_147_423*1000 + 60_000 = 2_147_483_000 ≤ CEIL → 原样
+      expect(
+        resolveDispatchTimeoutMs({ agents: { defaults: { timeoutSeconds: 2_147_423 } } } as any, makeAccount()),
+      ).toBe(2_147_483_000);
+      // 2_147_424*1000 + 60_000 = 2_147_484_000 > CEIL → 夹到 CEIL
+      expect(
+        resolveDispatchTimeoutMs({ agents: { defaults: { timeoutSeconds: 2_147_424 } } } as any, makeAccount()),
+      ).toBe(CEIL);
+    });
+
+    it("explicit-path boundary: exactly ceil not clamped, ceil+1 clamped", () => {
+      const atCeil = makeAccount();
+      (atCeil.config as any).dispatchTimeoutMs = CEIL;
+      expect(resolveDispatchTimeoutMs({} as any, atCeil)).toBe(CEIL);
+      const overCeil = makeAccount();
+      (overCeil.config as any).dispatchTimeoutMs = 2 ** 31; // ceil + 1
+      expect(resolveDispatchTimeoutMs({} as any, overCeil)).toBe(CEIL);
+    });
+  });
+
   it("explicit dispatchTimeoutMs config wins over the derived value", () => {
     const account = makeAccount();
     account.config.dispatchTimeoutMs = 1_234_000;

--- a/src/inbound.ts
+++ b/src/inbound.ts
@@ -75,6 +75,12 @@ import { randomUUID } from "node:crypto";
 // Tests override via `_setDispatchTimeoutForTests` to keep the suite fast.
 const DISPATCH_TIMEOUT_BUFFER_MS = 60_000;
 const DEFAULT_AGENT_TIMEOUT_SECONDS = 600;
+// issue #121: 上限 clamp。dispatch 超时最终值会喂给 setTimeout,后者 delay 上限是
+// 32-bit signed int (2^31-1 ≈ 24.8 天);超限会被 Node 重置为 1ms 并抛
+// TimeoutOverflowWarning,导致每条消息秒发「处理超时」。夹到这个硬上限既堵死溢出,
+// 又因 24.8 天远超任何现实 agent 运行 → 对一切现实配置,兜底仍严格晚于 agent-run
+// 超时触发(保上面 #113 注释里的不变量),不会提前误杀健康长任务。
+const DISPATCH_TIMEOUT_MAX_MS = 2 ** 31 - 1;
 let dispatchTimeoutTestOverrideMs: number | null = null;
 // How long we wait for the user-facing "处理超时" apology to post, AND for the
 // happy-path buffered-text final flush, before giving up. The whole point of
@@ -111,14 +117,17 @@ export function resolveDispatchTimeoutMs(
   if (dispatchTimeoutTestOverrideMs !== null) return dispatchTimeoutTestOverrideMs;
   const explicit = account.config.dispatchTimeoutMs;
   if (typeof explicit === "number" && Number.isFinite(explicit) && explicit > 0) {
-    return explicit;
+    return Math.min(explicit, DISPATCH_TIMEOUT_MAX_MS);
   }
   const configured = cfg.agents?.defaults?.timeoutSeconds;
   const agentTimeoutSeconds =
     typeof configured === "number" && Number.isFinite(configured) && configured > 0
       ? configured
       : DEFAULT_AGENT_TIMEOUT_SECONDS;
-  return agentTimeoutSeconds * 1000 + DISPATCH_TIMEOUT_BUFFER_MS;
+  return Math.min(
+    agentTimeoutSeconds * 1000 + DISPATCH_TIMEOUT_BUFFER_MS,
+    DISPATCH_TIMEOUT_MAX_MS,
+  );
 }
 
 export function _setDispatchApologyTimeoutForTests(ms: number | null): void {


### PR DESCRIPTION
Fixes #121

## 问题

`resolveDispatchTimeoutMs`(PR #114 引入)对超大但有限的 `agents.defaults.timeoutSeconds` / `channels.octo.dispatchTimeoutMs` 只校验了 `isFinite && > 0`,没有上限保护。配成 `Number.MAX_SAFE_INTEGER`(本意"不限制超时")时,`*1000 + 60000 ≈ 9e18ms` 远超 Node `setTimeout` 的 32-bit 上限(`2^31-1`),被重置为 1ms 并抛 `TimeoutOverflowWarning` → 每条入站消息秒发「⚠️ 处理超时，请稍后重试。」,随后真答案才迟到补上。

## 改动

- 新增 `DISPATCH_TIMEOUT_MAX_MS = 2 ** 31 - 1`,对两条返回路径(显式 `dispatchTimeoutMs` + `timeoutSeconds` 派生)用 `Math.min(value, DISPATCH_TIMEOUT_MAX_MS)` 夹顶。
- 上限选 `2^31-1`(≈24.8 天,setTimeout 硬上限)而非更小的保守值:它远超任何现实 agent 运行,clamp 只在 `timeoutSeconds > ~24.85 天` 这种荒谬配置下生效,故对一切现实配置仍保持 #114「dispatch 兜底严格晚于 agent-run 超时触发」的不变量,不会重蹈 #113 提前误杀健康长任务。
- 现有校验(NaN/0/负数/Infinity 回退)与 test override 路径不变。

## 测试

- 新增 5 条回归用例,补上现有测试只覆盖 `0/-1/NaN/Infinity` 的缺口:`MAX_SAFE_INTEGER`、30 天有限值、显式超大值被夹到 `2^31-1`;派生路径(`2_147_423`↔`2_147_424`)与显式路径(`ceil`↔`ceil+1`)边界。
- [x] `npx vitest run src/inbound-dispatch-timeout.test.ts` 全绿(17/17)
- [x] 全量 `npm test` 1127/1127 通过
- [x] `npm run type-check` 干净