### PR TITLE
fix: cleanupStaleCaches reclaims parent-keyed cache entries (#128)

### DIFF
--- a/src/cache-cleanup.test.ts
+++ b/src/cache-cleanup.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+// Mock api-fetch before importing channel (channel imports api-fetch indirectly)
+vi.mock("./api-fetch.js", () => ({
+  sendMessage: vi.fn(),
+  sendMediaMessage: vi.fn(),
+  getUploadPresign: vi.fn(),
+  uploadFileToPresignedUrl: vi.fn(),
+  inferContentType: () => "text/plain",
+  ensureTextCharset: (s: string) => s,
+  parseImageDimensions: () => null,
+  parseImageDimensionsFromFile: async () => null,
+  registerBot: vi.fn(),
+  sendHeartbeat: vi.fn(),
+  fetchBotGroups: vi.fn().mockResolvedValue([]),
+  getGroupMembers: vi.fn().mockResolvedValue([]),
+  getGroupMd: vi.fn(),
+}));
+
+import {
+  touchCache,
+  cleanupStaleCaches,
+  _testGetCacheActivity,
+  _testGetGroupCacheTimestamps,
+  _testGetCurrentGroupMembersMaps,
+  _testGetMemberMaps,
+  _testResetCaches,
+} from "./channel.js";
+
+// CACHE_MAX_AGE_MS = 4h in channel.ts
+const CACHE_MAX_AGE_MS = 4 * 60 * 60 * 1000;
+
+describe("Issue #128: cleanupStaleCaches parent-key cache reclamation", () => {
+  const ACCOUNT = "test-account-1";
+
+  beforeEach(() => {
+    _testResetCaches();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-27T12:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("reclaims parent-keyed _groupCacheTimestamps when thread goes stale", () => {
+    // Simulate: thread channel_id = "GROUP1____thread1"
+    // refreshGroupMemberCache writes _groupCacheTimestamps under parent groupNo "GROUP1"
+    const threadChannelId = "GROUP1____thread1";
+    const parentGroupNo = "GROUP1";
+
+    // touchCache records raw channel_id (as inbound.ts does at line 1409)
+    touchCache(ACCOUNT, threadChannelId);
+
+    // refreshGroupMemberCache writes timestamp under parent groupNo
+    const timestamps = _testGetGroupCacheTimestamps();
+    const accountTimestamps = new Map<string, number>();
+    accountTimestamps.set(parentGroupNo, Date.now());
+    timestamps.set(ACCOUNT, accountTimestamps);
+
+    // Advance time past cache max age
+    vi.advanceTimersByTime(CACHE_MAX_AGE_MS + 1000);
+
+    // Run cleanup
+    cleanupStaleCaches();
+
+    // The parent-keyed timestamp should be reclaimed
+    expect(timestamps.get(ACCOUNT)?.has(parentGroupNo)).toBe(false);
+  });
+
+  it("reclaims parent-keyed _currentGroupMembersMaps when thread goes stale", () => {
+    const threadChannelId = "GROUP2____threadA";
+    const parentGroupNo = "GROUP2";
+
+    touchCache(ACCOUNT, threadChannelId);
+
+    // Simulate refreshGroupMemberCache populating the roster under parent groupNo
+    const membersMaps = _testGetCurrentGroupMembersMaps();
+    const accountMembers = new Map<string, any[]>();
+    accountMembers.set(parentGroupNo, [{ uid: "u1", name: "Alice" }]);
+    membersMaps.set(ACCOUNT, accountMembers);
+
+    vi.advanceTimersByTime(CACHE_MAX_AGE_MS + 1000);
+    cleanupStaleCaches();
+
+    expect(membersMaps.get(ACCOUNT)?.has(parentGroupNo)).toBe(false);
+  });
+
+  it("does NOT evict parent-keyed cache when a sibling thread is still active", () => {
+    const thread1 = "GROUP3____thread1"; // will go stale
+    const thread2 = "GROUP3____thread2"; // still active
+    const parentGroupNo = "GROUP3";
+
+    // Both threads were active at t=0
+    touchCache(ACCOUNT, thread1);
+    touchCache(ACCOUNT, thread2);
+
+    // Populate parent-keyed caches
+    const timestamps = _testGetGroupCacheTimestamps();
+    const accountTimestamps = new Map<string, number>();
+    accountTimestamps.set(parentGroupNo, Date.now());
+    timestamps.set(ACCOUNT, accountTimestamps);
+
+    const membersMaps = _testGetCurrentGroupMembersMaps();
+    const accountMembers = new Map<string, any[]>();
+    accountMembers.set(parentGroupNo, [{ uid: "u1", name: "Alice" }]);
+    membersMaps.set(ACCOUNT, accountMembers);
+
+    // Advance time — thread1 goes stale, but advance only partway
+    vi.advanceTimersByTime(CACHE_MAX_AGE_MS + 1000);
+
+    // "Refresh" thread2 (simulating a new message arriving)
+    touchCache(ACCOUNT, thread2);
+
+    cleanupStaleCaches();
+
+    // Parent-keyed cache should still be present (thread2 is active)
+    expect(timestamps.get(ACCOUNT)?.has(parentGroupNo)).toBe(true);
+    expect(membersMaps.get(ACCOUNT)?.has(parentGroupNo)).toBe(true);
+
+    // But the stale thread1 raw key should be removed from activity
+    expect(_testGetCacheActivity().get(ACCOUNT)?.has(thread1)).toBe(false);
+    // Active thread2 should still be in activity
+    expect(_testGetCacheActivity().get(ACCOUNT)?.has(thread2)).toBe(true);
+  });
+
+  it("evicts parent-keyed cache only when ALL sibling threads are stale", () => {
+    const thread1 = "GROUP4____t1";
+    const thread2 = "GROUP4____t2";
+    const parentGroupNo = "GROUP4";
+
+    touchCache(ACCOUNT, thread1);
+    touchCache(ACCOUNT, thread2);
+
+    const timestamps = _testGetGroupCacheTimestamps();
+    const accountTimestamps = new Map<string, number>();
+    accountTimestamps.set(parentGroupNo, Date.now());
+    timestamps.set(ACCOUNT, accountTimestamps);
+
+    // Advance past max age — both stale
+    vi.advanceTimersByTime(CACHE_MAX_AGE_MS + 1000);
+    cleanupStaleCaches();
+
+    // Now the parent-keyed entry should be gone
+    expect(timestamps.get(ACCOUNT)?.has(parentGroupNo)).toBe(false);
+  });
+
+  it("still correctly cleans raw-keyed caches (plain group, no thread)", () => {
+    // Plain group channel (no ____ suffix)
+    const plainGroup = "GROUP5";
+
+    touchCache(ACCOUNT, plainGroup);
+
+    // Raw-keyed maps
+    const memberMaps = _testGetMemberMaps();
+    const accountMembers = new Map<string, string>();
+    accountMembers.set(plainGroup, "Alice");
+    memberMaps.set(ACCOUNT, accountMembers);
+
+    // Parent-keyed maps (for plain group, parent = raw key)
+    const timestamps = _testGetGroupCacheTimestamps();
+    const accountTimestamps = new Map<string, number>();
+    accountTimestamps.set(plainGroup, Date.now());
+    timestamps.set(ACCOUNT, accountTimestamps);
+
+    vi.advanceTimersByTime(CACHE_MAX_AGE_MS + 1000);
+    cleanupStaleCaches();
+
+    // Both raw-keyed and parent-keyed should be cleaned
+    expect(memberMaps.get(ACCOUNT)?.has(plainGroup)).toBe(false);
+    expect(timestamps.get(ACCOUNT)?.has(plainGroup)).toBe(false);
+    // Account entry removed entirely (only entry was stale)
+    expect(_testGetCacheActivity().has(ACCOUNT)).toBe(false);
+  });
+
+  it("cleans up empty account entries from _cacheActivity", () => {
+    touchCache(ACCOUNT, "GROUP6____t1");
+
+    vi.advanceTimersByTime(CACHE_MAX_AGE_MS + 1000);
+    cleanupStaleCaches();
+
+    expect(_testGetCacheActivity().has(ACCOUNT)).toBe(false);
+  });
+});

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -359,39 +359,88 @@ const CACHE_MAX_AGE_MS = 4 * 60 * 60 * 1000;
 const CACHE_CLEANUP_INTERVAL_MS = 30 * 60 * 1000;
 const _cacheActivity = new Map<string, Map<string, number>>();
 
-function touchCache(accountId: string, groupId: string): void {
+export function touchCache(accountId: string, groupId: string): void {
   const id = normalizeAccountId(accountId);
   let m = _cacheActivity.get(id);
   if (!m) { m = new Map(); _cacheActivity.set(id, m); }
   m.set(groupId, Date.now());
 }
 
-function cleanupStaleCaches(): void {
+export function cleanupStaleCaches(): void {
   const cutoff = Date.now() - CACHE_MAX_AGE_MS;
   for (const [accountId, activityMap] of _cacheActivity) {
+    // Separate stale raw keys from active ones. Active raw keys' parent
+    // groupNos must NOT be evicted from parent-keyed maps — a sibling thread
+    // may still be using the shared per-group cache. (#128)
+    const staleRawKeys: string[] = [];
+    const activeParentGroupNos = new Set<string>();
+
     for (const [groupId, lastAccess] of activityMap) {
       if (lastAccess < cutoff) {
-        _historyMaps.get(accountId)?.delete(groupId);
-        _lastBotReplySeq.get(accountId)?.delete(groupId);
-        _memberMaps.get(accountId)?.delete(groupId);
-        // Note: uidToNameMap is a flat uid→name map (not keyed by groupId),
-        // so we don't delete from it here — names remain valid across groups.
-        _groupCacheTimestamps.get(accountId)?.delete(groupId);
-        // Delete by the SAME key cleanup uses for _groupCacheTimestamps (raw
-        // channel_id from touchCache) so the roster is reclaimed on exactly the
-        // same cleanup pass as its freshness timestamp. (Steady-state they are
-        // not strictly 1:1 — refreshGroupMemberCache's failure branch keeps a
-        // backoff timestamp while deleting the roster — but the read path
-        // tolerates a missing roster via `?? []`, so co-deletion at cleanup is
-        // what matters here.) Deleting by parent groupNo instead would drop the
-        // roster while a sibling thread keeps the timestamp fresh, leaving the
-        // next message to early-return with no roster.
-        _currentGroupMembersMaps.get(accountId)?.delete(groupId);
-        activityMap.delete(groupId);
+        staleRawKeys.push(groupId);
+      } else {
+        activeParentGroupNos.add(extractParentGroupNo(groupId));
       }
+    }
+
+    // Delete raw-keyed caches by raw key (same dimension as touchCache).
+    for (const groupId of staleRawKeys) {
+      _historyMaps.get(accountId)?.delete(groupId);
+      _lastBotReplySeq.get(accountId)?.delete(groupId);
+      _memberMaps.get(accountId)?.delete(groupId);
+    }
+
+    // Delete parent-keyed caches by parent groupNo, but only when no sibling
+    // thread under the same parent is still active. refreshGroupMemberCache
+    // writes these maps under extractParentGroupNo(channel_id), so cleanup
+    // must use the same key to actually reclaim the entries. (#128)
+    const evictedParents = new Set<string>();
+    for (const groupId of staleRawKeys) {
+      const parentGroupNo = extractParentGroupNo(groupId);
+      if (!activeParentGroupNos.has(parentGroupNo) && !evictedParents.has(parentGroupNo)) {
+        _groupCacheTimestamps.get(accountId)?.delete(parentGroupNo);
+        _currentGroupMembersMaps.get(accountId)?.delete(parentGroupNo);
+        evictedParents.add(parentGroupNo);
+      }
+    }
+
+    for (const groupId of staleRawKeys) {
+      activityMap.delete(groupId);
     }
     if (activityMap.size === 0) _cacheActivity.delete(accountId);
   }
+}
+
+// --- Test helpers (exported for unit tests) ---
+
+/** @internal — test-only: access _cacheActivity for assertions */
+export function _testGetCacheActivity(): Map<string, Map<string, number>> {
+  return _cacheActivity;
+}
+
+/** @internal — test-only: access _groupCacheTimestamps for assertions */
+export function _testGetGroupCacheTimestamps(): Map<string, Map<string, number>> {
+  return _groupCacheTimestamps;
+}
+
+/** @internal — test-only: access _currentGroupMembersMaps for assertions */
+export function _testGetCurrentGroupMembersMaps(): Map<string, Map<string, any[]>> {
+  return _currentGroupMembersMaps;
+}
+
+/** @internal — test-only: access _memberMaps for assertions */
+export function _testGetMemberMaps(): Map<string, Map<string, string>> {
+  return _memberMaps;
+}
+
+/** @internal — test-only: reset all cache state */
+export function _testResetCaches(): void {
+  _cacheActivity.clear();
+  _groupCacheTimestamps.clear();
+  _currentGroupMembersMaps.clear();
+  _memberMaps.clear();
+  _historyMaps.clear();
+  _lastBotReplySeq.clear();
 }
 
 // Known bot robot_ids across all accounts — for bot-to-bot loop prevention.


### PR DESCRIPTION
## Root Cause

`cleanupStaleCaches` (`src/channel.ts`) iterates `_cacheActivity` which is keyed by raw `channel_id` from `touchCache`. For thread/community-topic channels, the raw key is `parentGroupNo____shortId`. However, `refreshGroupMemberCache` writes `_groupCacheTimestamps` and `_currentGroupMembersMaps` under `extractParentGroupNo(channel_id)` — the parent groupNo.

The cleanup was calling `.delete(rawChannelId)` on these parent-keyed maps, which never matched → cache entries for thread-only groups were never reclaimed.

## Fix

- Derive `parentGroupNo` via `extractParentGroupNo(groupId)` for the two parent-keyed maps
- Only evict a parent entry when **all** sibling threads under the same parent are stale (active sibling threads must keep the shared per-group cache alive)
- Raw-keyed maps (`_historyMaps`, `_lastBotReplySeq`, `_memberMaps`) continue to delete by raw key (unchanged)

## Tests

6 new unit tests in `src/cache-cleanup.test.ts`:
- ✅ Parent-keyed timestamp reclamation for stale threads
- ✅ Parent-keyed roster reclamation for stale threads  
- ✅ Sibling thread safety — active thread prevents parent eviction
- ✅ Full eviction when all siblings are stale
- ✅ Plain group (no thread suffix) still works correctly
- ✅ Empty account cleanup from `_cacheActivity`

All 1138 tests pass (28 files, 0 failures).

Fixes #128