### PR TITLE
feat(inbound): live status edit-in-place for long-running tasks

### DIFF
--- a/src/api-fetch.test.ts
+++ b/src/api-fetch.test.ts
@@ -2217,3 +2217,164 @@ describe("#138 — send functions reject empty channelId", () => {
     expect(fetchSpy).toHaveBeenCalledTimes(1);
   });
 });
+
+// ---------------------------------------------------------------------------
+// editMessage — POST /v1/bot/message/edit (长任务 live 状态 edit-in-place)
+// ---------------------------------------------------------------------------
+describe("editMessage — /v1/bot/message/edit contract", () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  const captureEdit = () => {
+    const calls: Array<{ url: string; body: any }> = [];
+    global.fetch = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
+      calls.push({ url, body: JSON.parse(init?.body as string) });
+      return new Response("", {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as unknown as typeof fetch;
+    return calls;
+  };
+
+  it("POSTs to /v1/bot/message/edit with required fields", async () => {
+    const calls = captureEdit();
+    const { editMessage } = await import("./api-fetch.js");
+    await editMessage({
+      apiUrl: "http://localhost:8090",
+      botToken: "test-token",
+      channelId: "group1",
+      channelType: ChannelType.Group,
+      messageId: "123456789012345678",
+      contentEdit: "⏳ 处理中 · 已运行 6s",
+    });
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toBe("http://localhost:8090/v1/bot/message/edit");
+    const body = calls[0].body;
+    expect(body.message_id).toBe("123456789012345678");
+    expect(body.channel_id).toBe("group1");
+    expect(body.channel_type).toBe(ChannelType.Group);
+    expect(body).toHaveProperty("content_edit");
+  });
+
+  it("wraps content_edit as a JSON object {type:1,content} (not plain text)", async () => {
+    // 🔴 回归防护：纯文本 content_edit 会被服务端 200 接受但回读端 json.Unmarshal
+    // 失败→nil→omitempty 丢字段→UI 永不刷新。必须发同构 JSON 对象。
+    const calls = captureEdit();
+    const { editMessage } = await import("./api-fetch.js");
+    await editMessage({
+      apiUrl: "http://localhost:8090",
+      botToken: "test-token",
+      channelId: "group1",
+      channelType: ChannelType.Group,
+      messageId: "999",
+      contentEdit: "✅ 已完成 · 用时 12s",
+    });
+    const body = calls[0].body;
+    // content_edit 是字符串（JSON 编码），不是裸对象
+    expect(typeof body.content_edit).toBe("string");
+    // 反序列化后深等 {type:1,content:'…'}
+    expect(JSON.parse(body.content_edit)).toEqual({
+      type: MessageType.Text,
+      content: "✅ 已完成 · 用时 12s",
+    });
+  });
+
+  it("omits on_behalf_of entirely (edit identity is always the bot)", async () => {
+    const calls = captureEdit();
+    const { editMessage } = await import("./api-fetch.js");
+    await editMessage({
+      apiUrl: "http://localhost:8090",
+      botToken: "test-token",
+      channelId: "group1",
+      channelType: ChannelType.Group,
+      messageId: "999",
+      contentEdit: "⏳ 处理中",
+    });
+    expect(calls[0].body).not.toHaveProperty("on_behalf_of");
+  });
+
+  it("includes message_seq only when provided (seq fast-path)", async () => {
+    const calls = captureEdit();
+    const { editMessage } = await import("./api-fetch.js");
+    await editMessage({
+      apiUrl: "http://localhost:8090",
+      botToken: "t",
+      channelId: "c",
+      channelType: ChannelType.Group,
+      messageId: "1",
+      contentEdit: "x",
+      messageSeq: 42,
+    });
+    expect(calls[0].body.message_seq).toBe(42);
+
+    const calls2 = captureEdit();
+    await editMessage({
+      apiUrl: "http://localhost:8090",
+      botToken: "t",
+      channelId: "c",
+      channelType: ChannelType.Group,
+      messageId: "1",
+      contentEdit: "x",
+    });
+    expect(calls2[0].body).not.toHaveProperty("message_seq");
+  });
+
+  it("throws on non-2xx response", async () => {
+    global.fetch = vi.fn().mockResolvedValue(
+      new Response("forbidden", { status: 403, statusText: "Forbidden" }),
+    ) as unknown as typeof fetch;
+    const { editMessage } = await import("./api-fetch.js");
+    await expect(
+      editMessage({
+        apiUrl: "http://localhost:8090",
+        botToken: "t",
+        channelId: "c",
+        channelType: ChannelType.Group,
+        messageId: "1",
+        contentEdit: "x",
+      }),
+    ).rejects.toThrow(/failed \(403\)/);
+  });
+
+  it("throws when channelId is empty (last-line guard)", async () => {
+    const fetchSpy = vi.fn();
+    global.fetch = fetchSpy as unknown as typeof fetch;
+    const { editMessage } = await import("./api-fetch.js");
+    await expect(
+      editMessage({
+        apiUrl: "http://localhost:8090",
+        botToken: "t",
+        channelId: "",
+        channelType: ChannelType.Group,
+        messageId: "1",
+        contentEdit: "x",
+      }),
+    ).rejects.toThrow(/channelId/i);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("throws when messageId is empty (last-line guard)", async () => {
+    const fetchSpy = vi.fn();
+    global.fetch = fetchSpy as unknown as typeof fetch;
+    const { editMessage } = await import("./api-fetch.js");
+    await expect(
+      editMessage({
+        apiUrl: "http://localhost:8090",
+        botToken: "t",
+        channelId: "c",
+        channelType: ChannelType.Group,
+        messageId: "",
+        contentEdit: "x",
+      }),
+    ).rejects.toThrow(/messageId/i);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/api-fetch.ts
+++ b/src/api-fetch.ts
@@ -394,6 +394,50 @@ export async function sendTyping(params: {
   }, params.signal);
 }
 
+/**
+ * 原地编辑一条 bot 已发出的消息（长任务 live 状态占位的 edit-in-place）。
+ *
+ * POST /v1/bot/message/edit —— 对齐 sendTyping/sendMessage 的 postJson 风格。
+ *
+ * 契约（已核 octo-server send.go botMessageEdit + bot_api.go 路由）：
+ *   - body 字段是 `content_edit`（不是 content），必填 message_id+channel_id+
+ *     channel_type，可选 message_seq（走 seq 快路径）。
+ *   - edit **无** on_behalf_of 字段，编辑身份恒为 bot 本体。故本封装签名刻意不给
+ *     onBehalfOf 口子——OBO 占位消息不能被 edit（send.go 权限门 msgFromUID!=robotID
+ *     → 403），状态占位消息必须以 bot 本体身份发送。
+ *   - 幂等：服务端对 (message_id, content_edit_hash) 去重，相同内容重复 edit 为 no-op。
+ *
+ * 🔴 content_edit 编码（核 octo-server：写入侧 richtext.NormalizeContentEdit 对
+ * 「非 JSON 对象」原样放行返回 200，但回读侧 newMessageExtraResp / reply 路径对
+ * content_edit 做 json.Unmarshal，纯文本解析失败→nil→`content_edit,omitempty`
+ * 丢字段→客户端 sync 拿不到编辑内容→**UI 永不原地刷新**）：content_edit 必须是与
+ * send payload 同构的 JSON 对象。本封装对外仍暴露 `contentEdit: string`，内部把它
+ * 包成 `{type: MessageType.Text, content}` 再 JSON.stringify 落到 content_edit，
+ * 对齐 sendMessage 的 payload.content 口径，调用方无感。
+ */
+export async function editMessage(params: {
+  apiUrl: string;
+  botToken: string;
+  channelId: string;
+  channelType: ChannelType;
+  messageId: string;
+  contentEdit: string;
+  messageSeq?: number;
+  signal?: AbortSignal;
+}): Promise<void> {
+  if (!params.channelId?.trim()) throw new Error("octo: channelId is required to edit a message");
+  if (!params.messageId?.trim()) throw new Error("octo: messageId is required to edit a message");
+  await postJson(params.apiUrl, params.botToken, "/v1/bot/message/edit", {
+    message_id: params.messageId,
+    channel_id: params.channelId,
+    channel_type: params.channelType,
+    // 与 send payload 同构的 JSON 对象（见上方 content_edit 编码说明），
+    // 而非纯文本——纯文本会被服务端接受(200)但回读端丢弃，UI 永不刷新。
+    content_edit: JSON.stringify({ type: MessageType.Text, content: params.contentEdit }),
+    ...(params.messageSeq != null ? { message_seq: params.messageSeq } : {}),
+  }, params.signal);
+}
+
 export async function sendReadReceipt(params: {
   apiUrl: string;
   botToken: string;

--- a/src/inbound.test.ts
+++ b/src/inbound.test.ts
@@ -3702,3 +3702,254 @@ describe("/fork command history leak filter (regression)", () => {
     expect(filterApiMsgs(apiMessages)).toHaveLength(3);
   });
 });
+
+// ─── 长任务 live 状态 edit-in-place（双轨：typing + status）────────────────
+//
+// handleInboundMessage 没有独立的完整 harness（见本文件顶部注释）。这里用与
+// inbound.ts 内联实现同构的最小 harness 复现 status 轨控制流，驱动真实的
+// sendMessage/editMessage（真 fetch mock），验证 GH#146 的关键不变量：
+//   1. edit 失败(fetch reject)不阻塞正文 sendMessage；
+//   2. OBO 会话占位 sendMessage 参数不含 onBehalfOf（占位恒 bot 本体身份）；
+//   3. finalize 幂等 + 停 status 轨。
+// 另用源码断言覆盖「clearInterval(statusInterval) 在全部 3 处退出点均被调用」。
+describe("长任务 live 状态 edit-in-place（status 轨）", () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  // 与 inbound.ts:handleInboundMessage 内联 status 轨同构的最小复现。
+  // effectiveOnBehalfOf 传入时，占位 send 仍刻意不带 onBehalfOf（bot 本体身份）。
+  async function runStatusTrack(opts: {
+    apiUrl: string;
+    botToken: string;
+    replyChannelId: string;
+    replyChannelType: ChannelType;
+    effectiveOnBehalfOf?: string;
+    placeholderSendId?: string; // 模拟占位 send 返回的 message_id；undefined=占位失败
+  }) {
+    const { sendMessage, editMessage } = await import("./api-fetch.js");
+    const statusStartTs = Date.now();
+    let statusMessageId: string | undefined;
+    let statusMessageSeq: number | undefined;
+    let statusFinalized = false;
+
+    // 开工发占位——刻意不带 onBehalfOf（硬约束3）。
+    const placeholderSend = sendMessage({
+      apiUrl: opts.apiUrl,
+      botToken: opts.botToken,
+      channelId: opts.replyChannelId,
+      channelType: opts.replyChannelType,
+      content: "⏳ 已接收，处理中…",
+    })
+      .then((r) => { statusMessageId = r?.message_id; statusMessageSeq = r?.message_seq; })
+      .catch(() => {});
+
+    const tickEdit = () => {
+      if (!statusMessageId || statusFinalized) return Promise.resolve();
+      const secs = Math.round((Date.now() - statusStartTs) / 1000);
+      return editMessage({
+        apiUrl: opts.apiUrl,
+        botToken: opts.botToken,
+        channelId: opts.replyChannelId,
+        channelType: opts.replyChannelType,
+        messageId: statusMessageId,
+        messageSeq: statusMessageSeq,
+        contentEdit: `⏳ 处理中 · 已运行 ${secs}s`,
+      }).catch(() => {});
+    };
+
+    const finalizeStatus = (kind: "ok" | "fail", detail?: string) => {
+      if (statusFinalized) return Promise.resolve();
+      statusFinalized = true;
+      if (!statusMessageId) return Promise.resolve();
+      const secs = Math.round((Date.now() - statusStartTs) / 1000);
+      const contentEdit = kind === "ok"
+        ? `✅ 已完成 · 用时 ${secs}s`
+        : `❌ 失败：${detail ?? "处理出错"}`;
+      return editMessage({
+        apiUrl: opts.apiUrl,
+        botToken: opts.botToken,
+        channelId: opts.replyChannelId,
+        channelType: opts.replyChannelType,
+        messageId: statusMessageId,
+        messageSeq: statusMessageSeq,
+        contentEdit,
+      }).catch(() => {});
+    };
+
+    // 正文回复（走 OBO 身份，若有）——与占位轨独立。
+    const sendBody = (content: string) => sendMessage({
+      apiUrl: opts.apiUrl,
+      botToken: opts.botToken,
+      channelId: opts.replyChannelId,
+      channelType: opts.replyChannelType,
+      content,
+      ...(opts.effectiveOnBehalfOf ? { onBehalfOf: opts.effectiveOnBehalfOf } : {}),
+    });
+
+    return { placeholderSend, tickEdit, finalizeStatus, sendBody, getStatusMessageId: () => statusMessageId };
+  }
+
+  it("edit 失败(fetch reject)不阻塞正文 sendMessage", async () => {
+    const bodies: any[] = [];
+    let editCalls = 0;
+    global.fetch = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
+      const body = JSON.parse(init?.body as string);
+      if (String(url).includes("/v1/bot/message/edit")) {
+        editCalls++;
+        // edit 端点：fetch reject（网络失败）——必须被 status 轨 .catch 吞掉。
+        throw new Error("network down");
+      }
+      // sendMessage 端点：占位 + 正文都走这里。
+      bodies.push({ url, body });
+      return new Response(JSON.stringify({ message_id: "111", message_seq: 7 }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as unknown as typeof fetch;
+
+    const track = await runStatusTrack({
+      apiUrl: "http://localhost:8090",
+      botToken: "t",
+      replyChannelId: "group1",
+      replyChannelType: ChannelType.Group,
+    });
+    await track.placeholderSend;
+    expect(track.getStatusMessageId()).toBe("111");
+
+    // edit 会 reject，但不得抛出未捕获错误。
+    await expect(track.tickEdit()).resolves.toBeUndefined();
+    // 正文照常发出。
+    await track.sendBody("这是最终回复");
+    // finalize 的 edit 也 reject，同样不得抛。
+    await expect(track.finalizeStatus("ok")).resolves.toBeUndefined();
+
+    expect(editCalls).toBeGreaterThanOrEqual(1);
+    const bodyContents = bodies.map((b) => b.body.payload.content);
+    expect(bodyContents).toContain("⏳ 已接收，处理中…"); // 占位
+    expect(bodyContents).toContain("这是最终回复");        // 正文仍发
+  });
+
+  it("OBO 会话占位 sendMessage 参数不含 onBehalfOf；正文走 OBO 身份", async () => {
+    const sends: any[] = [];
+    global.fetch = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
+      const body = JSON.parse(init?.body as string);
+      if (String(url).includes("/v1/bot/sendMessage")) {
+        sends.push(body);
+      }
+      return new Response(JSON.stringify({ message_id: "222", message_seq: 1 }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as unknown as typeof fetch;
+
+    const track = await runStatusTrack({
+      apiUrl: "http://localhost:8090",
+      botToken: "t",
+      replyChannelId: "group1",
+      replyChannelType: ChannelType.Group,
+      effectiveOnBehalfOf: "grantor-uid-xyz",
+    });
+    await track.placeholderSend;
+    await track.sendBody("正文（OBO）");
+
+    // 第一条是占位：必须不含 on_behalf_of（占位恒 bot 本体身份，否则 edit 403）。
+    const placeholder = sends.find((s) => s.payload.content === "⏳ 已接收，处理中…");
+    expect(placeholder).toBeDefined();
+    expect(placeholder).not.toHaveProperty("on_behalf_of");
+
+    // 正文：走 OBO 身份，含 on_behalf_of。
+    const bodyMsg = sends.find((s) => s.payload.content === "正文（OBO）");
+    expect(bodyMsg).toBeDefined();
+    expect(bodyMsg.on_behalf_of).toBe("grantor-uid-xyz");
+  });
+
+  it("占位 send 失败→status 轨空转（无 edit 调用），降级 typing-only", async () => {
+    let editCalls = 0;
+    global.fetch = vi.fn().mockImplementation(async (url: string) => {
+      if (String(url).includes("/v1/bot/message/edit")) {
+        editCalls++;
+        return new Response("", { status: 200, headers: { "Content-Type": "application/json" } });
+      }
+      // 占位 send 失败。
+      return new Response("boom", { status: 500, statusText: "Internal Error" });
+    }) as unknown as typeof fetch;
+
+    const track = await runStatusTrack({
+      apiUrl: "http://localhost:8090",
+      botToken: "t",
+      replyChannelId: "group1",
+      replyChannelType: ChannelType.Group,
+    });
+    await track.placeholderSend;
+    expect(track.getStatusMessageId()).toBeUndefined();
+
+    // statusMessageId undefined → tick/finalize 都 no-op，不产生任何 edit。
+    await track.tickEdit();
+    await track.finalizeStatus("ok");
+    expect(editCalls).toBe(0);
+  });
+
+  it("finalize 幂等：重复调用只 edit 一次终态", async () => {
+    let editCalls = 0;
+    let editContents: string[] = [];
+    global.fetch = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
+      if (String(url).includes("/v1/bot/message/edit")) {
+        editCalls++;
+        editContents.push(JSON.parse(JSON.parse(init?.body as string).content_edit).content);
+        return new Response("", { status: 200, headers: { "Content-Type": "application/json" } });
+      }
+      return new Response(JSON.stringify({ message_id: "333", message_seq: 1 }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as unknown as typeof fetch;
+
+    const track = await runStatusTrack({
+      apiUrl: "http://localhost:8090",
+      botToken: "t",
+      replyChannelId: "group1",
+      replyChannelType: ChannelType.Group,
+    });
+    await track.placeholderSend;
+    await track.finalizeStatus("fail", "处理超时");
+    await track.finalizeStatus("ok"); // 第二次应 no-op
+    expect(editCalls).toBe(1);
+    expect(editContents[0]).toContain("失败：处理超时");
+  });
+});
+
+// ─── 源码结构断言：status 轨在全部 3 处退出点收尾（GH#146 验收 #3）──────────
+describe("inbound.ts status 轨退出点收尾（源码断言）", () => {
+  const readSource = () => {
+    const fs = require("node:fs") as typeof import("node:fs");
+    const path = require("node:path") as typeof import("node:path");
+    return fs.readFileSync(path.join(__dirname, "inbound.ts"), "utf-8");
+  };
+
+  it("clearInterval(statusInterval) 不泄漏：经由 finalizeStatus 在 3 处退出点均收尾", () => {
+    const src = readSource();
+    // typing 轨的 3 处退出点保持不变（fallback 绝不移除）。
+    const typingExits = src.match(/clearInterval\(typingInterval\)/g) ?? [];
+    expect(typingExits.length).toBe(3);
+    // status 轨在 finalizeStatus 内统一 clearInterval(statusInterval)（收敛点）。
+    expect(src).toMatch(/clearInterval\(statusInterval\)/);
+    // 3 处退出点各自触发 finalizeStatus（onError/timeout=fail，finally=ok）。
+    const finalizeCalls = src.match(/finalizeStatus\((?:"ok"|"fail")/g) ?? [];
+    expect(finalizeCalls.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("占位消息发送不带 onBehalfOf（bot 本体身份，硬约束3）", () => {
+    const src = readSource();
+    // 占位 send 的调用块：content 为占位文案且不出现 onBehalfOf。
+    const m = src.match(/sendMessage\(\{[^}]*?content:\s*"⏳ 已接收，处理中…"[^}]*?\}\)/s);
+    expect(m).not.toBeNull();
+    expect(m![0]).not.toMatch(/onBehalfOf/);
+  });
+});

--- a/src/inbound.test.ts
+++ b/src/inbound.test.ts
@@ -3738,6 +3738,25 @@ describe("长任务 live 状态 edit-in-place（status 轨）", () => {
     let statusMessageId: string | undefined;
     let statusMessageSeq: number | undefined;
     let statusFinalized = false;
+    // B1：占位 id 未就绪时 finalize 记下终态，占位 resolve 后 flush。
+    let pendingTerminalContent: string | undefined;
+    // N1：周期 edit 的 in-flight 句柄（Promise 或 null）——重叠守卫 + 终态串行化。
+    let statusEditInFlight: Promise<void> | null = null;
+
+    const applyTerminalEdit = (id: string, contentEdit: string) => {
+      const fire = () =>
+        editMessage({
+          apiUrl: opts.apiUrl,
+          botToken: opts.botToken,
+          channelId: opts.replyChannelId,
+          channelType: opts.replyChannelType,
+          messageId: id,
+          messageSeq: statusMessageSeq,
+          contentEdit,
+        }).catch(() => {});
+      // 终态串到最后一次周期 edit 之后，避免旧 `⏳` 请求覆盖终态。
+      return statusEditInFlight ? statusEditInFlight.then(fire, fire) : fire();
+    };
 
     // 开工发占位——刻意不带 onBehalfOf（硬约束3）。
     const placeholderSend = sendMessage({
@@ -3747,13 +3766,24 @@ describe("长任务 live 状态 edit-in-place（status 轨）", () => {
       channelType: opts.replyChannelType,
       content: "⏳ 已接收，处理中…",
     })
-      .then((r) => { statusMessageId = r?.message_id; statusMessageSeq = r?.message_seq; })
+      .then((r) => {
+        statusMessageId = r?.message_id;
+        statusMessageSeq = r?.message_seq;
+        // B1 flush：id 就绪且已有待决终态 → 立刻 edit 成终态，消除孤儿。
+        if (statusMessageId && pendingTerminalContent !== undefined) {
+          const contentEdit = pendingTerminalContent;
+          pendingTerminalContent = undefined;
+          return applyTerminalEdit(statusMessageId, contentEdit);
+        }
+        return undefined;
+      })
       .catch(() => {});
 
+    // N1：in-flight 守卫——上一 edit 未落地则跳过本 tick。
     const tickEdit = () => {
-      if (!statusMessageId || statusFinalized) return Promise.resolve();
+      if (!statusMessageId || statusFinalized || statusEditInFlight) return Promise.resolve();
       const secs = Math.round((Date.now() - statusStartTs) / 1000);
-      return editMessage({
+      const p = editMessage({
         apiUrl: opts.apiUrl,
         botToken: opts.botToken,
         channelId: opts.replyChannelId,
@@ -3762,25 +3792,24 @@ describe("长任务 live 状态 edit-in-place（status 轨）", () => {
         messageSeq: statusMessageSeq,
         contentEdit: `⏳ 处理中 · 已运行 ${secs}s`,
       }).catch(() => {});
+      statusEditInFlight = p;
+      p.finally(() => { if (statusEditInFlight === p) statusEditInFlight = null; });
+      return p;
     };
 
     const finalizeStatus = (kind: "ok" | "fail", detail?: string) => {
       if (statusFinalized) return Promise.resolve();
       statusFinalized = true;
-      if (!statusMessageId) return Promise.resolve();
       const secs = Math.round((Date.now() - statusStartTs) / 1000);
       const contentEdit = kind === "ok"
         ? `✅ 已完成 · 用时 ${secs}s`
         : `❌ 失败：${detail ?? "处理出错"}`;
-      return editMessage({
-        apiUrl: opts.apiUrl,
-        botToken: opts.botToken,
-        channelId: opts.replyChannelId,
-        channelType: opts.replyChannelType,
-        messageId: statusMessageId,
-        messageSeq: statusMessageSeq,
-        contentEdit,
-      }).catch(() => {});
+      if (!statusMessageId) {
+        // B1：占位 id 未就绪 → 记下终态待 flush（占位真失败则永不 flush）。
+        pendingTerminalContent = contentEdit;
+        return Promise.resolve();
+      }
+      return applyTerminalEdit(statusMessageId, contentEdit);
     };
 
     // 正文回复（走 OBO 身份，若有）——与占位轨独立。
@@ -3923,6 +3952,145 @@ describe("长任务 live 状态 edit-in-place（status 轨）", () => {
     expect(editCalls).toBe(1);
     expect(editContents[0]).toContain("失败：处理超时");
   });
+
+  // ─── B1 回归：占位 POST 在任务完成之后才 resolve（快完成竞态）──────────────
+  // 旧代码：finalize 时 statusMessageId 还 undefined → 直接 no-op，占位 POST 随后
+  // resolve 记下 id 但已无人 edit → 永久 `⏳ 处理中` 孤儿。
+  // 新代码：finalize 记下 pending 终态，占位 resolve 后 flush 成终态。
+  it("B1：占位 POST 晚于任务完成 resolve → 仍 edit 到终态，无孤儿", async () => {
+    const edits: string[] = [];
+    let resolvePlaceholder!: (r: Response) => void;
+    const placeholderGate = new Promise<Response>((res) => { resolvePlaceholder = res; });
+
+    global.fetch = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
+      if (String(url).includes("/v1/bot/message/edit")) {
+        edits.push(JSON.parse(JSON.parse(init?.body as string).content_edit).content);
+        return new Response("", { status: 200, headers: { "Content-Type": "application/json" } });
+      }
+      // 占位 sendMessage：刻意 gate 住，直到测试放行才 resolve（模拟慢 POST）。
+      return placeholderGate;
+    }) as unknown as typeof fetch;
+
+    const track = await runStatusTrack({
+      apiUrl: "http://localhost:8090",
+      botToken: "t",
+      replyChannelId: "group1",
+      replyChannelType: ChannelType.Group,
+    });
+
+    // 任务「秒完成」：占位 POST 尚未 resolve → id 仍 undefined。
+    expect(track.getStatusMessageId()).toBeUndefined();
+    await track.finalizeStatus("ok"); // 此刻无 id → 记 pending 终态，尚未 edit。
+    expect(edits.length).toBe(0);
+
+    // 占位 POST 现在才 resolve，带回 id → 应 flush pending 终态。
+    resolvePlaceholder(new Response(JSON.stringify({ message_id: "late-1", message_seq: 9 }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    }));
+    await track.placeholderSend;
+
+    // 关键断言：占位最终被 edit 成 ✅ 终态，没有僵尸 `⏳ 处理中`。
+    expect(track.getStatusMessageId()).toBe("late-1");
+    expect(edits.length).toBe(1);
+    expect(edits[0]).toContain("✅ 已完成");
+    expect(edits.some((e) => e.includes("处理中"))).toBe(false);
+  });
+
+  // ─── B2 回归：非超时 dispatcher rejection 必须 finalize 成 ❌（非 ✅）─────────
+  // 旧代码：finally 恒 finalizeStatus("ok") → 非超时 rejection 也把占位 edit 成
+  // ✅ 已完成，实际失败。新代码：dispatchSucceeded 仅正常返回时置真，finally 用
+  // finalizeStatus(dispatchSucceeded ? "ok" : "fail")。
+  it("B2：dispatcher 抛非超时 rejection → finalize 为 fail(❌) 而非 ok(✅)", async () => {
+    const edits: string[] = [];
+    global.fetch = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
+      if (String(url).includes("/v1/bot/message/edit")) {
+        edits.push(JSON.parse(JSON.parse(init?.body as string).content_edit).content);
+        return new Response("", { status: 200, headers: { "Content-Type": "application/json" } });
+      }
+      return new Response(JSON.stringify({ message_id: "b2-1", message_seq: 3 }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as unknown as typeof fetch;
+
+    const track = await runStatusTrack({
+      apiUrl: "http://localhost:8090",
+      botToken: "t",
+      replyChannelId: "group1",
+      replyChannelType: ChannelType.Group,
+    });
+    await track.placeholderSend;
+    expect(track.getStatusMessageId()).toBe("b2-1");
+
+    // 模拟 inbound.ts 的 try/finally 控制流：dispatch 抛非超时 rejection。
+    // dispatchSucceeded 只有 race 正常返回后才置真——此处永不置真。
+    let dispatchSucceeded = false;
+    let caught: unknown;
+    try {
+      // 非超时 rejection（resolver/runtime rejection，非我方 timeoutError）。
+      await Promise.reject(new Error("resolver blew up"));
+      dispatchSucceeded = true; // 不可达
+    } catch (err) {
+      caught = err; // 非 timeoutError → 不 finalize fail，交给 finally
+    } finally {
+      await track.finalizeStatus(dispatchSucceeded ? "ok" : "fail");
+    }
+
+    expect(caught).toBeInstanceOf(Error);
+    // 关键断言：终态是 ❌ 失败，绝不能是 ✅ 已完成。
+    expect(edits.length).toBe(1);
+    expect(edits[0]).toContain("❌ 失败");
+    expect(edits[0]).not.toContain("✅");
+  });
+
+  // ─── N1 回归：终态 edit 串在飞行中的周期 edit 之后（不被旧 `⏳` 覆盖）─────────
+  // 若终态在周期 edit 仍飞行时发出，且服务端按到达顺序应用，旧 `⏳` 若晚于终态到达
+  // 会把终态覆盖回处理中。修法：applyTerminalEdit 串到 in-flight 周期 edit 之后。
+  it("N1：周期 edit 在飞行中时 finalize → 终态请求晚于该周期 edit 发出", async () => {
+    const editOrder: string[] = [];
+    let resolveTick!: () => void;
+    const tickGate = new Promise<void>((res) => { resolveTick = res; });
+
+    global.fetch = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
+      if (String(url).includes("/v1/bot/message/edit")) {
+        const content = JSON.parse(JSON.parse(init?.body as string).content_edit).content;
+        // 周期 `⏳` edit：gate 住直到测试放行，模拟一个仍在飞行的请求。
+        if (content.includes("处理中")) {
+          await tickGate;
+        }
+        editOrder.push(content);
+        return new Response("", { status: 200, headers: { "Content-Type": "application/json" } });
+      }
+      return new Response(JSON.stringify({ message_id: "ord-1", message_seq: 2 }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as unknown as typeof fetch;
+
+    const track = await runStatusTrack({
+      apiUrl: "http://localhost:8090",
+      botToken: "t",
+      replyChannelId: "group1",
+      replyChannelType: ChannelType.Group,
+    });
+    await track.placeholderSend;
+
+    // 启动一个周期 edit（`⏳`）——它会 gate 住不落地。
+    track.tickEdit();
+    // 任务此刻完成 → finalize 终态；应串到周期 edit 之后，尚未落地。
+    const finalizePromise = track.finalizeStatus("ok");
+    expect(editOrder.length).toBe(0);
+
+    // 放行周期 edit：`⏳` 先落地，终态随后落地。
+    resolveTick();
+    await finalizePromise;
+
+    // 关键断言：落地顺序 = 周期 `⏳` 在前、终态 ✅ 在后（终态不被覆盖）。
+    expect(editOrder.length).toBe(2);
+    expect(editOrder[0]).toContain("处理中");
+    expect(editOrder[1]).toContain("✅ 已完成");
+  });
 });
 
 // ─── 源码结构断言：status 轨在全部 3 处退出点收尾（GH#146 验收 #3）──────────
@@ -3940,9 +4108,31 @@ describe("inbound.ts status 轨退出点收尾（源码断言）", () => {
     expect(typingExits.length).toBe(3);
     // status 轨在 finalizeStatus 内统一 clearInterval(statusInterval)（收敛点）。
     expect(src).toMatch(/clearInterval\(statusInterval\)/);
-    // 3 处退出点各自触发 finalizeStatus（onError/timeout=fail，finally=ok）。
-    const finalizeCalls = src.match(/finalizeStatus\((?:"ok"|"fail")/g) ?? [];
-    expect(finalizeCalls.length).toBeGreaterThanOrEqual(3);
+    // 3 处退出点各自触发 finalizeStatus：onError=fail、timeout=fail、finally=
+    // 三元(dispatchSucceeded ? "ok" : "fail")。
+    const finalizeFailCalls = src.match(/finalizeStatus\("fail"/g) ?? [];
+    expect(finalizeFailCalls.length).toBeGreaterThanOrEqual(2); // onError + timeout
+    // B2：finally 分支据 dispatchSucceeded 决定终态，不再恒 "ok"。
+    expect(src).toMatch(/finalizeStatus\(dispatchSucceeded \? "ok" : "fail"\)/);
+    // B2：dispatchSucceeded 仅在 race 正常返回后置真。
+    expect(src).toMatch(/dispatchSucceeded = true;/);
+  });
+
+  it("N1：status 轨 edit 均带 bounded AbortSignal + in-flight 守卫（无重叠 edit）", () => {
+    const src = readSource();
+    // bounded signal 常量存在且喂给 status 轨的 editMessage。
+    expect(src).toMatch(/STATUS_EDIT_TIMEOUT_MS/);
+    expect(src).toMatch(/AbortSignal\.timeout\(STATUS_EDIT_TIMEOUT_MS\)/);
+    // periodic tick 有 in-flight 守卫：未落地则跳过本 tick。
+    expect(src).toMatch(/statusEditInFlight/);
+  });
+
+  it("B1：finalize 在占位 id 未就绪时记 pending 终态，占位 resolve 后 flush", () => {
+    const src = readSource();
+    // finalize 无 id 时不再直接 return no-op，而是记下待决终态。
+    expect(src).toMatch(/pendingTerminalContent = contentEdit;/);
+    // 占位 .then 里在 id 就绪后 flush 待决终态。
+    expect(src).toMatch(/pendingTerminalContent !== undefined/);
   });
 
   it("占位消息发送不带 onBehalfOf（bot 本体身份，硬约束3）", () => {

--- a/src/inbound.ts
+++ b/src/inbound.ts
@@ -20,7 +20,7 @@ const isReplyPayloadNonTerminalToolErrorWarning =
     ? replyPayloadCompat.isReplyPayloadNonTerminalToolErrorWarning
     : undefined;
 const resolveSendableOutboundReplyParts = replyPayloadSdk.resolveSendableOutboundReplyParts;
-import { sendMessage, sendReadReceipt, sendTyping, getChannelMessages, getGroupMembers, getGroupMd, postJson, sendMediaMessage, inferContentType, ensureTextCharset, parseImageDimensions, parseImageDimensionsFromFile, getUploadPresign, uploadFileToPresignedUrl, fetchUserInfo } from "./api-fetch.js";
+import { sendMessage, editMessage, sendReadReceipt, sendTyping, getChannelMessages, getGroupMembers, getGroupMd, postJson, sendMediaMessage, inferContentType, ensureTextCharset, parseImageDimensions, parseImageDimensionsFromFile, getUploadPresign, uploadFileToPresignedUrl, fetchUserInfo } from "./api-fetch.js";
 import type { GroupMember } from "./api-fetch.js";
 import { getMentionPrefFromCache, invalidateMentionPref } from "./mention-prefs.js";
 import { normalizeAccountId } from "./account-id.js";
@@ -2525,10 +2525,51 @@ export async function handleInboundMessage(params: {
       .catch((err) => log?.error?.(`octo: typing failed: ${String(err)}`));
   }
 
-  // Keep sending typing indicator while AI is processing
+  // Keep sending typing indicator while AI is processing.
+  // 这是 fallback 轨，绝不移除：占位 send 失败 / edit 不被支持时，长任务仍有 typing 心跳。
   const typingInterval = setInterval(() => {
     sendTyping({ apiUrl, botToken, channelId: replyChannelId, channelType: replyChannelType, ...(effectiveOnBehalfOf ? { onBehalfOf: effectiveOnBehalfOf } : {}) }).catch(() => {});
   }, 5000);
+
+  // --- 长任务 live 状态：粗粒度 edit-in-place（与 typing 双轨并行）---
+  //
+  // 开工发一条状态占位消息，运行中周期性 edit 成「已运行 Ns」，结束 finalize 成
+  // ✅/❌。与 typing 轨互不阻塞：占位 send 失败 / edit 失败都静默降级到 typing-only。
+  //
+  // 🔴 身份硬约束：占位消息必须以 bot 本体身份发送（不带 onBehalfOf）——OBO 发的
+  // 消息 fromUID=on_behalf_of，编辑权限门 msgFromUID!=robotID 会 403。故 OBO 会话
+  // 下状态占位与 OBO 正文回复身份不一致（已知取舍，见 GH#146 plan 降级策略）。
+  const statusStartTs = Date.now();
+  let statusMessageId: string | undefined;
+  let statusMessageSeq: number | undefined;
+  let statusFinalized = false;
+  // 占位失败→statusMessageId 恒 undefined→全程降级 typing-only（status 轨空转）。
+  sendMessage({ apiUrl, botToken, channelId: replyChannelId, channelType: replyChannelType, content: "⏳ 已接收，处理中…" })
+    .then((r) => { statusMessageId = r?.message_id; statusMessageSeq = r?.message_seq; })
+    .catch(() => {});
+  // status edit 轨：独立 interval，节流 3s（前置真机 gate 结论后可调 2–5s）。
+  // 单次 edit 失败 .catch 静默，不阻塞正文。文案是 adapter 自造固定模板，
+  // 不拼接任何 runtime 输出/参数/路径/token（脱敏）。
+  const statusInterval = setInterval(() => {
+    if (!statusMessageId || statusFinalized) return;
+    const secs = Math.round((Date.now() - statusStartTs) / 1000);
+    editMessage({ apiUrl, botToken, channelId: replyChannelId, channelType: replyChannelType, messageId: statusMessageId, messageSeq: statusMessageSeq, contentEdit: `⏳ 处理中 · 已运行 ${secs}s` }).catch(() => {});
+  }, 3000);
+
+  // finalize 收敛 helper：结束时停 status 轨并把占位 edit 成终态。幂等（重复调用
+  // no-op）。成功→✅ 用时 Ns；失败/超时→❌ 脱敏原因。占位 send 未成功时静默跳过。
+  // detail 只取固定短语类别，绝不透传原始 error message（脱敏）。
+  const finalizeStatus = (kind: "ok" | "fail", detail?: string): void => {
+    if (statusFinalized) return;
+    statusFinalized = true;
+    clearInterval(statusInterval);
+    if (!statusMessageId) return;
+    const secs = Math.round((Date.now() - statusStartTs) / 1000);
+    const contentEdit = kind === "ok"
+      ? `✅ 已完成 · 用时 ${secs}s`
+      : `❌ 失败：${detail ?? "处理出错"}`;
+    editMessage({ apiUrl, botToken, channelId: replyChannelId, channelType: replyChannelType, messageId: statusMessageId, messageSeq: statusMessageSeq, contentEdit }).catch(() => {});
+  };
 
   // Buffer text across streaming deliver calls; only send once after dispatcher finishes.
   // Media is sent immediately (no edit problem); text is buffered (each call overwrites).
@@ -2765,6 +2806,9 @@ export async function handleInboundMessage(params: {
         },
         onError: async (err: unknown, info: { kind: string }) => {
           clearInterval(typingInterval);
+          // status 轨同步收尾：占位 edit 成失败终态（脱敏，不透传 err 原文），
+          // 与下方 apology sendMessage 并存不互斥。
+          finalizeStatus("fail", "上游错误");
           log?.error?.(`octo ${info.kind} reply failed: ${String(err)}`);
           // Prevent finally block from sending stale buffered text after error
           deliverBuffer.lastText = null;
@@ -2832,6 +2876,8 @@ export async function handleInboundMessage(params: {
     // out of scope for #75 (see scope-note comment above timeoutError).
     if (err === timeoutError) {
       clearInterval(typingInterval);
+      // status 轨同步收尾：占位 edit 成超时终态（复用 timeout 分支同款脱敏文案）。
+      finalizeStatus("fail", "处理超时");
       log?.warn?.(
         `octo: dispatch hung past ${dispatchTimeoutMs}ms, aborting to unblock per-group queue (session=${route?.sessionKey ?? "?"})`,
       );
@@ -2879,6 +2925,10 @@ export async function handleInboundMessage(params: {
       }
     }
     clearInterval(typingInterval);
+    // status 轨最终收尾（所有正常/异常路径都经 finally）：finalizeStatus 幂等——
+    // onError/timeout 分支已 finalize 成 fail 的场景这里是 no-op；正常完成则占位
+    // edit 成 ✅ 已完成。即便占位未成功(statusMessageId undefined)也 no-op。
+    finalizeStatus("ok");
     // Safety net: clean up pending inbound context in case the hook didn't fire
     pendingInboundContext.delete(route.sessionKey);
 

--- a/src/inbound.ts
+++ b/src/inbound.ts
@@ -95,6 +95,14 @@ let dispatchTimeoutTestOverrideMs: number | null = null;
 const DISPATCH_TIMEOUT_APOLOGY_DEFAULT_MS = 10_000;
 let DISPATCH_TIMEOUT_APOLOGY_MS = DISPATCH_TIMEOUT_APOLOGY_DEFAULT_MS;
 
+// N1: bounded signal for status-track edits. The periodic edit (and the flush
+// on the placeholder-resolve path) hits the same Octo API that issue #75 warns
+// can hang; a hung edit must not pin the in-flight guard forever. 5s is a
+// healthy round-trip yet short enough that a sick API releases the guard within
+// ~2 skipped ticks. Status-track failures are always silently degraded to
+// typing-only, so this signal only bounds, it never surfaces.
+const STATUS_EDIT_TIMEOUT_MS = 5_000;
+
 export function _setDispatchTimeoutForTests(ms: number | null): void {
   dispatchTimeoutTestOverrideMs = ms;
 }
@@ -2543,32 +2551,76 @@ export async function handleInboundMessage(params: {
   let statusMessageId: string | undefined;
   let statusMessageSeq: number | undefined;
   let statusFinalized = false;
+  // B1（快完成竞态）：短任务（缓存/trivial 回复/早退错误）可能在占位 POST resolve
+  // 前就跑完 → finalize 时 statusMessageId 仍 undefined，无从 edit，留下永久
+  // `⏳ 处理中` 僵尸。修法：finalize 若 id 未就绪，把已决定的终态文案记进
+  // pendingTerminalContent，待占位 .then 拿到 id 后立刻 flush。undefined=无待决终态。
+  // 注意：占位 send 真失败时 id 恒 undefined、flush 永不触发——这正是「占位失败→
+  // 降级 typing-only、无占位消息可孤儿」的既有不变量，不受影响。
+  let pendingTerminalContent: string | undefined;
+  // N1：周期 edit 的 in-flight 句柄（Promise 或 null）。既做「未落地则跳过本 tick」
+  // 的重叠守卫，又让终态 edit 串到最后一次周期 edit 之后（见 applyTerminalEdit）——
+  // 避免一个仍在飞行的旧 `⏳ 处理中` 请求在终态之后落地、把终态覆盖回处理中。
+  let statusEditInFlight: Promise<void> | null = null;
+  // 统一终态 edit：占位恒 bot 本体身份；bounded signal（N1）防单次 edit 挂起。
+  // 若有周期 edit 尚在飞行，串到它之后再发终态，保证客户端发出顺序 = 终态请求
+  // 晚于最后一次 `⏳` 请求（同一 message，服务端按到达顺序应用）。
+  const applyTerminalEdit = (id: string, contentEdit: string): void => {
+    const fire = () => {
+      editMessage({ apiUrl, botToken, channelId: replyChannelId, channelType: replyChannelType, messageId: id, messageSeq: statusMessageSeq, contentEdit, signal: AbortSignal.timeout(STATUS_EDIT_TIMEOUT_MS) }).catch(() => {});
+    };
+    if (statusEditInFlight) {
+      statusEditInFlight.then(fire, fire);
+    } else {
+      fire();
+    }
+  };
   // 占位失败→statusMessageId 恒 undefined→全程降级 typing-only（status 轨空转）。
   sendMessage({ apiUrl, botToken, channelId: replyChannelId, channelType: replyChannelType, content: "⏳ 已接收，处理中…" })
-    .then((r) => { statusMessageId = r?.message_id; statusMessageSeq = r?.message_seq; })
+    .then((r) => {
+      statusMessageId = r?.message_id;
+      statusMessageSeq = r?.message_seq;
+      // B1 flush：若在 id 就绪前已 finalize，占位一到位立刻 edit 成终态。
+      if (statusMessageId && pendingTerminalContent !== undefined) {
+        const contentEdit = pendingTerminalContent;
+        pendingTerminalContent = undefined;
+        applyTerminalEdit(statusMessageId, contentEdit);
+      }
+    })
     .catch(() => {});
   // status edit 轨：独立 interval，节流 3s（前置真机 gate 结论后可调 2–5s）。
   // 单次 edit 失败 .catch 静默，不阻塞正文。文案是 adapter 自造固定模板，
   // 不拼接任何 runtime 输出/参数/路径/token（脱敏）。
+  // N:in-flight 守卫——上一 edit 未落地则跳过本 tick，避免 edit 挂起时对同一
+  // 消息堆叠重叠 edit；配合 bounded signal 兜底一个挂死的 edit 最多占一档节流窗。
   const statusInterval = setInterval(() => {
-    if (!statusMessageId || statusFinalized) return;
+    if (!statusMessageId || statusFinalized || statusEditInFlight) return;
     const secs = Math.round((Date.now() - statusStartTs) / 1000);
-    editMessage({ apiUrl, botToken, channelId: replyChannelId, channelType: replyChannelType, messageId: statusMessageId, messageSeq: statusMessageSeq, contentEdit: `⏳ 处理中 · 已运行 ${secs}s` }).catch(() => {});
+    const p = editMessage({ apiUrl, botToken, channelId: replyChannelId, channelType: replyChannelType, messageId: statusMessageId, messageSeq: statusMessageSeq, contentEdit: `⏳ 处理中 · 已运行 ${secs}s`, signal: AbortSignal.timeout(STATUS_EDIT_TIMEOUT_MS) })
+      .catch(() => {});
+    statusEditInFlight = p;
+    p.finally(() => { if (statusEditInFlight === p) statusEditInFlight = null; });
   }, 3000);
 
   // finalize 收敛 helper：结束时停 status 轨并把占位 edit 成终态。幂等（重复调用
-  // no-op）。成功→✅ 用时 Ns；失败/超时→❌ 脱敏原因。占位 send 未成功时静默跳过。
+  // no-op）。成功→✅ 用时 Ns；失败/超时→❌ 脱敏原因。占位 id 未就绪时（B1）记下
+  // 终态待 flush，占位 send 真失败时静默丢弃（降级 typing-only）。
   // detail 只取固定短语类别，绝不透传原始 error message（脱敏）。
   const finalizeStatus = (kind: "ok" | "fail", detail?: string): void => {
     if (statusFinalized) return;
     statusFinalized = true;
     clearInterval(statusInterval);
-    if (!statusMessageId) return;
     const secs = Math.round((Date.now() - statusStartTs) / 1000);
     const contentEdit = kind === "ok"
       ? `✅ 已完成 · 用时 ${secs}s`
       : `❌ 失败：${detail ?? "处理出错"}`;
-    editMessage({ apiUrl, botToken, channelId: replyChannelId, channelType: replyChannelType, messageId: statusMessageId, messageSeq: statusMessageSeq, contentEdit }).catch(() => {});
+    if (!statusMessageId) {
+      // B1：占位 id 还没就绪 → 记下终态，占位 .then resolve 后 flush（若占位最终
+      // 失败则永不 flush = 无占位消息可孤儿，符合降级不变量）。
+      pendingTerminalContent = contentEdit;
+      return;
+    }
+    applyTerminalEdit(statusMessageId, contentEdit);
   };
 
   // Buffer text across streaming deliver calls; only send once after dispatcher finishes.
@@ -2698,6 +2750,12 @@ export async function handleInboundMessage(params: {
   };
 
   let replySucceeded = false;
+  // B2（非超时派发失败被误标成功）：dispatchReplyWithBufferedBlockDispatcher 抛出的
+  // 非超时 rejection（resolver/runtime rejection，SDK dispatchReplyFromConfig 会
+  // rethrow，区别于走 onError 的 per-delivery deliver 错误）会在 rethrow 前先经
+  // finally——旧代码 finally 恒 finalizeStatus("ok")，把占位误 edit 成 ✅。修法：
+  // 仅在 dispatch 正常返回后置真，finally 据此决定终态（ok / fail）。
+  let dispatchSucceeded = false;
 
   // Timeout guard: see resolveDispatchTimeoutMs at top of file. Without this,
   // an upstream dispatch hang would leave the per-group queue's Promise chain
@@ -2864,6 +2922,9 @@ export async function handleInboundMessage(params: {
       }),
       dispatchTimeoutPromise,
     ]);
+    // B2：dispatch 正常返回（未 timeout、未 reject）才算成功；finally 据此 finalize
+    // 成 ✅，否则 ❌。置真必须在 race 之后、任何后续 throw 之前。
+    dispatchSucceeded = true;
   } catch (err) {
     // Timeout: dispatch never returned within dispatchTimeoutMs. Tell the
     // user, suppress any stale buffered text (so the finally-flush branch
@@ -2926,9 +2987,12 @@ export async function handleInboundMessage(params: {
     }
     clearInterval(typingInterval);
     // status 轨最终收尾（所有正常/异常路径都经 finally）：finalizeStatus 幂等——
-    // onError/timeout 分支已 finalize 成 fail 的场景这里是 no-op；正常完成则占位
-    // edit 成 ✅ 已完成。即便占位未成功(statusMessageId undefined)也 no-op。
-    finalizeStatus("ok");
+    // onError/timeout 分支已 finalize 成 fail 的场景这里是 no-op。B2：非超时
+    // dispatcher rejection 会走到这里但 dispatchSucceeded 仍为 false，据此 finalize
+    // 成 ❌（而非旧代码恒 "ok" 误标 ✅）；只有 dispatch 正常返回才 ✅ 已完成。
+    // 即便占位未就绪(statusMessageId undefined)，finalizeStatus 也会记 pending 终态
+    // 或 no-op（占位真失败）。
+    finalizeStatus(dispatchSucceeded ? "ok" : "fail");
     // Safety net: clean up pending inbound context in case the hook didn't fire
     pendingInboundContext.delete(route.sessionKey);
 


### PR DESCRIPTION
## What

Long-running bot tasks now show a **live status** that updates in place, instead of only a typing indicator that gives no sense of progress. A status placeholder is posted at the start, edited every ~3s while the task runs (`⏳ 处理中 · 已运行 Ns`), and finalized at the end (`✅ 已完成 · 用时 Ns` / `❌ 失败：<脱敏原因>`).

This runs as a **second track in parallel with the existing typing indicator**, which is kept unchanged as the fallback and never removed.

## Why the `content_edit` field is a JSON object, not plain text

The edit endpoint (`POST /v1/bot/message/edit`) has a subtle contract: sending `content_edit` as **plain text** returns **200 OK** but the message **never re-renders on the client**. Verified against octo-server:

- **Write side**: `NormalizeContentEdit` passes any non-JSON-object through unchanged with no error → 200 OK.
- **Read-back side** (`newMessageExtraResp` + reply sync path): `json.Unmarshal` of the stored `content_edit` fails on plain text → `contentEditMap` stays nil → `content_edit,omitempty` drops the field from the sync response → the client receives no edit → the UI never updates.

So `editMessage()` sends `content_edit` as a JSON object isomorphic to the send payload — `{type:1,content:"…"}` — matching `sendMessage`'s `payload.content`. The wrapper keeps a plain `contentEdit: string` public signature and does the JSON wrapping internally; callers are unaware.

## Key design points

- **Placeholder identity**: the status placeholder is always sent as the bot itself (no `on_behalf_of`), because an OBO-sent message would `403` on edit (`msgFromUID != robotID`). The reply body still uses the OBO identity. Consequence: in OBO sessions the status message and the reply body have different senders — a known trade-off.
- **`editMessage()` exposes no `onBehalfOf`** — edit identity is always the bot, so the wrapper doesn't offer the option.
- **Redaction**: status text is a fixed adapter-authored template; no runtime output/args/paths/token are interpolated. Failure reasons are fixed categories (`处理超时`, `上游错误`), never the raw error message.
- **Three-layer degradation**: (1) placeholder-send failure → the status track idles and it degrades to typing-only; (2) a single edit failure is swallowed and never blocks the reply; (3) `finalizeStatus` is idempotent.
- **No interval leak**: the status track is finalized and `clearInterval(statusInterval)` runs at all three typing exit points (`onError` → fail, timeout → fail, `finally` → ok), via a `finalizeStatus` helper.

## Scope

Adapter-only. No octo-server changes. Body reply logic / deliver-buffer / dispatch timeout are untouched — the status track is purely additive.

## ⚠️ Pre-merge manual gate (required)

Automated tests assert the HTTP body shape and type only — they cannot prove the client actually re-renders in place. A real-device check is required before merge and its result should be recorded here:

- **TARGET**: octo client + a bound bot conversation, trigger a >30s task.
- **STEPS**: send command → placeholder appears → status updates ~every 3s → finalize at the end.
- **ASSERT**: each edit produces **no new unread badge, no ring, does not bump the conversation to the top**; the placeholder changes in place; updates stop at the end.

If every-3s edits are found to disturb (unread/ring/reorder), fall back to "edit only on stage-label change" and record the finding here.

## Tests

- `api-fetch.test.ts`: `editMessage` posts to `/v1/bot/message/edit`; body carries `message_id`/`channel_id`/`channel_type`/`content_edit`; `content_edit` deserializes deep-equal to `{type:1,content:'…'}`; no `on_behalf_of`; `message_seq` only when provided; non-2xx throws; empty-id guards.
- `inbound.test.ts`: edit failure (fetch reject) does not block the reply `sendMessage`; OBO-session placeholder `sendMessage` carries no `onBehalfOf` while the body does; placeholder-send failure → status track idles (zero edits); idempotent finalize; source-level assertions that all three exit points finalize the status track.
- `npm run type-check` clean; `npm test` all green (1313 tests).

Fixes #146


---

## Rework (round 1 — status-lifecycle correctness)

Independent review flagged two blocking state-lifecycle bugs (both reproducible without any octo-server change) plus one non-blocking hardening item. All fixed additively; the body reply / deliver-buffer / dispatch-timeout main logic and the `content_edit` encoding / OBO handling / redaction are untouched.

### 🔴 B1 — fast-completion race left a permanent `⏳ 处理中` orphan
The placeholder `sendMessage(...).then(r => statusMessageId = r.message_id)` is fire-and-forget. When a short task (cache hit / trivial reply / early-return error) finishes **before** that POST resolves, `finalizeStatus` ran while `statusMessageId` was still `undefined` → it set `statusFinalized`, cleared the interval, and no-op'd. The placeholder POST then resolved, recording an id nobody edits → a permanent `⏳ 已接收，处理中…` orphan.

**Fix:** when finalize runs before the id is ready, it stashes the decided terminal content in `pendingTerminalContent`; the placeholder `.then` flushes it to the terminal state as soon as the id arrives. A genuine placeholder-send failure keeps the id `undefined` forever → nothing is flushed → the existing "degrade to typing-only, no message to orphan" invariant is preserved.

### 🔴 B2 — non-timeout dispatch failure was mislabeled `✅ 已完成`
The outer `catch` only finalized as fail when `err === timeoutError`. Any other rejection (resolver/runtime rejection rethrown by the SDK's `dispatchReplyFromConfig`, distinct from per-delivery `onError`) hit the `finally` **before** the rethrow, where `finalizeStatus("ok")` was called unconditionally → the placeholder was edited to `✅ 已完成` for an actually-failed run.

**Fix:** a `dispatchSucceeded` flag is set `true` only after the dispatch `Promise.race` returns normally; the `finally` now calls `finalizeStatus(dispatchSucceeded ? "ok" : "fail")`.

### 🟡 N1 — periodic edit concurrency/timeout guard
Added an in-flight guard so a 3s tick is skipped while the previous edit is still unsettled (no stacked overlapping edits on the same message), a bounded `AbortSignal.timeout(STATUS_EDIT_TIMEOUT_MS)` on every status edit, and — closing a review follow-up — serialization of the terminal edit **after** any in-flight periodic edit so a late `⏳` request can't land after and overwrite the terminal `✅`/`❌`.

### New regression tests
The prior harness always `await`ed the placeholder send before finalizing, which serialized the B1 race away, and never exercised a non-timeout dispatcher rejection (B2). Added:
1. **B1**: placeholder POST resolves *after* the task completes → asserts the final edit reaches the terminal state with no orphan.
2. **B2**: dispatcher throws a non-timeout rejection → asserts finalize is `❌` (fail), not `✅`.
3. **N1**: finalize while a periodic edit is in flight → asserts the terminal edit is issued only after the periodic edit settles (terminal state not overwritten).

Plus source-level assertions for the new invariants. `npm run type-check` clean; `npm test` all green (1318 tests).
