### PR TITLE
chore(comments): strip review-process noise from code comments

### DIFF
--- a/src/actions.test.ts
+++ b/src/actions.test.ts
@@ -393,7 +393,7 @@ describe("handleOctoMessageAction", () => {
         ["uid_bob", "bob"],
       ]);
       // uid_unknown is NOT in uidToNameMap and is not a 32-hex / space-prefixed
-      // uid, so the P0-3 outbound guard strips it (server would reject it
+      // uid, so the outbound guard strips it (server would reject it
       // anyway). uid_bob is in the map → kept.
 
       const { handleOctoMessageAction } = await import("./actions.js");
@@ -442,7 +442,7 @@ describe("handleOctoMessageAction", () => {
     });
   });
 
-  describe("send — P0-3 outbound sanitizer", () => {
+  describe("send — outbound sanitizer", () => {
     const HEX_A = "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6";
 
     it("bracketless @uid:name (valid uid) → @displayName + entity, no raw uid:name leaked", async () => {
@@ -500,7 +500,7 @@ describe("handleOctoMessageAction", () => {
     });
   });
 
-  describe("send — P0-1 sub-topic parent group prefetch", () => {
+  describe("send — sub-topic parent group prefetch", () => {
     const HEX_A = "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6";
 
     it("fetches members from the PARENT group_no for a sub-topic target", async () => {
@@ -1114,8 +1114,8 @@ describe("handleOctoMessageAction", () => {
       expect(sentPayload.channel_type).toBe(2);
     });
 
-    it("9h — stacked-prefix target (group:octo:<id>) — guard AND delivery use same normalization (PR#103 Jerry-Xin)", async () => {
-      // 🔴 Regression guard for the bug Jerry-Xin caught on PR #103:
+    it("9h — stacked-prefix target (group:octo:<id>) — guard AND delivery use same normalization", async () => {
+      // 🔴 Regression guard for stacked-prefix target handling:
       // handleSend's effectiveThreadId guard collapsed stacked prefixes
       // recursively (stripAllChannelPrefixes), but resolveOutboundOctoTarget
       // only stripped a SINGLE leading prefix. So target="group:octo:grp1"
@@ -1429,7 +1429,7 @@ describe("handleOctoMessageAction", () => {
     });
 
     it("scope:'parent' on a DM target → sent as DM, NOT rewritten to a group", async () => {
-      // Boundary bug (issue #98 review round 4): scope:"parent" used to
+      // Boundary bug: scope:"parent" used to
       // unconditionally strip the suffix and rewrite the target to
       // "group:<bare>". For a DM (`user:<uid>`) target that produced
       // "group:user:uid", which resolved to a Group and sent the message to a
@@ -3555,8 +3555,8 @@ describe("resolveOutboundOctoTarget", () => {
       .toBe("grp1____topicA");
   });
 
-  it("collapses stacked prefixes on the TARGET itself, not just threadId (PR#103 Jerry-Xin)", async () => {
-    // 🔴 PR #103 Jerry-Xin blocking finding: the threadId path strips stacked
+  it("collapses stacked prefixes on the TARGET itself, not just threadId", async () => {
+    // 🔴 The threadId path strips stacked
     // prefixes recursively, but the target path used to only strip one. A
     // stacked target like "group:octo:grp1" parsed to channelId="octo:grp1"
     // (wrong group), so threadId merge produced "octo:grp1____<short>". The

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -99,8 +99,8 @@ function stripGroupPrefix(raw: string): string {
  * agent-tool / multi-bot routing layer occasionally produces stacked forms
  * such as `"group:octo:grp1"` or `"channel:octo:grp1"`. Without canonical
  * collapse, the downstream parseTarget would only strip one leading prefix and
- * mis-parse the stacked inner segment as part of the group id (PR #103
- * Jerry-Xin: `"group:octo:grp1"` → channelId `"octo:grp1"` → message routed to
+ * mis-parse the stacked inner segment as part of the group id
+ * (`"group:octo:grp1"` → channelId `"octo:grp1"` → message routed to
  * the wrong group). The recursive collapse below makes the guard at handleSend
  * (which uses stripAllChannelPrefixes) and this delivery path agree on the
  * canonical bare groupId.
@@ -534,8 +534,7 @@ async function handleSend(params: {
   // different group than the current session. Normalization on BOTH sides
   // (currentChannelId via bareCurrentChannelId; target via bareTarget) so
   // prefixed forms ("octo:grp1", "group:grp1____x", "group:grp1@uid1,uid2")
-  // do not mis-compare and silently drop a legitimate threadId. Fixes a
-  // latent bug exposed by issue #98 review (codex round 3 MAJOR #1).
+  // do not mis-compare and silently drop a legitimate threadId.
   let effectiveThreadId: typeof threadId = threadId;
   if (effectiveThreadId != null && bareCurrentChannelId) {
     const currentParent = extractParentGroupNo(bareCurrentChannelId);
@@ -566,7 +565,7 @@ async function handleSend(params: {
   // no parent group, so the "strip suffix + rewrite group:" logic must NOT run
   // on it — otherwise "user:uid" would become "group:user:uid", resolve to a
   // Group, and the message would be sent to a bogus group instead of the DM,
-  // destroying the `user:` prefix semantics (issue #98 review round 4). scope is
+  // destroying the `user:` prefix semantics. scope is
   // meaningless on a DM, so leave the target untouched and let it pass through
   // as a normal DM. Reuse the same parse path as resolveOutboundOctoTarget
   // (normalizeOutboundChannelPrefix + parseTarget + getKnownGroupIds) so the
@@ -591,7 +590,7 @@ async function handleSend(params: {
 
   const { channelId, channelType } = resolveOutboundOctoTarget(targetForResolve, effectiveThreadId);
 
-  // P0 #98: auto-reroute bare-parent target back to current thread when the
+  // Auto-reroute bare-parent target back to current thread when the
   // agent is operating inside a thread session AND the resolved target is the
   // SAME group's parent. Overwhelmingly an LLM mistake ("send to the group"
   // when the user means "send here"); silent misrouting causes visibility/
@@ -671,7 +670,7 @@ async function handleSend(params: {
     resolutionReason = "passthrough";
   }
 
-  // P0-1: ensure member maps are populated before @ conversion. The message-tool
+  // Ensure member maps are populated before @ conversion. The message-tool
   // send path (agent-initiated @, new sub-topic) has no inbound refresh, so the
   // passed-in maps can be empty/stale. Only when the message contains an `@`,
   // pull the target group's members from the shared 5-min-TTL cache (cache hit =
@@ -739,7 +738,7 @@ async function handleSend(params: {
         mentionUids = mentionEntities.map(e => e.uid);
       }
 
-      // P0-3: last-line guard — rewrite/downgrade/strip malformed @ that the
+      // Last-line guard — rewrite/downgrade/strip malformed @ that the
       // conversion+fallback couldn't resolve, and drop illegal uids so a bad
       // mention is never leaked to the server.
       if (uidToNameMap) {

--- a/src/agent-tools.test.ts
+++ b/src/agent-tools.test.ts
@@ -1387,7 +1387,7 @@ describe("createOctoManagementTools", () => {
     });
 
     // -------------------------------------------------------------------
-    // 🔴 PATH CONFINEMENT (P0): the file destination must stay in the jail.
+    // 🔴 PATH CONFINEMENT: the file destination must stay in the jail.
     // -------------------------------------------------------------------
     it("rejects parent-directory traversal, no resolve, no write", async () => {
       const result = await writeSecret({ alias: "k", filePath: "../escape.txt" });
@@ -1437,7 +1437,7 @@ describe("createOctoManagementTools", () => {
       }
     });
 
-    // 🔴 P0 REGRESSION — dangling-symlink jail escape. The earlier guard only
+    // 🔴 REGRESSION — dangling-symlink jail escape. The earlier guard only
     // rejected symlinks whose target ALREADY existed; a symlink pointing OUT of
     // the jail at a target that does NOT yet exist (dangling) slipped through,
     // and writeFile() then created the plaintext secret at the out-of-jail
@@ -1504,7 +1504,7 @@ describe("createOctoManagementTools", () => {
       await expect(readFile(inJailButMissing, "utf8")).rejects.toThrow();
     });
 
-    // 🔴 P1 REGRESSION — intermediate-dir symlink TOCTOU. confineSecretPath()
+    // 🔴 REGRESSION — intermediate-dir symlink TOCTOU. confineSecretPath()
     // walks the path BEFORE the parent dirs exist, so it cannot catch a symlink
     // swapped onto a parent AFTER mkdir creates it. O_NOFOLLOW only guards the
     // leaf basename, not intermediate components — the kernel still follows a
@@ -1573,7 +1573,7 @@ describe("createOctoManagementTools", () => {
       expect(await readFile(join(root, "atroot.txt"), "utf8")).toBe(PLAINTEXT);
     });
 
-    // 🔴 FAIL-CLOSED (P0): no secretsFileRoot configured → refuse every write.
+    // 🔴 FAIL-CLOSED: no secretsFileRoot configured → refuse every write.
     // There is deliberately NO process.cwd() fallback (that fallback was the
     // root cause of the `/`-degenerate self-lock + fail-open bugs).
     it("fails closed when secretsFileRoot is unset — no resolve, no write", async () => {
@@ -1797,7 +1797,7 @@ describe("createOctoManagementTools", () => {
         expect(await readFile(join(root, "via-defaults.env"), "utf8")).toBe(PLAINTEXT);
       });
 
-      // 🔴 P0 (Jerry-Xin + yujiawei) — NON-DEFAULT agent jail = per-agent
+      // 🔴 NON-DEFAULT agent jail = per-agent
       // SUBDIRECTORY of defaults.workspace, NEVER the bare shared parent. Here
       // bot-A is not the default agent (someone-else is), so the platform's
       // canonical resolveAgentWorkspaceDir derives <defaults.workspace>/<agentId>.
@@ -1823,7 +1823,7 @@ describe("createOctoManagementTools", () => {
         ).rejects.toThrow();
       });
 
-      // 🔴 P0 (Jerry-Xin + yujiawei) — a non-default agent must NOT be able to
+      // 🔴 A non-default agent must NOT be able to
       // climb out of its per-agent subdir into a SIBLING agent's directory and
       // write the owner's plaintext there. This is the concrete cross-agent
       // secret-write escape the bare-defaults jail allowed: a `worker` writing
@@ -1929,7 +1929,7 @@ describe("createOctoManagementTools", () => {
         expect(resolveSecret).not.toHaveBeenCalled();
       });
 
-      // 🔴 BLOCKING REGRESSION (Jerry-Xin) — symlink-to-`/` fail-open.
+      // 🔴 REGRESSION — symlink-to-`/` fail-open.
       // The old guard checked the LEXICAL form (`resolvePath(workspace) === sep`),
       // so a workspace configured as a symlink whose REAL target is "/" slipped
       // past it (the lexical path is the link, ≠ "/") and only degenerated into a
@@ -1956,7 +1956,7 @@ describe("createOctoManagementTools", () => {
         expect(JSON.stringify(result)).not.toContain(PLAINTEXT);
       });
 
-      // 🔴 BLOCKING (Jerry-Xin) — Windows drive root must fail closed too. The old
+      // 🔴 Windows drive root must fail closed too. The old
       // `=== sep` compare never matched "C:\\" (resolvePath("C:\\") !== "/"), so a
       // drive-root workspace would have degenerated into a root-wide jail. The
       // path.parse(p).root === p check covers POSIX and Windows roots alike.
@@ -1975,7 +1975,7 @@ describe("createOctoManagementTools", () => {
         expect(resolveSecret).not.toHaveBeenCalled();
       });
 
-      // 必修2 — match key namespace. The workspace is indexed by OpenClaw AGENT
+      // match key namespace. The workspace is indexed by OpenClaw AGENT
       // id, not the channel/Octo account id. When the two differ (e.g. agent
       // `main` ↔ octo account `default`), keying on the account id silently misses
       // the per-agent workspace and falls back to defaults. Assert that passing a
@@ -2003,7 +2003,7 @@ describe("createOctoManagementTools", () => {
         expect(JSON.stringify(result)).not.toContain(PLAINTEXT);
       });
 
-      // 必修2 — agentId takes precedence over agentAccountId when both match
+      // agentId takes precedence over agentAccountId when both match
       // different entries. The correct (per-agent-id) workspace must win.
       it("prefers agentId over agentAccountId when both match different entries", async () => {
         setupMocks();
@@ -2034,7 +2034,7 @@ describe("createOctoManagementTools", () => {
         }
       });
 
-      // 必修2 — agent id matching is namespace-normalized (lower/slug), matching
+      // agent id matching is namespace-normalized (lower/slug), matching
       // the platform's normalizeAgentId. A config entry id with different casing
       // must still match the runtime agent id.
       it("matches the agent workspace case-insensitively (normalizeAgentId)", async () => {
@@ -2051,7 +2051,7 @@ describe("createOctoManagementTools", () => {
         expect(await readFile(join(root, "case.env"), "utf8")).toBe(PLAINTEXT);
       });
 
-      // 必修3 — `~` expansion. A workspace configured as "~/<subdir>" must expand
+      // `~` expansion. A workspace configured as "~/<subdir>" must expand
       // to $HOME, matching the platform's canonical resolveAgentWorkspaceDir,
       // rather than being treated as a literal "./~" segment.
       it("expands a leading ~ in the workspace to the home directory", async () => {
@@ -2076,7 +2076,7 @@ describe("createOctoManagementTools", () => {
         }
       });
 
-      // 必修3 — $VAR / ${VAR} expansion. A workspace parameterized by an env var
+      // $VAR / ${VAR} expansion. A workspace parameterized by an env var
       // must expand before the path is used as the jail root.
       it("expands $VAR / ${VAR} in the workspace path", async () => {
         setupMocks();
@@ -2098,7 +2098,7 @@ describe("createOctoManagementTools", () => {
         }
       });
 
-      // 🔴 必修2 / P1-A (lml2468) — symlink-ANCESTOR first-write must NOT be
+      // 🔴 Symlink-ANCESTOR first-write must NOT be
       // false-rejected. When the jail root sits under a symlinked ancestor AND
       // the workspace dir does not exist yet (the common first-write case), the
       // old code stored the root in its LEXICAL form but compared it post-mkdir
@@ -2108,7 +2108,7 @@ describe("createOctoManagementTools", () => {
       // the jail root (confineSecretPath) through their nearest existing ancestor,
       // so every comparison is symlink-free.
       //
-      // lml2468 asked for coverage of three real-world ancestor-symlink shapes,
+      // Cover three real-world ancestor-symlink shapes,
       // not just one. Each case builds a genuine symlinked-ancestor root whose
       // workspace leaf does not exist yet, then asserts the FIRST write succeeds
       // and the file materializes at the REAL (symlink-resolved) target.
@@ -2199,7 +2199,7 @@ describe("createOctoManagementTools", () => {
         });
       }
 
-      // 🔴 P1-B (Yu CR) — an UNDEFINED env var in the workspace path must FAIL
+      // 🔴 An UNDEFINED env var in the workspace path must FAIL
       // CLOSED, not anchor the jail to process.cwd(). A literal, unexpanded
       // `${UNDEF}` fed to path.resolve() silently roots the relative remainder at
       // the current working directory, which would sail past both filesystem-root
@@ -2317,7 +2317,7 @@ describe("createOctoManagementTools", () => {
       expect(data.candidates).toBeUndefined();
     });
 
-    // 🔴 BLOCKER: a single RETURNED candidate that is NOT the whole match set
+    // 🔴 A single RETURNED candidate that is NOT the whole match set
     // (total>1 and/or truncated) must NOT auto-resolve — otherwise a limit:1
     // request over 5 matches would silently treat a partial result as a
     // confident pick. It must fall through to the candidates branch so the agent

--- a/src/agent-tools.ts
+++ b/src/agent-tools.ts
@@ -109,7 +109,7 @@ function isInsideRoot(root: string, candidate: string): boolean {
 /**
  * Confine a caller-supplied write target to an operator-approved jail root.
  *
- * 🔴 SECURITY (P0): `filePath` comes from the LLM tool call, which is reachable
+ * 🔴 SECURITY: `filePath` comes from the LLM tool call, which is reachable
  * via inbound group-chat messages — an untrusted, prompt-injectable surface.
  * Without confinement, `write-secret` is an arbitrary-file-write of the owner's
  * plaintext secret (e.g. "append my key to ~/.bashrc" / ".ssh/authorized_keys"

--- a/src/api-fetch.ts
+++ b/src/api-fetch.ts
@@ -904,7 +904,7 @@ export async function getBotOboGrant(params: {
   // Accept grant when `has_grant: true` is explicit, OR when the field is
   // absent (undefined) and the response contains a `grantor_uid` — some
   // server versions omit `has_grant` entirely.  An explicit `has_grant: false`
-  // is authoritative denial and must fail closed (Jerry-Xin review R1).
+  // is authoritative denial and must fail closed.
   const hasGrant = raw.has_grant === true ||
     (raw.has_grant === undefined &&
       typeof raw.grantor_uid === "string" &&

--- a/src/channel.test.ts
+++ b/src/channel.test.ts
@@ -644,7 +644,7 @@ describe("outbound.sendMedia — threadId wiring", () => {
 });
 
 /**
- * Streaming size cap for the outbound HTTP-URL branch (PR#66 R2 — lml2468 阻断点).
+ * Streaming size cap for the outbound HTTP-URL branch.
  *
  * channel.ts#downloadToTempFile is the only line of defense after dropping the
  * HEAD-based pre-check. This test drives the cap through octoPlugin.outbound.sendMedia
@@ -653,7 +653,7 @@ describe("outbound.sendMedia — threadId wiring", () => {
  *   - presigned PUT is never called
  *   - partial temp file under /tmp/octo-upload is unlinked on failure
  */
-describe("outbound.sendMedia — HTTP streaming size cap (R2)", () => {
+describe("outbound.sendMedia — HTTP streaming size cap", () => {
   const cfg = {
     channels: {
       octo: {
@@ -945,7 +945,7 @@ describe("outbound sendText/sendMedia — messageId propagation (#51)", () => {
   });
 });
 
-// ─── P0-2: messageToolHints @mention format hint ─────────────────────────────
+// ─── messageToolHints @mention format hint ─────────────────────────────
 
 describe("agentPrompt.messageToolHints — @mention format hint", () => {
   it("appends the shared MENTION_FORMAT_HINT with group-members + anti-patterns", async () => {
@@ -976,9 +976,9 @@ describe("agentPrompt.messageToolHints — @mention format hint", () => {
   });
 });
 
-// ─── P0-1: outbound member prefetch (cold start) ─────────────────────────────
+// ─── outbound member prefetch (cold start) ─────────────────────────────
 
-describe("outbound.sendText — P0-1 member prefetch", () => {
+describe("outbound.sendText — member prefetch", () => {
   const cfg = {
     channels: {
       octo: {

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -243,7 +243,7 @@ function getOrCreateGroupCacheTimestamps(accountId: string): Map<string, number>
 }
 
 /**
- * Outbound @mention prefetch (P0-1).
+ * Outbound @mention prefetch.
  *
  * Proactive sends (cron, new sub-topic, agent-initiated @) never go through the
  * inbound member-cache refresh, so the per-account memberMap/uidToNameMap can be
@@ -917,7 +917,7 @@ export const octoPlugin: ChannelPlugin<ResolvedOctoAccount> = {
         const accountMemberMap = getOrCreateMemberMap(accountId);
         const uidToNameMap = getOrCreateUidToNameMap(accountId);
 
-        // P0-1: ensure member maps are populated for proactive sends (cron / new
+        // Ensure member maps are populated for proactive sends (cron / new
         // sub-topic / agent-initiated @) where the inbound refresh never ran.
         await prefetchOutboundMembers({
           content: finalContent,
@@ -955,7 +955,7 @@ export const octoPlugin: ChannelPlugin<ResolvedOctoAccount> = {
           }
         }
 
-        // P0-3: last-line guard — rewrite/downgrade/strip any malformed @ the
+        // Last-line guard — rewrite/downgrade/strip any malformed @ the
         // conversion+fallback couldn't resolve, and drop illegal uids so a bad
         // mention is never leaked to the server.
         const sanitized = sanitizeOutboundMentions({
@@ -1216,7 +1216,7 @@ export const octoPlugin: ChannelPlugin<ResolvedOctoAccount> = {
         }
       } catch { /* config snapshot inaccessible — non-fatal */ }
 
-      // F3 (PR #131 review, Octo-Q): `commands.fork.scope` accepts four values in
+      // `commands.fork.scope` accepts four values in
       // the schema, but v1's fork hook only honors the default "owner-mentioned"
       // (wiring inbound to a configured value is a v1.1 TODO). Warn once per
       // account at startup if an operator set a non-default value, so it is not

--- a/src/commands/fork-inbound.ts
+++ b/src/commands/fork-inbound.ts
@@ -34,7 +34,7 @@ import { executeFork, parseForkCommand, type ForkLogger, type ForkOrchestrator }
 import { buildForkOrchestrator, type ForkRuntimeDeps, type ForkSeedContext } from "./fork-runtime.js";
 
 /**
- * Bounded timeout for the parent-group receipt send (P2, yujiawei). The dispatch
+ * Bounded timeout for the parent-group receipt send. The dispatch
  * timeout only guards the seed dispatch; without this, a hung Octo API on the
  * receipt POST would still strand the parent enqueueInbound serial queue. Mirrors
  * the `AbortSignal.timeout(DISPATCH_TIMEOUT_APOLOGY_MS)` pattern in inbound.ts.
@@ -105,9 +105,9 @@ export async function dispatchForkSeedReply(params: {
     AccountId: childRoute.accountId ?? accountId,
   };
 
-  // Fork-isolation guard (PR #131 review — upgraded from warn-only to
-  // fail-closed). get-reply only forks the parent transcript when
-  // ParentSessionKey !== SessionKey. If they coincide, the seed would run ON the
+  // Fork-isolation guard (fail-closed). get-reply only forks the parent
+  // transcript when ParentSessionKey !== SessionKey. If they coincide, the seed
+  // would run ON the
   // parent session and pollute it — the exact outcome /fork promises to avoid.
   // So we refuse to dispatch instead of warn-and-continue. Only reachable on a
   // user-defined group-merged route (octo's default per-thread routing gives the
@@ -139,7 +139,7 @@ export async function dispatchForkSeedReply(params: {
     });
   };
 
-  // Timeout guard (PR #131 Critical, issue #75). dispatchReplyWithBufferedBlock-
+  // Timeout guard (issue #75). dispatchReplyWithBufferedBlock-
   // Dispatcher is observed to occasionally hang forever (no resolve/reject/
   // onError). This seed is awaited synchronously inside the parent group's
   // enqueueInbound serial queue, so a bare await would lock that queue until the
@@ -155,7 +155,7 @@ export async function dispatchForkSeedReply(params: {
 
   const buffer = { lastText: null as string | null };
   let delivered = false;
-  // P1 (Jerry-Xin): the SDK dispatcher routes deliver()/onError failures WITHOUT
+  // The SDK dispatcher routes deliver()/onError failures WITHOUT
   // rejecting the outer promise, so a failed user-facing send would otherwise
   // look like fork success and the user gets "已开 fork 子区" while the first
   // reply never landed. Track delivery failure and convert it to a thrown error
@@ -211,7 +211,7 @@ export async function dispatchForkSeedReply(params: {
     throw err; // → spawnChildBoundSession catch → seedFailed: true
   } finally {
     if (dispatchTimeoutHandle) clearTimeout(dispatchTimeoutHandle);
-    // P2-5: isolate the flush. If the dispatcher already threw, a flush failure
+    // Isolate the flush. If the dispatcher already threw, a flush failure
     // must NOT replace the original error (it carries the root-cause signal).
     // Log and swallow the flush error; never let it shadow the dispatch error.
     if (buffer.lastText && !delivered) {
@@ -227,7 +227,7 @@ export async function dispatchForkSeedReply(params: {
 
   // Settled without throwing, but a final/tool delivery may have failed silently
   // (the SDK does not reject the outer promise for deliver/onError failures).
-  // Surface it so spawnChildBoundSession reports seedFailed → ok_seed_failed (P1).
+  // Surface it so spawnChildBoundSession reports seedFailed → ok_seed_failed.
   if (deliverFailed) {
     throw new Error("octo: [fork-seed] delivery failed: user-facing reply did not send");
   }
@@ -328,7 +328,7 @@ export async function handleForkCommandIfMatched(params: {
         channelType: params.parentChannelType,
         content: text,
         // Bound the receipt POST so a hung Octo API cannot strand the parent
-        // enqueueInbound queue (P2). safeSendReceipt swallows the resulting
+        // enqueueInbound queue. safeSendReceipt swallows the resulting
         // timeout error, so the fork's main effect (thread + seed) still stands.
         signal: AbortSignal.timeout(RECEIPT_SEND_TIMEOUT_MS),
       });

--- a/src/commands/fork-inherit-md.test.ts
+++ b/src/commands/fork-inherit-md.test.ts
@@ -135,7 +135,7 @@ describe("inheritParentMdToChildThread", () => {
     expect(updateThreadMd).not.toHaveBeenCalled();
   });
 
-  it("13. ok write → mirrors content into local disk cache via broadcastThreadMdUpdate (P2)", async () => {
+  it("13. ok write → mirrors content into local disk cache via broadcastThreadMdUpdate", async () => {
     getGroupMd.mockResolvedValue(mdResp("group rules"));
     updateThreadMd.mockResolvedValue({ version: 7 });
     const status = await inheritParentMdToChildThread(groupParent);

--- a/src/commands/fork-inherit-md.ts
+++ b/src/commands/fork-inherit-md.ts
@@ -98,7 +98,7 @@ export async function inheritParentMdToChildThread(params: {
   // 4) Write the child thread's THREAD.md.
   try {
     const { version } = await updateThreadMd({ apiUrl, botToken, groupNo: childGroupNo, shortId: childShortId, content });
-    // Mirror the write into the local disk cache (P2, Jerry-Xin). updateThreadMd
+    // Mirror the write into the local disk cache. updateThreadMd
     // only writes the octo server, but before_prompt_build's getGroupMdForPrompt
     // reads the local cache — without this, the inherited md would be invisible
     // to the child's first dispatch. The server write is the SSOT, so a local

--- a/src/commands/fork-seed-dispatch.test.ts
+++ b/src/commands/fork-seed-dispatch.test.ts
@@ -122,7 +122,7 @@ describe("dispatchForkSeedReply", () => {
     expect(ctx.AccountId).toBe("acctX");
   });
 
-  it("ISOLATION GUARD (fail-closed, P2-1): SessionKey === ParentSessionKey → throws, does NOT dispatch", async () => {
+  it("ISOLATION GUARD (fail-closed): SessionKey === ParentSessionKey → throws, does NOT dispatch", async () => {
     // Child route resolves to the SAME key as the seed's ParentSessionKey →
     // auto-fork would not trigger and the seed would run ON the parent session.
     // Upgraded from warn-and-continue to fail-closed: refuse to dispatch.
@@ -222,7 +222,7 @@ describe("dispatchForkSeedReply", () => {
     expect(arg.mentionEntities && arg.mentionEntities.length).toBeGreaterThan(0);
   });
 
-  it("TIMEOUT GUARD (Critical, #75): a hung dispatcher times out and rejects, never hangs forever", async () => {
+  it("TIMEOUT GUARD (issue #75): a hung dispatcher times out and rejects, never hangs forever", async () => {
     _setDispatchTimeoutForTests(50);
     mockDispatch.mockImplementation(() => new Promise<void>(() => {})); // never settles
     const warn = vi.fn();
@@ -261,7 +261,7 @@ describe("dispatchForkSeedReply", () => {
     expect(warn.mock.calls.some((c) => String(c[0]).includes("hung past"))).toBe(false);
   });
 
-  it("finally flush failure does NOT mask the original dispatch error (P2-5)", async () => {
+  it("finally flush failure does NOT mask the original dispatch error", async () => {
     driveDeliver([{ kind: "block", text: "partial" }], { throwAfter: true });
     // The single sendMessage call is the finally flush; make it throw too.
     mockSendMessage.mockImplementationOnce(async () => {
@@ -283,7 +283,7 @@ describe("dispatchForkSeedReply", () => {
     expect(error.mock.calls.some((c) => String(c[0]).includes("finally flush failed"))).toBe(true);
   });
 
-  it("DELIVERY FAILURE (P1): a final send error → throws (→ seedFailed → ok_seed_failed)", async () => {
+  it("DELIVERY FAILURE: a final send error → throws (→ seedFailed → ok_seed_failed)", async () => {
     // deliver() for a final block tries to send; the send throws. The SDK does
     // not reject the outer promise for this, so without tracking it the fork
     // would falsely report success. We track it and throw after settle.
@@ -294,7 +294,7 @@ describe("dispatchForkSeedReply", () => {
     await expect(run()).rejects.toThrow(/delivery failed/i);
   });
 
-  it("DELIVERY FAILURE (P1): onError(final) → throws even though the dispatcher resolved", async () => {
+  it("DELIVERY FAILURE: onError(final) → throws even though the dispatcher resolved", async () => {
     mockDispatch.mockImplementation(async (o: any) => {
       // dispatcher resolves normally; the failure surfaces only via onError.
       await o.dispatcherOptions.onError(new Error("upstream boom"), { kind: "final" });

--- a/src/commands/fork.ts
+++ b/src/commands/fork.ts
@@ -135,7 +135,7 @@ export const DEFAULT_FORK_SCOPE: ForkScope = "owner-mentioned";
 
 /**
  * Startup warning for a configured `commands.fork.scope` that v1 does not yet
- * honor (F3, PR #131 review). v1's inbound hook always uses the default
+ * honor. v1's inbound hook always uses the default
  * `owner-mentioned`; wiring a configured value is a v1.1 TODO. So an operator
  * who sets a non-default scope would be silently fail-closed — confusing.
  *

--- a/src/content-disposition.test.ts
+++ b/src/content-disposition.test.ts
@@ -14,7 +14,7 @@ import { extractFilename, sanitizeFilename } from "./inbound.js";
  */
 
 // ---------------------------------------------------------------------------
-// sanitizeFilename + extractFilename — path traversal defense (P1-2)
+// sanitizeFilename + extractFilename — path traversal defense
 // ---------------------------------------------------------------------------
 describe("sanitizeFilename — path traversal defense", () => {
   it("strips leading directory components", () => {
@@ -40,7 +40,7 @@ describe("sanitizeFilename — path traversal defense", () => {
   });
 });
 
-describe("extractFilename — path traversal via URL-encoded segments (P1-2)", () => {
+describe("extractFilename — path traversal via URL-encoded segments", () => {
   it("URL-encoded ..%2F..%2Fetc%2Fpasswd does NOT escape temp dir", () => {
     // Before fix: extractFilename returned "../../etc/passwd" and a caller
     // doing `path.join("/tmp/octo-upload", filename)` resolved to

--- a/src/group-md.test.ts
+++ b/src/group-md.test.ts
@@ -625,7 +625,7 @@ describe("broadcastGroupMdUpdate", () => {
 });
 
 // =========================================================================
-// P0: getGroupMdForPrompt with thread channelIds
+// getGroupMdForPrompt with thread channelIds
 // =========================================================================
 
 describe("getGroupMdForPrompt (thread support)", () => {

--- a/src/inbound-mention-gate.test.ts
+++ b/src/inbound-mention-gate.test.ts
@@ -7,11 +7,11 @@ import { _clearMentionPrefCache, _setMentionPrefEntry, _hasMentionPrefEntry } fr
 import type { ResolvedOctoAccount } from "./accounts.js";
 
 /**
- * Integration test for the inbound mention-gate 免@ relaxation (PR#57 review P1).
+ * Integration test for the inbound mention-gate 免@ relaxation.
  *
  * The 免@ (no_mention=true) group preference relaxes requireMention so the bot
  * replies to non-@ messages. The fix scopes that relaxation to HUMAN senders,
- * and does so FAIL-CLOSED (round-4): the gate relaxes requireMention ONLY for a
+ * and does so FAIL-CLOSED: the gate relaxes requireMention ONLY for a
  * sender the server-authoritative member list positively confirms is human
  * (memberRobotMap.get(uid) === false). Unknown senders, ANY robot, and the case
  * where the member refresh fails/returns empty (so the robot flag is undefined)
@@ -173,7 +173,7 @@ function installFetchStubMembersDown(mode: "error" | "empty" = "error") {
   return { sends };
 }
 
-describe("inbound mention-gate 免@ relaxation (P1: human-only)", () => {
+describe("inbound mention-gate 免@ relaxation (human-only)", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
     _clearKnownBots();
@@ -305,7 +305,7 @@ describe("inbound mention-gate 免@ relaxation (P1: human-only)", () => {
   });
 
   it("suppresses the group-pref lookup for an explicit @bot message (no needless latency)", async () => {
-    // round-3 non-blocking #1: an explicit @bot message already passes the gate,
+    // An explicit @bot message already passes the gate,
     // so the 免@ pref can't change the outcome. The lookup must be short-
     // circuited (computed AFTER mention flags, only when !isMentioned) so a
     // cold/slow pref backend never adds latency to normal @bot replies.
@@ -336,7 +336,7 @@ describe("inbound mention-gate 免@ relaxation (P1: human-only)", () => {
   });
 
   it("does NOT reply to a CROSS-PROCESS bot (robot:true in member list, NOT registerKnownBot'd)", async () => {
-    // Regression for PR#57 round-2 P1: the loop guard must use the
+    // Regression: the loop guard must use the
     // server-authoritative GroupMember.robot signal, not just the local
     // registerKnownBot() set. EXTERNAL_BOT_UID is robot:true in the group
     // member list but was never registered, so isKnownBot() returns false for
@@ -366,7 +366,7 @@ describe("inbound mention-gate 免@ relaxation (P1: human-only)", () => {
   });
 
   it("does NOT reply to a CROSS-PROCESS bot whose robot flag is NUMERIC (robot:1)", async () => {
-    // Regression for PR#57 round-3 P1: the backend serializes GroupMember.robot
+    // Regression: the backend serializes GroupMember.robot
     // as a number, so a strict `=== true` would treat robot:1 as human → relax
     // requireMention → reply to the non-@ bot message → bot-to-bot loop. The
     // gate must coerce robot:1 to a bot exactly like robot:true.
@@ -418,7 +418,7 @@ describe("inbound mention-gate 免@ relaxation (P1: human-only)", () => {
   });
 
   it("does NOT reply to a HUMAN non-@ message when member refresh FAILS (fail-closed)", async () => {
-    // round-4 P1: the loop guard inverts to a whitelist. A sender is relaxed
+    // The loop guard inverts to a whitelist. A sender is relaxed
     // ONLY when the member list positively confirms them human. When the
     // members endpoint errors out, refreshGroupMemberCache leaves memberRobotMap
     // unpopulated → robot flag is undefined → classification unknown → keep

--- a/src/inbound.test.ts
+++ b/src/inbound.test.ts
@@ -957,7 +957,7 @@ describe("uploadAndSendMedia timeout", () => {
 });
 
 /**
- * Streaming size cap (PR#66 R2 — lml2468 阻断点).
+ * Streaming size cap.
  *
  * After dropping the HEAD-based pre-check, the streaming cap inside
  * uploadMedia is the only line of defense against oversize remote downloads.
@@ -966,7 +966,7 @@ describe("uploadAndSendMedia timeout", () => {
  *   - presigned PUT API is never called (no upload attempted past the cap)
  *   - partial temp file under /tmp/octo-upload is unlinked on failure
  */
-describe("uploadMedia — streaming size cap (R2)", () => {
+describe("uploadMedia — streaming size cap", () => {
   const originalFetch = globalThis.fetch;
 
   afterEach(() => {
@@ -1303,7 +1303,7 @@ describe("resolveInboundMediaList (Fixes #58)", () => {
  * returns undefined so the whole message falls back to the MediaUrls (remote
  * http) branch. This deliberately avoids sparse MediaPaths: Core's sandbox media
  * staging treats MediaPaths as a plain string[] (resolveRawPaths → raw.trim())
- * and would crash on an undefined slot (Jerry-Xin round-3 P1). The return type
+ * and would crash on an undefined slot. The return type
  * is string[] — no non-string element ever reaches MediaPaths.
  */
 describe("resolveInboundMediaPaths (#59 — all-or-nothing, never sparse)", () => {
@@ -1387,7 +1387,7 @@ describe("isRemoteMediaUrl", () => {
 });
 
 /**
- * Integration-style test (#59 round-3 P1): assert the inbound media payload built
+ * Integration-style test: assert the inbound media payload built
  * by inbound.ts (MediaPaths / MediaUrls / MediaTypes) flows correctly through
  * Core's REAL normalizeMediaAttachments (= normalizeAttachments). This guards the
  * all-or-nothing contract directly against Core: all-local goes through the fs
@@ -1434,7 +1434,7 @@ describe("inbound media payload × Core normalizeMediaAttachments (#59 all-or-no
       { localPath: undefined, remoteUrl: "https://cdn.example.com/b.png" },
     ];
     const payload = buildPayload(items);
-    // Mixed-fail: NO MediaPaths (never sparse) — the round-3 P1 guarantee.
+    // Mixed-fail: NO MediaPaths (never sparse) — the array-shape guarantee.
     expect(payload.MediaPaths).toBeUndefined();
     expect(payload.MediaUrls).toEqual([
       "https://cdn.example.com/a.jpg",
@@ -1911,7 +1911,7 @@ describe("pendingInboundContext", () => {
     expect(entry?.memberListPrefix).toBe("members...");
   });
 
-  // P1 (yujiawei): every group inbound sets pendingInboundContext before the
+  // Every group inbound sets pendingInboundContext before the
   // command split; the fork hook early-returns BEFORE the normal dispatch
   // delete and before the before_prompt_build get/delete, so the fork branch
   // must delete the entry itself or it leaks. This documents that invariant by
@@ -1975,7 +1975,7 @@ describe("sessionAccountMap (composite-keyed)", () => {
   });
 
   it("does NOT overwrite when two accounts share the same sessionKey (multi-account isolation)", () => {
-    // 🔴 PR#69 R3 regression guard: two distinct accounts can legitimately
+    // 🔴 Regression guard: two distinct accounts can legitimately
     // share the same sessionKey. The composite-key map must keep both
     // entries so the hook can disambiguate per-account; otherwise the
     // second account's persona prompt would leak into the first account's
@@ -2857,7 +2857,7 @@ describe("OBO v2 sender identity validation (GH#63)", () => {
 });
 
 /**
- * Tests for OBO v2 effective identity authority (PR#61 R5).
+ * Tests for OBO v2 effective identity authority.
  *
  * In the isOBOv2 branch of inbound.ts (~L1685), `effectiveOnBehalfOf` is the
  * identity we use as `on_behalf_of` for replies/typing. It MUST come from the
@@ -2865,7 +2865,7 @@ describe("OBO v2 sender identity validation (GH#63)", () => {
  * `obo_respond_as` (which is attacker-controllable in transit). When the two
  * disagree, we keep the configured grantor and emit a warn for visibility.
  */
-describe("OBO v2 effective identity authority (PR#61 R5)", () => {
+describe("OBO v2 effective identity authority", () => {
   type WarnSink = { warn: (msg: string) => void; info?: (msg: string) => void };
 
   // Mirrors the assignment at inbound.ts:1685 (post-fix).
@@ -3028,9 +3028,9 @@ describe("OBO v2 relevance filter", () => {
 });
 
 /**
- * Tests for OBO v2 detection + relevance filter ordering (PR#61 R10).
+ * Tests for OBO v2 detection + relevance filter ordering.
  *
- * Jerry-Xin + lml2468 R10 found: at d46efad8, `recordInboundSession` was
+ * Regression: at d46efad8, `recordInboundSession` was
  * fired BEFORE the OBO v2 relevance filter, so irrelevant OBO v2 fan-out
  * messages (e.g. AI-only) were already persisted to the bot's DM session
  * with the grantor — including any `obo_system_hint` from the payload as
@@ -3042,7 +3042,7 @@ describe("OBO v2 relevance filter", () => {
  * BEFORE finalizeInboundContext / recordInboundSession in inbound.ts.
  * These tests guard against regressing the ordering.
  */
-describe("OBO v2 detection + filter ordering vs recordInboundSession (PR#61 R10)", () => {
+describe("OBO v2 detection + filter ordering vs recordInboundSession", () => {
   type ObovPayload = {
     obo_origin_channel_id?: string;
     obo_origin_channel_type?: number;
@@ -3228,7 +3228,7 @@ describe("OBO v2 detection + filter ordering vs recordInboundSession (PR#61 R10)
   /**
    * Source-ordering regression guard: read inbound.ts and verify that the
    * `recordInboundSession` call is AFTER the OBO v2 relevance-filter early
-   * return. This is the structural invariant R10 enforces — if a future
+   * return. This is the structural ordering invariant — if a future
    * patch reorders the calls back to the buggy d46efad8 layout, this test
    * fails immediately.
    */
@@ -3242,7 +3242,7 @@ describe("OBO v2 detection + filter ordering vs recordInboundSession (PR#61 R10)
 
     const lines = src.split("\n");
     // First `if (isOBOv2)` block in the inbound function gates the early
-    // return that R10 introduces.
+    // return for the OBO v2 relevance filter.
     let firstIsObovBlockLine = -1;
     let firstReturnAfterIsObov = -1;
     let recordInboundSessionLine = -1;
@@ -3646,7 +3646,7 @@ describe("/fork command history leak filter (regression)", () => {
 
   // Simulate the filteredApiMsgs filter pipeline from handleInboundMessage:
   // the existing (drop-bot/empty) filter plus the new fork-command filter.
-  // String(m.content ?? "") mirrors the production coerce (P2, yujiawei).
+  // String(m.content ?? "") mirrors the production coerce.
   const filterApiMsgs = (apiMessages: any[]) =>
     apiMessages
       .filter((m: any) => m.from_uid !== botUid && (m.content || m.type !== 1))
@@ -3687,7 +3687,7 @@ describe("/fork command history leak filter (regression)", () => {
     expect(bodies).toEqual(["@Max 我想用 /fork 功能", "/forked repo 怎么同步"]);
   });
 
-  it("does NOT throw on non-string content (RichText etc.) and keeps it (P2, yujiawei)", () => {
+  it("does NOT throw on non-string content (RichText etc.) and keeps it", () => {
     // getChannelMessages types content as string, but RichText (type 14) and
     // similar payloads carry a non-string m.content. A bare .replace() on those
     // crashes the whole backfill; String(...) coerce keeps it safe. A coerced

--- a/src/inbound.ts
+++ b/src/inbound.ts
@@ -148,7 +148,7 @@ export const pendingInboundContext = new Map<string, { historyPrefix: string; me
 // octo-adapters#68) depends on this — without it, getPersonaPromptForSession
 // can never be called with the correct accountId from the hook.
 //
-// 🔴 Multi-account isolation (PR#69 R3, Jerry-Xin):
+// 🔴 Multi-account isolation:
 // The map is keyed by the COMPOSITE `${accountId}:${sessionKey}`, NOT by
 // `sessionKey` alone. Two distinct bot accounts (e.g. a persona clone and a
 // regular bot, or two persona clones) running on the same OpenClaw node can
@@ -1738,7 +1738,7 @@ export async function handleInboundMessage(params: {
   // /v1/bot/groups/:group_no/mention_pref (TTL 30s); any failure falls back to
   // the account-level config, so the gate never crashes.
   //
-  // The 免@ relaxation is HUMAN-ONLY and FAIL-CLOSED (PR#57 round-4 P1).
+  // The 免@ relaxation is HUMAN-ONLY and FAIL-CLOSED.
   // channel.ts forwards other bots' group messages into here on purpose,
   // relying on this mention gate to drop the non-@ ones. If we relaxed
   // requireMention for a non-human sender, two 免@ bots in the same group would
@@ -1971,7 +1971,7 @@ export async function handleInboundMessage(params: {
           // content with String(): getChannelMessages types it as string, but
           // RichText (type 14) and similar payloads can carry a non-string
           // m.content, and a bare .replace() on those throws and crashes the
-          // whole backfill (P2, yujiawei).
+          // whole backfill.
           .filter((m: any) => !isForkCommandHistoryMessage(
             String(m.content ?? ""),
             extractMentionUids(m.payload?.mention).includes(botUid),
@@ -2256,12 +2256,12 @@ export async function handleInboundMessage(params: {
     // dispatch path's pendingInboundContext.delete (below) and before the
     // before_prompt_build hook's get/delete (index.ts) — neither runs for a
     // fork. Drop the entry set above (pendingInboundContext.set) so a fork does
-    // not leak a Map entry / inject a stale historyPrefix later (P1, yujiawei).
+    // not leak a Map entry / inject a stale historyPrefix later.
     pendingInboundContext.delete(route.sessionKey);
     return;
   }
 
-  // OBO v2 detection + relevance filter (R10): Must run BEFORE
+  // OBO v2 detection + relevance filter: Must run BEFORE
   // finalizeInboundContext / recordInboundSession so that irrelevant
   // OBO v2 messages (e.g. AI-only fan-out) do not leak any state —
   // including `obo_system_hint` as GroupSystemPrompt — into the bot's
@@ -2297,7 +2297,7 @@ export async function handleInboundMessage(params: {
   // grantor UID mentions also remain relevant, because they target the grantor
   // identity directly.
   //
-  // CRITICAL (R10): this filter MUST run before finalizeInboundContext /
+  // CRITICAL: this filter MUST run before finalizeInboundContext /
   // recordInboundSession — otherwise an irrelevant OBO v2 message would
   // already have been persisted to the bot's DM session with the grantor,
   // including any `obo_system_hint` as GroupSystemPrompt.
@@ -2459,7 +2459,7 @@ export async function handleInboundMessage(params: {
   //
   // Detection (`isOBOv2`) and the relevance filter that gates an early-return
   // have already run BEFORE finalizeInboundContext / recordInboundSession
-  // (see R10 fix above) so that irrelevant OBO v2 fan-out messages do not
+  // (see the filter above) so that irrelevant OBO v2 fan-out messages do not
   // leak `obo_system_hint` (as GroupSystemPrompt) into the bot's DM session.
   // The reply-routing variables below (`replyChannelId`, `replyChannelType`,
   // `effectiveOnBehalfOf`) are derived here using the previously-computed
@@ -2781,7 +2781,7 @@ export async function handleInboundMessage(params: {
               // Same bounded signal as the timeout-path apology: if upstream
               // signals an error AND the Octo API is also sick, this recovery
               // sendMessage would otherwise hold the per-group queue until
-              // the outer dispatch timeout kicks in. PR #83 review.
+              // the outer dispatch timeout kicks in.
               signal: AbortSignal.timeout(DISPATCH_TIMEOUT_APOLOGY_MS),
             });
           } catch (sendErr) {

--- a/src/manifest-schema-sync.test.ts
+++ b/src/manifest-schema-sync.test.ts
@@ -36,7 +36,7 @@ describe("openclaw.plugin.json channelConfigs", () => {
 
   // Description drift guard: secretsFileRoot carries operator-facing semantics
   // (the write-secret jail default + fail-closed behavior). A stale manifest
-  // description here is what Jerry-Xin flagged on PR#92, so pin both copies to
+  // description here drifts from the schema, so pin both copies to
   // the single source of truth in OctoConfigJsonSchema.
   it("secretsFileRoot description matches between manifest and OctoConfigJsonSchema", () => {
     const tsDesc = (OctoConfigJsonSchema.schema.properties.secretsFileRoot as any)

--- a/src/mention-utils.test.ts
+++ b/src/mention-utils.test.ts
@@ -753,7 +753,7 @@ describe("inbound text fallback regex", () => {
   });
 });
 
-// ── Outbound mention sanitizer (P0-3) + shared format hint (P1) ──────────────
+// ── Outbound mention sanitizer + shared format hint ──────────────
 
 const HEX_A = "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6"; // Alice
 const HEX_B = "0f1e2d3c4b5a69788796a5b4c3d2e1f0"; // Bob
@@ -869,7 +869,7 @@ describe("sanitizeOutboundMentions", () => {
     expect(r.uids).not.toContain("somebody_bot");
   });
 
-  it("@username with usernameMap hit → reverse-looked-up entity (P2)", () => {
+  it("@username with usernameMap hit → reverse-looked-up entity", () => {
     const uidToNameMap = new Map([[HEX_A, "Alice"]]);
     const usernameMap = new Map([["somebody_bot", HEX_A]]);
     const r = sanitizeOutboundMentions({
@@ -1092,7 +1092,7 @@ describe("sanitizeOutboundMentions", () => {
     expect(r.uids).toEqual([spaceUid]);
   });
 
-  // ── Blocking #1: bareHex left-boundary anchor — @<32hex> embedded inside an
+  // ── bareHex left-boundary anchor — @<32hex> embedded inside an
   // email local part / SSH URL / mailto must NOT be matched (the @ used to be
   // swallowed, corrupting the surrounding text). ──────────────────────────────
   describe("bareHex left boundary: email / SSH / mailto preserved", () => {
@@ -1153,7 +1153,7 @@ describe("sanitizeOutboundMentions", () => {
     });
   });
 
-  // ── Blocking #2: cold-start (empty map) structured mention must survive ──────
+  // ── Cold-start (empty map) structured mention must survive ──────
   it("cold start (empty uidToNameMap): structured @[uid:name] uid survives the final guard", () => {
     // prefetch failed → uidToNameMap empty. Agent wrote a correct @[uid:Alice].
     // The structured-source uid is trusted and must NOT be dropped by the guard,
@@ -1192,7 +1192,7 @@ describe("sanitizeOutboundMentions", () => {
   });
 });
 
-describe("MENTION_FORMAT_HINT (P1) + >10 prefix regression guard (test #13)", () => {
+describe("MENTION_FORMAT_HINT + >10 prefix regression guard", () => {
   it("never itself parses into an illegal {uid:'uid'} mention", () => {
     const parsed = parseStructuredMentions(MENTION_FORMAT_HINT);
     expect(parsed.every((m) => m.uid !== "uid")).toBe(true);

--- a/src/persona-prompt.test.ts
+++ b/src/persona-prompt.test.ts
@@ -406,8 +406,8 @@ describe("generation guard (abort in-flight fetches)", () => {
   });
 });
 
-describe("cache lifecycle on reconfigure (PR#69 R4 Jerry-Xin)", () => {
-  // Blocking 1: persona → regular bot must not leave a stale hint behind.
+describe("cache lifecycle on reconfigure", () => {
+  // persona → regular bot must not leave a stale hint behind.
   it("clears the cached hint when the account is reconfigured to drop onBehalfOf", async () => {
     // 1. Seed the cache as a persona-clone.
     mockFetchOnce({
@@ -447,7 +447,7 @@ describe("cache lifecycle on reconfigure (PR#69 R4 Jerry-Xin)", () => {
     expect(getRegisteredPersonaAccountIds()).not.toContain("bot_switch");
   });
 
-  // Blocking 2: re-init with a different grantor must not serve the old
+  // Re-init with a different grantor must not serve the old
   // grantor's hint during the new fetch's in-flight window.
   it("returns undefined during the refetch window when re-init switches grantor", async () => {
     // Seed cache with grantor A's hint.
@@ -544,7 +544,7 @@ describe("getRegisteredPersonaAccountIds", () => {
   });
 });
 
-describe("resolvePersonaHintForSession — multi-account isolation (PR#69 R3)", () => {
+describe("resolvePersonaHintForSession — multi-account isolation", () => {
   async function seedPersonaCache(accountId: string, personaPrompt: string) {
     mockFetchOnce({
       has_grant: true,
@@ -614,7 +614,7 @@ describe("resolvePersonaHintForSession — multi-account isolation (PR#69 R3)", 
   });
 
   it("returns undefined when two persona accounts share the same sessionKey (no cross-account leak)", async () => {
-    // 🔴 Core regression guard for PR#69 R3 (Jerry-Xin blocker):
+    // 🔴 Core regression guard for cross-account isolation:
     // when two persona-clone accounts collide on a sessionKey we MUST
     // refuse to inject either persona prompt rather than guessing,
     // because the hook cannot tell which account the prompt build is for.

--- a/src/persona-prompt.ts
+++ b/src/persona-prompt.ts
@@ -64,7 +64,7 @@ const _firstFetchLogged = new Set<string>();
  * Without this guard, an account stop/reconfigure that races with an
  * in-flight `getBotOboGrant` call would let the old fetch resolve later
  * and overwrite the cleared cache (or replace the next account's fresh
- * hint). See PR#69 review.
+ * hint).
  */
 const _generation = new Map<string, number>();
 
@@ -216,7 +216,7 @@ export function initPersonaPromptCache(
 ): void {
   const acc = withNormalizedAccount(account);
   if (!acc.onBehalfOf) {
-    // PR#69 R4 (Jerry-Xin) Blocking 1: when an account is reconfigured
+    // When an account is reconfigured
     // from persona-clone (`onBehalfOf` set) to a regular bot (`onBehalfOf`
     // cleared), a bare early return would leave the previous timer and
     // cached hint in place, so the before_prompt_build hook would keep
@@ -236,7 +236,7 @@ export function initPersonaPromptCache(
   // and bail out before mutating _cache.
   _bumpGeneration(acc.accountId);
 
-  // PR#69 R4 (Jerry-Xin) Blocking 2: on reconfigure (e.g. grantor
+  // On reconfigure (e.g. grantor
   // switched from A to B), the previous grantor's hint is still sitting
   // in _cache. The new fetch we kick off below is async — until it
   // resolves, getPersonaPromptForSession would keep serving the OLD
@@ -327,8 +327,7 @@ export function getRegisteredPersonaAccountIds(): string[] {
  * sessionKey?". If exactly one persona account matches we return its cached
  * hint; on 0 or >1 matches we return undefined (fail safe — better to drop
  * the persona injection than to attach the wrong account's identity to the
- * prompt). This is the multi-account isolation fix called out in PR#69 R3
- * (Jerry-Xin).
+ * prompt). This is the multi-account isolation guard.
  *
  * Extracted as a pure helper so the resolution logic is unit-testable
  * without standing up the full plugin hook surface.

--- a/src/thread-binding-adapter.test.ts
+++ b/src/thread-binding-adapter.test.ts
@@ -324,7 +324,7 @@ describe("registerOctoThreadBindingAdapter", () => {
   });
 
   // -------------------------------------------------------------------------
-  // Mixed-case account ID round-trip (regression for PR #32 review feedback).
+  // Mixed-case account ID round-trip (regression for issue #33).
   // -------------------------------------------------------------------------
   // OpenClaw's session-binding service normalizes adapter accountIds and
   // conversation refs to lowercase before invoking adapter methods. A previous


### PR DESCRIPTION
## 背景

代码注释与测试 `describe`/`it` 标题里残留了一批 **评审过程痕迹**:reviewer 人名、评审轮次(round / Rx)、finding 代号(P0/P1/P2/BLOCKER/Critical/必修N)、中文「阻断点」等。这些对读代码的人没有长期价值,且与仓库注释规范冲突。

## 改动

**纯注释 / 测试标题改动,零运行时逻辑变更。** 等价改写后完整保留每条注释原有的技术理由(为什么这么写、防的是什么 bug/竞态),只去掉痕迹前缀。

- 22 个文件,+110/-112
- 删:reviewer 人名 / 工具名 / 评审轮次 / finding 代号 / 阻断点
- 保留:技术理由本身、issue 引用(#33/#75/#77)、跨仓库契约溯源(`octo-server PR#301`/`#337`)、测试数据值(thread shortId `P1`/`P2`)、产品排期「(P2 能力)」、`[AUDIT]` 日志前缀、测试对话步骤(`Round 1/2`)

## 验证

- `npm run type-check` ✅
- `npm test` 2599/2600 通过
  - 唯一失败 `sendMedia — HTTP streaming size cap` 是**预先存在**的本地环境失败(macOS temp-cleanup 时序),与本次改动无关:stash 全部改动后照样失败、改动纯注释、且 CI 上 main 该用例为 SUCCESS
- 经两条独立 reviewer 复审,均确认:无误删有用技术内容、无运行时逻辑改动