### PR TITLE
feat(fork): /fork command — create child thread with parent context

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -148,6 +148,22 @@
             "type": "number",
             "minimum": 1000,
             "description": "Per-inbound dispatch timeout in milliseconds (infrastructure backstop that releases the per-group queue when an upstream dispatch hangs). When unset, derived from agents.defaults.timeoutSeconds (default 600) as timeoutSeconds*1000 + 60000, so it always fires after the agent-run timeout. Set explicitly only when you need to decouple it from the agent timeout."
+          },
+          "commands": {
+            "type": "object",
+            "properties": {
+              "fork": {
+                "type": "object",
+                "properties": {
+                  "scope": {
+                    "type": "string",
+                    "enum": ["owner-mentioned", "any-mentioned", "owner-only", "any"],
+                    "default": "owner-mentioned",
+                    "description": "Authorization scope for the /fork command. v1 honors only the default (owner-mentioned); wiring inbound to read a configured value is a v1.1 TODO. The enum accepts all four values so a future config does not fail validation today."
+                  }
+                }
+              }
+            }
           }
         }
       }

--- a/src/api-fetch.test.ts
+++ b/src/api-fetch.test.ts
@@ -2084,3 +2084,54 @@ describe("resolveTargetsByName", () => {
     expect(result.truncated).toBe(true);
   });
 });
+
+describe("httpStatusFromApiFetchError", () => {
+  it("extracts the 3-digit status from a `failed (NNN)` message", async () => {
+    const { httpStatusFromApiFetchError } = await import("./api-fetch.js");
+    expect(httpStatusFromApiFetchError(new Error("getThreadMd failed (404): not found"))).toBe(404);
+    expect(httpStatusFromApiFetchError(new Error("updateThreadMd failed (403): denied"))).toBe(403);
+  });
+
+  it("returns undefined when there is no embedded status (e.g. network timeout)", async () => {
+    const { httpStatusFromApiFetchError } = await import("./api-fetch.js");
+    expect(httpStatusFromApiFetchError(new Error("network timeout"))).toBeUndefined();
+  });
+
+  it("returns undefined for a non-Error throw", async () => {
+    const { httpStatusFromApiFetchError } = await import("./api-fetch.js");
+    expect(httpStatusFromApiFetchError("just a string")).toBeUndefined();
+  });
+
+  it("matches the messages thrown by the api-fetch helpers (format SSOT)", async () => {
+    const { httpStatusFromApiFetchError, API_FETCH_STATUS_RE } = await import("./api-fetch.js");
+    // Mirrors the real throw format in getThreadMd/getGroupMd/updateThreadMd.
+    expect(API_FETCH_STATUS_RE.test("getGroupMd failed (500): boom")).toBe(true);
+    expect(httpStatusFromApiFetchError(new Error("getGroupMd failed (500): boom"))).toBe(500);
+  });
+
+  it("parses the status from a REAL getThreadMd throw (end-to-end format guard, S1)", async () => {
+    // Unlike the hand-written cases above, this drives the actual getThreadMd
+    // throw path so the test breaks if api-fetch.ts:657's throw format ever
+    // drifts away from `failed (NNN)` and the SSOT regex silently stops matching.
+    const originalFetch = global.fetch;
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 404,
+      statusText: "Not Found",
+      text: async () => "thread md not found",
+    }) as unknown as typeof fetch;
+    try {
+      const { getThreadMd, httpStatusFromApiFetchError } = await import("./api-fetch.js");
+      let caught: unknown;
+      try {
+        await getThreadMd({ apiUrl: "http://octo.test", botToken: "bf_tok", groupNo: "G1", shortId: "P1" });
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBeInstanceOf(Error);
+      expect(httpStatusFromApiFetchError(caught)).toBe(404);
+    } finally {
+      global.fetch = originalFetch;
+    }
+  });
+});

--- a/src/api-fetch.ts
+++ b/src/api-fetch.ts
@@ -43,6 +43,30 @@ function parseOctoJson<T>(text: string): T {
   return JSON.parse(safeText) as T;
 }
 
+/**
+ * Regex matching the `failed (<status>)` fragment in this module's thrown error
+ * messages. Single source of truth for the throw format so external parsers do
+ * not hardcode their own copy. See {@link httpStatusFromApiFetchError}.
+ */
+export const API_FETCH_STATUS_RE = /failed \((\d{3})\)/;
+
+/**
+ * Extract the HTTP status from an api-fetch error. The fetch helpers here throw
+ * `Error("<who> failed (<status>): <text>")` on non-2xx, so the status is only
+ * recoverable from the message. Centralizing the parse here means a caller (e.g.
+ * fork-inherit-md) does not couple to the throw format, and a future format
+ * change only needs updating in this module.
+ *
+ * @returns The 3-digit status, or undefined for errors without an embedded
+ *   `(NNN)` (e.g. a network timeout, or a non-Error throw) — callers treat that
+ *   as a generic failure.
+ */
+export function httpStatusFromApiFetchError(err: unknown): number | undefined {
+  const message = err instanceof Error ? err.message : String(err);
+  const match = message.match(API_FETCH_STATUS_RE);
+  return match ? Number(match[1]) : undefined;
+}
+
 export async function postJson<T>(
   apiUrl: string,
   botToken: string,

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -5,8 +5,8 @@ import type {
 } from "openclaw/plugin-sdk";
 import type { ChannelOutboundContext } from "openclaw/plugin-sdk/channel-contract";
 import { DEFAULT_ACCOUNT_ID } from "./sdk-compat.js";
-import { OctoConfigJsonSchema } from "./config-schema.js";
-import { CHANNEL_ID, MAX_UPLOAD_SIZE, stripAllChannelPrefixes } from "./constants.js";
+import { OctoConfigJsonSchema, type OctoConfig } from "./config-schema.js";
+import { CHANNEL_ID, MAX_UPLOAD_SIZE, stripAllChannelPrefixes, getChannelConfig } from "./constants.js";
 import { streamToFileWithCap } from "./stream-helpers.js";
 import {
   listOctoAccountIds,
@@ -17,6 +17,7 @@ import {
 import { registerBot, sendMessage, sendHeartbeat, sendMediaMessage, inferContentType, ensureTextCharset, fetchBotGroups, getGroupMd, parseImageDimensions, parseImageDimensionsFromFile, getUploadPresign, uploadFileToPresignedUrl } from "./api-fetch.js";
 import { PLUGIN_VERSION } from "./version.js";
 import { getOctoRuntime } from "./runtime.js";
+import { forkScopeStartupWarning } from "./commands/fork.js";
 
 /** Get OpenClaw host version from PluginRuntime.version (provided by SDK). */
 function getAgentVersion(): string {
@@ -1105,6 +1106,18 @@ export const octoPlugin: ChannelPlugin<ResolvedOctoAccount> = {
             `octo: detected ${mixedCount} mixed-case Octo accountId(s); internal storage normalized (see openclaw-channel-octo#33)`,
           );
         }
+      } catch { /* config snapshot inaccessible — non-fatal */ }
+
+      // F3 (PR #131 review, Octo-Q): `commands.fork.scope` accepts four values in
+      // the schema, but v1's fork hook only honors the default "owner-mentioned"
+      // (wiring inbound to a configured value is a v1.1 TODO). Warn once per
+      // account at startup if an operator set a non-default value, so it is not
+      // silently ignored. Same one-shot granularity as the mixed-case audit above.
+      try {
+        const warning = forkScopeStartupWarning(
+          getChannelConfig<OctoConfig>(ctx.cfg).commands?.fork?.scope,
+        );
+        if (warning) log?.warn?.(warning);
       } catch { /* config snapshot inaccessible — non-fatal */ }
 
       log?.info?.(`[${account.accountId}] registering Octo bot...`);

--- a/src/commands/fork-history-filter.test.ts
+++ b/src/commands/fork-history-filter.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import { isForkCommandHistoryMessage } from "./fork-history-filter.js";
+
+describe("isForkCommandHistoryMessage", () => {
+  describe("matches /fork commands", () => {
+    it("`/fork hello` (no @prefix, not mentioned) → true", () => {
+      expect(isForkCommandHistoryMessage("/fork hello", false)).toBe(true);
+    });
+
+    it("`@Max /fork hello` (mentioned) → true", () => {
+      expect(isForkCommandHistoryMessage("@Max /fork hello", true)).toBe(true);
+    });
+
+    it("`@Max /fork` (empty prompt, mentioned) → true", () => {
+      expect(isForkCommandHistoryMessage("@Max /fork", true)).toBe(true);
+    });
+
+    it("`@Max /fork   ` (whitespace-only prompt, mentioned) → true", () => {
+      expect(isForkCommandHistoryMessage("@Max /fork   ", true)).toBe(true);
+    });
+
+    it("bare `/fork` (no @prefix) → true", () => {
+      expect(isForkCommandHistoryMessage("/fork", false)).toBe(true);
+    });
+  });
+
+  describe("rejects non-fork messages", () => {
+    it("`@Max hello /fork world` (fork not at start) → false", () => {
+      expect(isForkCommandHistoryMessage("@Max hello /fork world", true)).toBe(false);
+    });
+
+    it("`@Max /forks hello` (prefix, not exact /fork) → false", () => {
+      expect(isForkCommandHistoryMessage("@Max /forks hello", true)).toBe(false);
+    });
+
+    it("`/forked` → false", () => {
+      expect(isForkCommandHistoryMessage("/forked", false)).toBe(false);
+    });
+
+    it("`@Max /btw hello` (different command) → false", () => {
+      expect(isForkCommandHistoryMessage("@Max /btw hello", true)).toBe(false);
+    });
+
+    it("`@Max /Fork hello` (case-sensitive, /Fork ≠ /fork) → false", () => {
+      expect(isForkCommandHistoryMessage("@Max /Fork hello", true)).toBe(false);
+    });
+
+    it("ordinary group message → false", () => {
+      expect(isForkCommandHistoryMessage("今天天气如何", false)).toBe(false);
+    });
+
+    it("empty body → false", () => {
+      expect(isForkCommandHistoryMessage("", false)).toBe(false);
+    });
+  });
+
+  describe("mention gating mirrors the live command path", () => {
+    // When the bot was NOT explicitly mentioned, the @prefix is NOT stripped,
+    // so `@Max /fork x` stays as-is and does not parse as a fork command — same
+    // as resolveCommandBody's behavior on the inbound hot path.
+    it("`@Max /fork hello` with isExplicitBotMention=false → false (no strip)", () => {
+      expect(isForkCommandHistoryMessage("@Max /fork hello", false)).toBe(false);
+    });
+  });
+});

--- a/src/commands/fork-history-filter.ts
+++ b/src/commands/fork-history-filter.ts
@@ -1,0 +1,44 @@
+// `/fork` history-leak filter.
+//
+// The fork hook (inbound.ts, handleForkCommandIfMatched) keeps a /fork command
+// out of the bot's OWN session: it early-returns before
+// finalizeInboundContext / recordInboundSession. But it does NOT cover the
+// other path by which a /fork command can re-enter the bot's context: when the
+// bot is later @mentioned and inbound.ts backfills group history from
+// `getChannelMessages` (or its in-memory `groupHistories` cache), a prior
+// `/fork ...` message would otherwise be injected into the historyPrefix and
+// become visible to the LLM.
+//
+// /fork commands are control-flow, not conversation — they must never appear in
+// the bot's ctx history. octo Bot API cannot delete the user's original /fork
+// message from the server, so this plugin-side filter is the mitigation: the
+// message stays visible to humans in the group UI, but is invisible to the bot.
+//
+// See docs/specs/2026-06-18-fork-command-design.md.
+
+import { resolveCommandBody } from "../inbound.js";
+import { parseForkCommand } from "./fork.js";
+
+/**
+ * Whether a group-history message body is a `/fork` command that must be
+ * excluded from historyPrefix injection.
+ *
+ * Mirrors the inbound command-split path: the raw body is first stripped of any
+ * leading `@bot ` prefix (only when the bot was explicitly mentioned, same as
+ * `resolveCommandBody`), then matched against the `/fork` grammar. Both a valid
+ * `/fork <prompt>` and a bare `/fork` (empty prompt) count as fork commands;
+ * anything else (`/forks`, `/btw`, `/Fork`, ordinary text) does not.
+ *
+ * @param rawBody Raw message body, possibly carrying a leading `@bot ` prefix.
+ * @param isExplicitBotMention Whether this history message explicitly @mentioned
+ *   the bot — gates the prefix strip exactly as the live command path does.
+ */
+export function isForkCommandHistoryMessage(
+  rawBody: string,
+  isExplicitBotMention: boolean,
+): boolean {
+  if (!rawBody) return false;
+  const stripped = resolveCommandBody(rawBody, /* isGroup */ true, isExplicitBotMention);
+  const parsed = parseForkCommand(stripped);
+  return parsed.ok || parsed.reason === "empty";
+}

--- a/src/commands/fork-inbound.test.ts
+++ b/src/commands/fork-inbound.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// DM hint path calls the real `sendMessage` (api-fetch); group paths go through
+// the injected mock orchestrator and never touch it. Mock so the DM test can
+// assert the hint without a live API.
+const { mockSendMessage } = vi.hoisted(() => ({ mockSendMessage: vi.fn(async () => ({})) }));
+vi.mock("../api-fetch.js", () => ({
+  sendMessage: mockSendMessage,
+  createThread: vi.fn(),
+}));
+
+import { handleForkCommandIfMatched, type BuildForkOrchestratorFn } from "./fork-inbound.js";
+import type { ForkOrchestrator } from "./fork.js";
+import { ChannelType } from "../types.js";
+
+const fixedNow = () => new Date("2026-06-22T10:20:30.123Z");
+
+function makeOrchestrator(overrides: Partial<ForkOrchestrator> = {}) {
+  const spawnChildBoundSession = vi.fn(async () => ({ childChannelId: "group123____new" }));
+  const sendParentReceipt = vi.fn(async () => {});
+  const orch: ForkOrchestrator = {
+    spawnChildBoundSession,
+    sendParentReceipt,
+    log: vi.fn(),
+    ...overrides,
+  };
+  const build: BuildForkOrchestratorFn = vi.fn(() => orch);
+  return { orch, build, spawnChildBoundSession, sendParentReceipt };
+}
+
+const base = {
+  commandAuthorized: true,
+  isGroup: true,
+  parentChannelId: "group123",
+  parentChannelType: ChannelType.Group,
+  parentSessionKey: "octo:acct1:group123",
+  accountId: "acct1",
+  apiUrl: "https://api.test",
+  botToken: "bf_tok",
+  requesterUid: "user_hash",
+  requesterName: "刘建辉",
+  config: {} as never,
+  now: fixedNow,
+  log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } as never,
+};
+
+describe("handleForkCommandIfMatched", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("non-fork message → false (falls through, nothing built)", async () => {
+    const { build, spawnChildBoundSession } = makeOrchestrator();
+    const handled = await handleForkCommandIfMatched({
+      ...base,
+      commandBody: "hello there",
+      buildOrchestrator: build,
+    });
+    expect(handled).toBe(false);
+    expect(build).not.toHaveBeenCalled();
+    expect(spawnChildBoundSession).not.toHaveBeenCalled();
+  });
+
+  it("/fork in a DM → true (hint sent, swallowed — never reaches the LLM)", async () => {
+    const { build } = makeOrchestrator();
+    const handled = await handleForkCommandIfMatched({
+      ...base,
+      isGroup: false,
+      commandBody: "/fork explain this",
+      buildOrchestrator: build,
+    });
+    expect(handled).toBe(true); // swallowed, not sent to LLM as ordinary text
+    expect(mockSendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ content: "/fork 仅在群聊中可用" }),
+    );
+    expect(build).not.toHaveBeenCalled(); // no thread spawned in a DM
+  });
+
+  it("/fork in a DM, sendMessage throws → still true (swallowed), error logged, never bubbles", async () => {
+    const { build } = makeOrchestrator();
+    mockSendMessage.mockRejectedValueOnce(new Error("network down"));
+    // If the throw bubbled, this await would reject and the test would fail —
+    // so resolving to `true` is itself the no-bubble assertion (I1).
+    const handled = await handleForkCommandIfMatched({
+      ...base,
+      isGroup: false,
+      commandBody: "/fork explain this",
+      buildOrchestrator: build,
+    });
+    expect(handled).toBe(true); // hint-send failure must not change swallow semantics
+    expect(
+      (base.log as unknown as { error: ReturnType<typeof vi.fn> }).error,
+    ).toHaveBeenCalledWith(expect.stringContaining("DM hint send failed"));
+    expect(build).not.toHaveBeenCalled();
+  });
+
+  it("non-fork text in a DM → false (normal DM conversation unaffected)", async () => {
+    const { build } = makeOrchestrator();
+    const handled = await handleForkCommandIfMatched({
+      ...base,
+      isGroup: false,
+      commandBody: "hello there",
+      buildOrchestrator: build,
+    });
+    expect(handled).toBe(false);
+    expect(mockSendMessage).not.toHaveBeenCalled();
+    expect(build).not.toHaveBeenCalled();
+  });
+
+  it("unauthorized /fork in group → true (swallowed), nothing built", async () => {
+    const { build, spawnChildBoundSession } = makeOrchestrator();
+    const handled = await handleForkCommandIfMatched({
+      ...base,
+      commandAuthorized: false,
+      commandBody: "/fork explain this",
+      buildOrchestrator: build,
+    });
+    expect(handled).toBe(true); // swallowed — never reaches the LLM
+    expect(build).not.toHaveBeenCalled();
+    expect(spawnChildBoundSession).not.toHaveBeenCalled();
+  });
+
+  it("authorized /fork → true, spawns child + sends receipt", async () => {
+    const { build, spawnChildBoundSession, sendParentReceipt } = makeOrchestrator();
+    const handled = await handleForkCommandIfMatched({
+      ...base,
+      commandBody: "/fork explain the bug",
+      buildOrchestrator: build,
+    });
+    expect(handled).toBe(true);
+    expect(spawnChildBoundSession).toHaveBeenCalledWith({
+      parentChannelId: "group123",
+      parentSessionKey: "octo:acct1:group123",
+      prompt: "explain the bug",
+      threadName: "explain the bug",
+    });
+    expect(sendParentReceipt).toHaveBeenCalledWith({ text: "已开 fork 子区：explain the bug" });
+  });
+
+  it("passes requester identity + clock into the orchestrator builder", async () => {
+    const { build } = makeOrchestrator();
+    await handleForkCommandIfMatched({
+      ...base,
+      commandBody: "/fork x",
+      buildOrchestrator: build,
+    });
+    expect(build).toHaveBeenCalledWith(
+      expect.objectContaining({
+        accountId: "acct1",
+        requesterUid: "user_hash",
+        requesterName: "刘建辉",
+        apiUrl: "https://api.test",
+        botToken: "bf_tok",
+      }),
+    );
+  });
+
+  it("empty `/fork` (authorized) → true, usage hint, no spawn", async () => {
+    const { build, spawnChildBoundSession, sendParentReceipt } = makeOrchestrator();
+    const handled = await handleForkCommandIfMatched({
+      ...base,
+      commandBody: "/fork",
+      buildOrchestrator: build,
+    });
+    expect(handled).toBe(true);
+    expect(spawnChildBoundSession).not.toHaveBeenCalled();
+    expect(sendParentReceipt).toHaveBeenCalledWith({ text: "用法：/fork <你的问题>" });
+  });
+
+  it("nested fork (parent is a thread) → handled; thread parentChannelId threaded through", async () => {
+    const { build, spawnChildBoundSession } = makeOrchestrator();
+    const handled = await handleForkCommandIfMatched({
+      ...base,
+      parentChannelId: "group123____parent",
+      parentChannelType: ChannelType.CommunityTopic,
+      parentSessionKey: "octo:acct1:group123____parent",
+      commandBody: "/fork dig deeper",
+      buildOrchestrator: build,
+    });
+    expect(handled).toBe(true);
+    // sibling-thread derivation (extractParentGroupNo) is covered in
+    // fork-runtime.test.ts; here we assert the thread channelId is passed through.
+    expect(spawnChildBoundSession).toHaveBeenCalledWith(
+      expect.objectContaining({ parentChannelId: "group123____parent" }),
+    );
+  });
+});

