### PR TITLE
fix(inbound): scope group member context to current group, not cross-group union

### DIFF
--- a/docs/superpowers/specs/2026-06-23-group-member-count-cross-group-design.md
+++ b/docs/superpowers/specs/2026-06-23-group-member-count-cross-group-design.md
@@ -1,0 +1,155 @@
+# #125 群成员数虚高(跨群污染)修复设计
+
+- 日期: 2026-06-23
+- Issue: Mininglamp-OSS/openclaw-channel-octo#125
+- 分支: `fix/group-member-count-cross-group`
+
+## 背景与现象
+
+群里 @bot 问"群成员数多少",bot 回答的人数远大于实际,并会列出**不在本群**的成员。
+
+真机证据(bot `mintest`,本群真实 3 人:齐乐 / caster-Q / mintest):
+
+- 一次答 "4 个人:齐乐、caster-Q,以及两个机器人 costest 和 mintest"
+- bot 自陈纠正:"costest 其实不在群里"
+
+`costest` 是 `mintest` 在**另一个群**("costest、mintest、cast")的成员,被泄漏进了本群上下文。
+
+线上反馈(原 issue):7 人群答 87 人、不到 20 人群答 500 多人。
+
+## 根因
+
+`buildMemberListPrefix(uidToNameMap)`(`src/inbound.ts`)把一个 **per-account 累积** 的 `uidToNameMap` 当成了"本群名单":
+
+1. `getOrCreateUidToNameMap(accountId)`(`src/channel.ts`)按 accountId 缓存,**同一 bot 的所有群共用同一个 Map**。
+2. startup prefetch(`src/channel.ts` 群预取循环)遍历 bot 加入的**所有群**,把每个群的成员都 `set` 进这同一个 Map。
+3. inbound 的 `refreshGroupMemberCache`(`src/inbound.ts`)刷新成员时**只 `set` 不 `clear`**,退群成员永久残留。
+4. `buildMemberListPrefix` 用 `uidToNameMap.size` 当人数、用 `uidToNameMap.entries()` 当名单喂给 LLM(`[Group Members]` / `[Group Info] This group has N members`)。
+
+四者叠加 → 注入给 LLM 的"本群成员"实为 bot 待过的所有群成员**并集**,人数虚高且泄漏外群成员。LLM 偶尔能把不认识的名字滤掉(表现为"有时答对"),但数据源本身是脏的。
+
+## 关键约束
+
+`uidToNameMap`(及对应 `memberMap`)的**累积语义必须保留**。除 `buildMemberListPrefix` 外,它还服务于:
+
+- senderName 解析(`resolveSenderName`)
+- @mention 解析(`findUidByName` / `buildEntitiesFromFallback`)
+- bot 名查找(防 bot-to-bot loop 的 fallback mention)
+- persona-clone grantor 名解析
+
+这些用途**需要跨群累积**才能解析名字。因此**不得 clear 该 Map、不得改其填充逻辑**。本 bug 的唯一缺陷是 `buildMemberListPrefix` 误用它当本群名单。
+
+## 方案
+
+**复用 inbound 这条消息已经拉到的当前群名单**,不引入第二套数据源。
+
+`handleGroupMessage`(`src/inbound.ts`)在每条群消息里已经调用 `refreshGroupMemberCache({ sessionId: memberCacheGroupNo, ... })`(~1700),其中 `memberCacheGroupNo = extractParentGroupNo(message.channel_id)`(~1696,已正确处理线程复合 channelId)。该函数内部已用 `getGroupMembers({ groupNo: sessionId })` 拉到**当前群**的 `GroupMember[]`(~1281),但只把成员 `set` 进累积 map,没有把名单交出来。
+
+> 为什么不用 `getGroupMembersFromCache`:`member-cache.ts` 的 `_memberCache` **不被 inbound 刷新写入**(inbound 走 api-fetch 的 `getGroupMembers` 直连,只有 startup preload 和该模块内部的 `refreshGroupMembers` 才写 `_memberCache`)。走它会引入第二套数据源 + 退群最长 5min 才剔除 + 同一消息重复打一次 API。复用 inbound 实拉名单可一次性规避这三点。
+
+### 改动 1:把当前群名单写入一个 per-account 的 `currentGroupMembersMap`
+
+**不改 `refreshGroupMemberCache` 的 `boolean` 返回类型**(避免漏改 ~2535 mention force-refresh 调用点 `if (refreshed)`)。改为让它在写累积 map 的同时,把"本次当前群名单"写进一个**新的 per-account map**:
+
+- `channel.ts` 照 `memberRobotMap` 的模式新增 `_currentGroupMembersMaps`(`Map<accountId, Map<groupNo, GroupMember[]>>`)+ `getOrCreateCurrentGroupMembersMap(accountId)`(内部 `normalizeAccountId`),在 `handleInboundMessage` 调用点(~1371)随其它 per-account map 一起传入。**key 跟随 per-account 传入 map,与 `groupCacheTimestamps` 同源同账号隔离**(不新开模块级仅 groupNo 的缓存)。
+- **`currentGroupMembersMap` 在 `handleInboundMessage` / `refreshGroupMemberCache` 中均为可选参数**,函数内 `?? new Map()` fallback。这样 `src/inbound-mention-gate.test.ts`(14 处)、`src/inbound-dispatch-timeout.test.ts`(1 处)等现有 `handleInboundMessage` 直接调用点**无需改动**(不传即用临时 Map,行为等价于本轮无成员上下文)。
+- `refreshGroupMemberCache` 内,以 `sessionId`(=parent groupNo)为 key:
+  - **成功分支(~1311)**:`currentGroupMembersMap.set(sessionId, members)`(本次拉到的当前群名单)。
+  - **空返回 / catch 失败分支(~1315 / ~1320)**:`currentGroupMembersMap.delete(sessionId)`(**负缓存**:失败即清当前群名单,下条消息 early-return 也拿不到旧名单,兑现"失败就不注入")。
+  - **命中缓存 early-return 分支(~1274,未过期)**:不动 map,沿用上次成功写入的当前群名单(语义与 `groupCacheTimestamps` 的 TTL 一致)。
+- 累积 map / `memberRobotMap` 的 `set` 逻辑、`refreshGroupMemberCache` 的返回值与所有调用点(~1700 / ~2535)**全部保持不变**。
+- **`cleanupStaleCaches`(`channel.ts:349`)同步清理**:在现有 `_memberMaps`/`_groupCacheTimestamps` 的 stale 群条目删除处(~356/359)旁补一行 `_currentGroupMembersMaps.get(accountId)?.delete(groupId)`(与邻居两行**同 key 同删除时机**)。
+  - **为何按 raw `groupId` 删(而非 `extractParentGroupNo(groupId)`)**:cleanup 遍历的 `groupId` 来自 `touchCache(account.accountId, msg.channel_id)`(`channel.ts:1357`,raw key)。让 roster 缓存与 `_groupCacheTimestamps` **同 key 同生命周期**,可保证一条强不变量:`roster` 存在 ⟺ `timestamp` 存在(两者同写、同删、同 key)。若改按 parent 删 roster 而 timestamp 仍按 raw 删,会脱节:同群线程 A stale 删了 parent roster、但线程 B 仍活跃使 timestamp[parent] fresh → 下条 B 消息 `refreshGroupMemberCache` early-return 不重拉 → roster 空 → 丢成员上下文。按 raw 删彻底规避此回归。
+  - **代价(有界、可接受)**:纯线程活跃的群,roster 按 parent key 存、cleanup 按 raw key 删 → 清不到,常驻一条。但这与 `_memberMaps`/`_groupCacheTimestamps` 的**既有行为完全一致**(它们也 parent-key 写 / raw-key 删),且**有界**:每群至多一条 `GroupMember[]`,每条消息刷新即覆盖,不随时间增长。本 issue 不顺手修既有 raw/parent 错配(避免扩大改动面、动既有 `_groupCacheTimestamps` 清理逻辑),仅保证新 map 与既有缓存行为一致、不引入新的不变量破坏。
+
+### 改动 2:`buildMemberListPrefix` 改签名
+
+```
+- export function buildMemberListPrefix(uidToNameMap: Map<string, string>): string
++ export function buildMemberListPrefix(members: GroupMember[]): string
+```
+
+内部逻辑不变(`length <= 10` 列名 + mention hint;`> 10` 报数 + 查询指引),数据源改为传入的 `members`:
+
+- `members.length === 0` → 返回 `""`(与旧 `size === 0` 等价)
+- `length <= 10` → 用 `members.map(m => `  ${m.name} (${m.uid})`)` 列名,mention 示例锚点取 `members[0]`
+- `> 10` → `This group has ${members.length} members`
+
+### 改动 3:调用点(`src/inbound.ts` ~2128)
+
+~1700 那次 `refreshGroupMemberCache` 已把当前群名单写进 `currentGroupMembersMap`。调用点直接读它,不再传累积 map:
+
+```
+- const memberListPrefix = isGroup ? buildMemberListPrefix(uidToNameMap) : "";
++ const currentGroupMembers = isGroup
++   ? (currentGroupMembersMap.get(memberCacheGroupNo) ?? [])
++   : [];
++ const memberListPrefix = isGroup ? buildMemberListPrefix(currentGroupMembers) : "";
+```
+
+`memberCacheGroupNo`(parent groupNo)在 ~1696 已算好;命中则为当前群名单,失败/空已被负缓存 `delete` → `?? []` → prefix 空。
+
+### 数据流(改后)
+
+```
+message.channel_id ──extractParentGroupNo──> memberCacheGroupNo (线程安全)
+        │
+        ▼
+refreshGroupMemberCache(memberCacheGroupNo)   [每条消息已调,零额外 API]
+   ├─ set 进累积 map(senderName/mention 用,不变)
+   ├─ 成功: currentGroupMembersMap.set(groupNo, 当前群名单)
+   └─ 失败/空: currentGroupMembersMap.delete(groupNo)  (负缓存)
+        │
+        ▼
+currentGroupMembersMap.get(memberCacheGroupNo) ──> buildMemberListPrefix ──> [Group Members] 仅含本群
+```
+
+per-account `uidToNameMap` 继续服务 senderName / mention 解析,**保持不变**。
+
+## 边界处理
+
+1. **线程消息**:成员名单一律用 `memberCacheGroupNo = extractParentGroupNo(message.channel_id)`,不直接用 raw `channel_id`(复合格式会查错群)。
+2. **fetch 失败 / 空返回**:`refreshGroupMemberCache` 的空/catch 分支 `currentGroupMembersMap.delete(groupNo)`(负缓存)。即使 30s backoff 期内下条消息 early-return,`get` 也拿不到旧名单 → prefix 空。**绝不回退 per-account 累积 Map**。"不注入" 优于 "注入错的"。
+3. **缓存命中(未过期)**:沿用上次成功写入的当前群名单;成员变动在下次过期/强刷后反映(与现有 `refreshGroupMemberCache` 的 TTL/backoff 语义一致,不新增延迟)。
+4. **零额外 API / 不重复拉取**:复用 ~1700 已有的那次刷新,不新增 API 调用。
+5. **多账号隔离**:`currentGroupMembersMap` 按 accountId 建(`getOrCreateCurrentGroupMembersMap` 内 `normalizeAccountId`),与 `groupCacheTimestamps` / `memberRobotMap` 同源,不会跨账号串名单。
+6. **mention / bot 区分 / 返回值不受影响**:`memberRobotMap`、mention 解析、`refreshGroupMemberCache` 的 boolean 返回值与 ~1700 / ~2535 两调用点全部不变。
+
+## 测试(TDD)
+
+新增 / 改写测试(`src/inbound.test.ts`):
+
+| 测试 | 验证 |
+|---|---|
+| 跨群隔离 | `buildMemberListPrefix(群B名单)` 只报 4 人、不含群 A 成员(脏累积 map 同时存在也不影响) |
+| ≤10 列名 | 列出的成员与传入名单逐条一致 |
+| >10 报数 | `This group has N members` 的 N == members.length |
+| 空名单 | `buildMemberListPrefix([])` 返回 `""` |
+| 线程 channelId | 当前群名单按 `extractParentGroupNo(groupNo____shortId)` 解析,不查错群 |
+| 当前群名单来源 | 刷新成功后 `currentGroupMembersMap.get(groupNo)` == 当前群名单(非累积 map) |
+| 失败负缓存 | 先成功缓存名单 → 再失败/空返回 → `get` 为空 → 连续第二条消息(backoff 内)仍不注入旧名单 |
+| 多账号隔离 | 账号 A、账号 B 同 groupNo,各自 `currentGroupMembersMap` 互不串名单 |
+| mention 不回归 | ~2535 force-refresh 调用点行为不变(刷新失败时 `if (refreshed)` 仍为 false,不跑脏 mention 解析) |
+| 缓存清理 | (`channel.test.ts`)`cleanupStaleCaches` 清 stale 条目时,`_currentGroupMembersMaps` 按 raw `groupId` 同步删除(与 `_groupCacheTimestamps` 同 key 同生命周期) |
+| roster⟺timestamp 不变量 | 同群多线程(一条 stale 一条 active)下,roster 与 timestamp 不脱节:不会出现 timestamp fresh 但 roster 已被清致丢成员上下文 |
+| 可选参数兼容 | 不传 `currentGroupMembersMap` 时 `handleInboundMessage` 用临时 Map,现有 mention-gate / dispatch-timeout 测试零改动通过 |
+
+现有 6 个 `buildMemberListPrefix` 单测(`src/inbound.test.ts:1532+`)随签名改为传数组。
+
+## 影响面
+
+- 改动文件:
+  - `src/inbound.ts`:`refreshGroupMemberCache` 增**可选** `currentGroupMembersMap` 参数 + 三分支写/删名单(返回值不变);`buildMemberListPrefix` 改签名;调用点 ~2128 读 map。
+  - `src/channel.ts`:新增 `_currentGroupMembersMaps` + `getOrCreateCurrentGroupMembersMap`(照 `memberRobotMap` 模式),`handleInboundMessage` 调用点(~1371)传入,`cleanupStaleCaches`(~349)同步清理。**新增 `import type { GroupMember } from "./api-fetch.js"`**(`_currentGroupMembersMaps` 的 value 类型 `GroupMember[]` 需要)。
+  - `src/inbound.test.ts`:`buildMemberListPrefix` 签名改 + 成员上下文相关用例。
+  - `src/channel.test.ts`:`cleanupStaleCaches` 对 `_currentGroupMembersMaps` 的清理用例(该 map 与 cleanup 同在 `channel.ts` 私有作用域,清理测试放此文件,通过公开行为 / 既有 test helper 触发 cleanup)。
+- **不需改动**的现有调用点(靠可选参数 + fallback):`src/inbound-mention-gate.test.ts`(14 处)、`src/inbound-dispatch-timeout.test.ts`(1 处)直接调用 `handleInboundMessage` 处。
+- 新增 import:`src/inbound.ts` 与 `src/channel.ts` 各加 `import type { GroupMember } from "./api-fetch.js"`。`GroupMember` 已是 inbound 内 `getGroupMembers` 返回元素类型,无新依赖。
+- 不改:`src/member-cache.ts`、mention / senderName / persona 路径、累积 map 的 set 逻辑、`refreshGroupMemberCache` 返回值与既有调用点语义。
+- 无新增依赖,无 child_process。
+
+## 非目标
+
+- 不重构 `uidToNameMap` 的 per-account 累积模型。
+- 不处理 #124(多条回复丢失)——独立 issue。
+- 不动 octo-server 侧。

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -377,11 +377,15 @@ function cleanupStaleCaches(): void {
         // Note: uidToNameMap is a flat uid→name map (not keyed by groupId),
         // so we don't delete from it here — names remain valid across groups.
         _groupCacheTimestamps.get(accountId)?.delete(groupId);
-        // Same key (raw channel_id from touchCache) as _groupCacheTimestamps so
-        // the roster and its freshness timestamp share one lifecycle: roster
-        // exists iff timestamp exists. Deleting by parent groupNo here would
-        // break that invariant (timestamp kept fresh by a sibling thread while
-        // the roster is dropped → next message early-returns with no roster).
+        // Delete by the SAME key cleanup uses for _groupCacheTimestamps (raw
+        // channel_id from touchCache) so the roster is reclaimed on exactly the
+        // same cleanup pass as its freshness timestamp. (Steady-state they are
+        // not strictly 1:1 — refreshGroupMemberCache's failure branch keeps a
+        // backoff timestamp while deleting the roster — but the read path
+        // tolerates a missing roster via `?? []`, so co-deletion at cleanup is
+        // what matters here.) Deleting by parent groupNo instead would drop the
+        // roster while a sibling thread keeps the timestamp fresh, leaving the
+        // next message to early-return with no roster.
         _currentGroupMembersMaps.get(accountId)?.delete(groupId);
         activityMap.delete(groupId);
       }

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -15,6 +15,7 @@ import {
   type ResolvedOctoAccount,
 } from "./accounts.js";
 import { registerBot, sendMessage, sendHeartbeat, sendMediaMessage, inferContentType, ensureTextCharset, fetchBotGroups, getGroupMd, parseImageDimensions, parseImageDimensionsFromFile, getUploadPresign, uploadFileToPresignedUrl } from "./api-fetch.js";
