### PR TITLE
fix(outbound): reject empty target before send instead of posting empty channel_id (#138)

### DIFF
--- a/src/actions.test.ts
+++ b/src/actions.test.ts
@@ -609,6 +609,26 @@ describe("handleOctoMessageAction", () => {
       expect(result.ok).toBe(false);
       expect(result.error).toContain("target");
     });
+
+    // #138: whitespace / prefix-only targets must also be rejected at the
+    // message-tool boundary — the old `if (!target)` let them through to the
+    // outbound path, which posted an empty channel_id and got a 500.
+    it("returns error (no fetch) for whitespace / prefix-only targets", async () => {
+      const fetchSpy = vi.fn();
+      globalThis.fetch = fetchSpy as any;
+      const { handleOctoMessageAction } = await import("./actions.js");
+      for (const bad of ["   ", "group:", "octo:", "channel:"]) {
+        const result = await handleOctoMessageAction({
+          action: "send",
+          args: { target: bad, message: "Hello" },
+          apiUrl: "http://localhost:8090",
+          botToken: "test-token",
+        });
+        expect(result.ok, `target=${JSON.stringify(bad)}`).toBe(false);
+        expect(result.error).toContain("target");
+      }
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
   });
 
   describe("send — missing message and media", () => {
@@ -3638,6 +3658,62 @@ describe("resolveOutboundOctoTarget", () => {
     const result = resolveOutboundOctoTarget("group:grp1", "____topic");
     expect(result.channelId).toBe("grp1");
     expect(result.channelType).toBe(ChannelType.Group);
+  });
+
+  // --- #138: fail-fast on a target that resolves to an empty channel ---
+  // parseTarget yields channelId="" for these; without this guard the framework
+  // outbound path would POST channel_id="" and the server answers an opaque 500.
+  describe("#138 — empty resolved channel rejected", () => {
+    it("throws on empty / whitespace / prefix-only / empty-entity targets", async () => {
+      const { resolveOutboundOctoTarget } = await import("./actions.js");
+      for (const bad of [
+        "",
+        "   ",
+        "group:",
+        "octo:",
+        "channel:",
+        "user:",
+        "octo:user:",
+        "group:@uid1,uid2",
+        "group:  ",
+      ]) {
+        expect(() => resolveOutboundOctoTarget(bad), `target=${JSON.stringify(bad)}`).toThrow(
+          /empty|target|channel/i,
+        );
+      }
+    });
+
+    it("throws when a threadId would synthesise a thread on an empty parent", async () => {
+      const { resolveOutboundOctoTarget } = await import("./actions.js");
+      // "group:" parses to {channelId:"", channelType:Group}; a naive end-of-function
+      // check would let the threadId merge produce "____t1" and slip through. The
+      // guard must fire BEFORE the merge.
+      expect(() => resolveOutboundOctoTarget("group:", "t1")).toThrow(/empty|target|channel/i);
+      expect(() => resolveOutboundOctoTarget("group:@uid1,uid2", "t1")).toThrow(
+        /empty|target|channel/i,
+      );
+    });
+
+    it("does NOT throw for valid targets (regression)", async () => {
+      const { resolveOutboundOctoTarget } = await import("./actions.js");
+      registerBotGroupIds(["grp1"]);
+      expect(resolveOutboundOctoTarget("group:grp1")).toEqual({
+        channelId: "grp1",
+        channelType: ChannelType.Group,
+      });
+      expect(resolveOutboundOctoTarget("group:grp1", "t1").channelType).toBe(
+        ChannelType.CommunityTopic,
+      );
+      expect(resolveOutboundOctoTarget("user:uid1")).toEqual({
+        channelId: "uid1",
+        channelType: ChannelType.DM,
+      });
+      expect(resolveOutboundOctoTarget("grp1").channelType).toBe(ChannelType.Group);
+      expect(resolveOutboundOctoTarget("group:grp1@uid1,uid2")).toEqual({
+        channelId: "grp1",
+        channelType: ChannelType.Group,
+      });
+    });
   });
 });
 

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -179,6 +179,21 @@ export function resolveOutboundOctoTarget(
 
   const parsed = parseTarget(targetForParse, undefined, getKnownGroupIds());
 
+  // Fail-fast on a target that resolves to an empty channel — BEFORE the
+  // threadId merge below. parseTarget yields channelId="" for "", "group:",
+  // "user:", "group:@uid" (mention-only), etc. The framework outbound path
+  // (sendText/sendMedia) would otherwise POST channel_id="" and the server
+  // answers an opaque 500. The check must run here and not at the end: "group:"
+  // parses to {channelId:"", channelType:Group}, so a following threadId merge
+  // would synthesise a non-empty "____<short_id>" and slip past any end-of-
+  // function guard. A non-empty parsed channel can only grow longer through the
+  // merge, never become empty, so one check here covers every case. (#138)
+  if (!parsed.channelId.trim()) {
+    throw new Error(
+      "octo: outbound target resolves to an empty channel — a valid channel/user target is required",
+    );
+  }
+
   // Merge framework-provided threadId only when ctx.to was a bare group — if the
   // caller already encoded the thread via "____" in ctx.to, parsed.channelType
   // is already CommunityTopic and we pass through.
@@ -479,8 +494,14 @@ async function handleSend(params: {
   const { args, apiUrl, botToken, memberMap, uidToNameMap, currentChannelId, threadId, log } = params;
 
   const target = args.target as string | undefined;
-  if (!target) {
-    return { ok: false, error: "Missing required parameter: target" };
+  // Reject a missing, blank, or prefix-only target here so the agent gets a
+  // structured {ok:false} instead of a thrown error bubbling from the outbound
+  // resolver. stripAllChannelPrefixes collapses "group:"/"octo:"/"channel:" so
+  // a prefix-only target ("group:") is treated as empty. user:/group:@uid that
+  // slip past this early check are still caught by resolveOutboundOctoTarget's
+  // fail-fast (defense in depth). (#138)
+  if (!target || !stripAllChannelPrefixes(target.trim()).trim()) {
+    return { ok: false, error: "Missing or empty required parameter: target" };
   }
 
   // issue #98 scope:"parent" escape hatch (the follow-up #100 explicitly

--- a/src/api-fetch.test.ts
+++ b/src/api-fetch.test.ts
@@ -2135,3 +2135,85 @@ describe("httpStatusFromApiFetchError", () => {
     }
   });
 });
+
+// ---------------------------------------------------------------------------
+// #138 — channelId fail-fast: the HTTP layer is the last line of defense.
+// An empty channelId must never reach the server (which answers an opaque 500);
+// reject before fetch so the request never leaves the client.
+// ---------------------------------------------------------------------------
+describe("#138 — send functions reject empty channelId", () => {
+  const originalFetch = global.fetch;
+  let fetchSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    fetchSpy = vi.fn(async () =>
+      new Response(JSON.stringify({ message_id: 1 }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    global.fetch = fetchSpy as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it("sendMessage throws and does not call fetch", async () => {
+    const { sendMessage } = await import("./api-fetch.js");
+    for (const channelId of ["", "   "]) {
+      await expect(
+        sendMessage({
+          apiUrl: "http://localhost:8090",
+          botToken: "test-token",
+          channelId,
+          channelType: ChannelType.Group,
+          content: "hi",
+        }),
+      ).rejects.toThrow(/channelId/i);
+    }
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("sendMediaMessage throws and does not call fetch", async () => {
+    const { sendMediaMessage } = await import("./api-fetch.js");
+    await expect(
+      sendMediaMessage({
+        apiUrl: "http://localhost:8090",
+        botToken: "test-token",
+        channelId: "",
+        channelType: ChannelType.Group,
+        type: MessageType.Image,
+        url: "https://cdn.example.com/img.png",
+      }),
+    ).rejects.toThrow(/channelId/i);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("sendRichTextMessage throws and does not call fetch", async () => {
+    const { sendRichTextMessage } = await import("./api-fetch.js");
+    await expect(
+      sendRichTextMessage({
+        apiUrl: "http://localhost:8090",
+        botToken: "test-token",
+        channelId: "",
+        channelType: ChannelType.Group,
+        blocks: [],
+      }),
+    ).rejects.toThrow(/channelId/i);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not throw for a valid channelId (regression)", async () => {
+    const { sendMessage } = await import("./api-fetch.js");
+    await sendMessage({
+      apiUrl: "http://localhost:8090",
+      botToken: "test-token",
+      channelId: "chan1",
+      channelType: ChannelType.Group,
+      content: "hi",
+    });
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/api-fetch.ts
+++ b/src/api-fetch.ts
@@ -120,6 +120,12 @@ export async function sendMediaMessage(params: {
   clientMsgNo?: string;
   signal?: AbortSignal;
 }): Promise<SendMessageResult | undefined> {
+  // Last-line guard: never POST an empty channel_id — the server answers an
+  // opaque 500. Upstream resolvers should already reject this, but any future
+  // caller that bypasses them is stopped here. (#138)
+  if (!params.channelId || !params.channelId.trim()) {
+    throw new Error("octo: channelId is required to send a message");
+  }
   const payload: Record<string, unknown> = {
     type: params.type,
     url: params.url,
@@ -262,6 +268,12 @@ export async function sendMessage(params: {
   clientMsgNo?: string;
   signal?: AbortSignal;
 }): Promise<SendMessageResult | undefined> {
+  // Last-line guard: never POST an empty channel_id — the server answers an
+  // opaque 500. Upstream resolvers should already reject this, but any future
+  // caller that bypasses them is stopped here. (#138)
+  if (!params.channelId || !params.channelId.trim()) {
+    throw new Error("octo: channelId is required to send a message");
+  }
   const payload: Record<string, unknown> = {
     type: MessageType.Text,
     content: params.content,
@@ -325,6 +337,12 @@ export async function sendRichTextMessage(params: {
   clientMsgNo?: string;
   signal?: AbortSignal;
 }): Promise<SendMessageResult | undefined> {
+  // Last-line guard: never POST an empty channel_id — the server answers an
+  // opaque 500. Upstream resolvers should already reject this, but any future
+  // caller that bypasses them is stopped here. (#138)
+  if (!params.channelId || !params.channelId.trim()) {
+    throw new Error("octo: channelId is required to send a message");
+  }
   const payload: Record<string, unknown> = {
     type: MessageType.RichText,
     content: params.blocks,

--- a/src/channel.test.ts
+++ b/src/channel.test.ts
@@ -615,6 +615,32 @@ describe("outbound.sendMedia — threadId wiring", () => {
     expect(call.channelId).toBe("grp1____topicA");
     expect(call.channelType).toBe(5);
   });
+
+  // #138: an empty/prefix-only target must fail BEFORE any media work — no
+  // download, no presign, no upload — so we never burn an upload on a send
+  // that can't be routed (and never POST channel_id="").
+  it("rejects an empty target before uploading (no presign/upload)", async () => {
+    const { octoPlugin } = await import("./channel.js");
+    const { getUploadPresign, uploadFileToPresignedUrl, sendMediaMessage } = await import(
+      "./api-fetch.js"
+    );
+
+    for (const bad of ["", "group:"]) {
+      await expect(
+        octoPlugin.outbound!.sendMedia!({
+          cfg,
+          to: bad,
+          text: "",
+          mediaUrl: "data:text/plain;base64,aGVsbG8=",
+          accountId: "default",
+        } as any),
+      ).rejects.toThrow(/empty|target|channel/i);
+    }
+
+    expect(getUploadPresign).not.toHaveBeenCalled();
+    expect(uploadFileToPresignedUrl).not.toHaveBeenCalled();
+    expect(sendMediaMessage).not.toHaveBeenCalled();
+  });
 });
 
 /**

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -948,6 +948,12 @@ export const octoPlugin: ChannelPlugin<ResolvedOctoAccount> = {
         throw new Error("sendMedia called without mediaUrl");
       }
 
+      // Resolve + validate the target BEFORE any media work (download / presign
+      // / upload). resolveOutboundOctoTarget throws on an empty/prefix-only
+      // target (#138); doing it here means an unroutable send fails fast instead
+      // of burning an upload first (and orphaning the uploaded object).
+      const { channelId, channelType } = resolveOutboundOctoTarget(ctx.to, ctx.threadId);
+
       // 1. Resolve file — stream-based for HTTP/file paths, Buffer for data URIs
       let fileBuffer: Buffer | undefined;   // body for data: URIs (held in memory)
       let bodyPath: string | undefined;     // body streamed from disk (file:// / temp)
@@ -1054,11 +1060,8 @@ export const octoPlugin: ChannelPlugin<ResolvedOctoAccount> = {
           contentDisposition: presign.contentDisposition,
         });
 
-        // 3. Resolve target — merge framework-provided threadId into
-        // CommunityTopic (channel_type=5) when ctx.to is a bare group.
-        const { channelId, channelType } = resolveOutboundOctoTarget(ctx.to, ctx.threadId);
-
         // 4. Determine message type and send
+        // (target already resolved + validated up front, before upload — #138)
         const msgType = contentType.startsWith("image/")
           ? MessageType.Image
           : MessageType.File;


### PR DESCRIPTION
## 背景

agent 主动发送（proactive，非 reply）消息但不带目标 channel 时，`POST /v1/bot/sendMessage` 返回不透明的 500。

根因在客户端：`parseTarget("")` 解析出 `{ channelId: "", channelType: DM }`，framework outbound 路径（`sendText` / `sendMedia`）把空 `channel_id` 透传给 server，server 才报 500。不止空串——`"group:"` / `"octo:"` / `"user:"` / `"group:@uid"`（仅 mention）/ 空白这些**字符串非空但解析后实体 id 为空**的目标同样会透传空 channelId。

reply 路径自带 `channel_id`，不受影响；message-tool 的 `handleSend` 原有 `if (!target)` 只挡 undefined/空串，挡不住空白与前缀-only。

## 改动

客户端 fail-fast，四处防线，确保任何空 target 的请求都不出门：

1. **`resolveOutboundOctoTarget`（主防线）**：在 `parseTarget` 之后、threadId 合并**之前**判 `parsed.channelId.trim()` 为空则抛错。必须在合并前——`"group:"` 解析为 Group 但 channelId 为空，合并 threadId 会合成非空 `"____<short_id>"` 绕过末尾校验。
2. **`handleSend`**：空白 / 前缀-only target 提前返回结构化 `{ ok:false }`，给 agent 干净反馈。
3. **`sendMessage` / `sendMediaMessage` / `sendRichTextMessage`**：HTTP 出口最后兜底，任何未来调用方漏判都挡在这里，不甩锅给 server。
4. **`sendMedia`**：target 解析+校验上移到任何下载/presign/上传**之前**，避免无效 target 白白上传（并 orphan 已上传对象）。

## 不在本 PR 范围

- server 端对任意客户端缺 target 返回干净 400：属 octo-server 仓，本 PR 修完后本插件的请求已不会到达那条路径。
- 「send 缺 target 回落到当前会话频道」：framework outbound 无可靠的"当前会话"概念，放弃 fallback。

## 测试

- `resolveOutboundOctoTarget`：空 / 空白 / 前缀-only / 空实体 / `"group:"+threadId` 全部抛错 + 正常 target 回归
- `handleSend`：空白 / 前缀-only 返结构化错误且不触发 fetch
- `api-fetch` 三发送函数：空 channelId 抛错且 fetch 未被调用 + 正常 channelId 回归
- `sendMedia`：空 target 时 presign / 上传均未被调用
- 全量 `npm test` 1292 passed，`npm run type-check` 通过

Fixes #138