--- a/src/commands/fork-inbound.test.ts
+++ b/src/commands/fork-inbound.test.ts
@@ -35,6 +35,7 @@ const base = {
   parentChannelType: ChannelType.Group,
   parentSessionKey: "octo:acct1:group123",
   accountId: "acct1",
+  account: { config: {} } as never,
   apiUrl: "https://api.test",
   botToken: "bf_tok",
   requesterUid: "user_hash",

--- a/src/commands/fork-inbound.ts
+++ b/src/commands/fork-inbound.ts
@@ -33,6 +33,14 @@ import { ChannelType, type MentionEntity } from "../types.js";
 import { executeFork, parseForkCommand, type ForkLogger, type ForkOrchestrator } from "./fork.js";
 import { buildForkOrchestrator, type ForkRuntimeDeps, type ForkSeedContext } from "./fork-runtime.js";
 
+/**
+ * Bounded timeout for the parent-group receipt send (P2, yujiawei). The dispatch
+ * timeout only guards the seed dispatch; without this, a hung Octo API on the
+ * receipt POST would still strand the parent enqueueInbound serial queue. Mirrors
+ * the `AbortSignal.timeout(DISPATCH_TIMEOUT_APOLOGY_MS)` pattern in inbound.ts.
+ */
+const RECEIPT_SEND_TIMEOUT_MS = 30_000;
+
 /** Adapt the channel log sink to the {@link ForkLogger} signature. */
 function toForkLogger(log?: ChannelLogSink): ForkLogger {
   return (level, message, meta) => {
@@ -147,6 +155,12 @@ export async function dispatchForkSeedReply(params: {
 
   const buffer = { lastText: null as string | null };
   let delivered = false;
+  // P1 (Jerry-Xin): the SDK dispatcher routes deliver()/onError failures WITHOUT
+  // rejecting the outer promise, so a failed user-facing send would otherwise
+  // look like fork success and the user gets "已开 fork 子区" while the first
+  // reply never landed. Track delivery failure and convert it to a thrown error
+  // after settle → spawnChildBoundSession seedFailed → ok_seed_failed.
+  let deliverFailed = false;
   try {
     await Promise.race([
       core.channel.reply.dispatchReplyWithBufferedBlockDispatcher({
@@ -159,9 +173,15 @@ export async function dispatchForkSeedReply(params: {
             const content = payload.text?.trim() ?? "";
             if (!content) return;
             if (info.kind === "final" || info.kind === "tool") {
-              await sendSeedText(content);
-              delivered = true;
-              buffer.lastText = null;
+              try {
+                await sendSeedText(content);
+                delivered = true;
+                buffer.lastText = null;
+              } catch (sendErr) {
+                // User-facing answer failed to send → the seed did not land.
+                log?.error?.(`octo: [fork-seed] ${info.kind} send failed: ${String(sendErr)}`);
+                deliverFailed = true;
+              }
             } else {
               // block / other: buffer, flush once after the dispatcher settles
               buffer.lastText = content;
@@ -169,6 +189,10 @@ export async function dispatchForkSeedReply(params: {
           },
           onError: async (err: unknown, info: { kind: string }) => {
             log?.error?.(`octo: [fork-seed] ${info.kind} reply failed: ${String(err)}`);
+            // A final/tool error means the user-facing reply did not land.
+            if (info.kind === "final" || info.kind === "tool") {
+              deliverFailed = true;
+            }
           },
         },
       } as Parameters<typeof core.channel.reply.dispatchReplyWithBufferedBlockDispatcher>[0]),
@@ -199,6 +223,13 @@ export async function dispatchForkSeedReply(params: {
         );
       }
     }
+  }
+
+  // Settled without throwing, but a final/tool delivery may have failed silently
+  // (the SDK does not reject the outer promise for deliver/onError failures).
+  // Surface it so spawnChildBoundSession reports seedFailed → ok_seed_failed (P1).
+  if (deliverFailed) {
+    throw new Error("octo: [fork-seed] delivery failed: user-facing reply did not send");
   }
 }
 
@@ -296,6 +327,10 @@ export async function handleForkCommandIfMatched(params: {
         channelId: params.parentChannelId,
         channelType: params.parentChannelType,
         content: text,
+        // Bound the receipt POST so a hung Octo API cannot strand the parent
+        // enqueueInbound queue (P2). safeSendReceipt swallows the resulting
+        // timeout error, so the fork's main effect (thread + seed) still stands.
+        signal: AbortSignal.timeout(RECEIPT_SEND_TIMEOUT_MS),
       });
     },
     dispatchSeed: async (seedCtx) => {

--- a/src/commands/fork-inbound.ts
+++ b/src/commands/fork-inbound.ts
@@ -24,7 +24,9 @@ import type { ChannelLogSink } from "openclaw/plugin-sdk/channel-contract";
 import type { ReplyPayload, ReplyDispatchKind } from "openclaw/plugin-sdk/reply-runtime";
 
 import { sendMessage } from "../api-fetch.js";
+import type { ResolvedOctoAccount } from "../accounts.js";
 import { CHANNEL_ID } from "../constants.js";
+import { resolveDispatchTimeoutMs } from "../inbound.js";
 import { convertStructuredMentions, parseStructuredMentions } from "../mention-utils.js";
 import { getOctoRuntime } from "../runtime.js";
 import { ChannelType, type MentionEntity } from "../types.js";
@@ -70,12 +72,13 @@ export async function dispatchForkSeedReply(params: {
   seedCtx: ForkSeedContext;
   childChannelId: string;
   accountId: string;
+  account: ResolvedOctoAccount;
   apiUrl: string;
   botToken: string;
   config: OpenClawConfig;
   log?: ChannelLogSink;
 }): Promise<void> {
-  const { seedCtx, childChannelId, accountId, apiUrl, botToken, config, log } = params;
+  const { seedCtx, childChannelId, accountId, account, apiUrl, botToken, config, log } = params;
   const core = getOctoRuntime();
 
   const childRoute = core.channel.routing.resolveAgentRoute({
@@ -94,17 +97,23 @@ export async function dispatchForkSeedReply(params: {
     AccountId: childRoute.accountId ?? accountId,
   };
 
-  // Fork-trigger guard (S-1): get-reply only forks the parent transcript when
-  // ParentSessionKey !== SessionKey. If they coincide, the auto-fork silently
-  // does NOT trigger and the child starts without parent context. With octo's
-  // default per-thread routing the child channelId yields a distinct sessionKey,
-  // so this is only reachable on a user-defined group-merged route. Warn (do not
-  // block) so the signal is on record before dispatch; the runtime still decides.
+  // Fork-isolation guard (PR #131 review — upgraded from warn-only to
+  // fail-closed). get-reply only forks the parent transcript when
+  // ParentSessionKey !== SessionKey. If they coincide, the seed would run ON the
+  // parent session and pollute it — the exact outcome /fork promises to avoid.
+  // So we refuse to dispatch instead of warn-and-continue. Only reachable on a
+  // user-defined group-merged route (octo's default per-thread routing gives the
+  // child channelId a distinct sessionKey). The child thread already exists, so
+  // spawnChildBoundSession turns this throw into seedFailed → the user is told to
+  // resend in the now-live child thread.
   if (ctx.SessionKey === ctx.ParentSessionKey) {
     log?.warn?.(
-      `octo: [fork-seed] SessionKey === ParentSessionKey (${ctx.SessionKey}) for child ${childChannelId} — ` +
-        "runtime auto-fork will NOT trigger; child likely shares the parent session " +
-        "(only reachable on a user-defined group-merged route)",
+      `octo: [fork-seed] isolation guard: SessionKey === ParentSessionKey (${ctx.SessionKey}) ` +
+        `for child ${childChannelId} — refusing to dispatch (would pollute the parent session); ` +
+        "only reachable on a user-defined group-merged route",
+    );
+    throw new Error(
+      `fork isolation guard: child SessionKey collides with ParentSessionKey (${ctx.SessionKey})`,
     );
   }
 
@@ -122,35 +131,73 @@ export async function dispatchForkSeedReply(params: {
     });
   };
 
+  // Timeout guard (PR #131 Critical, issue #75). dispatchReplyWithBufferedBlock-
+  // Dispatcher is observed to occasionally hang forever (no resolve/reject/
+  // onError). This seed is awaited synchronously inside the parent group's
+  // enqueueInbound serial queue, so a bare await would lock that queue until the
+  // gateway restarts. Race against the same per-inbound timeout as the normal
+  // path (inbound.ts:2636) and rethrow on timeout so spawnChildBoundSession
+  // surfaces seedFailed and the parent queue can advance.
+  const dispatchTimeoutMs = resolveDispatchTimeoutMs(config, account);
+  let dispatchTimeoutHandle: ReturnType<typeof setTimeout> | undefined;
+  const timeoutError = new Error(`octo: [fork-seed] dispatch timed out after ${dispatchTimeoutMs}ms`);
+  const dispatchTimeoutPromise = new Promise<never>((_, reject) => {
+    dispatchTimeoutHandle = setTimeout(() => reject(timeoutError), dispatchTimeoutMs);
+  });
+
   const buffer = { lastText: null as string | null };
   let delivered = false;
   try {
-    await core.channel.reply.dispatchReplyWithBufferedBlockDispatcher({
-      ctx: ctxPayload,
-      cfg: config,
-      replyOptions: {},
-      dispatcherOptions: {
-        deliver: async (payload: ReplyPayload, info: { kind: ReplyDispatchKind }) => {
-          if (payload.isReasoning) return;
-          const content = payload.text?.trim() ?? "";
-          if (!content) return;
-          if (info.kind === "final" || info.kind === "tool") {
-            await sendSeedText(content);
-            delivered = true;
-            buffer.lastText = null;
-          } else {
-            // block / other: buffer, flush once after the dispatcher settles
-            buffer.lastText = content;
-          }
+    await Promise.race([
+      core.channel.reply.dispatchReplyWithBufferedBlockDispatcher({
+        ctx: ctxPayload,
+        cfg: config,
+        replyOptions: {},
+        dispatcherOptions: {
+          deliver: async (payload: ReplyPayload, info: { kind: ReplyDispatchKind }) => {
+            if (payload.isReasoning) return;
+            const content = payload.text?.trim() ?? "";
+            if (!content) return;
+            if (info.kind === "final" || info.kind === "tool") {
+              await sendSeedText(content);
+              delivered = true;
+              buffer.lastText = null;
+            } else {
+              // block / other: buffer, flush once after the dispatcher settles
+              buffer.lastText = content;
+            }
+          },
+          onError: async (err: unknown, info: { kind: string }) => {
+            log?.error?.(`octo: [fork-seed] ${info.kind} reply failed: ${String(err)}`);
+          },
         },
-        onError: async (err: unknown, info: { kind: string }) => {
-          log?.error?.(`octo: [fork-seed] ${info.kind} reply failed: ${String(err)}`);
-        },
-      },
-    } as Parameters<typeof core.channel.reply.dispatchReplyWithBufferedBlockDispatcher>[0]);
+      } as Parameters<typeof core.channel.reply.dispatchReplyWithBufferedBlockDispatcher>[0]),
+      dispatchTimeoutPromise,
+    ]);
+  } catch (err) {
+    if (err === timeoutError) {
+      log?.warn?.(
+        `octo: [fork-seed] dispatch hung past ${dispatchTimeoutMs}ms, aborting to unblock the ` +
+          `parent group queue (child=${childChannelId})`,
+      );
+      // Suppress stale buffered text so the finally-flush does not send a partial
+      // seed reply after we have already given up (mirrors inbound.ts:2797).
+      buffer.lastText = null;
+    }
+    throw err; // → spawnChildBoundSession catch → seedFailed: true
   } finally {
+    if (dispatchTimeoutHandle) clearTimeout(dispatchTimeoutHandle);
+    // P2-5: isolate the flush. If the dispatcher already threw, a flush failure
+    // must NOT replace the original error (it carries the root-cause signal).
+    // Log and swallow the flush error; never let it shadow the dispatch error.
     if (buffer.lastText && !delivered) {
-      await sendSeedText(buffer.lastText);
+      try {
+        await sendSeedText(buffer.lastText);
+      } catch (flushErr) {
+        log?.error?.(
+          `octo: [fork-seed] finally flush failed: ${flushErr instanceof Error ? flushErr.message : String(flushErr)}`,
+        );
+      }
     }
   }
 }
@@ -181,6 +228,7 @@ export async function handleForkCommandIfMatched(params: {
   parentChannelType: ChannelType;
   parentSessionKey: string;
   accountId: string;
+  account: ResolvedOctoAccount;
   apiUrl: string;
   botToken: string;
   requesterUid: string;
@@ -263,6 +311,7 @@ export async function handleForkCommandIfMatched(params: {
         seedCtx,
         childChannelId: seedCtx.GroupSubject,
         accountId: params.accountId,
+        account: params.account,
         apiUrl: params.apiUrl,
         botToken: params.botToken,
         config: params.config,

--- a/src/commands/fork-inbound.ts
+++ b/src/commands/fork-inbound.ts
@@ -1,0 +1,282 @@
+// `/fork` inbound wiring (stage 2).
+//
+// Two pieces, both kept out of inbound.ts's body so the production hot path
+// only gains a single `if (await handleForkCommandIfMatched(...)) return;`:
+//
+//   1. handleForkCommandIfMatched — the command splitter. Parses the command
+//      body; if it is not `/fork`, returns false so the normal inbound flow
+//      proceeds unchanged. If it is `/fork`, it is handled here (authorized →
+//      run the fork; unauthorized → silently swallowed per spec §3.3) and the
+//      caller early-returns BEFORE finalizeInboundContext / recordInboundSession
+//      / the dispatch main path — so a fork never writes the parent session or
+//      reaches the LLM on the parent conversation.
+//
+//   2. dispatchForkSeedReply — the "2B-minimal" seed dispatch seam (spec §5.2,
+//      decided in stage-2 review). It drives the child-thread reply directly via
+//      `dispatchReplyWithBufferedBlockDispatcher`, deliberately bypassing the
+//      inbound mention gate (inbound.ts:1858): the fork is an already-decided
+//      action, so it must NOT be re-litigated by the "should I respond?" gate.
+//
+// See docs/specs/2026-06-18-fork-command-design.md.
+
+import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import type { ChannelLogSink } from "openclaw/plugin-sdk/channel-contract";
+import type { ReplyPayload, ReplyDispatchKind } from "openclaw/plugin-sdk/reply-runtime";
+
+import { sendMessage } from "../api-fetch.js";
+import { CHANNEL_ID } from "../constants.js";
+import { convertStructuredMentions, parseStructuredMentions } from "../mention-utils.js";
+import { getOctoRuntime } from "../runtime.js";
+import { ChannelType, type MentionEntity } from "../types.js";
+import { executeFork, parseForkCommand, type ForkLogger, type ForkOrchestrator } from "./fork.js";
+import { buildForkOrchestrator, type ForkRuntimeDeps, type ForkSeedContext } from "./fork-runtime.js";
+
+/** Adapt the channel log sink to the {@link ForkLogger} signature. */
+function toForkLogger(log?: ChannelLogSink): ForkLogger {
+  return (level, message, meta) => {
+    const line = meta ? `${message} ${JSON.stringify(meta)}` : message;
+    const sink = log?.[level] ?? log?.info;
+    sink?.(`octo: ${line}`);
+  };
+}
+
+/** Resolve the bot's `@[uid:name]` output into octo mention entities. */
+function resolveSeedMentions(content: string): { content: string; entities: MentionEntity[] } {
+  const structured = parseStructuredMentions(content);
+  if (structured.length === 0) return { content, entities: [] };
+  const converted = convertStructuredMentions(content, structured);
+  return { content: converted.content, entities: [...converted.entities] };
+}
+
+/**
+ * "2B-minimal" seed dispatch seam. Resolves the child thread's agent route,
+ * stamps the runtime-derived `SessionKey` onto the seed context (the other half
+ * of the auto-fork trigger — it must differ from `ParentSessionKey`), finalizes
+ * the context, and runs the reply dispatcher delivering into the child thread.
+ *
+ * DELIBERATELY OMITTED vs the full inbound deliver harness (stage-2 review
+ * decision; minimal divergence is acceptable for a one-shot seed):
+ * - typing indicators / readReceipt — UX polish for interactive turns; a seed
+ *   is a one-shot trigger, not a live conversation;
+ * - OBO v2 (on_behalf_of) — OBO is the "reply as a grantor" path; a fork seed
+ *   is the bot dispatching its own seed, so the OBO identity switch must NOT run;
+ * - streaming buffer dedup / tool-warning deferral — the final-kind path covers
+ *   the user-facing answer; the extra bookkeeping is interactive-turn polish;
+ * - outbound media — the fork's first reply rarely carries media, and dropping
+ *   it does not affect fork semantics (context/isolation). Revisit (and extract
+ *   the shared harness) only if a real need appears — see spec §5.2.
+ */
+export async function dispatchForkSeedReply(params: {
+  seedCtx: ForkSeedContext;
+  childChannelId: string;
+  accountId: string;
+  apiUrl: string;
+  botToken: string;
+  config: OpenClawConfig;
+  log?: ChannelLogSink;
+}): Promise<void> {
+  const { seedCtx, childChannelId, accountId, apiUrl, botToken, config, log } = params;
+  const core = getOctoRuntime();
+
+  const childRoute = core.channel.routing.resolveAgentRoute({
+    cfg: config,
+    channel: CHANNEL_ID,
+    accountId,
+    peer: { kind: "group", id: childChannelId },
+  });
+
+  // SessionKey completes the auto-fork trigger (get-reply forks when
+  // ParentSessionKey !== SessionKey). It is intentionally resolved here, not in
+  // assembleForkSeedContext, to avoid duplicating runtime routing.
+  const ctx = {
+    ...seedCtx,
+    SessionKey: childRoute.sessionKey,
+    AccountId: childRoute.accountId ?? accountId,
+  };
+
+  // Fork-trigger guard (S-1): get-reply only forks the parent transcript when
+  // ParentSessionKey !== SessionKey. If they coincide, the auto-fork silently
+  // does NOT trigger and the child starts without parent context. With octo's
+  // default per-thread routing the child channelId yields a distinct sessionKey,
+  // so this is only reachable on a user-defined group-merged route. Warn (do not
+  // block) so the signal is on record before dispatch; the runtime still decides.
+  if (ctx.SessionKey === ctx.ParentSessionKey) {
+    log?.warn?.(
+      `octo: [fork-seed] SessionKey === ParentSessionKey (${ctx.SessionKey}) for child ${childChannelId} — ` +
+        "runtime auto-fork will NOT trigger; child likely shares the parent session " +
+        "(only reachable on a user-defined group-merged route)",
+    );
+  }
+
+  const ctxPayload = core.channel.reply.finalizeInboundContext(ctx);
+
+  const sendSeedText = async (content: string): Promise<void> => {
+    const { content: finalContent, entities } = resolveSeedMentions(content);
+    await sendMessage({
+      apiUrl,
+      botToken,
+      channelId: childChannelId,
+      channelType: ChannelType.CommunityTopic,
+      content: finalContent,
+      ...(entities.length > 0 ? { mentionEntities: entities } : {}),
+    });
+  };
+
+  const buffer = { lastText: null as string | null };
+  let delivered = false;
+  try {
+    await core.channel.reply.dispatchReplyWithBufferedBlockDispatcher({
+      ctx: ctxPayload,
+      cfg: config,
+      replyOptions: {},
+      dispatcherOptions: {
+        deliver: async (payload: ReplyPayload, info: { kind: ReplyDispatchKind }) => {
+          if (payload.isReasoning) return;
+          const content = payload.text?.trim() ?? "";
+          if (!content) return;
+          if (info.kind === "final" || info.kind === "tool") {
+            await sendSeedText(content);
+            delivered = true;
+            buffer.lastText = null;
+          } else {
+            // block / other: buffer, flush once after the dispatcher settles
+            buffer.lastText = content;
+          }
+        },
+        onError: async (err: unknown, info: { kind: string }) => {
+          log?.error?.(`octo: [fork-seed] ${info.kind} reply failed: ${String(err)}`);
+        },
+      },
+    } as Parameters<typeof core.channel.reply.dispatchReplyWithBufferedBlockDispatcher>[0]);
+  } finally {
+    if (buffer.lastText && !delivered) {
+      await sendSeedText(buffer.lastText);
+    }
+  }
+}
+
+/** Test seam: lets unit tests inject a fake orchestrator. */
+export type BuildForkOrchestratorFn = (deps: ForkRuntimeDeps) => ForkOrchestrator;
+
+/**
+ * Detect and handle a `/fork` command at the inbound command-split point
+ * (after `resolveCommandBody`, before `finalizeInboundContext`).
+ *
+ * @returns `true` when the message was a `/fork` command and has been fully
+ *   handled — the caller MUST early-return. `false` when the message is not a
+ *   fork command and normal inbound processing should continue.
+ *
+ * Authorization uses the already-computed `commandAuthorized` (owner-mentioned;
+ * `commands.fork.scope` is a v1.1 wiring TODO). An unauthorized `/fork` is
+ * swallowed silently (spec §3.3) — still returns `true` so it never reaches the
+ * LLM. `/fork` in a DM is unsupported in v1 (no group to thread under): it sends
+ * a hint and is swallowed (returns `true`), so the raw command never reaches the
+ * LLM as ordinary text.
+ */
+export async function handleForkCommandIfMatched(params: {
+  commandBody: string;
+  commandAuthorized: boolean;
+  isGroup: boolean;
+  parentChannelId: string;
+  parentChannelType: ChannelType;
+  parentSessionKey: string;
+  accountId: string;
+  apiUrl: string;
+  botToken: string;
+  requesterUid: string;
+  requesterName: string;
+  config: OpenClawConfig;
+  now?: () => Date;
+  log?: ChannelLogSink;
+  /** Injectable for tests; defaults to the real runtime orchestrator. */
+  buildOrchestrator?: BuildForkOrchestratorFn;
+}): Promise<boolean> {
+  const parsed = parseForkCommand(params.commandBody);
+  if (!parsed.ok && parsed.reason === "not_fork_command") {
+    return false; // not /fork — let normal inbound flow proceed unchanged
+  }
+
+  // From here it IS a /fork attempt (a valid prompt, or empty).
+  if (!params.isGroup) {
+    // DM: /fork has no group to create a sub-thread under. Do NOT fall through
+    // and let the raw "/fork ..." reach the LLM as ordinary text (that confuses
+    // the user — they typed a command, not a question). Send a hint and swallow,
+    // same shape as the unauthorized branch below (spec §3.1 drift fix, S5).
+    params.log?.info?.("octo: [fork] /fork in DM is unsupported — sending hint, swallowed");
+    try {
+      await sendMessage({
+        apiUrl: params.apiUrl,
+        botToken: params.botToken,
+        channelId: params.parentChannelId,
+        channelType: params.parentChannelType,
+        content: "/fork 仅在群聊中可用",
+      });
+    } catch (err) {
+      // Swallow — same shape as safeSendReceipt (fork.ts:215): a hint-send
+      // failure must not bubble out of the inbound handler (it would otherwise
+      // reach the enqueueInbound .catch as a generic handler error). Log so ops
+      // keeps the send-failure signal. Keeps all three early-return branches
+      // (DM / unauthorized / receipt) defensively consistent.
+      params.log?.error?.(
+        `octo: [fork] DM hint send failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+    return true; // swallow — never reaches the LLM
+  }
+
+  if (!params.commandAuthorized) {
+    params.log?.info?.("octo: [fork] unauthorized /fork ignored silently");
+    return true; // swallow per spec §3.3 — never reaches the LLM
+  }
+
+  const forkLog = toForkLogger(params.log);
+  const build = params.buildOrchestrator ?? buildForkOrchestrator;
+
+  const orchestrator = build({
+    apiUrl: params.apiUrl,
+    botToken: params.botToken,
+    accountId: params.accountId,
+    commandAuthorized: params.commandAuthorized,
+    requesterUid: params.requesterUid,
+    requesterName: params.requesterName,
+    now: params.now ?? (() => new Date()),
+    log: forkLog,
+    sendParentReceipt: async ({ text }) => {
+      await sendMessage({
+        apiUrl: params.apiUrl,
+        botToken: params.botToken,
+        channelId: params.parentChannelId,
+        channelType: params.parentChannelType,
+        content: text,
+      });
+    },
+    dispatchSeed: async (seedCtx) => {
+      // Performance trade-off (stage-3 review S-6): this seed dispatch is awaited
+      // synchronously inside the parent group's inbound handler, so it holds the
+      // per-group serial queue (enqueueInbound, channel.ts) for ~the seed's
+      // get-reply/LLM latency. Messages the user sends in the PARENT group during
+      // that window queue behind it. Accepted for v1 (after /fork the user's
+      // attention moves to the child thread); revisit by firing the seed async +
+      // not awaiting if parent-queue latency becomes a problem — at the cost of
+      // the create→seed→receipt atomicity.
+      await dispatchForkSeedReply({
+        seedCtx,
+        childChannelId: seedCtx.GroupSubject,
+        accountId: params.accountId,
+        apiUrl: params.apiUrl,
+        botToken: params.botToken,
+        config: params.config,
+        log: params.log,
+      });
+    },
+  });
+
+  await executeFork(orchestrator, {
+    prompt: parsed.ok ? parsed.prompt : "",
+    parentChannelId: params.parentChannelId,
+    parentSessionKey: params.parentSessionKey,
+    now: params.now ?? (() => new Date()),
+  });
+
+  return true;
+}

--- a/src/commands/fork-inherit-md.test.ts
+++ b/src/commands/fork-inherit-md.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { inheritParentMdToChildThread } from "./fork-inherit-md.js";
+import * as api from "../api-fetch.js";
+
+// Mock only the network calls; keep the real `httpStatusFromApiFetchError`
+// (a pure parser) so status extraction is exercised end-to-end, not re-stubbed.
+vi.mock("../api-fetch.js", async (importActual) => ({
+  ...(await importActual<typeof import("../api-fetch.js")>()),
+  getGroupMd: vi.fn(),
+  getThreadMd: vi.fn(),
+  updateThreadMd: vi.fn(),
+}));
+
+const getGroupMd = vi.mocked(api.getGroupMd);
+const getThreadMd = vi.mocked(api.getThreadMd);
+const updateThreadMd = vi.mocked(api.updateThreadMd);
+
+const mdResp = (content: string) => ({ content, version: 1, updated_at: null, updated_by: "tester" });
+const httpErr = (who: string, status: number) => new Error(`${who} failed (${status}): nope`);
+
+const base = { apiUrl: "http://octo.test", botToken: "bf_token" };
+// Parent is a plain group.
+const groupParent = { ...base, parentChannelId: "G1", childGroupNo: "G1", childShortId: "C1" };
+// Parent is itself a thread (G1____P1).
+const threadParent = { ...base, parentChannelId: "G1____P1", childGroupNo: "G1", childShortId: "C1" };
+
+describe("inheritParentMdToChildThread", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    updateThreadMd.mockResolvedValue({ version: 1 });
+  });
+
+  it("1. parent group + non-empty GROUP.md → ok, writes once", async () => {
+    getGroupMd.mockResolvedValue(mdResp("group rules"));
+    const status = await inheritParentMdToChildThread(groupParent);
+    expect(status).toBe("ok");
+    expect(getGroupMd).toHaveBeenCalledTimes(1);
+    expect(updateThreadMd).toHaveBeenCalledTimes(1);
+    expect(updateThreadMd).toHaveBeenCalledWith(
+      expect.objectContaining({ groupNo: "G1", shortId: "C1", content: "group rules" }),
+    );
+  });
+
+  it("2. parent group + empty GROUP.md → skipped_empty, no write", async () => {
+    getGroupMd.mockResolvedValue(mdResp(""));
+    const status = await inheritParentMdToChildThread(groupParent);
+    expect(status).toBe("skipped_empty");
+    expect(updateThreadMd).not.toHaveBeenCalled();
+  });
+
+  it("3. parent group + GROUP.md 404 → skipped_empty", async () => {
+    getGroupMd.mockRejectedValue(httpErr("getGroupMd", 404));
+    const status = await inheritParentMdToChildThread(groupParent);
+    expect(status).toBe("skipped_empty");
+    expect(updateThreadMd).not.toHaveBeenCalled();
+  });
+
+  it("4. parent group + whitespace-only GROUP.md → skipped_empty", async () => {
+    getGroupMd.mockResolvedValue(mdResp("   \n\t "));
+    const status = await inheritParentMdToChildThread(groupParent);
+    expect(status).toBe("skipped_empty");
+    expect(updateThreadMd).not.toHaveBeenCalled();
+  });
+
+  it("5. parent thread + non-empty THREAD.md → ok, uses thread.md content", async () => {
+    getThreadMd.mockResolvedValue(mdResp("from-thread"));
+    const status = await inheritParentMdToChildThread(threadParent);
+    expect(status).toBe("ok");
+    expect(getThreadMd).toHaveBeenCalledWith(
+      expect.objectContaining({ groupNo: "G1", shortId: "P1" }),
+    );
+    expect(getGroupMd).not.toHaveBeenCalled(); // decision (a): no group.md fallback
+    expect(updateThreadMd).toHaveBeenCalledWith(
+      expect.objectContaining({ groupNo: "G1", shortId: "C1", content: "from-thread" }),
+    );
+  });
+
+  it("6. (a) invariant: parent thread + empty THREAD.md → skipped_empty, NO group.md fallback", async () => {
+    getThreadMd.mockResolvedValue(mdResp(""));
+    const status = await inheritParentMdToChildThread(threadParent);
+    expect(status).toBe("skipped_empty");
+    expect(getGroupMd).not.toHaveBeenCalled();
+    expect(updateThreadMd).not.toHaveBeenCalled();
+  });
+
+  it("7. (a) invariant: parent thread + THREAD.md 404 → skipped_empty, NO group.md fallback", async () => {
+    getThreadMd.mockRejectedValue(httpErr("getThreadMd", 404));
+    const status = await inheritParentMdToChildThread(threadParent);
+    expect(status).toBe("skipped_empty");
+    expect(getGroupMd).not.toHaveBeenCalled();
+    expect(updateThreadMd).not.toHaveBeenCalled();
+  });
+
+  it("8. content exactly 10240 bytes → ok", async () => {
+    getGroupMd.mockResolvedValue(mdResp("a".repeat(10240)));
+    const status = await inheritParentMdToChildThread(groupParent);
+    expect(status).toBe("ok");
+    expect(updateThreadMd).toHaveBeenCalledTimes(1);
+  });
+
+  it("9. content 10241 bytes → skipped_too_large, no write", async () => {
+    getGroupMd.mockResolvedValue(mdResp("a".repeat(10241)));
+    const status = await inheritParentMdToChildThread(groupParent);
+    expect(status).toBe("skipped_too_large");
+    expect(updateThreadMd).not.toHaveBeenCalled();
+  });
+
+  it("10. updateThreadMd throws 403 → no_permission (no escaping exception)", async () => {
+    getGroupMd.mockResolvedValue(mdResp("rules"));
+    updateThreadMd.mockRejectedValue(httpErr("updateThreadMd", 403));
+    const status = await inheritParentMdToChildThread(groupParent);
+    expect(status).toBe("no_permission");
+  });
+
+  it("11. updateThreadMd throws non-403 → update_failed", async () => {
+    getGroupMd.mockResolvedValue(mdResp("rules"));
+    updateThreadMd.mockRejectedValue(httpErr("updateThreadMd", 500));
+    const status = await inheritParentMdToChildThread(groupParent);
+    expect(status).toBe("update_failed");
+  });
+
+  it("12. getGroupMd network error (no HTTP status) → fetch_failed", async () => {
+    getGroupMd.mockRejectedValue(new Error("network timeout"));
+    const status = await inheritParentMdToChildThread(groupParent);
+    expect(status).toBe("fetch_failed");
+    expect(updateThreadMd).not.toHaveBeenCalled();
+  });
+});

--- a/src/commands/fork-inherit-md.test.ts
+++ b/src/commands/fork-inherit-md.test.ts
@@ -11,14 +11,23 @@ vi.mock("../api-fetch.js", async (importActual) => ({
   updateThreadMd: vi.fn(),
 }));
 
+// Mock only the disk-cache broadcast; keep the real path-parsing helpers
+// (extractParentGroupNo / extractThreadShortId) that inherit-md also uses.
+vi.mock("../group-md.js", async (importActual) => ({
+  ...(await importActual<typeof import("../group-md.js")>()),
+  broadcastThreadMdUpdate: vi.fn(),
+}));
+import * as groupMd from "../group-md.js";
+
 const getGroupMd = vi.mocked(api.getGroupMd);
 const getThreadMd = vi.mocked(api.getThreadMd);
 const updateThreadMd = vi.mocked(api.updateThreadMd);
+const broadcastThreadMdUpdate = vi.mocked(groupMd.broadcastThreadMdUpdate);
 
 const mdResp = (content: string) => ({ content, version: 1, updated_at: null, updated_by: "tester" });
 const httpErr = (who: string, status: number) => new Error(`${who} failed (${status}): nope`);
 
-const base = { apiUrl: "http://octo.test", botToken: "bf_token" };
+const base = { apiUrl: "http://octo.test", botToken: "bf_token", accountId: "acct1" };
 // Parent is a plain group.
 const groupParent = { ...base, parentChannelId: "G1", childGroupNo: "G1", childShortId: "C1" };
 // Parent is itself a thread (G1____P1).
@@ -124,5 +133,36 @@ describe("inheritParentMdToChildThread", () => {
     const status = await inheritParentMdToChildThread(groupParent);
     expect(status).toBe("fetch_failed");
     expect(updateThreadMd).not.toHaveBeenCalled();
+  });
+
+  it("13. ok write → mirrors content into local disk cache via broadcastThreadMdUpdate (P2)", async () => {
+    getGroupMd.mockResolvedValue(mdResp("group rules"));
+    updateThreadMd.mockResolvedValue({ version: 7 });
+    const status = await inheritParentMdToChildThread(groupParent);
+    expect(status).toBe("ok");
+    expect(broadcastThreadMdUpdate).toHaveBeenCalledWith({
+      accountId: "acct1",
+      groupNo: "G1",
+      shortId: "C1",
+      content: "group rules",
+      version: 7,
+    });
+  });
+
+  it("14. server write ok but local cache broadcast throws → still ok (server is SSOT)", async () => {
+    getGroupMd.mockResolvedValue(mdResp("group rules"));
+    updateThreadMd.mockResolvedValue({ version: 1 });
+    broadcastThreadMdUpdate.mockImplementationOnce(() => {
+      throw new Error("disk full");
+    });
+    const status = await inheritParentMdToChildThread(groupParent);
+    expect(status).toBe("ok");
+  });
+
+  it("15. skipped/failed paths do NOT touch the local cache", async () => {
+    getGroupMd.mockResolvedValue(mdResp("")); // empty → skipped_empty, no write
+    const status = await inheritParentMdToChildThread(groupParent);
+    expect(status).toBe("skipped_empty");
+    expect(broadcastThreadMdUpdate).not.toHaveBeenCalled();
   });
 });

--- a/src/commands/fork-inherit-md.ts
+++ b/src/commands/fork-inherit-md.ts
@@ -1,0 +1,121 @@
+// `/fork` follow-up: inherit the parent location's markdown into the freshly
+// created child thread's THREAD.md.
+//
+// When `/fork` runs in group A (or sub-thread X), after the child thread Y is
+// created we copy the "parent location's md" into Y's THREAD.md:
+//   - parent is a group  → source is the group's GROUP.md
+//   - parent is a thread → source is THAT thread's THREAD.md (decision (a):
+//     thread.md ONLY, never fall back to the group's GROUP.md)
+//
+// Design constraints (owner decisions 2026-06-23):
+//   - fire-and-forget: callers do NOT await this on the fork main path;
+//   - fully silent: no user-facing receipt marker, warn-level logs only;
+//   - assume permission: no pre-flight permission spike; a 403 at write time is
+//     caught and reported as `no_permission` (then logged + swallowed).
+//
+// This helper NEVER throws — every failure mode maps to an InheritMdStatus so a
+// caller can `void`-fire it safely.
+
+import { getGroupMd, getThreadMd, updateThreadMd, httpStatusFromApiFetchError } from "../api-fetch.js";
+import { extractParentGroupNo, extractThreadShortId } from "../group-md.js";
+import type { ForkLogger } from "./fork.js";
+
+/** Server-side THREAD.md cap (octo-server GetGroupMdMaxSize), in bytes. */
+const THREAD_MD_MAX_BYTES = 10240;
+
+/** Terminal status of an {@link inheritParentMdToChildThread} run. */
+export type InheritMdStatus =
+  | "ok" // content written to child THREAD.md
+  | "skipped_empty" // parent md empty / whitespace / 404 (not found)
+  | "skipped_too_large" // parent md exceeds the 10,240-byte cap
+  | "no_permission" // updateThreadMd returned 403
+  | "fetch_failed" // fetching parent md failed (non-404)
+  | "update_failed"; // updateThreadMd failed (non-403)
+
+/**
+ * Copy the parent location's md into the child thread's THREAD.md.
+ *
+ * Never throws: all failures are returned as an {@link InheritMdStatus} and
+ * logged at warn level, so the caller can fire-and-forget.
+ *
+ * @param params.parentChannelId ChannelId of the fork trigger location. A
+ *   thread channelId (`<groupNo>____<shortId>`) sources the parent thread's
+ *   THREAD.md; a bare group channelId sources the group's GROUP.md.
+ * @param params.childGroupNo Group the new child thread lives under.
+ * @param params.childShortId Short id of the new child thread.
+ * @returns The terminal status of the inheritance attempt.
+ */
+export async function inheritParentMdToChildThread(params: {
+  apiUrl: string;
+  botToken: string;
+  parentChannelId: string;
+  childGroupNo: string;
+  childShortId: string;
+  log?: ForkLogger;
+}): Promise<InheritMdStatus> {
+  const { apiUrl, botToken, parentChannelId, childGroupNo, childShortId, log } = params;
+  const parentGroupNo = extractParentGroupNo(parentChannelId);
+  const parentShortId = extractThreadShortId(parentChannelId);
+
+  // 1) Fetch parent md. Decision (a): when the parent is a thread, read ONLY
+  //    that thread's THREAD.md — never fall back to the group's GROUP.md.
+  let content: string;
+  try {
+    const resp = parentShortId
+      ? await getThreadMd({ apiUrl, botToken, groupNo: parentGroupNo, shortId: parentShortId })
+      : await getGroupMd({ apiUrl, botToken, groupNo: parentGroupNo });
+    content = resp.content ?? "";
+  } catch (err) {
+    if (httpStatusFromApiFetchError(err) === 404) {
+      log?.("warn", "[fork] inherit md: parent md not found (404), skipping", { parentChannelId });
+      return "skipped_empty";
+    }
+    log?.("warn", "[fork] inherit md: failed to fetch parent md", {
+      parentChannelId,
+      error: String(err),
+    });
+    return "fetch_failed";
+  }
+
+  // 2) Empty / whitespace-only parent md → nothing to inherit.
+  if (content.trim() === "") {
+    log?.("info", "[fork] inherit md: parent md empty, skipping", { parentChannelId });
+    return "skipped_empty";
+  }
+
+  // 3) Size guard. Pre-check the byte length so we never issue an update that
+  //    the server would reject; decision keeps updateThreadMd uncalled here.
+  const byteLength = new TextEncoder().encode(content).byteLength;
+  if (byteLength > THREAD_MD_MAX_BYTES) {
+    log?.("warn", "[fork] inherit md: parent md exceeds size cap, skipping", {
+      parentChannelId,
+      byteLength,
+    });
+    return "skipped_too_large";
+  }
+
+  // 4) Write the child thread's THREAD.md.
+  try {
+    await updateThreadMd({ apiUrl, botToken, groupNo: childGroupNo, shortId: childShortId, content });
+    log?.("info", "[fork] inherit md: copied parent md to child thread.md", {
+      childGroupNo,
+      childShortId,
+      byteLength,
+    });
+    return "ok";
+  } catch (err) {
+    if (httpStatusFromApiFetchError(err) === 403) {
+      log?.("warn", "[fork] inherit md: no permission to write child thread.md (403)", {
+        childGroupNo,
+        childShortId,
+      });
+      return "no_permission";
+    }
+    log?.("warn", "[fork] inherit md: failed to update child thread.md", {
+      childGroupNo,
+      childShortId,
+      error: String(err),
+    });
+    return "update_failed";
+  }
+}

--- a/src/commands/fork-inherit-md.ts
+++ b/src/commands/fork-inherit-md.ts
@@ -17,7 +17,7 @@
 // caller can `void`-fire it safely.
 
 import { getGroupMd, getThreadMd, updateThreadMd, httpStatusFromApiFetchError } from "../api-fetch.js";
-import { extractParentGroupNo, extractThreadShortId } from "../group-md.js";
+import { extractParentGroupNo, extractThreadShortId, broadcastThreadMdUpdate } from "../group-md.js";
 import type { ForkLogger } from "./fork.js";
 
 /** Server-side THREAD.md cap (octo-server GetGroupMdMaxSize), in bytes. */
@@ -48,12 +48,13 @@ export type InheritMdStatus =
 export async function inheritParentMdToChildThread(params: {
   apiUrl: string;
   botToken: string;
+  accountId: string;
   parentChannelId: string;
   childGroupNo: string;
   childShortId: string;
   log?: ForkLogger;
 }): Promise<InheritMdStatus> {
-  const { apiUrl, botToken, parentChannelId, childGroupNo, childShortId, log } = params;
+  const { apiUrl, botToken, accountId, parentChannelId, childGroupNo, childShortId, log } = params;
   const parentGroupNo = extractParentGroupNo(parentChannelId);
   const parentShortId = extractThreadShortId(parentChannelId);
 
@@ -96,7 +97,21 @@ export async function inheritParentMdToChildThread(params: {
 
   // 4) Write the child thread's THREAD.md.
   try {
-    await updateThreadMd({ apiUrl, botToken, groupNo: childGroupNo, shortId: childShortId, content });
+    const { version } = await updateThreadMd({ apiUrl, botToken, groupNo: childGroupNo, shortId: childShortId, content });
+    // Mirror the write into the local disk cache (P2, Jerry-Xin). updateThreadMd
+    // only writes the octo server, but before_prompt_build's getGroupMdForPrompt
+    // reads the local cache — without this, the inherited md would be invisible
+    // to the child's first dispatch. The server write is the SSOT, so a local
+    // cache failure must NOT downgrade the "ok" status (server already has it).
+    try {
+      broadcastThreadMdUpdate({ accountId, groupNo: childGroupNo, shortId: childShortId, content, version });
+    } catch (cacheErr) {
+      log?.("warn", "[fork] inherit md: server write ok but local cache update failed", {
+        childGroupNo,
+        childShortId,
+        error: String(cacheErr),
+      });
+    }
     log?.("info", "[fork] inherit md: copied parent md to child thread.md", {
       childGroupNo,
       childShortId,

--- a/src/commands/fork-runtime.test.ts
+++ b/src/commands/fork-runtime.test.ts
@@ -1,0 +1,281 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  assembleForkSeedContext,
+  buildForkOrchestrator,
+  type CreateThreadFn,
+  type ForkRuntimeDeps,
+} from "./fork-runtime.js";
+
+const fixedNow = () => new Date("2026-06-22T10:20:30.123Z");
+
+function makeRuntimeDeps(overrides: Partial<ForkRuntimeDeps> = {}): ForkRuntimeDeps {
+  return {
+    apiUrl: "https://api.example.test",
+    botToken: "bf_token",
+    accountId: "acct1",
+    commandAuthorized: true,
+    requesterUid: "user_hash_32",
+    requesterName: "刘建辉",
+    now: fixedNow,
+    log: vi.fn(),
+    sendParentReceipt: vi.fn(async () => {}),
+    createThread: vi.fn(async () => ({ short_id: "abc", name: "n", creator_uid: "bot" })),
+    dispatchSeed: vi.fn(async () => {}),
+    ...overrides,
+  };
+}
+
+describe("assembleForkSeedContext", () => {
+  const deps = makeRuntimeDeps();
+
+  const ctx = assembleForkSeedContext({
+    deps,
+    childChannelId: "group123____abc",
+    parentSessionKey: "octo:acct1:group123",
+    prompt: "explain the bug",
+  });
+
+  it("sets the prompt across all body fields", () => {
+    expect(ctx.Body).toBe("explain the bug");
+    expect(ctx.BodyForAgent).toBe("explain the bug");
+    expect(ctx.RawBody).toBe("explain the bug");
+    expect(ctx.CommandBody).toBe("explain the bug");
+    expect(ctx.BodyForCommands).toBe("explain the bug");
+  });
+
+  it("sets ParentSessionKey === ModelParentSessionKey === parent key (drives auto-fork)", () => {
+    expect(ctx.ParentSessionKey).toBe("octo:acct1:group123");
+    expect(ctx.ModelParentSessionKey).toBe("octo:acct1:group123");
+  });
+
+  it("omits SessionKey (resolved at the stage-2 dispatch seam)", () => {
+    expect("SessionKey" in ctx).toBe(false);
+  });
+
+  it("attributes the seed to the fork requester", () => {
+    expect(ctx.SenderId).toBe("user_hash_32");
+    expect(ctx.SenderName).toBe("刘建辉");
+    expect(ctx.SenderUsername).toBe("user_hash_32");
+    expect(ctx.From).toBe("octo:user_hash_32");
+  });
+
+  it("routes To / OriginatingTo / GroupSubject / ConversationLabel at the child channel", () => {
+    expect(ctx.To).toBe("octo:group123____abc");
+    expect(ctx.OriginatingTo).toBe("octo:group123____abc");
+    expect(ctx.GroupSubject).toBe("group123____abc");
+    expect(ctx.ConversationLabel).toBe("group:group123____abc");
+  });
+
+  it("marks the seed non-mention, group, octo surface", () => {
+    expect(ctx.WasMentioned).toBe(false);
+    expect(ctx.ChatType).toBe("group");
+    expect(ctx.Provider).toBe("octo");
+    expect(ctx.Surface).toBe("octo");
+    expect(ctx.OriginatingChannel).toBe("octo");
+    expect(ctx.AccountId).toBe("acct1");
+  });
+
+  it("threads CommandAuthorized from deps (not hardcoded) — true and false propagate", () => {
+    // v1 path: requester is owner-mentioned-authorized.
+    expect(ctx.CommandAuthorized).toBe(true);
+    // v1.1 guard: a non-owner requester (commandAuthorized=false) must NOT get an
+    // authorized seed, even if a widened fork scope let them reach here.
+    const unauth = assembleForkSeedContext({
+      deps: makeRuntimeDeps({ commandAuthorized: false }),
+      childChannelId: "group123____abc",
+      parentSessionKey: "octo:acct1:group123",
+      prompt: "x",
+    });
+    expect(unauth.CommandAuthorized).toBe(false);
+  });
+
+  it("stamps a synthetic MessageSid and the injected clock", () => {
+    expect(ctx.MessageSid).toBe("fork-seed:group123____abc");
+    expect(ctx.Timestamp).toBe(new Date("2026-06-22T10:20:30.123Z").getTime());
+  });
+
+  it("includes GroupSystemPrompt only when provided", () => {
+    expect("GroupSystemPrompt" in ctx).toBe(false);
+    const withPrompt = assembleForkSeedContext({
+      deps: makeRuntimeDeps({ groupSystemPrompt: "be terse" }),
+      childChannelId: "g____a",
+      parentSessionKey: "k",
+      prompt: "p",
+    });
+    expect(withPrompt.GroupSystemPrompt).toBe("be terse");
+  });
+});
+
+describe("buildForkOrchestrator.spawnChildBoundSession", () => {
+  it("creates the thread under the parent group and returns the child channelId", async () => {
+    const deps = makeRuntimeDeps();
+    const orch = buildForkOrchestrator(deps);
+
+    const result = await orch.spawnChildBoundSession({
+      parentChannelId: "group123",
+      parentSessionKey: "octo:acct1:group123",
+      prompt: "explain the bug",
+      threadName: "explain the bug",
+    });
+
+    expect(result).toEqual({ childChannelId: "group123____abc" });
+    expect(deps.createThread).toHaveBeenCalledWith({
+      apiUrl: "https://api.example.test",
+      botToken: "bf_token",
+      groupNo: "group123",
+      name: "explain the bug",
+    });
+  });
+
+  it("dispatches the assembled seed context through the seam", async () => {
+    const dispatchSeed = vi.fn(async () => {});
+    const deps = makeRuntimeDeps({ dispatchSeed });
+    const orch = buildForkOrchestrator(deps);
+
+    await orch.spawnChildBoundSession({
+      parentChannelId: "group123",
+      parentSessionKey: "octo:acct1:group123",
+      prompt: "explain the bug",
+      threadName: "explain the bug",
+    });
+
+    expect(dispatchSeed).toHaveBeenCalledTimes(1);
+    const seedCtx = dispatchSeed.mock.calls[0][0];
+    expect(seedCtx.ParentSessionKey).toBe("octo:acct1:group123");
+    expect(seedCtx.To).toBe("octo:group123____abc");
+    expect(seedCtx.Body).toBe("explain the bug");
+  });
+
+  it("derives the parent group from a nested-thread parent channelId", async () => {
+    const deps = makeRuntimeDeps();
+    const orch = buildForkOrchestrator(deps);
+
+    const result = await orch.spawnChildBoundSession({
+      parentChannelId: "group123____parent",
+      parentSessionKey: "octo:acct1:group123____parent",
+      prompt: "p",
+      threadName: "p",
+    });
+
+    expect(deps.createThread).toHaveBeenCalledWith(expect.objectContaining({ groupNo: "group123" }));
+    expect(result.childChannelId).toBe("group123____abc");
+  });
+
+  it("propagates createThread failures", async () => {
+    const deps = makeRuntimeDeps({
+      createThread: vi.fn(async () => {
+        throw new Error("thread quota exceeded");
+      }) as unknown as CreateThreadFn,
+    });
+    const orch = buildForkOrchestrator(deps);
+
+    await expect(
+      orch.spawnChildBoundSession({
+        parentChannelId: "group123",
+        parentSessionKey: "k",
+        prompt: "p",
+        threadName: "p",
+      }),
+    ).rejects.toThrow("thread quota exceeded");
+  });
+
+  it("without a dispatch seam: still creates thread + warns (1b payload-only)", async () => {
+    const deps = makeRuntimeDeps({ dispatchSeed: undefined });
+    const orch = buildForkOrchestrator(deps);
+
+    const result = await orch.spawnChildBoundSession({
+      parentChannelId: "group123",
+      parentSessionKey: "k",
+      prompt: "p",
+      threadName: "p",
+    });
+
+    expect(result.childChannelId).toBe("group123____abc");
+    expect(deps.log).toHaveBeenCalledWith(
+      "warn",
+      expect.stringContaining("dispatch seam not wired"),
+      expect.objectContaining({ childChannelId: "group123____abc" }),
+    );
+  });
+
+  it("dispatchSeed failure does NOT mask the created thread → returns seedFailed (I-1)", async () => {
+    const createThread = vi.fn(async () => ({ short_id: "abc", name: "n", creator_uid: "bot" }));
+    const dispatchSeed = vi.fn(async () => {
+      throw new Error("dispatch boom");
+    });
+    const deps = makeRuntimeDeps({ createThread, dispatchSeed });
+    const orch = buildForkOrchestrator(deps);
+
+    const result = await orch.spawnChildBoundSession({
+      parentChannelId: "group123",
+      parentSessionKey: "octo:acct1:group123",
+      prompt: "explain the bug",
+      threadName: "explain the bug",
+    });
+
+    // Thread was created and the dispatch error is swallowed into a flag, not thrown.
+    expect(createThread).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ childChannelId: "group123____abc", seedFailed: true });
+  });
+
+  it("dispatchSeed failure is logged as error with the child channelId (I-1)", async () => {
+    const dispatchSeed = vi.fn(async () => {
+      throw new Error("dispatch boom");
+    });
+    const deps = makeRuntimeDeps({ dispatchSeed });
+    const orch = buildForkOrchestrator(deps);
+
+    await orch.spawnChildBoundSession({
+      parentChannelId: "group123",
+      parentSessionKey: "k",
+      prompt: "p",
+      threadName: "p",
+    });
+
+    expect(deps.log).toHaveBeenCalledWith(
+      "error",
+      "[fork] seed dispatch failed; child thread already exists",
+      expect.objectContaining({ childChannelId: "group123____abc", error: "dispatch boom" }),
+    );
+  });
+
+  it("fires inheritParentMd with the child group/shortId and parent channelId", async () => {
+    const inheritParentMd = vi.fn(async () => "ok" as const);
+    const deps = makeRuntimeDeps({ inheritParentMd });
+    const orch = buildForkOrchestrator(deps);
+
+    await orch.spawnChildBoundSession({
+      parentChannelId: "group123____parent",
+      parentSessionKey: "k",
+      prompt: "p",
+      threadName: "p",
+    });
+
+    expect(inheritParentMd).toHaveBeenCalledWith(
+      expect.objectContaining({
+        apiUrl: "https://api.example.test",
+        botToken: "bf_token",
+        parentChannelId: "group123____parent",
+        childGroupNo: "group123",
+        childShortId: "abc",
+      }),
+    );
+  });
+
+  it("does NOT await inheritParentMd: a hanging copy never blocks the fork", async () => {
+    // inherit never resolves; spawnChildBoundSession must still complete.
+    const inheritParentMd = vi.fn(() => new Promise<"ok">(() => {}));
+    const deps = makeRuntimeDeps({ inheritParentMd });
+    const orch = buildForkOrchestrator(deps);
+
+    const result = await orch.spawnChildBoundSession({
+      parentChannelId: "group123",
+      parentSessionKey: "k",
+      prompt: "p",
+      threadName: "p",
+    });
+
+    expect(result.childChannelId).toBe("group123____abc");
+    expect(inheritParentMd).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/commands/fork-runtime.ts
+++ b/src/commands/fork-runtime.ts
@@ -1,0 +1,248 @@
+// `/fork` runtime wiring — the impure half of the command.
+//
+// `fork.ts` is pure orchestration; this module supplies the concrete
+// `spawnChildBoundSession` it depends on. That involves one real octo Bot API
+// call (`createThread`) plus assembling the seed inbound context that — once
+// dispatched into the child thread — makes the OpenClaw reply pipeline auto-fork
+// the parent session.
+//
+// Fork mechanism (spec §5.2, "Plan B"): the fork is a side-effect of the seed
+// dispatch, not a plugin-driven step. `get-reply` forks the parent transcript
+// into the child session iff the inbound context carries `ParentSessionKey` and
+// it differs from the child's own `SessionKey`
+// (node_modules/openclaw/dist/get-reply-DuA7xbHV.js:3780). The only generic
+// producer of `ctx.ParentSessionKey` upstream is Discord's auto-thread layer
+// (threading-idEBBpQ_.js:334, Discord-only), so octo must set it itself here.
+//
+// 1b scope (payload-only): this module creates the thread, derives the child
+// channelId, and assembles the full seed context. The ACTUAL dispatch is left to
+// the injected `dispatchSeed` seam, wired in stage 2. The runtime dispatch entry
+// is `core.channel.reply.dispatchReplyWithBufferedBlockDispatcher`
+// (src/inbound.ts:2607); it consumes a context built by `finalizeInboundContext`
+// (src/inbound.ts:2299) and needs the deliver harness from
+// `handleInboundMessage` to route the fork reply back into the child thread —
+// reusing or replicating that harness is the stage-2 work.
+
+import { createThread as defaultCreateThread } from "../api-fetch.js";
+import { CHANNEL_ID, THREAD_ID_SEPARATOR } from "../constants.js";
+import { extractParentGroupNo } from "../group-md.js";
+import { inheritParentMdToChildThread } from "./fork-inherit-md.js";
+import type { ForkLogger, ForkOrchestrator } from "./fork.js";
+
+/** Subset of `createThread` used here, injectable for tests. */
+export type CreateThreadFn = (params: {
+  apiUrl: string;
+  botToken: string;
+  groupNo: string;
+  name: string;
+}) => Promise<{ short_id: string; name: string; creator_uid: string }>;
+
+/**
+ * The inbound context assembled for the fork seed message. Field choices mirror
+ * `finalizeInboundContext` in src/inbound.ts:2299-2363. The Plan-B-critical
+ * additions are `ParentSessionKey` / `ModelParentSessionKey`, which trigger the
+ * runtime auto-fork.
+ *
+ * `SessionKey` is intentionally absent: it is derived from the child channel's
+ * agent route at dispatch time (src/inbound.ts:2344, `SessionKey:
+ * route.sessionKey`). Resolving the route and setting it is the stage-2 dispatch
+ * seam's responsibility — keeping it out here avoids replicating runtime routing
+ * logic and the consequent divergence risk.
+ */
+export interface ForkSeedContext {
+  Body: string;
+  BodyForAgent: string;
+  RawBody: string;
+  CommandBody: string;
+  BodyForCommands: string;
+  /**
+   * The fork requester's command authorization (owner-mentioned), threaded from
+   * the originating inbound — NOT hardcoded. This is deliberately decoupled from
+   * the fork-scope gate: the seed must carry whether the requester may run
+   * *commands*, independent of whether they may *fork*. When `commands.fork.scope`
+   * is wired in v1.1 to let non-owners fork, their `commandAuthorized` stays false
+   * (owner-mentioned), so a non-owner's seed prompt can never be treated as an
+   * authorized command in the child session. Do not revert to a literal `true`.
+   */
+  CommandAuthorized: boolean;
+  From: string;
+  To: string;
+  /** Triggers the runtime auto-fork (must differ from the child `SessionKey`). */
+  ParentSessionKey: string;
+  ModelParentSessionKey: string;
+  AccountId: string;
+  ChatType: "group";
+  ConversationLabel: string;
+  SenderId: string;
+  SenderName: string;
+  SenderUsername: string;
+  /** Seed is a synthetic dispatch, not a real @mention. */
+  WasMentioned: false;
+  MessageSid: string;
+  Timestamp: number;
+  GroupSubject: string;
+  GroupSystemPrompt?: string;
+  Provider: typeof CHANNEL_ID;
+  Surface: typeof CHANNEL_ID;
+  OriginatingChannel: typeof CHANNEL_ID;
+  OriginatingTo: string;
+}
+
+/**
+ * Per-invocation runtime dependencies for {@link buildForkOrchestrator}. Built
+ * fresh for each `/fork` (in inbound.ts, stage 2), so the requester identity and
+ * account context are closure-captured rather than threaded through
+ * `spawnChildBoundSession`'s signature.
+ */
+export interface ForkRuntimeDeps {
+  apiUrl: string;
+  botToken: string;
+  accountId: string;
+  /**
+   * The requester's command authorization (owner-mentioned) from the originating
+   * inbound. Becomes the seed's `CommandAuthorized` — see {@link ForkSeedContext}
+   * for why this is threaded rather than hardcoded `true`.
+   */
+  commandAuthorized: boolean;
+  /** Identity attributed to the seed message — the user who ran `/fork`. */
+  requesterUid: string;
+  requesterName: string;
+  /** Optional group system prompt carried into the seed (group-md). */
+  groupSystemPrompt?: string;
+  now: () => Date;
+  log: ForkLogger;
+  /** Send the parent-group receipt (plain text). */
+  sendParentReceipt: ForkOrchestrator["sendParentReceipt"];
+  /** Injectable for tests; defaults to the real octo Bot API call. */
+  createThread?: CreateThreadFn;
+  /**
+   * Stage-2 dispatch seam. Resolves the child agent route, sets `SessionKey`,
+   * runs `finalizeInboundContext` + `dispatchReplyWithBufferedBlockDispatcher`,
+   * and delivers the fork reply back into the child thread. Absent in 1b — the
+   * thread is still created and the seed context assembled, but nothing is
+   * dispatched (a warning is logged).
+   */
+  dispatchSeed?: (ctx: ForkSeedContext) => Promise<void>;
+  /**
+   * Inherit the parent location's md into the new child thread's THREAD.md.
+   * Injectable for tests; defaults to the real {@link inheritParentMdToChildThread}.
+   * Always invoked fire-and-forget — never awaited on the fork main path
+   * (owner decision: md copy latency must not block the fork or its receipt).
+   */
+  inheritParentMd?: typeof inheritParentMdToChildThread;
+}
+
+/**
+ * Assemble the seed inbound context for a fork. Pure: no I/O, fully determined
+ * by its inputs (the clock is injected via `deps.now`).
+ *
+ * @param deps Runtime deps supplying requester identity, account, and clock.
+ * @param childChannelId Full channelId of the freshly created child thread.
+ * @param parentSessionKey Parent session key — drives the auto-fork.
+ * @param prompt The user's fork prompt (becomes the seed body).
+ */
+export function assembleForkSeedContext(args: {
+  deps: Pick<ForkRuntimeDeps, "accountId" | "commandAuthorized" | "requesterUid" | "requesterName" | "groupSystemPrompt" | "now">;
+  childChannelId: string;
+  parentSessionKey: string;
+  prompt: string;
+}): ForkSeedContext {
+  const { deps, childChannelId, parentSessionKey, prompt } = args;
+  return {
+    Body: prompt,
+    BodyForAgent: prompt,
+    RawBody: prompt,
+    CommandBody: prompt,
+    BodyForCommands: prompt,
+    CommandAuthorized: deps.commandAuthorized,
+    From: `${CHANNEL_ID}:${deps.requesterUid}`,
+    To: `${CHANNEL_ID}:${childChannelId}`,
+    ParentSessionKey: parentSessionKey,
+    ModelParentSessionKey: parentSessionKey,
+    AccountId: deps.accountId,
+    ChatType: "group",
+    ConversationLabel: `group:${childChannelId}`,
+    SenderId: deps.requesterUid,
+    SenderName: deps.requesterName,
+    SenderUsername: deps.requesterUid,
+    WasMentioned: false,
+    MessageSid: `fork-seed:${childChannelId}`,
+    Timestamp: deps.now().getTime(),
+    GroupSubject: childChannelId,
+    ...(deps.groupSystemPrompt ? { GroupSystemPrompt: deps.groupSystemPrompt } : {}),
+    Provider: CHANNEL_ID,
+    Surface: CHANNEL_ID,
+    OriginatingChannel: CHANNEL_ID,
+    OriginatingTo: `${CHANNEL_ID}:${childChannelId}`,
+  };
+}
+
+/**
+ * Build the concrete {@link ForkOrchestrator} for one `/fork` invocation.
+ *
+ * `spawnChildBoundSession` creates the child thread under the parent group,
+ * derives its channelId (`<groupNo>____<shortId>`), assembles the seed context,
+ * and hands it to the `dispatchSeed` seam. createThread errors propagate
+ * (executeFork turns them into the failure receipt).
+ */
+export function buildForkOrchestrator(deps: ForkRuntimeDeps): ForkOrchestrator {
+  const createThreadFn = deps.createThread ?? defaultCreateThread;
+  const inheritFn = deps.inheritParentMd ?? inheritParentMdToChildThread;
+
+  return {
+    async spawnChildBoundSession({ parentChannelId, parentSessionKey, prompt, threadName }) {
+      const groupNo = extractParentGroupNo(parentChannelId);
+      const thread = await createThreadFn({
+        apiUrl: deps.apiUrl,
+        botToken: deps.botToken,
+        groupNo,
+        name: threadName,
+      });
+      const childChannelId = `${groupNo}${THREAD_ID_SEPARATOR}${thread.short_id}`;
+
+      // Inherit parent md → child THREAD.md. Fire-and-forget (owner decision):
+      // the copy must never block the fork main path or the receipt. The helper
+      // never throws (returns a status enum), so the trailing .catch is purely
+      // a defensive backstop, not an expected path.
+      void inheritFn({
+        apiUrl: deps.apiUrl,
+        botToken: deps.botToken,
+        parentChannelId,
+        childGroupNo: groupNo,
+        childShortId: thread.short_id,
+        log: deps.log,
+      })
+        .then((status) => deps.log("info", "[fork] inherit md status", { status, childChannelId }))
+        .catch((error) => deps.log("warn", "[fork] inherit md threw uncaught", { error: String(error) }));
+
+      const seedCtx = assembleForkSeedContext({ deps, childChannelId, parentSessionKey, prompt });
+
+      // Seed dispatch is the only step that can fail AFTER the thread exists.
+      // Isolate it (I-1): a dispatch error must NOT propagate as a create-thread
+      // failure — the thread is already live. Surface `seedFailed: true` so
+      // executeFork keeps the "thread created" fact and asks the user to resend
+      // in the child thread, instead of the misleading "开 fork 子区失败".
+      if (deps.dispatchSeed) {
+        try {
+          await deps.dispatchSeed(seedCtx);
+          deps.log("info", "[fork] seed dispatched into child thread", { childChannelId });
+        } catch (err) {
+          deps.log("error", "[fork] seed dispatch failed; child thread already exists", {
+            childChannelId,
+            error: err instanceof Error ? err.message : String(err),
+          });
+          return { childChannelId, seedFailed: true };
+        }
+      } else {
+        deps.log("warn", "[fork] dispatch seam not wired (stage 2); child thread created + seed context assembled only", {
+          childChannelId,
+        });
+      }
+
+      return { childChannelId };
+    },
+
+    sendParentReceipt: deps.sendParentReceipt,
+    log: deps.log,
+  };
+}

--- a/src/commands/fork-runtime.ts
+++ b/src/commands/fork-runtime.ts
@@ -207,6 +207,7 @@ export function buildForkOrchestrator(deps: ForkRuntimeDeps): ForkOrchestrator {
       void inheritFn({
         apiUrl: deps.apiUrl,
         botToken: deps.botToken,
+        accountId: deps.accountId,
         parentChannelId,
         childGroupNo: groupNo,
         childShortId: thread.short_id,

--- a/src/commands/fork-seed-dispatch.test.ts
+++ b/src/commands/fork-seed-dispatch.test.ts
@@ -282,4 +282,30 @@ describe("dispatchForkSeedReply", () => {
     ).rejects.toThrow("dispatch boom"); // original error wins, NOT "flush boom"
     expect(error.mock.calls.some((c) => String(c[0]).includes("finally flush failed"))).toBe(true);
   });
+
+  it("DELIVERY FAILURE (P1): a final send error → throws (→ seedFailed → ok_seed_failed)", async () => {
+    // deliver() for a final block tries to send; the send throws. The SDK does
+    // not reject the outer promise for this, so without tracking it the fork
+    // would falsely report success. We track it and throw after settle.
+    driveDeliver([{ kind: "final", text: "the answer" }]);
+    mockSendMessage.mockImplementationOnce(async () => {
+      throw new Error("octo 500");
+    });
+    await expect(run()).rejects.toThrow(/delivery failed/i);
+  });
+
+  it("DELIVERY FAILURE (P1): onError(final) → throws even though the dispatcher resolved", async () => {
+    mockDispatch.mockImplementation(async (o: any) => {
+      // dispatcher resolves normally; the failure surfaces only via onError.
+      await o.dispatcherOptions.onError(new Error("upstream boom"), { kind: "final" });
+    });
+    await expect(run()).rejects.toThrow(/delivery failed/i);
+  });
+
+  it("onError(block) does NOT fail the seed (only final/tool are user-facing)", async () => {
+    mockDispatch.mockImplementation(async (o: any) => {
+      await o.dispatcherOptions.onError(new Error("block hiccup"), { kind: "block" });
+    });
+    await expect(run()).resolves.toBeUndefined();
+  });
 });

--- a/src/commands/fork-seed-dispatch.test.ts
+++ b/src/commands/fork-seed-dispatch.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock the runtime + octo Bot API so we can drive dispatchForkSeedReply's deliver
+// state machine and assert the fork-trigger invariant (SessionKey comes from the
+// CHILD route, not the seed ctx) without a live runtime.
+const { mockResolveAgentRoute, mockFinalize, mockDispatch, mockSendMessage } = vi.hoisted(() => ({
+  mockResolveAgentRoute: vi.fn(),
+  mockFinalize: vi.fn((ctx: unknown) => ctx),
+  mockDispatch: vi.fn(),
+  mockSendMessage: vi.fn(async () => ({})),
+}));
+
+vi.mock("../runtime.js", () => ({
+  getOctoRuntime: () => ({
+    channel: {
+      routing: { resolveAgentRoute: mockResolveAgentRoute },
+      reply: {
+        finalizeInboundContext: mockFinalize,
+        dispatchReplyWithBufferedBlockDispatcher: mockDispatch,
+      },
+    },
+  }),
+}));
+vi.mock("../api-fetch.js", () => ({
+  sendMessage: mockSendMessage,
+  createThread: vi.fn(),
+}));
+
+import { dispatchForkSeedReply } from "./fork-inbound.js";
+import type { ForkSeedContext } from "./fork-runtime.js";
+
+function makeSeedCtx(overrides: Partial<ForkSeedContext> = {}): ForkSeedContext {
+  return {
+    Body: "explain the bug",
+    BodyForAgent: "explain the bug",
+    RawBody: "explain the bug",
+    CommandBody: "explain the bug",
+    BodyForCommands: "explain the bug",
+    CommandAuthorized: true,
+    From: "octo:user_hash",
+    To: "octo:group123____abc",
+    ParentSessionKey: "octo:acct1:group123",
+    ModelParentSessionKey: "octo:acct1:group123",
+    AccountId: "acct1",
+    ChatType: "group",
+    ConversationLabel: "group:group123____abc",
+    SenderId: "user_hash",
+    SenderName: "刘建辉",
+    SenderUsername: "user_hash",
+    WasMentioned: false,
+    MessageSid: "fork-seed:group123____abc",
+    Timestamp: 0,
+    GroupSubject: "group123____abc",
+    Provider: "octo",
+    Surface: "octo",
+    OriginatingChannel: "octo",
+    OriginatingTo: "octo:group123____abc",
+    ...overrides,
+  };
+}
+
+type DeliverCall = { text?: string; isReasoning?: boolean; kind: string };
+
+/** Configure the dispatcher mock to replay a script of deliver() calls. */
+function driveDeliver(calls: DeliverCall[], opts: { throwAfter?: boolean } = {}) {
+  mockDispatch.mockImplementation(async (o: any) => {
+    for (const c of calls) {
+      await o.dispatcherOptions.deliver({ text: c.text, isReasoning: c.isReasoning }, { kind: c.kind });
+    }
+    if (opts.throwAfter) throw new Error("dispatch boom");
+  });
+}
+
+const run = (seedOverrides: Partial<ForkSeedContext> = {}) =>
+  dispatchForkSeedReply({
+    seedCtx: makeSeedCtx(seedOverrides),
+    childChannelId: "group123____abc",
+    accountId: "acct1",
+    apiUrl: "https://api.test",
+    botToken: "bf_tok",
+    config: {} as never,
+    log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } as never,
+  });
+
+describe("dispatchForkSeedReply", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockResolveAgentRoute.mockReturnValue({ sessionKey: "octo:acct1:group123____abc", accountId: "acct1" });
+    mockFinalize.mockImplementation((ctx: unknown) => ctx);
+    mockDispatch.mockResolvedValue(undefined);
+  });
+
+  it("resolves the CHILD route by childChannelId", async () => {
+    await run();
+    expect(mockResolveAgentRoute).toHaveBeenCalledWith(
+      expect.objectContaining({ peer: { kind: "group", id: "group123____abc" } }),
+    );
+  });
+
+  it("FORK-TRIGGER INVARIANT: SessionKey comes from the child route, not the seed ctx", async () => {
+    await run();
+    const ctx = mockFinalize.mock.calls[0][0] as ForkSeedContext & { SessionKey: string };
+    // SessionKey is the child route's key — NOT copied from any seed field.
+    expect(ctx.SessionKey).toBe("octo:acct1:group123____abc");
+    // ParentSessionKey is preserved from the seed.
+    expect(ctx.ParentSessionKey).toBe("octo:acct1:group123");
+    // The hard invariant that makes get-reply fork (and never pollute the parent).
+    expect(ctx.ParentSessionKey).not.toBe(ctx.SessionKey);
+  });
+
+  it("stamps AccountId from the child route", async () => {
+    mockResolveAgentRoute.mockReturnValue({ sessionKey: "child-key", accountId: "acctX" });
+    await run();
+    const ctx = mockFinalize.mock.calls[0][0] as ForkSeedContext;
+    expect(ctx.AccountId).toBe("acctX");
+  });
+
+  it("warns when SessionKey === ParentSessionKey (fork-trigger guard, S-1) but still dispatches", async () => {
+    // Child route resolves to the SAME key as the seed's ParentSessionKey →
+    // auto-fork would not trigger. Only reachable on a group-merged route.
+    mockResolveAgentRoute.mockReturnValue({ sessionKey: "octo:acct1:group123", accountId: "acct1" });
+    const warn = vi.fn();
+    await dispatchForkSeedReply({
+      seedCtx: makeSeedCtx(), // ParentSessionKey = "octo:acct1:group123"
+      childChannelId: "group123____abc",
+      accountId: "acct1",
+      apiUrl: "https://api.test",
+      botToken: "bf_tok",
+      config: {} as never,
+      log: { info: vi.fn(), warn, error: vi.fn(), debug: vi.fn() } as never,
+    });
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toContain("SessionKey === ParentSessionKey");
+    // The guard must NOT block dispatch — the runtime still decides.
+    expect(mockDispatch).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT warn when SessionKey differs from ParentSessionKey (normal fork)", async () => {
+    // beforeEach default child key "octo:acct1:group123____abc" ≠ parent key.
+    const warn = vi.fn();
+    await dispatchForkSeedReply({
+      seedCtx: makeSeedCtx(),
+      childChannelId: "group123____abc",
+      accountId: "acct1",
+      apiUrl: "https://api.test",
+      botToken: "bf_tok",
+      config: {} as never,
+      log: { info: vi.fn(), warn, error: vi.fn(), debug: vi.fn() } as never,
+    });
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("final kind → sends once into the child thread (CommunityTopic)", async () => {
+    driveDeliver([{ kind: "final", text: "here is the answer" }]);
+    await run();
+    expect(mockSendMessage).toHaveBeenCalledTimes(1);
+    expect(mockSendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channelId: "group123____abc",
+        channelType: 5, // ChannelType.CommunityTopic
+        content: "here is the answer",
+      }),
+    );
+  });
+
+  it("tool kind → also sends immediately", async () => {
+    driveDeliver([{ kind: "tool", text: "tool output" }]);
+    await run();
+    expect(mockSendMessage).toHaveBeenCalledTimes(1);
+    expect(mockSendMessage).toHaveBeenCalledWith(expect.objectContaining({ content: "tool output" }));
+  });
+
+  it("block-only → buffered, flushed once after the dispatcher settles", async () => {
+    driveDeliver([{ kind: "block", text: "buffered block" }]);
+    await run();
+    expect(mockSendMessage).toHaveBeenCalledTimes(1);
+    expect(mockSendMessage).toHaveBeenCalledWith(expect.objectContaining({ content: "buffered block" }));
+  });
+
+  it("reasoning / empty payloads are ignored", async () => {
+    driveDeliver([
+      { kind: "block", isReasoning: true, text: "thinking..." },
+      { kind: "final", text: "   " },
+    ]);
+    await run();
+    expect(mockSendMessage).not.toHaveBeenCalled();
+  });
+
+  it("final then a trailing block → only the final is sent (state machine)", async () => {
+    driveDeliver([
+      { kind: "final", text: "the answer" },
+      { kind: "block", text: "late stray block" },
+    ]);
+    await run();
+    expect(mockSendMessage).toHaveBeenCalledTimes(1);
+    expect(mockSendMessage).toHaveBeenCalledWith(expect.objectContaining({ content: "the answer" }));
+  });
+
+  it("dispatch throws after a buffered block → finally still flushes, then rejects", async () => {
+    driveDeliver([{ kind: "block", text: "partial work" }], { throwAfter: true });
+    await expect(run()).rejects.toThrow("dispatch boom");
+    expect(mockSendMessage).toHaveBeenCalledWith(expect.objectContaining({ content: "partial work" }));
+  });
+
+  it("resolves the bot's @[uid:name] output into mention entities", async () => {
+    driveDeliver([{ kind: "final", text: "ping @[u1:Alice] done" }]);
+    await run();
+    const arg = mockSendMessage.mock.calls[0][0] as { content: string; mentionEntities?: unknown[] };
+    expect(arg.mentionEntities && arg.mentionEntities.length).toBeGreaterThan(0);
+  });
+});

--- a/src/commands/fork-seed-dispatch.test.ts
+++ b/src/commands/fork-seed-dispatch.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 // Mock the runtime + octo Bot API so we can drive dispatchForkSeedReply's deliver
 // state machine and assert the fork-trigger invariant (SessionKey comes from the
@@ -27,6 +27,7 @@ vi.mock("../api-fetch.js", () => ({
 }));
 
 import { dispatchForkSeedReply } from "./fork-inbound.js";
+import { _setDispatchTimeoutForTests } from "../inbound.js";
 import type { ForkSeedContext } from "./fork-runtime.js";
 
 function makeSeedCtx(overrides: Partial<ForkSeedContext> = {}): ForkSeedContext {
@@ -76,6 +77,7 @@ const run = (seedOverrides: Partial<ForkSeedContext> = {}) =>
     seedCtx: makeSeedCtx(seedOverrides),
     childChannelId: "group123____abc",
     accountId: "acct1",
+    account: { config: {} } as never,
     apiUrl: "https://api.test",
     botToken: "bf_tok",
     config: {} as never,
@@ -88,6 +90,11 @@ describe("dispatchForkSeedReply", () => {
     mockResolveAgentRoute.mockReturnValue({ sessionKey: "octo:acct1:group123____abc", accountId: "acct1" });
     mockFinalize.mockImplementation((ctx: unknown) => ctx);
     mockDispatch.mockResolvedValue(undefined);
+    mockSendMessage.mockImplementation(async () => ({}));
+  });
+
+  afterEach(() => {
+    _setDispatchTimeoutForTests(null); // reset any per-test timeout override
   });
 
   it("resolves the CHILD route by childChannelId", async () => {
@@ -115,24 +122,29 @@ describe("dispatchForkSeedReply", () => {
     expect(ctx.AccountId).toBe("acctX");
   });
 
-  it("warns when SessionKey === ParentSessionKey (fork-trigger guard, S-1) but still dispatches", async () => {
+  it("ISOLATION GUARD (fail-closed, P2-1): SessionKey === ParentSessionKey → throws, does NOT dispatch", async () => {
     // Child route resolves to the SAME key as the seed's ParentSessionKey →
-    // auto-fork would not trigger. Only reachable on a group-merged route.
+    // auto-fork would not trigger and the seed would run ON the parent session.
+    // Upgraded from warn-and-continue to fail-closed: refuse to dispatch.
     mockResolveAgentRoute.mockReturnValue({ sessionKey: "octo:acct1:group123", accountId: "acct1" });
     const warn = vi.fn();
-    await dispatchForkSeedReply({
-      seedCtx: makeSeedCtx(), // ParentSessionKey = "octo:acct1:group123"
-      childChannelId: "group123____abc",
-      accountId: "acct1",
-      apiUrl: "https://api.test",
-      botToken: "bf_tok",
-      config: {} as never,
-      log: { info: vi.fn(), warn, error: vi.fn(), debug: vi.fn() } as never,
-    });
+    await expect(
+      dispatchForkSeedReply({
+        seedCtx: makeSeedCtx(), // ParentSessionKey = "octo:acct1:group123"
+        childChannelId: "group123____abc",
+        accountId: "acct1",
+        account: { config: {} } as never,
+        apiUrl: "https://api.test",
+        botToken: "bf_tok",
+        config: {} as never,
+        log: { info: vi.fn(), warn, error: vi.fn(), debug: vi.fn() } as never,
+      }),
+    ).rejects.toThrow(/isolation guard/i);
     expect(warn).toHaveBeenCalledTimes(1);
-    expect(warn.mock.calls[0][0]).toContain("SessionKey === ParentSessionKey");
-    // The guard must NOT block dispatch — the runtime still decides.
-    expect(mockDispatch).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toContain("isolation guard");
+    // fail-closed core assertion: neither finalize nor dispatch must run.
+    expect(mockFinalize).not.toHaveBeenCalled();
+    expect(mockDispatch).not.toHaveBeenCalled();
   });
 
   it("does NOT warn when SessionKey differs from ParentSessionKey (normal fork)", async () => {
@@ -142,6 +154,7 @@ describe("dispatchForkSeedReply", () => {
       seedCtx: makeSeedCtx(),
       childChannelId: "group123____abc",
       accountId: "acct1",
+      account: { config: {} } as never,
       apiUrl: "https://api.test",
       botToken: "bf_tok",
       config: {} as never,
@@ -207,5 +220,66 @@ describe("dispatchForkSeedReply", () => {
     await run();
     const arg = mockSendMessage.mock.calls[0][0] as { content: string; mentionEntities?: unknown[] };
     expect(arg.mentionEntities && arg.mentionEntities.length).toBeGreaterThan(0);
+  });
+
+  it("TIMEOUT GUARD (Critical, #75): a hung dispatcher times out and rejects, never hangs forever", async () => {
+    _setDispatchTimeoutForTests(50);
+    mockDispatch.mockImplementation(() => new Promise<void>(() => {})); // never settles
+    const warn = vi.fn();
+    await expect(
+      dispatchForkSeedReply({
+        seedCtx: makeSeedCtx(),
+        childChannelId: "group123____abc",
+        accountId: "acct1",
+        account: { config: {} } as never,
+        apiUrl: "https://api.test",
+        botToken: "bf_tok",
+        config: {} as never,
+        log: { info: vi.fn(), warn, error: vi.fn(), debug: vi.fn() } as never,
+      }),
+    ).rejects.toThrow(/timed out/i);
+    // The timeout rethrow is what lets spawnChildBoundSession surface seedFailed
+    // and the parent enqueueInbound queue advance instead of locking forever.
+    expect(warn.mock.calls.some((c) => String(c[0]).includes("hung past"))).toBe(true);
+  });
+
+  it("normal dispatch resolves well within the timeout (guard does not fire)", async () => {
+    _setDispatchTimeoutForTests(10_000);
+    driveDeliver([{ kind: "final", text: "quick answer" }]);
+    const warn = vi.fn();
+    await dispatchForkSeedReply({
+      seedCtx: makeSeedCtx(),
+      childChannelId: "group123____abc",
+      accountId: "acct1",
+      account: { config: {} } as never,
+      apiUrl: "https://api.test",
+      botToken: "bf_tok",
+      config: {} as never,
+      log: { info: vi.fn(), warn, error: vi.fn(), debug: vi.fn() } as never,
+    });
+    expect(mockSendMessage).toHaveBeenCalledWith(expect.objectContaining({ content: "quick answer" }));
+    expect(warn.mock.calls.some((c) => String(c[0]).includes("hung past"))).toBe(false);
+  });
+
+  it("finally flush failure does NOT mask the original dispatch error (P2-5)", async () => {
+    driveDeliver([{ kind: "block", text: "partial" }], { throwAfter: true });
+    // The single sendMessage call is the finally flush; make it throw too.
+    mockSendMessage.mockImplementationOnce(async () => {
+      throw new Error("flush boom");
+    });
+    const error = vi.fn();
+    await expect(
+      dispatchForkSeedReply({
+        seedCtx: makeSeedCtx(),
+        childChannelId: "group123____abc",
+        accountId: "acct1",
+        account: { config: {} } as never,
+        apiUrl: "https://api.test",
+        botToken: "bf_tok",
+        config: {} as never,
+        log: { info: vi.fn(), warn: vi.fn(), error, debug: vi.fn() } as never,
+      }),
+    ).rejects.toThrow("dispatch boom"); // original error wins, NOT "flush boom"
+    expect(error.mock.calls.some((c) => String(c[0]).includes("finally flush failed"))).toBe(true);
   });
 });

--- a/src/commands/fork.test.ts
+++ b/src/commands/fork.test.ts
@@ -4,6 +4,7 @@ import {
   deriveThreadName,
   isInsideThread,
   resolveForkScope,
+  forkScopeStartupWarning,
   executeFork,
   type ForkOrchestrator,
 } from "./fork.js";
@@ -341,5 +342,27 @@ describe("executeFork", () => {
       "[fork] sendParentReceipt failed",
       expect.objectContaining({ error: "send timeout" }),
     );
+  });
+});
+
+describe("forkScopeStartupWarning (F3)", () => {
+  it("undefined scope → null (nothing configured)", () => {
+    expect(forkScopeStartupWarning(undefined)).toBeNull();
+  });
+
+  it("default owner-mentioned → null (no warning needed)", () => {
+    expect(forkScopeStartupWarning("owner-mentioned")).toBeNull();
+  });
+
+  it("non-default scope → warning mentioning the value + the default", () => {
+    const msg = forkScopeStartupWarning("any");
+    expect(msg).toContain('commands.fork.scope="any"');
+    expect(msg).toContain("not yet wired");
+    expect(msg).toContain("owner-mentioned");
+  });
+
+  it("each non-default scope warns", () => {
+    expect(forkScopeStartupWarning("any-mentioned")).not.toBeNull();
+    expect(forkScopeStartupWarning("owner-only")).not.toBeNull();
   });
 });

--- a/src/commands/fork.test.ts
+++ b/src/commands/fork.test.ts
@@ -1,0 +1,345 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  parseForkCommand,
+  deriveThreadName,
+  isInsideThread,
+  resolveForkScope,
+  executeFork,
+  type ForkOrchestrator,
+} from "./fork.js";
+
+describe("parseForkCommand", () => {
+  it("parses `/fork hello` → ok with prompt", () => {
+    expect(parseForkCommand("/fork hello")).toEqual({ ok: true, prompt: "hello" });
+  });
+
+  it("trims surrounding whitespace from the prompt", () => {
+    expect(parseForkCommand("/fork   hello world  ")).toEqual({ ok: true, prompt: "hello world" });
+  });
+
+  it("captures multi-line prompts whole", () => {
+    expect(parseForkCommand("/fork line1\nline2")).toEqual({ ok: true, prompt: "line1\nline2" });
+  });
+
+  it("bare `/fork` → empty", () => {
+    expect(parseForkCommand("/fork")).toEqual({ ok: false, reason: "empty" });
+  });
+
+  it("`/fork   ` (whitespace only) → empty", () => {
+    expect(parseForkCommand("/fork   ")).toEqual({ ok: false, reason: "empty" });
+  });
+
+  it("`/forks foo` → not_fork_command", () => {
+    expect(parseForkCommand("/forks foo")).toEqual({ ok: false, reason: "not_fork_command" });
+  });
+
+  it("non-command text → not_fork_command", () => {
+    expect(parseForkCommand("hello /fork")).toEqual({ ok: false, reason: "not_fork_command" });
+  });
+
+  it("is case-sensitive: `/Fork x` → not_fork_command", () => {
+    expect(parseForkCommand("/Fork x")).toEqual({ ok: false, reason: "not_fork_command" });
+  });
+
+  it("trims the whole command body before matching: `  /fork x  ` → ok", () => {
+    expect(parseForkCommand("  /fork x  ")).toEqual({ ok: true, prompt: "x" });
+  });
+
+  it("`  /fork  ` (padded, no prompt) → empty", () => {
+    expect(parseForkCommand("  /fork  ")).toEqual({ ok: false, reason: "empty" });
+  });
+});
+
+describe("deriveThreadName", () => {
+  const fixedNow = () => new Date("2026-06-22T10:20:30.123Z");
+
+  it("keeps a short English prompt verbatim", () => {
+    expect(deriveThreadName("hello world", fixedNow)).toBe("hello world");
+  });
+
+  it("truncates a long Chinese prompt to 30 code points", () => {
+    const prompt = "中".repeat(40);
+    expect(deriveThreadName(prompt, fixedNow)).toBe("中".repeat(30));
+  });
+
+  it("counts astral emoji by code point without splitting surrogate pairs", () => {
+    const prompt = "😀".repeat(31);
+    const result = deriveThreadName(prompt, fixedNow);
+    expect([...result]).toHaveLength(30);
+    expect(result).toBe("😀".repeat(30));
+  });
+
+  it("empty string → ISO timestamp fallback without millis", () => {
+    expect(deriveThreadName("", fixedNow)).toBe("Forked: 2026-06-22T10:20:30Z");
+  });
+
+  it("whitespace-only string → fallback", () => {
+    expect(deriveThreadName("   \n\t ", fixedNow)).toBe("Forked: 2026-06-22T10:20:30Z");
+  });
+
+  it("trims leading/trailing whitespace before truncating", () => {
+    expect(deriveThreadName("  hello  ", fixedNow)).toBe("hello");
+  });
+
+  it("two spaces → fallback timestamp", () => {
+    expect(deriveThreadName("  ", fixedNow)).toBe("Forked: 2026-06-22T10:20:30Z");
+  });
+
+  it("boundary: exactly 30 chars kept verbatim", () => {
+    const prompt = "a".repeat(30);
+    expect(deriveThreadName(prompt, fixedNow)).toBe(prompt);
+  });
+
+  it("boundary: 31 chars truncated to 30", () => {
+    const prompt = "a".repeat(31);
+    expect(deriveThreadName(prompt, fixedNow)).toBe("a".repeat(30));
+  });
+});
+
+describe("isInsideThread", () => {
+  it("plain group channelId (no ____) → false", () => {
+    expect(isInsideThread("group123")).toBe(false);
+  });
+
+  it("thread channelId (groupNo____shortId) → true", () => {
+    expect(isInsideThread("group123____abc")).toBe(true);
+  });
+
+  it("multiple ____ separators → true", () => {
+    expect(isInsideThread("group123____abc____def")).toBe(true);
+  });
+});
+
+describe("resolveForkScope", () => {
+  // Truth table across all four scopes × (isGroup, isOwnerUser, isExplicitBotMention).
+  type Case = [boolean, boolean, boolean, boolean]; // isGroup, isOwner, mention, expected
+
+  const tables: Record<string, Case[]> = {
+    // DM → anyone; group → owner + mention.
+    "owner-mentioned": [
+      [false, false, false, true],
+      [false, false, true, true],
+      [false, true, false, true],
+      [false, true, true, true],
+      [true, false, false, false],
+      [true, false, true, false],
+      [true, true, false, false],
+      [true, true, true, true],
+    ],
+    // DM → anyone; group → any member + mention.
+    "any-mentioned": [
+      [false, false, false, true],
+      [false, false, true, true],
+      [false, true, false, true],
+      [false, true, true, true],
+      [true, false, false, false],
+      [true, false, true, true],
+      [true, true, false, false],
+      [true, true, true, true],
+    ],
+    // Must be owner everywhere; group still needs mention.
+    "owner-only": [
+      [false, false, false, false],
+      [false, false, true, false],
+      [false, true, false, true],
+      [false, true, true, true],
+      [true, false, false, false],
+      [true, false, true, false],
+      [true, true, false, false],
+      [true, true, true, true],
+    ],
+    // Anyone, anywhere.
+    "any": [
+      [false, false, false, true],
+      [false, false, true, true],
+      [false, true, false, true],
+      [false, true, true, true],
+      [true, false, false, true],
+      [true, false, true, true],
+      [true, true, false, true],
+      [true, true, true, true],
+    ],
+  };
+
+  for (const [scope, cases] of Object.entries(tables)) {
+    describe(`scope=${scope}`, () => {
+      for (const [isGroup, isOwner, mention, expected] of cases) {
+        it(`isGroup=${isGroup} owner=${isOwner} mention=${mention} → ${expected}`, () => {
+          expect(resolveForkScope(scope, isGroup, isOwner, mention)).toBe(expected);
+        });
+      }
+    });
+  }
+
+  it("undefined scope falls back to owner-mentioned", () => {
+    // group + non-owner + mention → false under owner-mentioned
+    expect(resolveForkScope(undefined, true, false, true)).toBe(false);
+    // group + owner + mention → true
+    expect(resolveForkScope(undefined, true, true, true)).toBe(true);
+  });
+
+  it("unknown scope value falls back to owner-mentioned", () => {
+    expect(resolveForkScope("bogus", true, false, true)).toBe(false);
+    expect(resolveForkScope("bogus", true, true, true)).toBe(true);
+  });
+});
+
+describe("executeFork", () => {
+  const fixedNow = () => new Date("2026-06-22T10:20:30.123Z");
+
+  function makeDeps(overrides: Partial<ForkOrchestrator> = {}): ForkOrchestrator {
+    return {
+      spawnChildBoundSession: vi.fn(async () => ({ childChannelId: "group123____abc" })),
+      sendParentReceipt: vi.fn(async () => {}),
+      log: vi.fn(),
+      ...overrides,
+    };
+  }
+
+  const baseInput = {
+    prompt: "explain the bug",
+    parentChannelId: "group123",
+    parentSessionKey: "octo:acct1:group123",
+    now: fixedNow,
+  };
+
+  it("full success: spawns child session, sends plain receipt", async () => {
+    const deps = makeDeps();
+    const result = await executeFork(deps, baseInput);
+
+    expect(result.status).toBe("ok");
+    expect(result.threadName).toBe("explain the bug");
+    expect(result.channelId).toBe("group123____abc");
+    expect(result.nested).toBe(false);
+    expect(result.replyText).toBe("已开 fork 子区：explain the bug");
+
+    expect(deps.spawnChildBoundSession).toHaveBeenCalledWith({
+      parentChannelId: "group123",
+      parentSessionKey: "octo:acct1:group123",
+      prompt: "explain the bug",
+      threadName: "explain the bug",
+    });
+    expect(deps.sendParentReceipt).toHaveBeenCalledWith({ text: "已开 fork 子区：explain the bug" });
+  });
+
+  it("empty prompt: early-returns with usage hint, nothing spawned", async () => {
+    const deps = makeDeps();
+    const result = await executeFork(deps, { ...baseInput, prompt: "   " });
+
+    expect(result.status).toBe("empty_prompt");
+    expect(result.replyText).toBe("用法：/fork <你的问题>");
+    expect(deps.spawnChildBoundSession).not.toHaveBeenCalled();
+    expect(deps.sendParentReceipt).toHaveBeenCalledWith({ text: "用法：/fork <你的问题>" });
+  });
+
+  it("spawn failure: aborts with failure receipt", async () => {
+    const deps = makeDeps({
+      spawnChildBoundSession: vi.fn(async () => {
+        throw new Error("thread quota exceeded");
+      }),
+    });
+    const result = await executeFork(deps, baseInput);
+
+    expect(result.status).toBe("spawn_failed");
+    expect(result.channelId).toBeUndefined();
+    expect(result.replyText).toBe("开 fork 子区失败：thread quota exceeded");
+    expect(deps.sendParentReceipt).toHaveBeenCalledWith({ text: "开 fork 子区失败：thread quota exceeded" });
+    expect(deps.log).toHaveBeenCalledWith(
+      "error",
+      "[fork] spawnChildBoundSession failed",
+      expect.objectContaining({ error: "thread quota exceeded" }),
+    );
+  });
+
+  it("nested fork: parent is already a thread → nested=true, logs info, flow proceeds", async () => {
+    const deps = makeDeps();
+    const result = await executeFork(deps, { ...baseInput, parentChannelId: "group123____parent" });
+
+    expect(result.status).toBe("ok");
+    expect(result.nested).toBe(true);
+    expect(deps.spawnChildBoundSession).toHaveBeenCalledWith({
+      parentChannelId: "group123____parent",
+      parentSessionKey: "octo:acct1:group123",
+      prompt: "explain the bug",
+      threadName: "explain the bug",
+    });
+    expect(deps.log).toHaveBeenCalledWith(
+      "info",
+      "[fork] nested fork: parent is a thread",
+      expect.objectContaining({ parentChannelId: "group123____parent" }),
+    );
+  });
+
+  it("seed-failed: thread exists but dispatch failed → ok_seed_failed + retry receipt (I-1)", async () => {
+    const deps = makeDeps({
+      spawnChildBoundSession: vi.fn(async () => ({ childChannelId: "group123____abc", seedFailed: true })),
+    });
+    const result = await executeFork(deps, baseInput);
+
+    expect(result.status).toBe("ok_seed_failed");
+    expect(result.channelId).toBe("group123____abc");
+    expect(result.threadName).toBe("explain the bug");
+    expect(result.replyText).toBe("已开 fork 子区：explain the bug（首条问题处理失败，请到子区重发）");
+    expect(deps.sendParentReceipt).toHaveBeenCalledWith({
+      text: "已开 fork 子区：explain the bug（首条问题处理失败，请到子区重发）",
+    });
+  });
+
+  it("receipt failure on the ok path: logged, swallowed, status stays ok (S-1)", async () => {
+    const deps = makeDeps({
+      sendParentReceipt: vi.fn(async () => {
+        throw new Error("send timeout");
+      }),
+    });
+    const result = await executeFork(deps, baseInput);
+
+    expect(result.status).toBe("ok");
+    expect(result.channelId).toBe("group123____abc");
+    expect(deps.log).toHaveBeenCalledWith(
+      "error",
+      "[fork] sendParentReceipt failed",
+      expect.objectContaining({ error: "send timeout" }),
+    );
+  });
+
+  it("receipt failure on the empty-prompt path: logged, swallowed, status stays empty_prompt (S-1)", async () => {
+    const deps = makeDeps({
+      sendParentReceipt: vi.fn(async () => {
+        throw new Error("send timeout");
+      }),
+    });
+    const result = await executeFork(deps, { ...baseInput, prompt: "   " });
+
+    expect(result.status).toBe("empty_prompt");
+    expect(deps.log).toHaveBeenCalledWith(
+      "error",
+      "[fork] sendParentReceipt failed",
+      expect.objectContaining({ error: "send timeout" }),
+    );
+  });
+
+  it("receipt failure on the spawn-failed path: logged, swallowed, status stays spawn_failed (S-1)", async () => {
+    const deps = makeDeps({
+      spawnChildBoundSession: vi.fn(async () => {
+        throw new Error("thread quota exceeded");
+      }),
+      sendParentReceipt: vi.fn(async () => {
+        throw new Error("send timeout");
+      }),
+    });
+    const result = await executeFork(deps, baseInput);
+
+    expect(result.status).toBe("spawn_failed");
+    // Both the spawn error and the receipt error are logged.
+    expect(deps.log).toHaveBeenCalledWith(
+      "error",
+      "[fork] spawnChildBoundSession failed",
+      expect.objectContaining({ error: "thread quota exceeded" }),
+    );
+    expect(deps.log).toHaveBeenCalledWith(
+      "error",
+      "[fork] sendParentReceipt failed",
+      expect.objectContaining({ error: "send timeout" }),
+    );
+  });
+});

--- a/src/commands/fork.ts
+++ b/src/commands/fork.ts
@@ -1,0 +1,290 @@
+// `/fork` command — pure orchestration layer.
+//
+// This module is intentionally free of any octo Bot API / OpenClaw runtime
+// calls. It only parses the command, derives metadata, resolves authorization
+// scope, and orchestrates the fork flow against a single injected dependency,
+// `spawnChildBoundSession`. The concrete implementation (octo `createThread` +
+// seed-context assembly + dispatch seam) lives in `fork-runtime.ts`.
+//
+// Fork model (spec §5.2, "Plan B"): the fork is NOT driven from the plugin.
+// Creating the child thread and dispatching the prompt into it — with the
+// parent session key on the inbound context — makes the OpenClaw reply pipeline
+// auto-fork the parent transcript into the child session. The plugin therefore
+// cannot synchronously observe whether the fork carried context or fell back to
+// isolated, so there is no `forkMode` here; the parent receipt is a flat
+// confirmation (decision matrix #3).
+//
+// See docs/specs/2026-06-18-fork-command-design.md.
+
+import { THREAD_ID_SEPARATOR } from "../constants.js";
+
+/** Result of parsing a stripped command body against the `/fork` grammar. */
+export type ParseForkResult =
+  | { ok: true; prompt: string }
+  | { ok: false; reason: "empty" | "not_fork_command" };
+
+/**
+ * Parse a command body (already stripped of any leading `@bot ` mention; see
+ * `resolveCommandBody` in inbound.ts) against the `/fork <prompt>` grammar.
+ *
+ * Matching is case-sensitive (`/Fork` is not `/fork`) and tolerant of
+ * surrounding whitespace (`  /fork x  ` matches). A bare `/fork` or one
+ * followed only by whitespace yields `empty`. Anything that is not the `/fork`
+ * token yields `not_fork_command`.
+ *
+ * @param commandBody Stripped command body.
+ * @returns Parsed prompt on success, or a reason for rejection.
+ */
+export function parseForkCommand(commandBody: string): ParseForkResult {
+  // `[\s\S]` (not `.`) so multi-line prompts are captured whole.
+  const match = commandBody.trim().match(/^\/fork(?:\s+([\s\S]*))?$/);
+  if (!match) {
+    return { ok: false, reason: "not_fork_command" };
+  }
+  const prompt = (match[1] ?? "").trim();
+  if (prompt === "") {
+    return { ok: false, reason: "empty" };
+  }
+  return { ok: true, prompt };
+}
+
+/** Maximum thread-name length, counted in Unicode code points (spec §3.2). */
+const THREAD_NAME_MAX_CODE_POINTS = 30;
+
+/**
+ * Derive the child thread name from the fork prompt (spec §3.2).
+ *
+ * Takes the first 30 Unicode code points of the prompt. Code-point counting
+ * (via the string iterator) keeps surrogate pairs — emoji, astral chars —
+ * intact; CJK wide chars count as one each. When the prompt is empty or
+ * whitespace-only, falls back to `Forked: <ISO timestamp without millis>`.
+ *
+ * @param prompt Fork prompt text.
+ * @param now Clock injection for deterministic fallback naming.
+ * @returns Thread name.
+ */
+export function deriveThreadName(prompt: string, now: () => Date): string {
+  const trimmed = prompt.trim();
+  if (trimmed === "") {
+    const iso = now().toISOString().replace(/\.\d{3}Z$/, "Z");
+    return `Forked: ${iso}`;
+  }
+  return [...trimmed].slice(0, THREAD_NAME_MAX_CODE_POINTS).join("");
+}
+
+/**
+ * Whether the given channelId already refers to a thread / sub-topic, i.e. it
+ * contains the `____` separator (`<groupNo>____<shortId>`). Used to detect a
+ * nested fork (spec §5.5).
+ */
+export function isInsideThread(channelId: string): boolean {
+  return channelId.includes(THREAD_ID_SEPARATOR);
+}
+
+/** Authorization scope for `/fork` (spec §5.4). */
+export type ForkScope = "owner-mentioned" | "any-mentioned" | "owner-only" | "any";
+
+const VALID_FORK_SCOPES: ReadonlySet<string> = new Set<ForkScope>([
+  "owner-mentioned",
+  "any-mentioned",
+  "owner-only",
+  "any",
+]);
+
+/**
+ * Resolve whether a sender is authorized to run `/fork` under the configured
+ * scope (spec §5.4). Unknown scope values fall back to the default
+ * `owner-mentioned`.
+ *
+ * Scope semantics:
+ * - `owner-mentioned` (default): DM → anyone; group → owner + explicit @bot.
+ *   Equivalent to the existing `resolveCommandAuthorized`.
+ * - `any-mentioned`: DM → anyone; group → any member + explicit @bot.
+ * - `owner-only`: must be owner everywhere; group still requires explicit @bot.
+ * - `any`: anyone, anywhere (widest; use with care).
+ *
+ * @param scope Configured scope, or undefined for the default.
+ * @param isGroup Whether the message is from a group (vs DM).
+ * @param isOwnerUser Whether the sender is the registered owner.
+ * @param isExplicitBotMention Whether the bot was explicitly @mentioned.
+ */
+export function resolveForkScope(
+  scope: string | undefined,
+  isGroup: boolean,
+  isOwnerUser: boolean,
+  isExplicitBotMention: boolean,
+): boolean {
+  const effective: ForkScope = VALID_FORK_SCOPES.has(scope ?? "")
+    ? (scope as ForkScope)
+    : "owner-mentioned";
+
+  switch (effective) {
+    case "owner-mentioned":
+      return !isGroup || (isOwnerUser && isExplicitBotMention);
+    case "any-mentioned":
+      return !isGroup || isExplicitBotMention;
+    case "owner-only":
+      return isOwnerUser && (!isGroup || isExplicitBotMention);
+    case "any":
+      return true;
+  }
+}
+
+export type ForkLogLevel = "debug" | "info" | "warn" | "error";
+export type ForkLogger = (level: ForkLogLevel, message: string, meta?: Record<string, unknown>) => void;
+
+/**
+ * Injected dependency for {@link executeFork}.
+ *
+ * `spawnChildBoundSession` merges what were previously separate create-thread,
+ * fork-session, and seed-message steps: under the Plan B fork model the child
+ * channelId only exists after the thread is created, and the fork itself is a
+ * runtime side-effect of the seed dispatch — so the three cannot be driven
+ * independently from the plugin. The concrete implementation lives in
+ * `fork-runtime.ts`.
+ */
+export interface ForkOrchestrator {
+  /**
+   * Create the child thread under the parent group, assemble the seed inbound
+   * context (carrying `parentSessionKey`), and dispatch the prompt into the new
+   * thread — which triggers the runtime auto-fork.
+   *
+   * Failure semantics are split by whether the thread got created (I-1):
+   * - throws → the thread was NOT created (e.g. createThread error); the fork
+   *   has no side effect and executeFork reports `spawn_failed`.
+   * - resolves with `seedFailed: true` → the thread DOES exist but the seed
+   *   dispatch failed; executeFork reports `ok_seed_failed` and tells the user
+   *   to retry in the now-live child thread.
+   * - resolves without `seedFailed` → full success.
+   */
+  spawnChildBoundSession(args: {
+    parentChannelId: string;
+    parentSessionKey: string;
+    prompt: string;
+    threadName: string;
+  }): Promise<{ childChannelId: string; seedFailed?: boolean }>;
+  /** Send the plain-text receipt back to the parent conversation. */
+  sendParentReceipt(args: { text: string }): Promise<void>;
+  log: ForkLogger;
+}
+
+/** Input to {@link executeFork}. */
+export interface ForkInput {
+  /** Parsed fork prompt (re-validated defensively inside executeFork). */
+  prompt: string;
+  /** ChannelId of the originating conversation (parent group, or a thread for nested forks). */
+  parentChannelId: string;
+  /** Session key of the parent conversation; seeds the runtime auto-fork. */
+  parentSessionKey: string;
+  /** Clock injection for deterministic thread-name fallback. */
+  now: () => Date;
+}
+
+/**
+ * Terminal status of an {@link executeFork} run.
+ *
+ * `ok_seed_failed`: the child thread was created but the seed dispatch failed
+ * (I-1). The thread is live and usable; the fork's first prompt just didn't
+ * land, so the receipt asks the user to resend it in the child thread.
+ */
+export type ForkStatus = "ok" | "ok_seed_failed" | "empty_prompt" | "spawn_failed";
+
+/** Structured result of {@link executeFork}. */
+export interface ForkResult {
+  status: ForkStatus;
+  /** Present when a thread was created. */
+  threadName?: string;
+  /** Present when a thread was created (the child thread channelId). */
+  channelId?: string;
+  /** Whether the parent was itself a thread (nested fork). */
+  nested: boolean;
+  /** Plain text already sent to the parent conversation. */
+  replyText: string;
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+/**
+ * Send the parent-group receipt, swallowing any failure (S-1). The fork's main
+ * effect (thread + seed dispatch) is already done by the time any receipt is
+ * sent, so a receipt error must never bubble out of executeFork or alter its
+ * status — it is logged and dropped.
+ */
+async function safeSendReceipt(deps: ForkOrchestrator, text: string): Promise<void> {
+  try {
+    await deps.sendParentReceipt({ text });
+  } catch (err) {
+    deps.log("error", "[fork] sendParentReceipt failed", { error: errorMessage(err) });
+  }
+}
+
+/**
+ * Orchestrate the `/fork` flow (spec §3): validate prompt → derive thread name →
+ * spawn the child bound session → send the parent-group receipt. Pure
+ * orchestration over the injected {@link ForkOrchestrator}; performs no
+ * octo/runtime calls itself.
+ *
+ * Exception handling (spec §3.3):
+ * - empty prompt → usage hint, nothing spawned;
+ * - spawnChildBoundSession throws → `开 fork 子区失败：<msg>` receipt, flow aborts
+ *   (thread was not created);
+ * - spawnChildBoundSession resolves with `seedFailed` → thread exists but the
+ *   first prompt didn't land; receipt asks the user to resend in the child (I-1);
+ * - sendParentReceipt failures are logged and swallowed, never bubbled (S-1);
+ * - nested fork (parent is already a thread) → allowed; logged.
+ *
+ * @param deps Injected orchestration dependency.
+ * @param input Fork input.
+ * @returns Structured result describing what happened.
+ */
+export async function executeFork(deps: ForkOrchestrator, input: ForkInput): Promise<ForkResult> {
+  const nested = isInsideThread(input.parentChannelId);
+  const prompt = input.prompt.trim();
+
+  if (prompt === "") {
+    const replyText = "用法：/fork <你的问题>";
+    await safeSendReceipt(deps, replyText);
+    return { status: "empty_prompt", nested, replyText };
+  }
+
+  if (nested) {
+    deps.log("info", "[fork] nested fork: parent is a thread", { parentChannelId: input.parentChannelId });
+  }
+
+  const threadName = deriveThreadName(prompt, input.now);
+
+  let spawned: { childChannelId: string; seedFailed?: boolean };
+  try {
+    spawned = await deps.spawnChildBoundSession({
+      parentChannelId: input.parentChannelId,
+      parentSessionKey: input.parentSessionKey,
+      prompt,
+      threadName,
+    });
+  } catch (err) {
+    const message = errorMessage(err);
+    deps.log("error", "[fork] spawnChildBoundSession failed", { error: message });
+    const replyText = `开 fork 子区失败：${message}`;
+    await safeSendReceipt(deps, replyText);
+    return { status: "spawn_failed", nested, replyText };
+  }
+
+  if (spawned.seedFailed) {
+    const replyText = `已开 fork 子区：${threadName}（首条问题处理失败，请到子区重发）`;
+    await safeSendReceipt(deps, replyText);
+    return { status: "ok_seed_failed", threadName, channelId: spawned.childChannelId, nested, replyText };
+  }
+
+  const replyText = `已开 fork 子区：${threadName}`;
+  await safeSendReceipt(deps, replyText);
+
+  return {
+    status: "ok",
+    threadName,
+    channelId: spawned.childChannelId,
+    nested,
+    replyText,
+  };
+}

--- a/src/commands/fork.ts
+++ b/src/commands/fork.ts
@@ -130,6 +130,26 @@ export function resolveForkScope(
   }
 }
 
+/** Default fork scope — the only value v1's inbound hook actually honors. */
+export const DEFAULT_FORK_SCOPE: ForkScope = "owner-mentioned";
+
+/**
+ * Startup warning for a configured `commands.fork.scope` that v1 does not yet
+ * honor (F3, PR #131 review). v1's inbound hook always uses the default
+ * `owner-mentioned`; wiring a configured value is a v1.1 TODO. So an operator
+ * who sets a non-default scope would be silently fail-closed — confusing.
+ *
+ * @returns The one-line warning when `scope` is a non-default value, or null
+ *   when it is unset or already the default (nothing to warn about).
+ */
+export function forkScopeStartupWarning(scope: string | undefined): string | null {
+  if (!scope || scope === DEFAULT_FORK_SCOPE) return null;
+  return (
+    `octo: commands.fork.scope="${scope}" is configured but not yet wired in v1; ` +
+    `using default "${DEFAULT_FORK_SCOPE}"`
+  );
+}
+
 export type ForkLogLevel = "debug" | "info" | "warn" | "error";
 export type ForkLogger = (level: ForkLogLevel, message: string, meta?: Record<string, unknown>) => void;
 

--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -1,5 +1,20 @@
 // Plain config types — no external dependencies
 
+/**
+ * Authorization scope for the `/fork` command (spec §5.4). v1 reads only the
+ * default (`owner-mentioned`); wiring inbound to honor a configured value is a
+ * v1.1 TODO. The schema accepts all four so a future config that sets it does
+ * not fail validation today.
+ */
+export type ForkCommandScope = "owner-mentioned" | "any-mentioned" | "owner-only" | "any";
+
+/** Per-command configuration (top-level only; not per-account in v1). */
+export interface OctoCommandsConfig {
+  fork?: {
+    scope?: ForkCommandScope;
+  };
+}
+
 export interface OctoAccountConfig {
   name?: string;
   enabled?: boolean;
@@ -34,6 +49,7 @@ export interface OctoConfig {
   onBehalfOf?: string;  // Persona clone: grantor uid — bot acts on behalf of this human
   secretsFileRoot?: string;  // Jail root for write-secret (see OctoAccountConfig)
   dispatchTimeoutMs?: number;  // Explicit per-inbound dispatch timeout override (ms); see OctoAccountConfig
+  commands?: OctoCommandsConfig;  // Per-command config (e.g. commands.fork.scope); v1 reads defaults only
   accounts?: Record<string, OctoAccountConfig | undefined>;
 }
 
@@ -56,6 +72,29 @@ export const SECRETS_FILE_ROOT_DESCRIPTION =
 export const DISPATCH_TIMEOUT_MS_DESCRIPTION =
   "Per-inbound dispatch timeout in milliseconds (infrastructure backstop that releases the per-group queue when an upstream dispatch hangs). When unset, derived from agents.defaults.timeoutSeconds (default 600) as timeoutSeconds*1000 + 60000, so it always fires after the agent-run timeout. Set explicitly only when you need to decouple it from the agent timeout.";
 
+// Shared description for commands.fork.scope, kept identical to the wording in
+// openclaw.plugin.json (manifest-schema-sync.test.ts asserts key-level sync).
+export const FORK_SCOPE_DESCRIPTION =
+  "Authorization scope for the /fork command. v1 honors only the default (owner-mentioned); wiring inbound to read a configured value is a v1.1 TODO. The enum accepts all four values so a future config does not fail validation today.";
+
+// Reusable JSON Schema fragment for the `commands` block (top-level only in v1).
+const COMMANDS_SCHEMA = {
+  type: "object" as const,
+  properties: {
+    fork: {
+      type: "object" as const,
+      properties: {
+        scope: {
+          type: "string" as const,
+          enum: ["owner-mentioned", "any-mentioned", "owner-only", "any"],
+          default: "owner-mentioned",
+          description: FORK_SCOPE_DESCRIPTION,
+        },
+      },
+    },
+  },
+};
+
 // JSON Schema for OpenClaw plugin config validation
 export const OctoConfigJsonSchema = {
   schema: {
@@ -76,6 +115,7 @@ export const OctoConfigJsonSchema = {
       onBehalfOf: { type: "string" },
       secretsFileRoot: { type: "string", description: SECRETS_FILE_ROOT_DESCRIPTION },
       dispatchTimeoutMs: { type: "number", minimum: 1000, description: DISPATCH_TIMEOUT_MS_DESCRIPTION },
+      commands: COMMANDS_SCHEMA,
       accounts: {
         type: "object",
         additionalProperties: {

--- a/src/inbound.test.ts
+++ b/src/inbound.test.ts
@@ -1893,6 +1893,19 @@ describe("pendingInboundContext", () => {
     expect(entry?.memberListPrefix).toBe("members...");
   });
 
+  // P1 (yujiawei): every group inbound sets pendingInboundContext before the
+  // command split; the fork hook early-returns BEFORE the normal dispatch
+  // delete and before the before_prompt_build get/delete, so the fork branch
+  // must delete the entry itself or it leaks. This documents that invariant by
+  // mirroring the set→fork-delete sequence. (The real call site is asserted via
+  // the dist build; inbound.test.ts has no full handleInboundMessage harness.)
+  it("fork early-return must delete the entry it set (no leak)", () => {
+    const key = "octo:acct1:group123";
+    pendingInboundContext.set(key, { historyPrefix: "h", memberListPrefix: "m" });
+    pendingInboundContext.delete(key); // the explicit delete added before `return`
+    expect(pendingInboundContext.has(key)).toBe(false);
+  });
+
   it("should allow delete after read (consume-once pattern)", () => {
     const key = "octo:group:consume";
     pendingInboundContext.set(key, {
@@ -3615,11 +3628,12 @@ describe("/fork command history leak filter (regression)", () => {
 
   // Simulate the filteredApiMsgs filter pipeline from handleInboundMessage:
   // the existing (drop-bot/empty) filter plus the new fork-command filter.
+  // String(m.content ?? "") mirrors the production coerce (P2, yujiawei).
   const filterApiMsgs = (apiMessages: any[]) =>
     apiMessages
       .filter((m: any) => m.from_uid !== botUid && (m.content || m.type !== 1))
       .filter((m: any) => !isForkCommandHistoryMessage(
-        m.content ?? "",
+        String(m.content ?? ""),
         extractMentionUids(m.payload?.mention).includes(botUid),
       ));
 
@@ -3653,5 +3667,20 @@ describe("/fork command history leak filter (regression)", () => {
     ];
     const bodies = filterApiMsgs(apiMessages).map((m) => m.content);
     expect(bodies).toEqual(["@Max 我想用 /fork 功能", "/forked repo 怎么同步"]);
+  });
+
+  it("does NOT throw on non-string content (RichText etc.) and keeps it (P2, yujiawei)", () => {
+    // getChannelMessages types content as string, but RichText (type 14) and
+    // similar payloads carry a non-string m.content. A bare .replace() on those
+    // crashes the whole backfill; String(...) coerce keeps it safe. A coerced
+    // object stringifies to "[object Object]" which is never a /fork command.
+    const apiMessages = [
+      { from_uid: "u1", content: { richText: [{ text: "hi" }] }, type: 14 },
+      { from_uid: "u1", content: ["arr", "ay"], type: 1 },
+      { from_uid: "u1", content: "正常消息", type: 1 },
+    ];
+    expect(() => filterApiMsgs(apiMessages)).not.toThrow();
+    // None of them are fork commands, so all survive the fork filter.
+    expect(filterApiMsgs(apiMessages)).toHaveLength(3);
   });
 });

--- a/src/inbound.test.ts
+++ b/src/inbound.test.ts
@@ -29,6 +29,7 @@ import {
   type ResolveFileResult,
 } from "./inbound.js";
 import { extractMentionUids, parseStructuredMentions } from "./mention-utils.js";
+import { isForkCommandHistoryMessage } from "./commands/fork-history-filter.js";
 import { normalizeMediaAttachments } from "openclaw/plugin-sdk/media-runtime";
 import { existsSync, unlinkSync, readFileSync } from "node:fs";
 
@@ -3606,5 +3607,51 @@ describe("recordSessionAccount normalizes both key AND value", () => {
     expect(sessionAccountMap.size).toBe(2);
     expect(sessionAccountMap.get("mixed_bot:sess1")).toBe("mixed_bot");
     expect(sessionAccountMap.get("mixed_bot:sess2")).toBe("mixed_bot");
+  });
+});
+
+describe("/fork command history leak filter (regression)", () => {
+  const botUid = "bot_uid_123";
+
+  // Simulate the filteredApiMsgs filter pipeline from handleInboundMessage:
+  // the existing (drop-bot/empty) filter plus the new fork-command filter.
+  const filterApiMsgs = (apiMessages: any[]) =>
+    apiMessages
+      .filter((m: any) => m.from_uid !== botUid && (m.content || m.type !== 1))
+      .filter((m: any) => !isForkCommandHistoryMessage(
+        m.content ?? "",
+        extractMentionUids(m.payload?.mention).includes(botUid),
+      ));
+
+  const mentionBot = (): MentionPayload => ({
+    entities: [{ uid: botUid, offset: 0, length: 4 }],
+  });
+
+  it("drops a prior @bot /fork command from backfilled history", () => {
+    const apiMessages = [
+      { from_uid: "u1", content: "@Max 帮我看下这个", type: 1 },
+      { from_uid: "u1", content: "@Max /fork 今天天气如何", type: 1, payload: { mention: mentionBot() } },
+      { from_uid: "u1", content: "好的谢谢", type: 1 },
+    ];
+    const bodies = filterApiMsgs(apiMessages).map((m) => m.content);
+    expect(bodies).toEqual(["@Max 帮我看下这个", "好的谢谢"]);
+  });
+
+  it("drops a bare @bot /fork (empty prompt) from history", () => {
+    const apiMessages = [
+      { from_uid: "u1", content: "@Max /fork", type: 1, payload: { mention: mentionBot() } },
+      { from_uid: "u1", content: "正常消息", type: 1 },
+    ];
+    const bodies = filterApiMsgs(apiMessages).map((m) => m.content);
+    expect(bodies).toEqual(["正常消息"]);
+  });
+
+  it("keeps ordinary messages and non-command text mentioning /fork mid-sentence", () => {
+    const apiMessages = [
+      { from_uid: "u1", content: "@Max 我想用 /fork 功能", type: 1, payload: { mention: mentionBot() } },
+      { from_uid: "u1", content: "/forked repo 怎么同步", type: 1 },
+    ];
+    const bodies = filterApiMsgs(apiMessages).map((m) => m.content);
+    expect(bodies).toEqual(["@Max 我想用 /fork 功能", "/forked repo 怎么同步"]);
   });
 });

--- a/src/inbound.ts
+++ b/src/inbound.ts
@@ -43,6 +43,8 @@ import {
 } from "./mention-utils.js";
 import type { MentionPayload, MentionEntity, SendMessageResult } from "./types.js";
 import { registerGroupAccount, ensureGroupMd, handleGroupMdEvent, broadcastGroupMdUpdate, extractParentGroupNo, extractThreadShortId, ensureThreadMd, handleThreadMdEvent } from "./group-md.js";
+import { handleForkCommandIfMatched } from "./commands/fork-inbound.js";
+import { isForkCommandHistoryMessage } from "./commands/fork-history-filter.js";
 import { isOwner } from "./owner-registry.js";
 import { isKnownBot } from "./bot-registry.js";
 import { getPersonaPromptForSession } from "./persona-prompt.js";
@@ -1860,6 +1862,13 @@ export async function handleInboundMessage(params: {
     log?.debug?.(`octo: [RECV] mention payload: isMentioned=${isMentioned}, originalCount=${originalMentionUids.length}`);
 
     if (!isMentioned) {
+      // /fork commands require an explicit @bot, so they normally never reach
+      // this non-mention cache path. Defensive: a `/fork ...` typed without
+      // @mention is control-flow noise, not conversation — never cache it as
+      // history, or it would leak into a later historyPrefix.
+      if (isForkCommandHistoryMessage(rawBody, isExplicitBotMention)) {
+        return;
+      }
       // Record as pending history context (manual — avoids SDK format incompatibility)
       if (!groupHistories.has(sessionId)) {
         groupHistories.set(sessionId, []);
@@ -1934,6 +1943,12 @@ export async function handleInboundMessage(params: {
 
         const filteredApiMsgs = apiMessages
           .filter((m: any) => m.from_uid !== botUid && (m.content || m.type !== 1))
+          // /fork commands are control-flow, already handled by the fork hook
+          // below; never inject them into the bot's historyPrefix ctx.
+          .filter((m: any) => !isForkCommandHistoryMessage(
+            m.content ?? "",
+            extractMentionUids(m.payload?.mention).includes(botUid),
+          ))
           .sort((a: any, b: any) => (a.message_seq ?? 0) - (b.message_seq ?? 0))
           .slice(-historyLimit);
         entries = filteredApiMsgs.map((m: any) => {
@@ -2178,6 +2193,32 @@ export async function handleInboundMessage(params: {
 
   const commandBody = resolveCommandBody(rawBody, isGroup, isExplicitBotMention);
   const commandAuthorized = resolveCommandAuthorized(isGroup, isOwner(account.accountId, message.from_uid), isExplicitBotMention);
+
+  // `/fork` command split (spec §3). Runs BEFORE OBO detection /
+  // finalizeInboundContext / recordInboundSession / the dispatch main path: a
+  // handled fork creates its child thread + seeds it, sends the parent receipt,
+  // and early-returns — so it never writes the parent session nor reaches the
+  // LLM on this (parent) conversation. Non-fork messages return false here and
+  // fall through unchanged (a cheap regex, no behavior change for the hot path).
+  if (
+    await handleForkCommandIfMatched({
+      commandBody,
+      commandAuthorized,
+      isGroup,
+      parentChannelId: message.channel_id ?? sessionId,
+      parentChannelType: message.channel_type ?? ChannelType.Group,
+      parentSessionKey: route.sessionKey,
+      accountId: account.accountId,
+      apiUrl: account.config.apiUrl ?? "",
+      botToken: account.config.botToken ?? "",
+      requesterUid: message.from_uid,
+      requesterName: senderName ?? message.from_uid,
+      config,
+      log,
+    })
+  ) {
+    return;
+  }
 
   // OBO v2 detection + relevance filter (R10): Must run BEFORE
   // finalizeInboundContext / recordInboundSession so that irrelevant

--- a/src/inbound.ts
+++ b/src/inbound.ts
@@ -2209,6 +2209,7 @@ export async function handleInboundMessage(params: {
       parentChannelType: message.channel_type ?? ChannelType.Group,
       parentSessionKey: route.sessionKey,
       accountId: account.accountId,
+      account,
       apiUrl: account.config.apiUrl ?? "",
       botToken: account.config.botToken ?? "",
       requesterUid: message.from_uid,

--- a/src/inbound.ts
+++ b/src/inbound.ts
@@ -1944,9 +1944,13 @@ export async function handleInboundMessage(params: {
         const filteredApiMsgs = apiMessages
           .filter((m: any) => m.from_uid !== botUid && (m.content || m.type !== 1))
           // /fork commands are control-flow, already handled by the fork hook
-          // below; never inject them into the bot's historyPrefix ctx.
+          // below; never inject them into the bot's historyPrefix ctx. Coerce
+          // content with String(): getChannelMessages types it as string, but
+          // RichText (type 14) and similar payloads can carry a non-string
+          // m.content, and a bare .replace() on those throws and crashes the
+          // whole backfill (P2, yujiawei).
           .filter((m: any) => !isForkCommandHistoryMessage(
-            m.content ?? "",
+            String(m.content ?? ""),
             extractMentionUids(m.payload?.mention).includes(botUid),
           ))
           .sort((a: any, b: any) => (a.message_seq ?? 0) - (b.message_seq ?? 0))
@@ -2218,6 +2222,12 @@ export async function handleInboundMessage(params: {
       log,
     })
   ) {
+    // The fork hook handled this message and early-returns BEFORE the normal
+    // dispatch path's pendingInboundContext.delete (below) and before the
+    // before_prompt_build hook's get/delete (index.ts) — neither runs for a
+    // fork. Drop the entry set above (pendingInboundContext.set) so a fork does
+    // not leak a Map entry / inject a stale historyPrefix later (P1, yujiawei).
+    pendingInboundContext.delete(route.sessionKey);
     return;
   }
 


### PR DESCRIPTION
## 背景

octo 群里跟 bot 多轮对话时，用户经常想就某个子问题开"分支"——既需要带上当前会话上下文，又不想污染主群对话流。Discord/Slack 等平台有原生 thread + auto-fork，octo channel 上没接通。

OpenClaw runtime 已具备会话 fork 能力（`forkSessionFromParent`），octo 也已具备建子区能力（`createThread`），但**插件层没把两者接通成一条命令**。这个 PR 把这条链路接通成 `/fork` slash 命令。

## 用户接口

owner 在群里 `@bot /fork <prompt>`：

1. bot 在父群下建一个子区，子区名 = prompt 前 30 字符
2. 主群回一句纯文本 `已开 fork 子区：<threadName>`
3. LLM 在子区里基于父群完整上下文回答 `<prompt>`
4. 父群当前会话**不受影响**，可继续正常 @bot 对话

边界场景：
- DM 里 `/fork ...` 不建子区，发提示 `/fork 仅在群聊中可用` 并 swallow（不进 LLM）
- 嵌套（子区里 `/fork`）→ 在父群下建 sibling thread（octo Thread API 无 nested）
- 父 session > 100k tokens → runtime 自动回落 isolated（child 无父上下文，receipt 不变）
- 非 owner 在群里 `/fork` → 静默 swallow（spec §3.3）

## 核心机制（Plan B）

fork 是 OpenClaw runtime `get-reply` pipeline 的副作用，**不是插件主动调** `forkSessionFromParent`：runtime 看到 child 的首条 inbound ctx 里 `ParentSessionKey !== SessionKey` 时，自动把 parent transcript fork 进 child session。SDK 里**唯一**写 `ctx.ParentSessionKey` 的代码是 Discord auto-thread 层（`threading-idEBBpQ_.js:334`，Discord 专属），octo 没有对应层 —— 所以本 PR 在 octo 插件层**自己**给 seed 消息 ctxPayload 塞 `ParentSessionKey + ModelParentSessionKey`，复刻 Discord 的语义。

为什么不直接调 `forkSessionFromParent`：(a) 它要 `parentEntry/agentId/sessionsDir` 插件层拿不到的 SDK 内部 API，(b) 它在 runtime 里已经被 get-reply pipeline 自动驱动（含 100k token fallback、parentSession 反向引用等），重新实装会 divergence。

## 设计取舍

- **Inbound hook 早返回**（`inbound.ts:2197`，在 OBO v2 / R10 / finalizeInboundContext / recordInboundSession / dispatch 之前）：fork 命中后不写父群 session，主群对话流不被污染。hot path delta = 一行 if，非 fork 消息走 cheap regex 返 false fall through，**inbound.ts 改动纯增量**。

- **Seed dispatch 2B-minimal**（`fork-inbound.ts:dispatchForkSeedReply`，~30 行）：runtime 的 `dispatchReplyWithBufferedBlockDispatcher` 入口能直接调，但完整的 deliver harness（typing / streaming buffer / OBO v2 / outbound media 等 ~250 行）跟 seed 一次性触发场景不匹配——seed 不是交互态。**有意省略** typing/OBO/streaming buffer/outbound media（文件内 docstring 逐项写明理由），保留必需的 final/tool/block 投递路径 + mention 解析。代价是首回复无 typing 提示、无流式 buffer dedup 等修饰；fork 这种"开子区做新讨论"场景不构成体感问题。

- **失败语义分离**：`createThread` 失败 = `spawn_failed`（thread 未建，回执 `开 fork 子区失败：<msg>`）；`dispatchSeed` 失败 = `ok_seed_failed`（thread 已建、receipt 提示用户到子区重发）；`sendParentReceipt` 失败 = log + swallow，不冒泡不改 status。三个早返回分支（DM hint / unauthorized / receipt）防御一致。

- **Seed `CommandAuthorized` 透传** 自 requester 的 inbound `commandAuthorized`（不硬编码 `true`），为未来 v1.1 接 `commands.fork.scope` 让 non-owner fork 时防"prompt 被当 owner 命令执行"的潜在提权。

- **History filter**：octo Bot API 不能服务端删用户消息，所以 `/fork ...` 原文用户在群里仍可见。但 bot 后续 @ 消息走 `getChannelMessages` 拉历史 + group cache 注入 historyPrefix 时，过滤掉 `/fork` 命令消息——bot 的 ctx 里不再看到 fork 命令本身。

- **THREAD.md 继承**：fork 出新子区后，fire-and-forget 把"父位置"的 md 复制到 child THREAD.md（父是子区时**只读父子区 THREAD.md，不 fallback group.md**；父是群时读 group.md）。失败静默 warn log，不阻塞 fork 主流程。

## 测试

`+178 tests (1079 → 1257)`：
- 6 个 fork 模块测试文件（fork / fork-runtime / fork-inbound / fork-seed-dispatch / fork-history-filter / fork-inherit-md）
- `inbound.test.ts` 回归 +3：fork hook 命中早返回不影响 mention/OBO/R10/dispatch、history filter 正反向（普通文本提"/fork"不被误杀）
- `api-fetch.test.ts` 含一条**端到端 SSOT 守卫**：mock real fetch 返 404 → 驱动真实 `getThreadMd` throw → 喂共享 `httpStatusFromApiFetchError` → 断言 404，未来 api-fetch throw 格式漂移会撞红
- `manifest-schema-sync` 校验 `commands.fork.scope` schema 顶层位置正确

覆盖路径：命令 parse / threadName 派生（trim + Unicode 截取）/ resolveForkScope 四档真值表 / executeFork 全部状态分支（ok / ok_seed_failed / empty_prompt / spawn_failed + receipt 失败三路径）/ FORK-TRIGGER 不变量 / seed dispatcher state machine / 嵌套 fork / md 继承 (a) 不变量 / DM 提示发送失败 swallow。

## 配置

`commands.fork.scope` 占位 schema（owner-mentioned 默认）+ resolveForkScope 四档实现 ready，**v1 只读默认值**，scope 接线留 v1.1。`openclaw.plugin.json` 已 mirror。

## Known limitations / follow-up

- `dispatchSeed` 同步 await 持父群 enqueueInbound 串行队列 ~LLM 延迟（fork 后用户注意力转子区，v1 接受）
- `commands.fork.scope` 四档实现 ready 但 inbound hook 仍用 `commandAuthorized`（v1.1 接线）
- `childChannelId` 通过 `seedCtx.GroupSubject` 隐式回传给 dispatchSeed（功能正确，约定脆弱，v1.1 显式参数）
- block-kind 缓冲只 flush 最后一条（2B-minimal 简化；final/tool 路径已覆盖用户可见答案）
- history filter ↔ inbound 函数级循环 import（运行时安全，轻微架构异味）
- octo 服务端系统通知"Max 创建了子区" 仍在群里可见（octo-server 未提供 silent thread creation API）

## 真机验证

本地 gateway 替换为本分支构建的插件后，在 `openclaw-octo` 父群 + 各类子区测试：

- 主群发 `/fork ...` → 建子区 + 主群纯文本回执 + 新子区里 bot 带父群完整上下文回答 ✓
- 在子区内 `/fork ...` → 在父群下建 sibling thread ✓
- 空 `/fork` → `用法：/fork <你的问题>`，不建子区 ✓
- 非 owner 群内 `/fork` → 静默无回复 ✓
- DM `/fork ...` → 提示 `/fork 仅在群聊中可用`，不进 LLM ✓
- 父 session > 100k token fallback isolated 路径已通过单测 + spec 文档描述（生产场景需配套 SDK 阈值调整）

经 4 轮 agent-skills:review 结构化扫描 + 多轮修复，Critical/Important 全部清空。