### PR TITLE
fix(setup): accept app_ App Bot tokens in bind/setup validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Bot accounts are stored in `~/.openclaw/openclaw.json` under `channels.octo.acco
 
 Configuration fields per account:
 
-- `botToken` (required): Bot token from BotFather (`bf_` prefix)
+- `botToken` (required): Bot token. Either a User Bot token from BotFather (`bf_` prefix, full group + thread access) or an App Bot token from the Octo admin console (`app_` prefix, direct-message only — server-enforced).
 - `apiUrl` (required): Octo server REST API base URL (e.g. `https://your-server/api`). The default `http://localhost:8090/api` only works for a local Octo dev server with the standard `/api` mount.
 - `wsUrl` (optional): WebSocket URL. Auto-detected from `apiUrl` if omitted.
 - `cdnUrl` (optional): CDN base URL for media files

--- a/docs/superpowers/specs/2026-06-23-app-bot-bind-design.md
+++ b/docs/superpowers/specs/2026-06-23-app-bot-bind-design.md
@@ -1,0 +1,67 @@
+# 放行 App Bot token 绑定
+
+## 背景
+
+Octo 有两类 bot token,前缀不同,server 端鉴权与能力也不同:
+
+| 前缀 | 类型 | 私聊 | 群聊写 | Thread | OBO |
+|---|---|---|---|---|---|
+| `bf_*` | User Bot(BotFather `/newbot`) | ✅ | ✅ | ✅ | ✅ |
+| `app_*` | App Bot(Admin 后台「应用 Bot」) | ✅ | ❌ | ❌ | ❌ |
+
+App Bot 的能力限制由 **server 强制**(`octo-server/modules/bot_api/`:`auth.go` 按前缀分流到不同鉴权路径,`send.go` / `threads.go` / `groups.go` 对 `BotKindApp` 显式拒绝群/thread/OBO 操作)。私聊(DM)对 App Bot 是放行的。
+
+当前插件 CLI 在两处把 token 前缀硬校验成必须 `bf_`:
+
+- `src/channel.ts:554`(交互式 wizard `finalize` 的 `validate`)
+- `src/channel.ts:585`(非交互式 `octoSetupAdapter.validateInput`)
+
+导致用户拿 Admin 后台 App Bot 的 `app_` token 走 `openclaw channels add` 时被 CLI 直接拒,报 `Bot token must start with 'bf_'` —— 用户连绑定都做不了,即使他只想要一个**私聊场景**的 Agent(App Bot 的私聊能力对此完全够用)。
+
+## 目标
+
+放行 `app_` token 通过 CLI 绑定。绑定成功后,这个 bot 的能力边界(私聊可用、群/thread 不可用)**完全由 server 决定**,插件不复制 server 的权限逻辑。
+
+## 非目标
+
+- **不**在插件侧感知 bot 类型、不为 App Bot 做群场景降级分支 —— 那是 server 的职责,在插件里抄一份权限判断会造成双写、易漂移。
+- **不**改 server 解除 App Bot 的 DM-only 限制 —— 那是产品/安全决策,不在本次范围。
+- **不**改 Admin 后台连接指南(包名过时、对 App Bot 误推 Agent 指南)—— 归 admin 侧,本次只解决「CLI 拒绝绑定」这一插件侧问题。
+
+## 设计
+
+把两处校验从「必须 `bf_`」放宽为「**`bf_` 或 `app_`,且长度 > 13**」,其余仍拒(挡掉空串、半截字符串、误粘的 API key 如 `uk_...` 等明显错误输入)。报错文案相应更新,并提示两种合法前缀及各自来源。
+
+### 改动点
+
+1. **`src/channel.ts:554-556`**(交互式 wizard `validate`)
+   - 校验:`if (!(v.startsWith("bf_") || v.startsWith("app_")) || v.length <= 13)`
+   - 文案:说明 `bf_`(BotFather `/newbot` 建的 User Bot,全功能)/ `app_`(Admin 后台 App Bot,仅私聊)两种均可。
+
+2. **`src/channel.ts:585-587`**(非交互式 `validateInput`)
+   - 校验:同上,前缀集合从 `{bf_}` 扩为 `{bf_, app_}`。
+   - 文案:同步更新。
+
+3. **文案点**(纯展示,去掉「只有 bf_」的暗示,改为前缀无关或并列):
+   - `src/channel.ts:524` `"Octo: needs bot token (bf_*)"` → 去掉 `(bf_*)` 限定,如 `"Octo: needs bot token"`。
+   - `src/channel.ts:548` `message: "Bot token (bf_*)"` → `"Bot token (bf_* or app_*)"`。
+   - `src/channel.ts:549` `placeholder: "bf_..."` → 保持 `bf_...`(User Bot 是推荐的全功能形态,占位符给主路径即可)或 `bf_... / app_...`。占位符选择在实现时定,不影响校验。
+
+### 不改
+
+- `src/api-fetch.ts:928`、`src/thread-binding-adapter.ts:114` 的 `bf_...` 是说明性注释,描述 token 一般形态,非校验,保留。
+- token 一律以 `Bearer <token>` 发给 server,鉴权与能力判断在 server,本次不动。
+
+## 测试
+
+`src/channel.test.ts`(或就近测试文件)新增/调整:
+
+- `app_` 前缀且长度 > 13 的 token → `validateInput` 返回 `undefined`(放行)。
+- `bf_` 前缀仍放行(回归保护)。
+- 非法输入仍拒:空串、`app_`/`bf_` 但长度 ≤ 13、其他前缀(如 `uk_xxx`)、非字符串。
+- 交互式 wizard 的 `validate` 同等覆盖(`app_` 放行、短串/错前缀拒)。
+
+## 影响面 / 风险
+
+- 用户若把 App Bot 拉进群并 @它,server 会返回 `app_bot_dm_only` 类错误;这是 server 既有行为,且是正确的能力反馈,不属于本次回归。插件如实透传 server 报错即可。
+- 不引入 child_process、不新增依赖、不动发布链路。

