### PR TITLE
fix: cleanupStaleCaches misses parent-keyed cache entries for thread channels (#128)

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -357,17 +357,23 @@ export function isAccountRegisteredForGroup(groupNo: string, accountId: string):
 // --- Cache cleanup: evict groups inactive for >4 hours ---
 const CACHE_MAX_AGE_MS = 4 * 60 * 60 * 1000;
 const CACHE_CLEANUP_INTERVAL_MS = 30 * 60 * 1000;
+export const _test_CACHE_MAX_AGE_MS = CACHE_MAX_AGE_MS;
 const _cacheActivity = new Map<string, Map<string, number>>();
 
-function touchCache(accountId: string, groupId: string): void {
+export function touchCache(accountId: string, groupId: string): void {
   const id = normalizeAccountId(accountId);
   let m = _cacheActivity.get(id);
   if (!m) { m = new Map(); _cacheActivity.set(id, m); }
   m.set(groupId, Date.now());
 }
 
-function cleanupStaleCaches(): void {
+export function cleanupStaleCaches(): void {
   const cutoff = Date.now() - CACHE_MAX_AGE_MS;
+
+  // First pass: clean stale raw-key activity entries and their raw-keyed maps.
+  // Parent-keyed maps (_groupCacheTimestamps, _currentGroupMembersMaps) are
+  // handled in the second pass to avoid deleting entries that a sibling
+  // thread still needs (#128).
   for (const [accountId, activityMap] of _cacheActivity) {
     for (const [groupId, lastAccess] of activityMap) {
       if (lastAccess < cutoff) {
@@ -376,23 +382,74 @@ function cleanupStaleCaches(): void {
         _memberMaps.get(accountId)?.delete(groupId);
         // Note: uidToNameMap is a flat uid→name map (not keyed by groupId),
         // so we don't delete from it here — names remain valid across groups.
-        _groupCacheTimestamps.get(accountId)?.delete(groupId);
-        // Delete by the SAME key cleanup uses for _groupCacheTimestamps (raw
-        // channel_id from touchCache) so the roster is reclaimed on exactly the
-        // same cleanup pass as its freshness timestamp. (Steady-state they are
-        // not strictly 1:1 — refreshGroupMemberCache's failure branch keeps a
-        // backoff timestamp while deleting the roster — but the read path
-        // tolerates a missing roster via `?? []`, so co-deletion at cleanup is
-        // what matters here.) Deleting by parent groupNo instead would drop the
-        // roster while a sibling thread keeps the timestamp fresh, leaving the
-        // next message to early-return with no roster.
-        _currentGroupMembersMaps.get(accountId)?.delete(groupId);
         activityMap.delete(groupId);
       }
     }
     if (activityMap.size === 0) _cacheActivity.delete(accountId);
   }
+
+  // Second pass: clean parent-keyed maps (_groupCacheTimestamps,
+  // _currentGroupMembersMaps). These are keyed by parent groupNo (via
+  // extractParentGroupNo), not raw channel_id. Delete only when:
+  // 1. The timestamp is stale, AND
+  // 2. No live (non-stale) raw-key activity maps to this parent groupNo.
+  // This correctly handles: thread channels sharing a parent (sibling kept
+  // alive), orphaned parent entries (all threads gone), and plain groups
+  // (extractParentGroupNo returns the group as-is).
+  for (const [accountId, tsMap] of _groupCacheTimestamps) {
+    const activityMap = _cacheActivity.get(accountId);
+    for (const [groupNo, ts] of tsMap) {
+      if (ts >= cutoff) continue; // fresh — skip
+      // Check if any live raw-key activity maps to this parent groupNo
+      let hasLiveThread = false;
+      if (activityMap) {
+        for (const [rawKey, rawTs] of activityMap) {
+          if (rawTs >= cutoff && extractParentGroupNo(rawKey) === groupNo) {
+            hasLiveThread = true;
+            break;
+          }
+        }
+      }
+      if (!hasLiveThread) {
+        tsMap.delete(groupNo);
+        _currentGroupMembersMaps.get(accountId)?.delete(groupNo);
+      }
+    }
+    if (tsMap.size === 0) _groupCacheTimestamps.delete(accountId);
+  }
 }
+
+// --- Test-only exports for cache cleanup verification (issue #128) ---
+/** @internal — for testing only */
+export const _test_caches = {
+  get cacheActivity() { return _cacheActivity; },
+  get groupCacheTimestamps() { return _groupCacheTimestamps; },
+  get currentGroupMembersMaps() { return _currentGroupMembersMaps; },
+  clear() {
+    _cacheActivity.clear();
+    _groupCacheTimestamps.clear();
+    _currentGroupMembersMaps.clear();
+  },
+  /** Directly set a _cacheActivity entry (bypasses touchCache's Date.now()) */
+  setActivity(accountId: string, groupId: string, ts: number) {
+    const id = normalizeAccountId(accountId);
+    let m = _cacheActivity.get(id);
+    if (!m) { m = new Map(); _cacheActivity.set(id, m); }
+    m.set(groupId, ts);
+  },
+  /** Directly set a _groupCacheTimestamps entry */
+  setGroupCacheTimestamp(accountId: string, groupNo: string, ts: number) {
+    const id = normalizeAccountId(accountId);
+    const m = getOrCreateGroupCacheTimestamps(id);
+    m.set(groupNo, ts);
+  },
+  /** Directly set a _currentGroupMembersMaps entry */
+  setCurrentGroupMembers(accountId: string, groupNo: string, members: GroupMember[]) {
+    const id = normalizeAccountId(accountId);
+    const m = getOrCreateCurrentGroupMembersMap(id);
+    m.set(groupNo, members);
+  },
+};
 
 // Known bot robot_ids across all accounts — for bot-to-bot loop prevention.
 // Backed by the shared bot-registry so inbound.ts can consult the same set

--- a/src/cleanup-stale-caches.test.ts
+++ b/src/cleanup-stale-caches.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  touchCache,
+  cleanupStaleCaches,
+  _test_caches,
+  _test_CACHE_MAX_AGE_MS,
+} from "./channel.js";
+
+/**
+ * Regression test for issue #128:
+ * cleanupStaleCaches deletes per-group cache entries by raw channel_id
+ * (from touchCache), but _groupCacheTimestamps and _currentGroupMembersMaps
+ * are keyed by parent groupNo (from extractParentGroupNo). For thread
+ * channels (channel_id = "parentGroupNo____shortId"), the delete never
+ * matches → cache entries are never reclaimed.
+ */
+
+const ACCOUNT = "test-account-128";
+const PARENT_GROUP = "G001";
+const THREAD_CHANNEL = `${PARENT_GROUP}____thread1`;
+const PLAIN_GROUP = "G002";
+
+describe("issue #128 — cleanupStaleCaches parent-key leak", () => {
+  beforeEach(() => {
+    _test_caches.clear();
+  });
+
+  it("should clean up _groupCacheTimestamps entries for thread channels", () => {
+    // Simulate: thread message arrives
+    // 1. touchCache records raw channel_id
+    const staleTime = Date.now() - _test_CACHE_MAX_AGE_MS - 1000;
+    _test_caches.setActivity(ACCOUNT, THREAD_CHANNEL, staleTime);
+    // 2. refreshGroupMemberCache writes under parent groupNo
+    _test_caches.setGroupCacheTimestamp(ACCOUNT, PARENT_GROUP, staleTime);
+
+    // Verify setup: both maps have entries
+    expect(
+      _test_caches.cacheActivity.get("test-account-128")?.has(THREAD_CHANNEL),
+    ).toBe(true);
+    expect(
+      _test_caches.groupCacheTimestamps
+        .get("test-account-128")
+        ?.has(PARENT_GROUP),
+    ).toBe(true);
+
+    // Run cleanup
+    cleanupStaleCaches();
+
+    // Both entries should be cleaned up
+    expect(
+      _test_caches.groupCacheTimestamps
+        .get("test-account-128")
+        ?.has(PARENT_GROUP) ?? false,
+    ).toBe(false);
+  });
+
+  it("should clean up _currentGroupMembersMaps entries for thread channels", () => {
+    const staleTime = Date.now() - _test_CACHE_MAX_AGE_MS - 1000;
+    _test_caches.setActivity(ACCOUNT, THREAD_CHANNEL, staleTime);
+    // In reality, refreshGroupMemberCache sets BOTH timestamps and roster
+    _test_caches.setGroupCacheTimestamp(ACCOUNT, PARENT_GROUP, staleTime);
+    _test_caches.setCurrentGroupMembers(ACCOUNT, PARENT_GROUP, [
+      { uid: "u1", name: "Alice" },
+    ]);
+
+    // Verify setup
+    expect(
+      _test_caches.currentGroupMembersMaps
+        .get("test-account-128")
+        ?.has(PARENT_GROUP),
+    ).toBe(true);
+
+    cleanupStaleCaches();
+
+    // Both parent-keyed entries should be cleaned up
+    expect(
+      _test_caches.groupCacheTimestamps
+        .get("test-account-128")
+        ?.has(PARENT_GROUP) ?? false,
+    ).toBe(false);
+    expect(
+      _test_caches.currentGroupMembersMaps
+        .get("test-account-128")
+        ?.has(PARENT_GROUP) ?? false,
+    ).toBe(false);
+  });
+
+  it("should still clean up plain groups (no ____ separator)", () => {
+    const staleTime = Date.now() - _test_CACHE_MAX_AGE_MS - 1000;
+    _test_caches.setActivity(ACCOUNT, PLAIN_GROUP, staleTime);
+    _test_caches.setGroupCacheTimestamp(ACCOUNT, PLAIN_GROUP, staleTime);
+    _test_caches.setCurrentGroupMembers(ACCOUNT, PLAIN_GROUP, [
+      { uid: "u2", name: "Bob" },
+    ]);
+
+    cleanupStaleCaches();
+
+    // Both should be cleaned up (extractParentGroupNo returns plain group as-is)
+    expect(
+      _test_caches.groupCacheTimestamps
+        .get("test-account-128")
+        ?.has(PLAIN_GROUP) ?? false,
+    ).toBe(false);
+    expect(
+      _test_caches.currentGroupMembersMaps
+        .get("test-account-128")
+        ?.has(PLAIN_GROUP) ?? false,
+    ).toBe(false);
+  });
+
+  it("should clean orphaned parent-groupNo entries (no raw-key activity)", () => {
+    // Scenario: thread activity was the only thing keeping parent alive,
+    // but the raw thread entry in _cacheActivity was already cleaned up
+    // in a previous pass. Now the parent-keyed maps have orphan entries.
+    const staleTime = Date.now() - _test_CACHE_MAX_AGE_MS - 1000;
+    // No _cacheActivity entry for anything related to this parent
+    // But parent-keyed maps still have entries
+    _test_caches.setGroupCacheTimestamp(ACCOUNT, PARENT_GROUP, staleTime);
+    _test_caches.setCurrentGroupMembers(ACCOUNT, PARENT_GROUP, [
+      { uid: "u1", name: "Alice" },
+    ]);
+
+    cleanupStaleCaches();
+
+    // Orphaned entries should be cleaned up
+    expect(
+      _test_caches.groupCacheTimestamps
+        .get("test-account-128")
+        ?.has(PARENT_GROUP) ?? false,
+    ).toBe(false);
+    expect(
+      _test_caches.currentGroupMembersMaps
+        .get("test-account-128")
+        ?.has(PARENT_GROUP) ?? false,
+    ).toBe(false);
+  });
+
+  it("should NOT clean parent entries when sibling thread is still active", () => {
+    // Setup: two threads from same parent. One stale, one fresh.
+    const now = Date.now();
+    const staleTime = now - _test_CACHE_MAX_AGE_MS - 1000;
+    const freshTime = now - 1000;
+
+    // Thread 1 is stale
+    _test_caches.setActivity(ACCOUNT, `${PARENT_GROUP}____thread_stale`, staleTime);
+    // Thread 2 is still active
+    _test_caches.setActivity(ACCOUNT, `${PARENT_GROUP}____thread_fresh`, freshTime);
+    // Parent-keyed maps were refreshed by thread 2's message
+    _test_caches.setGroupCacheTimestamp(ACCOUNT, PARENT_GROUP, freshTime);
+    _test_caches.setCurrentGroupMembers(ACCOUNT, PARENT_GROUP, [
+      { uid: "u1", name: "Alice" },
+    ]);
+
+    cleanupStaleCaches();
+
+    // Parent should still be alive (thread_fresh keeps it warm)
+    expect(
+      _test_caches.groupCacheTimestamps
+        .get("test-account-128")
+        ?.has(PARENT_GROUP),
+    ).toBe(true);
+    expect(
+      _test_caches.currentGroupMembersMaps
+        .get("test-account-128")
+        ?.has(PARENT_GROUP),
+    ).toBe(true);
+
+    // Stale thread's raw entry should be cleaned
+    expect(
+      _test_caches.cacheActivity
+        .get("test-account-128")
+        ?.has(`${PARENT_GROUP}____thread_stale`) ?? false,
+    ).toBe(false);
+
+    // Fresh thread should still be there
+    expect(
+      _test_caches.cacheActivity
+        .get("test-account-128")
+        ?.has(`${PARENT_GROUP}____thread_fresh`),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
<!-- multica:verify v1 -->

## 根因 / 实现说明

- `touchCache(accountId, msg.channel_id)` 按 **raw channel_id** 记录活跃时间（线程频道为 `parentGroupNo____shortId`）
- `_groupCacheTimestamps` 和 `_currentGroupMembersMaps` 按 **parent groupNo**（`extractParentGroupNo(channel_id)`）写入
- `cleanupStaleCaches` 遍历 `_cacheActivity`（raw key）后按 raw key 删除 parent-keyed 缓存 → **永远命中不了** → 缓存条目泄漏

## 修复

将 parent-keyed 缓存的清理移到**第二遍**：

1. **第一遍**：清理 raw-key 活跃条目及其 raw-keyed 缓存（`_historyMaps`、`_lastBotReplySeq`、`_memberMaps`）
2. **第二遍**：遍历 `_groupCacheTimestamps`，仅当 timestamp 过期 **且** 没有活跃的同父群线程时才清理。正确处理：
   - 线程频道共享同一父群 → 有活跃兄弟线程时保留父群条目
   - 所有线程过期 → 清理孤立的父群条目
   - 普通群（无 `____` 分隔符）→ `extractParentGroupNo` 返回原值，行为不变

## 改动摘要

- `src/channel.ts`：重构 `cleanupStaleCaches()`，两遍清理逻辑
- `src/channel.ts`：导出 `touchCache`、`cleanupStaleCaches`、`_test_caches`、`_test_CACHE_MAX_AGE_MS`（仅测试用）
- `src/cleanup-stale-caches.test.ts`：新增 5 个回归测试

## 测试

- 回归测试: `cleanup-stale-caches.test.ts` (5 tests) ✓
- 全量测试: 1137 passed (1132 original + 5 new), 0 failures ✓
- Build: `tsc --noEmit` 通过 ✓

## 验证 (baseline diff)

- after − baseline = 0 new failures
- 噪音: none

Fixes #128
