### PR TITLE
feat(prompt): explain octo_management unavailability under restrictive tools profiles (#137)

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,51 @@ Configuration fields per account:
 - `historyLimit` (optional): Group chat history message limit (default: 20)
 - `dispatchTimeoutMs` (optional): Per-inbound dispatch timeout in milliseconds — an infrastructure backstop that releases the per-group message queue if an upstream dispatch hangs. When unset, it is derived from OpenClaw's `agents.defaults.timeoutSeconds` (600 if unset) as `timeoutSeconds * 1000 + 60000`, so it always fires *after* the agent-run timeout: the agent terminates gracefully first, and this timeout only catches genuinely hung dispatches. Set explicitly only if you need to decouple it from the agent timeout.
 
+## Agent tools
+
+This plugin registers one agent tool, **`octo_management`**, covering all Octo
+management actions: listing groups, reading/updating GROUP.md and THREAD.md,
+managing threads and members, voice-correction context, and **`write-secret`**
+(writing a user's stored API key into a local file by alias, without ever
+exposing the plaintext to the model).
+
+`octo_management` is a **plugin tool**, and OpenClaw's `tools.profile` presets
+(`minimal`, `coding`, `messaging`, `full`) decide which tools the model sees
+*before* it sees them. Only `full` (`allow: ["*"]`) admits plugin tools; the
+three restrictive presets exclude plugin tools by default. So under `minimal`,
+`coding`, or `messaging`, `octo_management` is filtered out and **every action it
+provides — creating groups, threads, GROUP.md edits, and `write-secret` — becomes
+unavailable at once** (the agent simply does not see the tool).
+
+This matters because **a fresh OpenClaw install defaults `tools.profile` to
+`coding`**, not `full` — so out of the box, an Octo bot cannot use any
+`octo_management` action until the tool is allowed.
+
+To keep `octo_management` available under a restricted profile, add it via
+`tools.alsoAllow` (additive on top of the profile, the same way the bundled
+`browser` tool is enabled):
+
+```json5
+{
+  tools: {
+    profile: "coding",
+    alsoAllow: ["octo_management"],
+  },
+}
+```
+
+For a single agent, use `agents.list[].tools.alsoAllow: ["octo_management"]`.
+
+When `octo_management` is filtered out, the plugin injects a short system-prompt
+note so the agent attributes the gap correctly (a tools-profile restriction, not
+a missing Octo feature) instead of suggesting another platform or asking the user
+to paste a secret in plaintext. Whether to adjust the configuration is up to you.
+
+> Security note: `write-secret` exists precisely so users never have to paste a
+> plaintext key into chat. If the tool is unavailable because of the profile,
+> enable `octo_management` as above — do not work around it by pasting the
+> secret in plaintext.
+
 ## What it does
 
 1. Registers the bot with the Octo server via REST API

--- a/index.ts
+++ b/index.ts
@@ -26,6 +26,59 @@ import { resolvePersonaHintForSession } from "./src/persona-prompt.js";
 import { setOctoRuntime } from "./src/runtime.js";
 import { octoPlugin } from "./src/channel.js";
 import { createOctoManagementTools } from "./src/agent-tools.js";
+import { CHANNEL_ID } from "./src/constants.js";
+
+// ---------------------------------------------------------------------------
+// Tool-availability self-diagnostic (issue #137)
+//
+// Under a restrictive `tools.profile` (minimal/coding/messaging — and OpenClaw's
+// fresh-install default IS `coding`), OpenClaw does not register plugin tools, so
+// `octo_management` (which backs ALL Octo management actions: groups, threads,
+// GROUP.md, members, voice context, write-secret) is absent from the agent's tool
+// list. Without guidance the model mis-attributes the gap — it tells the user
+// "Octo can't do this" and suggests another platform, or (for write-secret)
+// suggests pasting the secret in plaintext, defeating the whole point of #71.
+//
+// We inject this as a SYSTEM section via before_prompt_build's
+// prependSystemContext. That path reaches the system prompt regardless of which
+// tools survive profile filtering — unlike channel `messageToolHints`, which the
+// system-prompt builder only expands when the `message` tool is available (and
+// the `message` tool is itself removed by restrictive profiles), so a hint hung
+// there would never appear in exactly the scenario it must cover.
+//
+// The text is conditional ("IF octo_management is not in your tools …") so it is
+// harmless for `full`-profile sessions where the tool is present.
+// ---------------------------------------------------------------------------
+export const OCTO_TOOL_AVAILABILITY_HINT =
+  "Octo management actions (create/manage groups, threads, GROUP.md/THREAD.md, " +
+  "member management, voice context, and write-secret) are provided by the " +
+  "`octo_management` tool. If `octo_management` is NOT in your available tools, this " +
+  "does NOT mean Octo lacks these capabilities — it means the current tool policy " +
+  "(the active `tools.profile` plus allow/deny lists) filtered the plugin tool out. " +
+  "OpenClaw's restrictive profiles (`minimal`, `coding`, `messaging`) exclude plugin " +
+  "tools by default; the `full` profile, or allowing it explicitly (global " +
+  "`tools.alsoAllow: [\"octo_management\"]` or per-agent " +
+  "`agents.list[].tools.alsoAllow: [\"octo_management\"]`), makes it available. In that " +
+  "situation, tell the user plainly that `octo_management` is unavailable due to the " +
+  "current tool policy (NOT that the feature is missing), and do NOT suggest switching " +
+  "to another platform or pasting a secret in plaintext. Whether to adjust the " +
+  "configuration is the user's decision.";
+
+/**
+ * Return the tool-availability diagnostic for an octo session, else null.
+ *
+ * before_prompt_build is a GLOBAL hook — it fires for non-octo sessions
+ * (telegram/webchat/…) too, so we must gate to Octo to avoid leaking the
+ * Octo-specific note into other channels' system prompts (issue #137 review).
+ *
+ * Gate on `messageProvider`, NOT `channelId`: in this hook ctx, `channelId`
+ * resolves to the per-conversation raw id (a group_no / uid), not the provider
+ * name — so `channelId === "octo"` would essentially never match in real
+ * sessions. `messageProvider` is the channel/provider id ("octo").
+ */
+export function _buildToolAvailabilityHint(messageProvider: string | undefined): string | null {
+  return messageProvider === CHANNEL_ID ? OCTO_TOOL_AVAILABILITY_HINT : null;
+}
 
 // ---------------------------------------------------------------------------
 // Plugin entry — uses defineBundledChannelEntry contract (OpenClaw 2026.5.x+).
@@ -170,6 +223,12 @@ export default defineBundledChannelEntry({
           })
         : undefined;
       if (personaHint) systemSections.push(personaHint);
+
+      // 4. Tool-availability self-diagnostic (#137) — gated to octo sessions
+      // via messageProvider (this is a global hook; ctx.channelId is the
+      // per-conversation raw id here, not the provider name).
+      const toolHint = _buildToolAvailabilityHint(ctx.messageProvider);
+      if (toolHint) systemSections.push(toolHint);
 
       if (contextSections.length === 0 && systemSections.length === 0) return;
       return {

--- a/src/__tests__/tool-availability-hint.test.ts
+++ b/src/__tests__/tool-availability-hint.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import {
+  OCTO_TOOL_AVAILABILITY_HINT,
+  _buildToolAvailabilityHint,
+} from "../../index.js";
+
+/**
+ * Issue #137: under a restrictive tools.profile (minimal/coding/messaging),
+ * OpenClaw does not register plugin tools, so `octo_management` disappears and
+ * the bot mis-attributes the gap ("Octo can't do this" → suggests another
+ * platform / pasting a plaintext secret). We inject a self-diagnostic section
+ * via before_prompt_build's prependSystemContext (which, unlike messageToolHints,
+ * is NOT gated behind the `message` tool being available). The section must only
+ * be injected for octo sessions (before_prompt_build is a global hook).
+ */
+describe("issue #137 — octo_management tool-availability diagnostic hint", () => {
+  it("the hint explains the real cause and forbids the wrong fallbacks", () => {
+    const h = OCTO_TOOL_AVAILABILITY_HINT;
+    // names the tool
+    expect(h).toContain("octo_management");
+    // attributes to tool policy / profile, not a missing feature
+    expect(h).toMatch(/tools\.profile|tool policy|alsoAllow/);
+    // points at the explicit allow path
+    expect(h).toContain("alsoAllow");
+    // forbids the two wrong fallbacks seen in the wild
+    expect(h.toLowerCase()).toContain("plaintext");
+    expect(h.toLowerCase()).toMatch(/another platform|switching to/);
+  });
+
+  it("returns the hint when the message provider is octo", () => {
+    expect(_buildToolAvailabilityHint("octo")).toBe(OCTO_TOOL_AVAILABILITY_HINT);
+  });
+
+  it("returns null for non-octo providers, and for a raw conversation id", () => {
+    // Gate is on messageProvider (the provider name), not channelId — which in
+    // this hook ctx is the per-conversation raw id. Other providers and any
+    // stray group_no/uid value must NOT get the Octo-specific note.
+    expect(_buildToolAvailabilityHint("telegram")).toBeNull();
+    expect(_buildToolAvailabilityHint("webchat")).toBeNull();
+    expect(_buildToolAvailabilityHint("g_123456")).toBeNull(); // looks like a group id
+    expect(_buildToolAvailabilityHint(undefined)).toBeNull();
+    expect(_buildToolAvailabilityHint("")).toBeNull();
+  });
+});


### PR DESCRIPTION
## 背景

受限 `tools.profile`(`minimal` / `coding` / `messaging`)下,OpenClaw **不注册插件 tool**,
`octo_management` 整个工具消失——它承载的**所有** Octo 管理 action(建群、子区、GROUP.md/THREAD.md、
成员管理、voice context、`write-secret`)在 agent 上下文里一并不可用。没有任何说明时,模型**错误归因**:
告诉用户"Octo 不支持这些功能"并建议改用其他平台,或对 `write-secret` 建议用户**粘贴明文密钥**——
正好违背 #71 的安全初衷。

> ⚠️ 关键背景:OpenClaw 新装 onboarding **默认 `tools.profile: "coding"`**(非 `full`),
> 所以这是"默认安装即触发",并非边缘场景。`write-secret` 只是用户第一个撞上的 action;
> 根因是整个 `octo_management` 在受限 profile 下被过滤。

## 根因(真环境实证)

- coding profile session 日志**无** `registerTool ctx` → 工具 factory 未被调用;加
  `tools.alsoAllow: ["octo_management"]` 后 `registerTool ctx` 出现 → 工具恢复。
- `CORE_TOOL_PROFILES`:仅 `full` 是 `allow:["*"]`;`minimal`/`coding`/`messaging` 是白名单,不含插件 tool。
- 框架审计文案亦证实受限 profile "exclude plugin tools"。

## 改动

在 `index.ts` 的 `before_prompt_build` hook 注入一条**自我诊断 system section**(经
`prependSystemContext`),让模型正确归因:`octo_management` 不可用是**当前 tool policy
(profile + allow/deny)**所致,可用 `tools.alsoAllow` 或 `full` profile 解除,**不是功能缺失**;
并明确禁止两种错误兜底(改用其他平台 / 粘贴明文)。是否调整配置由用户决定——不替用户做决定、不自动改配置。

**为什么用 `before_prompt_build`/`prependSystemContext` 而非 channel `messageToolHints`**:
system-prompt builder 只在 `availableTools.has("message")` 时才展开 `messageToolHints`,
而受限 profile **同时移除了 `message` 工具**,所以挂在 messageToolHints 上的提示在我们要覆盖的场景里
**永远不会出现**。`prependSystemContext` 经 `wrapPluginSystemContextSection` 直接进 system prompt,
不受 profile 过滤影响。

**gate 到 octo 会话**:`before_prompt_build` 是全局 hook(其他渠道也触发),用 `ctx.messageProvider`
(provider id)判定——注意此 hook 的 `ctx.channelId` 是**会话 raw id(群号/uid)**而非 provider 名,
所以不能用 channelId 做 gate。

`octo_management` 仍保持为 plugin tool——这正是 `write-secret` 明文不进模型上下文的保证,与本次诊断 hint 正交。

## 真环境验收(coding profile,octo_management 实际被挡)

| | 修复前 | 修复后 |
|---|---|---|
| 归因 | "这是企业微信的技能,不是 Octo 的" / "我没有建群工具" | "当前工具策略把这个插件工具过滤掉了" |
| 解法 | 建议改用企业微信 / 飞书 | "全局加 `tools.alsoAllow:[\"octo_management\"]` 或切到 `full` profile" |
| 边界 | — | "你先调 / 自己手动建,看你方便"(不替用户决定) |

## 测试

- `src/__tests__/tool-availability-hint.test.ts`:文案语义(含 octo_management / tool policy /
  禁止 plaintext+换平台)、octo provider 返回文案、非 octo provider 及 raw 会话 id 返 `null`(gate)。
- 全量 `npm test` 1295 passed,`npm run type-check` 通过。
- README 补充 profile/alsoAllow 关系 + coding 默认背景。

Fixes #137