--- a/src/channel.test.ts
+++ b/src/channel.test.ts
@@ -1065,11 +1065,11 @@ describe("octoSetupAdapter.validateInput token prefix", () => {
     // App Bot tokens (Admin 后台「应用 Bot」) are DM-only on the server side,
     // but the CLI must let them bind — the capability boundary is the server's
     // call, not the adapter's.
-    expect(validate({ botToken: "app_f33a87e108015aec1b6ad4410afebd82" })).toBeUndefined();
+    expect(validate({ botToken: "app_EXAMPLE_dummy_app_bot_token" })).toBeUndefined();
   });
 
   it("accepts app_ token via the `token` alias field", () => {
-    expect(validate({ token: "app_f33a87e108015aec1b6ad4410afebd82" })).toBeUndefined();
+    expect(validate({ token: "app_EXAMPLE_dummy_app_bot_token" })).toBeUndefined();
   });
 
   it("rejects an unknown prefix", () => {

--- a/src/channel.test.ts
+++ b/src/channel.test.ts
@@ -1058,7 +1058,7 @@ describe("octoSetupAdapter.validateInput token prefix", () => {
   });
 
   it("accepts a bf_ User Bot token", () => {
-    expect(validate({ botToken: "bf_0123456789abcdef" })).toBeUndefined();
+    expect(validate({ botToken: "bf_dummy_user_bot_token" })).toBeUndefined();
   });
 
   it("accepts an app_ App Bot token", () => {
@@ -1073,7 +1073,7 @@ describe("octoSetupAdapter.validateInput token prefix", () => {
   });
 
   it("rejects an unknown prefix", () => {
-    expect(validate({ botToken: "uk_0123456789abcdef" })).toBeTruthy();
+    expect(validate({ botToken: "uk_dummy_unknown_prefix" })).toBeTruthy();
   });
 
   it("rejects a too-short token even with a valid prefix", () => {

--- a/src/channel.test.ts
+++ b/src/channel.test.ts
@@ -1048,3 +1048,45 @@ describe("outbound.sendText — P0-1 member prefetch", () => {
     expect(call.mentionEntities).toBeUndefined();
   });
 });
+
+describe("octoSetupAdapter.validateInput token prefix", () => {
+  let validate: (input: any) => string | undefined;
+  beforeEach(async () => {
+    const { octoPlugin } = await import("./channel.js");
+    validate = (input: any) =>
+      (octoPlugin.setup as any).validateInput({ accountId: "test", input });
+  });
+
+  it("accepts a bf_ User Bot token", () => {
+    expect(validate({ botToken: "bf_0123456789abcdef" })).toBeUndefined();
+  });
+
+  it("accepts an app_ App Bot token", () => {
+    // App Bot tokens (Admin 后台「应用 Bot」) are DM-only on the server side,
+    // but the CLI must let them bind — the capability boundary is the server's
+    // call, not the adapter's.
+    expect(validate({ botToken: "app_f33a87e108015aec1b6ad4410afebd82" })).toBeUndefined();
+  });
+
+  it("accepts app_ token via the `token` alias field", () => {
+    expect(validate({ token: "app_f33a87e108015aec1b6ad4410afebd82" })).toBeUndefined();
+  });
+
+  it("rejects an unknown prefix", () => {
+    expect(validate({ botToken: "uk_0123456789abcdef" })).toBeTruthy();
+  });
+
+  it("rejects a too-short token even with a valid prefix", () => {
+    expect(validate({ botToken: "app_short" })).toBeTruthy();
+    expect(validate({ botToken: "bf_short" })).toBeTruthy();
+  });
+
+  it("rejects an empty / non-string token", () => {
+    expect(validate({ botToken: "" })).toBeTruthy();
+    expect(validate({ botToken: 123 })).toBeTruthy();
+  });
+
+  it("skips validation when no token field is present", () => {
+    expect(validate({ baseUrl: "https://im.example.com/api" })).toBeUndefined();
+  });
+});

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -477,6 +477,26 @@ const meta = {
 
 const ACCOUNT_ID_RE = /^[A-Za-z0-9_]+$/;
 
+// Two token prefixes bind through this channel:
+//   bf_*  — User Bot (BotFather /newbot): full group + thread + OBO access.
+//   app_* — App Bot (Admin 后台「应用 Bot」): DM-only, server-enforced.
+// The CLI's job is to let either bind; the capability boundary is enforced
+// server-side (octo-server bot_api rejects App Bot group/thread/OBO calls),
+// so we must not reject app_ here just because it can't do everything bf_ can.
+const BOT_TOKEN_PREFIXES = ["bf_", "app_"] as const;
+const BOT_TOKEN_ERROR =
+  "Bot token must start with 'bf_' (BotFather /newbot) or 'app_' (Admin App Bot) and be longer than 13 chars.";
+
+function isValidBotToken(v: unknown): v is string {
+  return (
+    typeof v === "string" &&
+    !!v.trim() &&
+    BOT_TOKEN_PREFIXES.some((p) => v.startsWith(p)) &&
+    v.length > 13
+  );
+}
+
+
 function setOctoAccountConfig(
   cfg: OpenClawConfig,
   accountId: string,
@@ -521,7 +541,7 @@ const octoSetupWizard = {
       return account.configured;
     },
     resolveStatusLines: async ({ cfg, accountId, configured }: { cfg: OpenClawConfig; accountId?: string; configured: boolean }) => {
-      if (!configured) return ["Octo: needs bot token (bf_*)"];
+      if (!configured) return ["Octo: needs bot token (bf_* or app_*)"];
       const account = resolveOctoAccount({ cfg, accountId: accountId ?? DEFAULT_ACCOUNT_ID });
       return [`Octo: configured (api: ${account.config.apiUrl})`];
     },
@@ -545,15 +565,13 @@ const octoSetupWizard = {
     const existing = resolveOctoAccount({ cfg, accountId });
 
     const botToken = await prompter.text({
-      message: "Bot token (bf_*)",
-      placeholder: "bf_...",
+      message: "Bot token (bf_* or app_*)",
+      placeholder: "bf_... or app_...",
       initialValue: existing.config.botToken ?? "",
       sensitive: true,
       validate: (v: string) => {
         if (!v || !v.trim()) return "Bot token is required.";
-        if (!v.startsWith("bf_") || v.length <= 13) {
-          return "Bot token must start with 'bf_'. Create one via /newbot in Octo BotFather.";
-        }
+        if (!isValidBotToken(v)) return BOT_TOKEN_ERROR;
         return undefined;
       },
     });
@@ -582,8 +600,8 @@ const octoSetupAdapter = {
     }
     const botToken = input.botToken ?? input.token;
     if (botToken !== undefined) {
-      if (typeof botToken !== "string" || !botToken.trim() || !botToken.startsWith("bf_") || botToken.length <= 13) {
-        return "Bot token must start with 'bf_' and be longer than 13 chars.";
+      if (!isValidBotToken(botToken)) {
+        return BOT_TOKEN_ERROR;
       }
     }
     const apiUrl = input.baseUrl ?? input.url ?? input.httpUrl;

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -620,7 +620,7 @@ const octoSetupAdapter = {
     // to DEFAULT_API_URL = "http://localhost:8090/api"), so the trailing ??
     // never fires in practice but is kept as a belt-and-suspenders default.
     const apiUrl = (input.baseUrl ?? input.url ?? input.httpUrl ?? existing.config.apiUrl).trim();
-    if (!botToken) throw new Error("Bot token is required. Pass --bot-token bf_xxx or --token bf_xxx.");
+    if (!botToken) throw new Error("Bot token is required. Pass --bot-token bf_xxx (or app_xxx) — also accepted via --token.");
     return setOctoAccountConfig(cfg, accountId, botToken, apiUrl);
   },
 };


### PR DESCRIPTION
## 背景

Octo 有两类 bot token:`bf_*`(BotFather `/newbot` 建的 User Bot,全功能)与 `app_*`(Admin 后台「应用 Bot」,server 端限制为 DM-only)。

setup / bind 的 token 校验此前**只接受 `bf_`**,对 `app_` 一律拒绝(`Bot token must start with 'bf_'`)。用户照着 Admin 后台「连接指南」拿 App Bot 的 `app_` token 绑定时,连绑都绑不上 —— 即使他只需要一个私聊场景的 Agent(App Bot 的私聊能力对此足够)。

关联反馈:Mininglamp-OSS/octo-adapters#129

## 改动

- token 前缀白名单从 `{bf_}` 放宽到 `{bf_, app_}`,抽到共享 helper `isValidBotToken`,交互式 wizard 与非交互式 setup adapter 共用,避免两处判断漂移。
- 同步更新 prompt / status / 报错文案,说明两种合法前缀及来源。
- 仍挡掉空串、非字符串、长度不足、未知前缀(如误粘的 `uk_` API key)等明显错误输入。

## 设计取舍

token 的能力边界由 **server 强制**(octo-server `bot_api` 按前缀分流鉴权,对 App Bot 的群/thread/OBO 调用显式拒绝)。因此客户端校验**不应**替 server 预先拒绝 `app_` —— 绑上后能做什么由 server 说了算。插件不复制 server 的权限逻辑(不为 App Bot 写群场景降级分支),保持单一职责。

非目标:不改 server 解除 App Bot 限制;不改 Admin 连接指南(包名过时 / 误推 Agent 指南,归 admin 侧)。

## 测试

`src/channel.test.ts` 新增 `validateInput` 前缀用例:`app_` / `bf_` 放行、`token` 别名字段、未知前缀拒、短串拒、空/非字符串拒、无 token 字段跳过。

全量 `npm test`(1138 passed)+ `npm run type-check` 通过。

设计文档:`docs/superpowers/specs/2026-06-23-app-bot-bind-design.md`