+import type { GroupMember } from "./api-fetch.js";
 import { PLUGIN_VERSION } from "./version.js";
 import { getOctoRuntime } from "./runtime.js";
 
@@ -298,6 +299,25 @@ function getOrCreateMemberRobotMap(accountId: string): Map<string, boolean> {
   return m;
 }
 
+// Current-group member roster: parent groupNo -> this group's GroupMember[].
+// Per-account (keyed by accountId), per-group inside. UNLIKE the flat
+// uidToNameMap (which accumulates names across every group for mention/sender
+// resolution and must NOT be cleared), this holds ONLY the current group's
+// roster so the [Group Members] / member-count prompt context reflects one
+// group, not the cross-group union (#125). Populated by refreshGroupMemberCache
+// on each inbound message; negative-cached (entry deleted) on fetch failure so
+// a stale roster is never re-injected.
+const _currentGroupMembersMaps = new Map<string, Map<string, GroupMember[]>>();
+function getOrCreateCurrentGroupMembersMap(accountId: string): Map<string, GroupMember[]> {
+  const id = normalizeAccountId(accountId);
+  let m = _currentGroupMembersMaps.get(id);
+  if (!m) {
+    m = new Map<string, GroupMember[]>();
+    _currentGroupMembersMaps.set(id, m);
+  }
+  return m;
+}
+
 
 // --- Group → Account mapping: tracks which accounts are active in each group ---
 // Used by handleAction to resolve the correct account when framework passes wrong accountId
@@ -357,6 +377,12 @@ function cleanupStaleCaches(): void {
         // Note: uidToNameMap is a flat uid→name map (not keyed by groupId),
         // so we don't delete from it here — names remain valid across groups.
         _groupCacheTimestamps.get(accountId)?.delete(groupId);
+        // Same key (raw channel_id from touchCache) as _groupCacheTimestamps so
+        // the roster and its freshness timestamp share one lifecycle: roster
+        // exists iff timestamp exists. Deleting by parent groupNo here would
+        // break that invariant (timestamp kept fresh by a sibling thread while
+        // the roster is dropped → next message early-returns with no roster).
+        _currentGroupMembersMaps.get(accountId)?.delete(groupId);
         activityMap.delete(groupId);
       }
     }
@@ -1299,6 +1325,10 @@ export const octoPlugin: ChannelPlugin<ResolvedOctoAccount> = {
       // 4e. Robot flags map — server-authoritative sender classification for the 免@ gate
       const memberRobotMap = getOrCreateMemberRobotMap(account.accountId);
 
+      // 4f. Current-group roster — current group's members only (per-group),
+      // for the [Group Members] / member-count prompt context (#125)
+      const currentGroupMembersMap = getOrCreateCurrentGroupMembersMap(account.accountId);
+
       // 5. Token refresh state — time-based cooldown to prevent refresh storms
       let lastTokenRefreshAt = 0;
       const TOKEN_REFRESH_COOLDOWN_MS = 60_000; // 60 seconds
@@ -1378,6 +1408,7 @@ export const octoPlugin: ChannelPlugin<ResolvedOctoAccount> = {
                 uidToNameMap,
                 groupCacheTimestamps,
                 memberRobotMap,
+                currentGroupMembersMap,
                 groupMdCache,
                 log,
                 statusSink,

--- a/src/inbound-member-roster.test.ts
+++ b/src/inbound-member-roster.test.ts
@@ -198,24 +198,41 @@ describe("#125 current-group roster (cross-group isolation)", () => {
     expect(currentGroupMembersMap.has(GROUP_A)).toBe(false);
   });
 
-  it("isolates rosters per account (same groupNo, two accounts)", async () => {
+  it("isolates rosters per account (two real account flows, separate per-account state)", async () => {
     installRuntimeStub();
-    installFetchStub({ [GROUP_A]: groupA });
-    const mapAcct1 = new Map<string, GroupMember[]>();
-    const mapAcct2 = new Map<string, GroupMember[]>();
+    // acct1 lives in GROUP_A (3 members); acct2 lives in GROUP_B (4 members).
+    installFetchStub({ [GROUP_A]: groupA, [GROUP_B]: groupB });
+
+    // Each account gets its OWN per-account state (as channel.ts does via the
+    // getOrCreate*(accountId) helpers) — nothing is shared between them.
+    const acct1 = {
+      account: makeAccount("acct1"),
+      currentGroupMembersMap: new Map<string, GroupMember[]>(),
+      memberMap: new Map<string, string>(),
+      uidToNameMap: new Map<string, string>(),
+      groupCacheTimestamps: new Map<string, number>(),
+    };
+    const acct2 = {
+      account: makeAccount("acct2"),
+      currentGroupMembersMap: new Map<string, GroupMember[]>(),
+      memberMap: new Map<string, string>(),
+      uidToNameMap: new Map<string, string>(),
+      groupCacheTimestamps: new Map<string, number>(),
+    };
     const common = {
       botUid: BOT_UID,
       groupHistories: new Map(),
       lastBotReplySeqMap: new Map(),
-      memberMap: new Map(),
-      uidToNameMap: new Map(),
-      groupCacheTimestamps: new Map(),
     };
 
-    await handleInboundMessage({ ...common, account: makeAccount("acct1"), currentGroupMembersMap: mapAcct1, message: makeTextMessage(GROUP_A, groupA[0].uid, "hi") });
+    // Drive a real inbound flow for BOTH accounts.
+    await handleInboundMessage({ ...common, ...acct1, message: makeTextMessage(GROUP_A, groupA[0].uid, "hi") });
+    await handleInboundMessage({ ...common, ...acct2, message: makeTextMessage(GROUP_B, groupB[0].uid, "hi") });
 
-    // acct2 has its own (empty) map; acct1's roster must not have leaked into it.
-    expect(mapAcct1.get(GROUP_A)?.length).toBe(3);
-    expect(mapAcct2.has(GROUP_A)).toBe(false);
+    // Each account's roster cache holds ONLY its own group — no cross-account bleed.
+    expect(acct1.currentGroupMembersMap.get(GROUP_A)?.map((m) => m.name)).toEqual(["Alice", "Bob", "Carol"]);
+    expect(acct1.currentGroupMembersMap.has(GROUP_B)).toBe(false);
+    expect(acct2.currentGroupMembersMap.get(GROUP_B)?.map((m) => m.name)).toEqual(["Dave", "Erin", "Frank", "Grace"]);
+    expect(acct2.currentGroupMembersMap.has(GROUP_A)).toBe(false);
   });
 });

--- a/src/inbound-member-roster.test.ts
+++ b/src/inbound-member-roster.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { ChannelType, MessageType } from "./types.js";
+import { handleInboundMessage } from "./inbound.js";
+import { setOctoRuntime } from "./runtime.js";
+import { _clearKnownBots } from "./bot-registry.js";
+import { _clearMentionPrefCache, _setMentionPrefEntry } from "./mention-prefs.js";
+import type { ResolvedOctoAccount } from "./accounts.js";
+import type { GroupMember } from "./api-fetch.js";
+
+/**
+ * Integration test for #125 — group member-count / roster context must reflect
+ * the CURRENT group only, never the cross-group union, and must not re-inject a
+ * stale roster after a failed refresh.
+ *
+ * Drives the real handleInboundMessage with a stubbed OpenClaw runtime + stubbed
+ * network. The current-group roster is observed via the per-account
+ * currentGroupMembersMap the caller passes in (channel.ts owns one per account);
+ * here each test owns the map so it can assert what got cached.
+ *
+ * Note on cleanupStaleCaches: the cleanup line that drops _currentGroupMembersMaps
+ * entries lives in channel.ts module-private scope (same as the existing
+ * _memberMaps/_groupCacheTimestamps cleanup, which has no unit test either) and
+ * is not exercised here. It is structurally identical to and shares the raw-key
+ * with the adjacent _groupCacheTimestamps.delete, so its correctness rests on
+ * type-check + that structural equivalence rather than a private-symbol test.
+ * The negative-cache behavior that the read path actually depends on IS asserted
+ * below.
+ */
+
+const API = "http://octo.test";
+const BOT_UID = "bot_self_0000000000000000000000000000";
+
+function makeAccount(accountId = "acct1"): ResolvedOctoAccount {
+  return {
+    accountId,
+    enabled: true,
+    configured: true,
+    config: {
+      botToken: "tok",
+      apiUrl: API,
+      pollIntervalMs: 1000,
+      heartbeatIntervalMs: 1000,
+      requireMention: false, // reply without @ so the dispatch path always runs
+    },
+  };
+}
+
+function makeTextMessage(groupId: string, fromUid: string, content: string) {
+  return {
+    message_id: `m_${groupId}`,
+    message_seq: 100,
+    from_uid: fromUid,
+    channel_id: groupId,
+    channel_type: ChannelType.Group,
+    timestamp: Math.floor(Date.now() / 1000),
+    payload: { type: MessageType.Text, content },
+  };
+}
+
+function installRuntimeStub() {
+  const dispatch = vi.fn(async (args: any) => {
+    await args.dispatcherOptions.deliver({ text: "hi" }, { kind: "final" });
+  });
+  setOctoRuntime({
+    config: { loadConfig: () => ({}) },
+    channel: {
+      reply: {
+        dispatchReplyWithBufferedBlockDispatcher: dispatch,
+        resolveEnvelopeFormatOptions: () => ({}),
+        formatAgentEnvelope: ({ body }: any) => body,
+        finalizeInboundContext: (ctx: any) => ctx,
+      },
+      routing: {
+        resolveAgentRoute: () => ({ agentId: "agent1", sessionKey: "sk1", accountId: "acct1" }),
+      },
+      session: {
+        resolveStorePath: () => "/tmp/store",
+        readSessionUpdatedAt: () => undefined,
+        recordInboundSession: async () => {},
+      },
+    },
+  } as any);
+  return { dispatch };
+}
+
+/**
+ * Network stub whose /members response is keyed by the groupNo in the request
+ * URL, so different groups return different rosters. membersDown forces /members
+ * to fail (500) to exercise the negative-cache path.
+ */
+function installFetchStub(rostersByGroup: Record<string, GroupMember[]>, opts: { membersDown?: boolean } = {}) {
+  globalThis.fetch = vi.fn(async (input: any, init?: any) => {
+    const url = typeof input === "string" ? input : input.toString();
+    const json = (data: unknown, status = 200) =>
+      new Response(JSON.stringify(data), { status, headers: { "Content-Type": "application/json" } });
+
+    if (url.includes("/members")) {
+      if (opts.membersDown) return json({ error: "boom" }, 500);
+      // Pick the roster whose groupNo appears in the request URL/body.
+      const body = init?.body ? String(init.body) : "";
+      const hay = url + body;
+      for (const [groupNo, roster] of Object.entries(rostersByGroup)) {
+        if (hay.includes(groupNo)) return json({ members: roster });
+      }
+      return json({ members: [] });
+    }
+    if (url.includes("/mention_pref")) return json({ no_mention: true, effective: true });
+    if (url.includes("/md")) return json({ content: "", version: 0, updated_at: null, updated_by: "" });
+    if (url.includes("/messages/sync")) return json({ messages: [] });
+    if (url.includes("/readReceipt")) return json({});
+    if (url.includes("/typing")) return json({});
+    if (url.includes("/sendMessage")) return json({ message_id: "r", message_seq: 0 });
+    return json({});
+  }) as unknown as typeof fetch;
+}
+
+const originalFetch = globalThis.fetch;
+
+const GROUP_A = "30000000000000000000000000000a";
+const GROUP_B = "30000000000000000000000000000b";
+const groupA: GroupMember[] = [
+  { uid: "a1aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", name: "Alice" },
+  { uid: "a2aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", name: "Bob" },
+  { uid: "a3aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", name: "Carol" },
+];
+const groupB: GroupMember[] = [
+  { uid: "b1bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", name: "Dave" },
+  { uid: "b2bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", name: "Erin" },
+  { uid: "b3bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", name: "Frank" },
+  { uid: "b4bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", name: "Grace" },
+];
+
+describe("#125 current-group roster (cross-group isolation)", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    _clearKnownBots();
+    _clearMentionPrefCache();
+  });
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    _clearKnownBots();
+    _clearMentionPrefCache();
+  });
+
+  it("caches ONLY the current group's roster, not the union across groups", async () => {
+    installRuntimeStub();
+    installFetchStub({ [GROUP_A]: groupA, [GROUP_B]: groupB });
+    const currentGroupMembersMap = new Map<string, GroupMember[]>();
+    const base = {
+      account: makeAccount(),
+      botUid: BOT_UID,
+      groupHistories: new Map(),
+      lastBotReplySeqMap: new Map(),
+      memberMap: new Map(),
+      uidToNameMap: new Map(),
+      groupCacheTimestamps: new Map(),
+      currentGroupMembersMap,
+    };
+
+    // Bot is messaged in group A, then in group B.
+    await handleInboundMessage({ ...base, message: makeTextMessage(GROUP_A, groupA[0].uid, "hi") });
+    await handleInboundMessage({ ...base, message: makeTextMessage(GROUP_B, groupB[0].uid, "hi") });
+
+    // Each group's cache entry holds only that group's members.
+    expect(currentGroupMembersMap.get(GROUP_A)?.map((m) => m.name)).toEqual(["Alice", "Bob", "Carol"]);
+    expect(currentGroupMembersMap.get(GROUP_B)?.map((m) => m.name)).toEqual(["Dave", "Erin", "Frank", "Grace"]);
+    // Group B's roster must NOT contain group A's members (no union/leak).
+    expect(currentGroupMembersMap.get(GROUP_B)?.some((m) => m.name === "Alice")).toBe(false);
+  });
+
+  it("negative-caches on members fetch failure (no stale roster re-injected)", async () => {
+    const currentGroupMembersMap = new Map<string, GroupMember[]>();
+    const groupCacheTimestamps = new Map<string, number>();
+    const base = {
+      account: makeAccount(),
+      botUid: BOT_UID,
+      groupHistories: new Map(),
+      lastBotReplySeqMap: new Map(),
+      memberMap: new Map(),
+      uidToNameMap: new Map(),
+      groupCacheTimestamps,
+      currentGroupMembersMap,
+    };
+
+    // 1) Successful refresh caches the roster.
+    installRuntimeStub();
+    installFetchStub({ [GROUP_A]: groupA });
+    await handleInboundMessage({ ...base, message: makeTextMessage(GROUP_A, groupA[0].uid, "hi") });
+    expect(currentGroupMembersMap.get(GROUP_A)?.length).toBe(3);
+
+    // 2) Force expiry so the next message actually refreshes, then fail /members.
+    groupCacheTimestamps.clear();
+    installRuntimeStub();
+    installFetchStub({}, { membersDown: true });
+    await handleInboundMessage({ ...base, message: makeTextMessage(GROUP_A, groupA[0].uid, "hi again") });
+
+    // Roster entry was deleted (negative cache) — not left stale.
+    expect(currentGroupMembersMap.has(GROUP_A)).toBe(false);
+  });
+
+  it("isolates rosters per account (same groupNo, two accounts)", async () => {
+    installRuntimeStub();
+    installFetchStub({ [GROUP_A]: groupA });
+    const mapAcct1 = new Map<string, GroupMember[]>();
+    const mapAcct2 = new Map<string, GroupMember[]>();
+    const common = {
+      botUid: BOT_UID,
+      groupHistories: new Map(),
+      lastBotReplySeqMap: new Map(),
+      memberMap: new Map(),
+      uidToNameMap: new Map(),
+      groupCacheTimestamps: new Map(),
+    };
+
+    await handleInboundMessage({ ...common, account: makeAccount("acct1"), currentGroupMembersMap: mapAcct1, message: makeTextMessage(GROUP_A, groupA[0].uid, "hi") });
+
+    // acct2 has its own (empty) map; acct1's roster must not have leaked into it.
+    expect(mapAcct1.get(GROUP_A)?.length).toBe(3);
+    expect(mapAcct2.has(GROUP_A)).toBe(false);
+  });
+});

--- a/src/inbound.test.ts
+++ b/src/inbound.test.ts
@@ -29,6 +29,7 @@ import {
   type ResolveFileResult,
 } from "./inbound.js";
 import { extractMentionUids, parseStructuredMentions } from "./mention-utils.js";
+import type { GroupMember } from "./api-fetch.js";
 import { normalizeMediaAttachments } from "openclaw/plugin-sdk/media-runtime";
 import { existsSync, unlinkSync, readFileSync } from "node:fs";
 
@@ -1530,18 +1531,23 @@ describe("Bot @ 检测（entities 支持）", () => {
 });
 
 describe("buildMemberListPrefix", () => {
-  it("should return empty string for empty map", () => {
-    const map = new Map<string, string>();
-    expect(buildMemberListPrefix(map)).toBe("");
+  // buildMemberListPrefix takes the CURRENT group's roster (per-group, clean),
+  // not the per-account accumulated uid→name map (#125: the accumulated map is
+  // the union across every group the bot has seen, which inflated the count and
+  // leaked other groups' members into the prompt).
+  const gm = (uid: string, name: string): GroupMember => ({ uid, name });
+
+  it("should return empty string for empty roster", () => {
+    expect(buildMemberListPrefix([])).toBe("");
   });
 
   it("should inject full member list when ≤ 10 members", () => {
-    const map = new Map<string, string>([
-      ["uid_alice", "Alice"],
-      ["uid_bob", "Bob"],
-      ["uid_chen", "陈皮皮"],
-    ]);
-    const result = buildMemberListPrefix(map);
+    const members = [
+      gm("uid_alice", "Alice"),
+      gm("uid_bob", "Bob"),
+      gm("uid_chen", "陈皮皮"),
+    ];
+    const result = buildMemberListPrefix(members);
     expect(result).toContain("[Group Members]");
     expect(result).toContain("Alice (uid_alice)");
     expect(result).toContain("Bob (uid_bob)");
@@ -1553,22 +1559,18 @@ describe("buildMemberListPrefix", () => {
   });
 
   it("should inject full member list when exactly 10 members", () => {
-    const map = new Map<string, string>();
-    for (let i = 1; i <= 10; i++) {
-      map.set(`uid_${i}`, `User${i}`);
-    }
-    const result = buildMemberListPrefix(map);
+    const members: GroupMember[] = [];
+    for (let i = 1; i <= 10; i++) members.push(gm(`uid_${i}`, `User${i}`));
+    const result = buildMemberListPrefix(members);
     expect(result).toContain("[Group Members]");
     expect(result).toContain("User1 (uid_1)");
     expect(result).toContain("User10 (uid_10)");
   });
 
   it("should inject hint message when > 10 members", () => {
-    const map = new Map<string, string>();
-    for (let i = 1; i <= 11; i++) {
-      map.set(`uid_${i}`, `User${i}`);
-    }
-    const result = buildMemberListPrefix(map);
+    const members: GroupMember[] = [];
+    for (let i = 1; i <= 11; i++) members.push(gm(`uid_${i}`, `User${i}`));
+    const result = buildMemberListPrefix(members);
     expect(result).toContain("[Group Info]");
     expect(result).toContain("11 members");
     expect(result).toContain("group management tool");
@@ -1577,19 +1579,35 @@ describe("buildMemberListPrefix", () => {
   });
 
   it("should inject hint message for large groups", () => {
-    const map = new Map<string, string>();
-    for (let i = 1; i <= 50; i++) {
-      map.set(`uid_${i}`, `User${i}`);
-    }
-    const result = buildMemberListPrefix(map);
+    const members: GroupMember[] = [];
+    for (let i = 1; i <= 50; i++) members.push(gm(`uid_${i}`, `User${i}`));
+    const result = buildMemberListPrefix(members);
     expect(result).toContain("[Group Info]");
     expect(result).toContain("50 members");
   });
 
+  it("reports the roster length as the count, not a cross-group union (#125)", () => {
+    // Group B has 4 real members. Even though the bot has seen other groups,
+    // the prefix must report exactly this roster — no inflation, no leakage.
+    const groupB = [
+      gm("uid_dave", "Dave"),
+      gm("uid_erin", "Erin"),
+      gm("uid_frank", "Frank"),
+      gm("uid_grace", "Grace"),
+    ];
+    const result = buildMemberListPrefix(groupB);
+    expect(result).toContain("[Group Members]");
+    expect(result).toContain("Dave (uid_dave)");
+    expect(result).toContain("Grace (uid_grace)");
+    // A member from another group must not appear.
+    expect(result).not.toContain("costest");
+    expect(result).not.toContain("uid_costest");
+  });
+
   it(">10 branch names the real group-members action + a real-form hex anchor", () => {
-    const map = new Map<string, string>();
-    for (let i = 1; i <= 13; i++) map.set(`uid_${i}`, `User${i}`);
-    const result = buildMemberListPrefix(map);
+    const members: GroupMember[] = [];
+    for (let i = 1; i <= 13; i++) members.push(gm(`uid_${i}`, `User${i}`));
+    const result = buildMemberListPrefix(members);
     // points at the real octo_management action, not a vague "tool"
     expect(result).toContain("group-members");
     // real-form hex example anchor (32-hex), never the literal word "uid"
@@ -1597,9 +1615,9 @@ describe("buildMemberListPrefix", () => {
   });
 
   it(">10 branch carries the convert promise, single-colon, brackets and anti-patterns", () => {
-    const map = new Map<string, string>();
-    for (let i = 1; i <= 13; i++) map.set(`uid_${i}`, `User${i}`);
-    const result = buildMemberListPrefix(map);
+    const members: GroupMember[] = [];
+    for (let i = 1; i <= 13; i++) members.push(gm(`uid_${i}`, `User${i}`));
+    const result = buildMemberListPrefix(members);
     expect(result).toContain("I will convert");
     expect(result).toContain("ONE colon");
     expect(result).toContain("REQUIRED");
@@ -1610,9 +1628,9 @@ describe("buildMemberListPrefix", () => {
   });
 
   it("regression guard (test #13): >10 text parses to exactly ONE legal structured mention", () => {
-    const map = new Map<string, string>();
-    for (let i = 1; i <= 13; i++) map.set(`uid_${i}`, `User${i}`);
-    const result = buildMemberListPrefix(map);
+    const members: GroupMember[] = [];
+    for (let i = 1; i <= 13; i++) members.push(gm(`uid_${i}`, `User${i}`));
+    const result = buildMemberListPrefix(members);
     const parsed = parseStructuredMentions(result);
     expect(parsed.every((mtn) => mtn.uid !== "uid")).toBe(true);
     expect(parsed).toHaveLength(1);
@@ -1620,9 +1638,9 @@ describe("buildMemberListPrefix", () => {
   });
 
   it("≤10 and >10 branches share the MENTION_FORMAT_HINT core (no drift)", () => {
-    const small = new Map<string, string>([["uid_a", "Alice"], ["uid_b", "Bob"]]);
-    const large = new Map<string, string>();
-    for (let i = 1; i <= 13; i++) large.set(`uid_${i}`, `User${i}`);
+    const small = [gm("uid_a", "Alice"), gm("uid_b", "Bob")];
+    const large: GroupMember[] = [];
+    for (let i = 1; i <= 13; i++) large.push(gm(`uid_${i}`, `User${i}`));
     const core = "@[<uid>:<displayName>]";
     expect(buildMemberListPrefix(small)).toContain(core);
     expect(buildMemberListPrefix(large)).toContain(core);

--- a/src/inbound.ts
+++ b/src/inbound.ts
@@ -21,6 +21,7 @@ const isReplyPayloadNonTerminalToolErrorWarning =
     : undefined;
 const resolveSendableOutboundReplyParts = replyPayloadSdk.resolveSendableOutboundReplyParts;
 import { sendMessage, sendReadReceipt, sendTyping, getChannelMessages, getGroupMembers, getGroupMd, postJson, sendMediaMessage, inferContentType, ensureTextCharset, parseImageDimensions, parseImageDimensionsFromFile, getUploadPresign, uploadFileToPresignedUrl, fetchUserInfo } from "./api-fetch.js";
+import type { GroupMember } from "./api-fetch.js";
 import { getMentionPrefFromCache, invalidateMentionPref } from "./mention-prefs.js";
 import { normalizeAccountId } from "./account-id.js";
 import type { ResolvedOctoAccount } from "./accounts.js";
@@ -1259,12 +1260,17 @@ async function refreshGroupMemberCache(opts: {
   // gate to suppress relaxation for ANY bot sender — including cross-process /
   // external bots this plugin never registered via registerKnownBot().
   memberRobotMap?: Map<string, boolean>;
+  // parent groupNo -> current group's roster (#125). When provided,
+  // refreshGroupMemberCache writes the freshly-fetched current-group roster
+  // here on success and deletes the entry on empty/failure (negative cache),
+  // so a stale roster is never re-injected into prompt context.
+  currentGroupMembersMap?: Map<string, GroupMember[]>;
   apiUrl: string;
   botToken: string;
   forceRefresh?: boolean;
   log?: ChannelLogSink;
 }): Promise<boolean> {
-  const { sessionId, memberMap, uidToNameMap, groupCacheTimestamps, memberRobotMap, apiUrl, botToken, log } = opts;
+  const { sessionId, memberMap, uidToNameMap, groupCacheTimestamps, memberRobotMap, currentGroupMembersMap, apiUrl, botToken, log } = opts;
   const forceRefresh = opts.forceRefresh ?? false;
 
   const lastFetched = groupCacheTimestamps.get(sessionId) ?? 0;
@@ -1309,15 +1315,22 @@ async function refreshGroupMemberCache(opts: {
         }
       }
       groupCacheTimestamps.set(sessionId, now);
+      // Cache the current group's roster (only this group's members) for the
+      // member-context prompt, keyed by parent groupNo (#125).
+      currentGroupMembersMap?.set(sessionId, members);
       log?.info?.(`octo: [CACHE] Loaded ${members.length} members, memberMap size: ${memberMap.size}`);
       return true;
     } else {
       groupCacheTimestamps.set(sessionId, now - GROUP_CACHE_EXPIRY_MS + 30000);
+      // Negative cache: drop any stale roster so we never re-inject it.
+      currentGroupMembersMap?.delete(sessionId);
       log?.warn?.(`octo: [CACHE] No members returned for group ${sessionId}, backoff 30s`);
       return false;
     }
   } catch (err) {
     groupCacheTimestamps.set(sessionId, now - GROUP_CACHE_EXPIRY_MS + 30000);
+    // Negative cache on failure: drop any stale roster.
+    currentGroupMembersMap?.delete(sessionId);
     log?.error?.(`octo: [CACHE] Failed to fetch group members: ${err}, backoff 30s`);
     return false;
   }
@@ -1349,22 +1362,21 @@ export function buildPersonaGroupSystemPrompt(
   );
 }
 
-export function buildMemberListPrefix(uidToNameMap: Map<string, string>): string {
-  if (uidToNameMap.size === 0) return "";
+export function buildMemberListPrefix(members: GroupMember[]): string {
+  if (members.length === 0) return "";
 
-  if (uidToNameMap.size <= 10) {
-    const members = Array.from(uidToNameMap.entries());
+  if (members.length <= 10) {
     const memberLines = members
-      .map(([uid, name]) => `  ${name} (${uid})`)
+      .map((m) => `  ${m.name} (${m.uid})`)
       .join("\n");
     // 真实形态示例锚点用真名 + 真 uid（来自内联名单）；格式说明/anti-pattern
     // 取自共享常量，三处同源不 drift。占位槽用尖括号，避免示例本身被
     // STRUCTURED_MENTION_PATTERN 解析成非法 {uid:"uid"}。
-    return `[Group Members]\n${memberLines}\n\n${MENTION_FORMAT_HINT}\n(e.g. @[${members[0][0]}:${members[0][1]}]).\n\n`;
+    return `[Group Members]\n${memberLines}\n\n${MENTION_FORMAT_HINT}\n(e.g. @[${members[0].uid}:${members[0].name}]).\n\n`;
   }
 
   return (
-    `[Group Info] This group has ${uidToNameMap.size} members — too many to list here.\n` +
+    `[Group Info] This group has ${members.length} members — too many to list here.\n` +
     `To @mention someone, FIRST look up their real uid and display name with the ` +
     `group management tool (octo_management action="group-members", ` +
     `target="group:<groupId>"); it returns each member's { uid, name }.\n` +
@@ -1421,6 +1433,14 @@ export async function handleInboundMessage(params: {
   uidToNameMap: Map<string, string>;  // uid -> displayName mapping (reverse)
   groupCacheTimestamps: Map<string, number>;  // groupId -> lastFetchedAt
   memberRobotMap?: Map<string, boolean>;  // uid -> robot flag (server-authoritative)
+  // parent groupNo -> current group's roster. Optional: when omitted (e.g.
+  // existing tests) it falls back to a throwaway Map below — member context
+  // still works WITHIN a single call (the refresh writes the roster, the
+  // prompt-build read reads it back), and only degrades to empty across calls
+  // (a cache-hit that skips refresh has nothing in the throwaway map). The
+  // persistent per-account map (real channel call site) enables cross-call
+  // reuse. (#125)
+  currentGroupMembersMap?: Map<string, GroupMember[]>;
   groupMdCache?: Map<string, { content: string; version: number }>;
   log?: ChannelLogSink;
   statusSink?: OctoStatusSink;
@@ -1430,6 +1450,9 @@ export async function handleInboundMessage(params: {
   // omits it so the gate logic below can read it unconditionally; the real
   // channel call site passes a persistent per-account map.
   const memberRobotMap = params.memberRobotMap ?? new Map<string, boolean>();
+  // Current-group roster cache (per-account, keyed by parent groupNo). Same
+  // fallback pattern as memberRobotMap so omitting it is harmless.
+  const currentGroupMembersMap = params.currentGroupMembersMap ?? new Map<string, GroupMember[]>();
 
   // Detect GROUP.md update/delete notification — refresh both memory + disk cache, do NOT pass to LLM
   const earlyEventType = (message.payload as any)?.event?.type;
@@ -1697,7 +1720,7 @@ export async function handleInboundMessage(params: {
     ? extractParentGroupNo(message.channel_id!)
     : sessionId;
   if (isGroup) {
-    await refreshGroupMemberCache({ sessionId: memberCacheGroupNo, memberMap, uidToNameMap, groupCacheTimestamps, memberRobotMap, apiUrl: account.config.apiUrl, botToken: account.config.botToken ?? "", log });
+    await refreshGroupMemberCache({ sessionId: memberCacheGroupNo, memberMap, uidToNameMap, groupCacheTimestamps, memberRobotMap, currentGroupMembersMap, apiUrl: account.config.apiUrl, botToken: account.config.botToken ?? "", log });
   }
 
   // --- Mention gating for group messages ---
@@ -2125,7 +2148,14 @@ export async function handleInboundMessage(params: {
 
   // memberListPrefix and historyPrefix are injected via before_prompt_build hook
   // (not persisted to session history). Only quotePrefix stays in Body.
-  const memberListPrefix = isGroup ? buildMemberListPrefix(uidToNameMap) : "";
+  // Use the CURRENT group's roster (per-group, keyed by parent groupNo), not the
+  // flat per-account uidToNameMap (which is the cross-group union) so the count
+  // and member list reflect this group only (#125). On fetch failure the entry
+  // is negative-cached (absent) → empty prefix, never a stale/foreign roster.
+  const currentGroupMembers = isGroup
+    ? (currentGroupMembersMap.get(memberCacheGroupNo) ?? [])
+    : [];
+  const memberListPrefix = isGroup ? buildMemberListPrefix(currentGroupMembers) : "";
   if (historyPrefix || memberListPrefix) {
     pendingInboundContext.set(route.sessionKey, { historyPrefix, memberListPrefix });
   }
@@ -2532,7 +2562,7 @@ export async function handleInboundMessage(params: {
 
         if (unresolvedNames.length > 0) {
           log?.info?.(`octo: [REPLY] ${unresolvedNames.length} unresolved names, force refreshing cache...`);
-          const refreshed = await refreshGroupMemberCache({ sessionId: memberCacheGroupNo, memberMap, uidToNameMap, groupCacheTimestamps, memberRobotMap, apiUrl: account.config.apiUrl, botToken: account.config.botToken ?? "", forceRefresh: true, log });
+          const refreshed = await refreshGroupMemberCache({ sessionId: memberCacheGroupNo, memberMap, uidToNameMap, groupCacheTimestamps, memberRobotMap, currentGroupMembersMap, apiUrl: account.config.apiUrl, botToken: account.config.botToken ?? "", forceRefresh: true, log });
           if (refreshed) {
             for (const { name, index } of unresolvedNames) {
               const uid = findUidByName(name, memberMap);


### PR DESCRIPTION
## 问题

群里 @bot 问「群成员几个人」时,bot 回答的人数远大于实际,并会把**不在本群**的成员说成本群成员。

- 真机:3 人群(齐乐 / caster-Q / mintest)被答成「4 个人,含 costest」,而 costest 属于该 bot 的**另一个群**。
- 线上反馈(#125):7 人群答 87 人、不到 20 人群答 500 多人。

## 根因

`buildMemberListPrefix` 把 **per-account 累积** 的 `uidToNameMap` 当成「本群名单」喂给 `[Group Members]` / 成员数 prompt。该 map 按 accountId 共享,被启动 prefetch + 每条 inbound 刷新**只 set、从不按群清理**地填充,因此它是 bot 待过的**所有群成员的并集**:人数虚高 + 跨群成员泄漏。

## 改动

- `refreshGroupMemberCache` 把本次拉到的**当前群名单**(已按 parent groupNo 取,线程 channelId 安全)写进一个新的 per-account `currentGroupMembersMap`;空返回 / fetch 失败时 `delete` 该条目(负缓存),避免再注入过期或外群名单。
- `buildMemberListPrefix` 改为接收当前群 `GroupMember[]`,而非累积 map。
- `cleanupStaleCaches` 同步清理新缓存,与 `groupCacheTimestamps` 共用 raw channel_id key、同生命周期(roster 与其时间戳同进同出)。
- **不动** `uidToNameMap` 的累积语义 —— sender-name 解析、@mention 解析仍依赖它跨群累积。

## 测试

- `buildMemberListPrefix` 单测改为传 `GroupMember[]`,新增跨群隔离用例。
- 新增 `inbound-member-roster.test.ts`:跨群隔离、失败负缓存、多账号隔离(端到端驱动真实 `handleInboundMessage`)。
- 变异测试验证负缓存用例有效(移除 delete 即变红),非恒过。
- `npm run type-check` + 全量 1131 测试通过。

## 真机验证

本地 gateway 替换为本分支构建的插件后,在原失败的多群场景复测,成员上下文不再混入外群成员。

Closes #125