### PR TITLE
feat(channel): message adapter migration + reactions + session routing (#111)

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "ws": "^8.21.0"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.4.15"
+    "openclaw": ">=2026.6.9"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -76,13 +76,13 @@
     "install": {
       "clawhubSpec": "clawhub:octo",
       "defaultChoice": "clawhub",
-      "minHostVersion": ">=2026.4.15"
+      "minHostVersion": ">=2026.6.9"
     },
     "compat": {
-      "pluginApi": ">=2026.4.15"
+      "pluginApi": ">=2026.6.9"
     },
     "build": {
-      "openclawVersion": "2026.5.4"
+      "openclawVersion": "2026.6.9"
     },
     "release": {
       "publishToClawHub": true,

--- a/src/actions.test.ts
+++ b/src/actions.test.ts
@@ -3923,6 +3923,33 @@ describe("handleOctoMessageAction — react", () => {
     expect(body.channel_id).toBe("peerUid"); // routed to the peer as a DM
   });
 
+  it("react in a DM when the runtime ALSO fills args.target with the ambient octo:<peer> (real case)", async () => {
+    // Confirmed in runtime: the message tool fills args.target with the current
+    // conversation id, so explicitTarget="octo:<peer>" is set even though the
+    // agent didn't deliberately pick a cross-channel target. The DM correction
+    // must NOT be gated on `!explicitTarget` — it must still rewrite to
+    // user:<peer>. (This is the exact failure that returned not_group_member.)
+    let body: any = null;
+    globalThis.fetch = mockFetch({
+      "/reactions": async (_u, init) => {
+        body = init?.body ? JSON.parse(init.body as string) : null;
+        return jsonResponse({}, 200);
+      },
+    });
+    const { handleOctoMessageAction } = await import("./actions.js");
+    const result = await handleOctoMessageAction({
+      action: "react",
+      args: { emoji: "👀", messageId: "m-dm-real", target: "octo:peerUid" },
+      apiUrl: "http://localhost:8090",
+      botToken: "test-token",
+      currentChannelId: "octo:peerUid",
+      requesterSenderId: "peerUid",
+    });
+    expect(result.ok).toBe(true);
+    expect(body.channel_type).toBe(ChannelType.DM); // 1, not group(2)
+    expect(body.channel_id).toBe("peerUid");
+  });
+
   it("react in a DM with space-prefixed currentChannelId (octo:<space>:<peer>) still corrects", async () => {
     let body: any = null;
     globalThis.fetch = mockFetch({

--- a/src/actions.test.ts
+++ b/src/actions.test.ts
@@ -3779,3 +3779,243 @@ describe("extractInlineMentionUids", () => {
     expect(extractInlineMentionUids("group:grp1@uid1,,uid2,")).toEqual(["uid1", "uid2"]);
   });
 });
+
+// #111 Sprint B — react action
+describe("handleOctoMessageAction — react", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("react add POSTs to the reactions endpoint with the emoji", async () => {
+    let url = "";
+    let method = "";
+    let body: any = null;
+    globalThis.fetch = mockFetch({
+      "/reactions": async (u, init) => {
+        url = u;
+        method = init?.method ?? "POST";
+        body = init?.body ? JSON.parse(init.body as string) : null;
+        return jsonResponse({}, 200);
+      },
+    });
+
+    const { handleOctoMessageAction } = await import("./actions.js");
+    const result = await handleOctoMessageAction({
+      action: "react",
+      args: { target: "group:chan123", messageId: "m1", emoji: "👍" },
+      apiUrl: "http://localhost:8090",
+      botToken: "test-token",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(url).toContain("/v1/bot/messages/m1/reactions");
+    expect(method).toBe("POST");
+    expect(body.emoji).toBe("👍");
+    expect(body.channel_id).toBe("chan123");
+  });
+
+  it("react remove DELETEs the reaction", async () => {
+    let method = "";
+    let url = "";
+    globalThis.fetch = mockFetch({
+      "/reactions": async (u, init) => {
+        url = u;
+        method = init?.method ?? "";
+        return new Response("", { status: 200 });
+      },
+    });
+
+    const { handleOctoMessageAction } = await import("./actions.js");
+    const result = await handleOctoMessageAction({
+      action: "react",
+      args: { target: "group:chan123", messageId: "m1", emoji: "👍", remove: true },
+      apiUrl: "http://localhost:8090",
+      botToken: "test-token",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(method).toBe("DELETE");
+    expect(url).toContain(encodeURIComponent("👍"));
+  });
+
+  it("react falls back to currentChannelId when no target is given", async () => {
+    let body: any = null;
+    globalThis.fetch = mockFetch({
+      "/reactions": async (_u, init) => {
+        body = init?.body ? JSON.parse(init.body as string) : null;
+        return jsonResponse({}, 200);
+      },
+    });
+
+    const { handleOctoMessageAction } = await import("./actions.js");
+    const result = await handleOctoMessageAction({
+      action: "react",
+      args: { messageId: "m1", emoji: "🎉" },
+      apiUrl: "http://localhost:8090",
+      botToken: "test-token",
+      currentChannelId: "group:chan999",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(body.channel_id).toBe("chan999");
+  });
+
+  it("react fails when messageId is missing", async () => {
+    const { handleOctoMessageAction } = await import("./actions.js");
+    const result = await handleOctoMessageAction({
+      action: "react",
+      args: { target: "group:chan123", emoji: "👍" },
+      apiUrl: "http://localhost:8090",
+      botToken: "test-token",
+    });
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/messageId/);
+  });
+
+  it("react falls back to currentMessageId (current inbound message)", async () => {
+    let url = "";
+    globalThis.fetch = mockFetch({
+      "/reactions": async (u, init) => {
+        url = u;
+        return jsonResponse({}, 200);
+      },
+    });
+    const { handleOctoMessageAction } = await import("./actions.js");
+    const result = await handleOctoMessageAction({
+      action: "react",
+      args: { emoji: "👍" }, // no messageId
+      apiUrl: "http://localhost:8090",
+      botToken: "test-token",
+      currentChannelId: "group:chan123",
+      currentMessageId: "inbound-msg-77",
+    });
+    expect(result.ok).toBe(true);
+    expect(url).toContain("/v1/bot/messages/inbound-msg-77/reactions");
+  });
+
+  it("react in a DM corrects target to user:<peer> (DM currentChannelId is octo:<peer>)", async () => {
+    // Regression (real DM shape, confirmed in runtime): the runtime hands
+    // currentChannelId as `octo:<peerUid>`. resolveOutboundOctoTarget's prefix
+    // normalization would turn that into `group:<peerUid>` → channel_type=2 →
+    // server not_group_member. The fix detects bare==peer (requesterSenderId)
+    // and forces `user:<peer>` so it routes as a DM (channel_type=1).
+    let body: any = null;
+    globalThis.fetch = mockFetch({
+      "/reactions": async (_u, init) => {
+        body = init?.body ? JSON.parse(init.body as string) : null;
+        return jsonResponse({}, 200);
+      },
+    });
+    const { handleOctoMessageAction } = await import("./actions.js");
+    const result = await handleOctoMessageAction({
+      action: "react",
+      args: { emoji: "👀", messageId: "m-dm-1" },
+      apiUrl: "http://localhost:8090",
+      botToken: "test-token",
+      currentChannelId: "octo:peerUid", // real DM shape from runtime
+      requesterSenderId: "peerUid",
+    });
+    expect(result.ok).toBe(true);
+    expect(body.channel_type).toBe(ChannelType.DM); // 1, not group(2)
+    expect(body.channel_id).toBe("peerUid"); // routed to the peer as a DM
+  });
+
+  it("react in a DM with space-prefixed currentChannelId (octo:<space>:<peer>) still corrects", async () => {
+    let body: any = null;
+    globalThis.fetch = mockFetch({
+      "/reactions": async (_u, init) => {
+        body = init?.body ? JSON.parse(init.body as string) : null;
+        return jsonResponse({}, 200);
+      },
+    });
+    const { handleOctoMessageAction } = await import("./actions.js");
+    const result = await handleOctoMessageAction({
+      action: "react",
+      args: { emoji: "👀", messageId: "m-dm-1b" },
+      apiUrl: "http://localhost:8090",
+      botToken: "test-token",
+      currentChannelId: "octo:space123:peerUid",
+      requesterSenderId: "peerUid",
+    });
+    expect(result.ok).toBe(true);
+    expect(body.channel_type).toBe(ChannelType.DM);
+    expect(body.channel_id).toBe("peerUid");
+  });
+
+  it("react with an explicit DM target is NOT overridden by the peer correction", async () => {
+    let body: any = null;
+    globalThis.fetch = mockFetch({
+      "/reactions": async (_u, init) => {
+        body = init?.body ? JSON.parse(init.body as string) : null;
+        return jsonResponse({}, 200);
+      },
+    });
+    const { handleOctoMessageAction } = await import("./actions.js");
+    const result = await handleOctoMessageAction({
+      action: "react",
+      args: { emoji: "👀", messageId: "m-dm-2", target: "user:explicitPeer" },
+      apiUrl: "http://localhost:8090",
+      botToken: "test-token",
+      currentChannelId: "octo:peerUid",
+      requesterSenderId: "someoneElse",
+    });
+    expect(result.ok).toBe(true);
+    expect(body.channel_id).toBe("explicitPeer"); // explicit target wins
+  });
+
+  it("react in a GROUP is NOT mis-corrected by the DM peer logic", async () => {
+    // Group currentChannelId is the group_no, which never equals requesterSenderId,
+    // so the DM correction must not fire — channel_type stays Group(2).
+    let body: any = null;
+    globalThis.fetch = mockFetch({
+      "/reactions": async (_u, init) => {
+        body = init?.body ? JSON.parse(init.body as string) : null;
+        return jsonResponse({}, 200);
+      },
+    });
+    const { handleOctoMessageAction } = await import("./actions.js");
+    const result = await handleOctoMessageAction({
+      action: "react",
+      args: { emoji: "👀", messageId: "m-grp-1" },
+      apiUrl: "http://localhost:8090",
+      botToken: "test-token",
+      currentChannelId: "group:grp123",
+      requesterSenderId: "peerUid", // a member, != group_no
+    });
+    expect(result.ok).toBe(true);
+    expect(body.channel_id).toBe("grp123");
+    expect(body.channel_type).toBe(ChannelType.Group);
+  });
+
+  it("react fails when emoji is missing", async () => {
+    const { handleOctoMessageAction } = await import("./actions.js");
+    const result = await handleOctoMessageAction({
+      action: "react",
+      args: { target: "group:chan123", messageId: "m1" },
+      apiUrl: "http://localhost:8090",
+      botToken: "test-token",
+    });
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/emoji/);
+  });
+});
+
+describe("#111 capabilities + actions", () => {
+  it("declares capabilities.reactions = true", async () => {
+    const { octoPlugin } = await import("./channel.js");
+    expect(octoPlugin.capabilities?.reactions).toBe(true);
+  });
+
+  it("getAvailableActions includes react but NOT reactions (no list endpoint yet)", async () => {
+    const { octoPlugin } = await import("./channel.js");
+    const cfg = {
+      channels: { octo: { accounts: { default: { botToken: "bf_t", apiUrl: "http://x" } } } },
+    };
+    const actions = (octoPlugin.actions as any).listActions({ cfg });
+    expect(actions).toContain("react");
+    expect(actions).not.toContain("reactions");
+  });
+});

--- a/src/actions.test.ts
+++ b/src/actions.test.ts
@@ -2627,6 +2627,90 @@ describe("handleOctoMessageAction", () => {
   });
 
   // -----------------------------------------------------------------------
+  // group-only actions reject DM target (Task 5)
+  // -----------------------------------------------------------------------
+  describe("group-only actions reject DM target", () => {
+    const DM_TARGET = "octo:user:42:uid";
+
+    beforeEach(() => {
+      // Clear owner registry so cross-channel permission check is bypassed for self-DM
+      _clearOwnerRegistry();
+    });
+
+    it("member-info rejects octo:user:42:uid without calling group API", async () => {
+      const fetchSpy = vi.fn();
+      globalThis.fetch = fetchSpy as any;
+
+      const { handleOctoMessageAction } = await import("./actions.js");
+      const result = await handleOctoMessageAction({
+        action: "member-info",
+        args: { target: DM_TARGET },
+        apiUrl: "http://localhost:8090",
+        botToken: "test-token",
+        requesterSenderId: "42",
+      });
+
+      expect(result.ok).toBe(false);
+      expect(result.error).toMatch(/group/i);
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it("channel-info rejects octo:user:42:uid without calling group API", async () => {
+      const fetchSpy = vi.fn();
+      globalThis.fetch = fetchSpy as any;
+
+      const { handleOctoMessageAction } = await import("./actions.js");
+      const result = await handleOctoMessageAction({
+        action: "channel-info",
+        args: { target: DM_TARGET },
+        apiUrl: "http://localhost:8090",
+        botToken: "test-token",
+        requesterSenderId: "42",
+      });
+
+      expect(result.ok).toBe(false);
+      expect(result.error).toMatch(/group/i);
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it("group-md-read rejects octo:user:42:uid without calling group API", async () => {
+      const fetchSpy = vi.fn();
+      globalThis.fetch = fetchSpy as any;
+
+      const { handleOctoMessageAction } = await import("./actions.js");
+      const result = await handleOctoMessageAction({
+        action: "group-md-read",
+        args: { target: DM_TARGET },
+        apiUrl: "http://localhost:8090",
+        botToken: "test-token",
+        currentChannelId: DM_TARGET,
+      });
+
+      expect(result.ok).toBe(false);
+      expect(result.error).toMatch(/group/i);
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it("group-md-update rejects octo:user:42:uid without calling group API", async () => {
+      const fetchSpy = vi.fn();
+      globalThis.fetch = fetchSpy as any;
+
+      const { handleOctoMessageAction } = await import("./actions.js");
+      const result = await handleOctoMessageAction({
+        action: "group-md-update",
+        args: { target: DM_TARGET, content: "# Updated" },
+        apiUrl: "http://localhost:8090",
+        botToken: "test-token",
+        currentChannelId: DM_TARGET,
+      });
+
+      expect(result.ok).toBe(false);
+      expect(result.error).toMatch(/group/i);
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  // -----------------------------------------------------------------------
   // channel-list action
   // -----------------------------------------------------------------------
   describe("channel-list — list bot groups", () => {

--- a/src/actions.test.ts
+++ b/src/actions.test.ts
@@ -4246,3 +4246,100 @@ describe("#111 capabilities + actions", () => {
     expect(actions).not.toContain("reactions");
   });
 });
+
+// Task 11(C5): Simulate runtime real injection behavior — when target is omitted,
+// the runtime fills args.target with the same value as currentChannelId
+// ("octo:user:<space>:<uid>"). Verify send/read/react all resolve to DM + bare uid.
+describe("runtime-injected default target (omitted target path)", () => {
+  const injected = "octo:user:42:uid";
+
+  it("send: injected octo:user:<space>:<uid> resolves DM + bare uid", async () => {
+    let sentPayload: any = null;
+    globalThis.fetch = mockFetch({
+      "/v1/bot/sendMessage": async (_url, init) => {
+        sentPayload = JSON.parse(init?.body as string);
+        return jsonResponse({ message_id: 1, message_seq: 1 });
+      },
+    });
+
+    const { handleOctoMessageAction } = await import("./actions.js");
+    const result = await handleOctoMessageAction({
+      action: "send",
+      args: { message: "hi", target: injected },
+      apiUrl: "http://localhost:8090",
+      botToken: "test-token",
+      currentChannelId: injected,
+      requesterSenderId: "uid",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(sentPayload.channel_type).toBe(ChannelType.DM);
+    expect(sentPayload.channel_id).toBe("uid");
+  });
+
+  it("read: injected octo:user:<space>:<uid> resolves DM + bare uid", async () => {
+    const fakeMessages = {
+      messages: [
+        {
+          from_uid: "peer",
+          message_id: "m1",
+          timestamp: 1709654400,
+          payload: Buffer.from(JSON.stringify({ type: 1, content: "DM msg" })).toString("base64"),
+        },
+      ],
+    };
+
+    let fetchUrl = "";
+    let fetchBody: any = null;
+    globalThis.fetch = mockFetch({
+      "/v1/bot/messages/sync": async (url, init) => {
+        fetchUrl = url;
+        fetchBody = JSON.parse(init?.body as string);
+        return jsonResponse(fakeMessages);
+      },
+    });
+
+    const { handleOctoMessageAction } = await import("./actions.js");
+    const result = await handleOctoMessageAction({
+      action: "read",
+      args: { target: injected },
+      apiUrl: "http://localhost:8090",
+      botToken: "test-token",
+      currentChannelId: injected,
+      requesterSenderId: "uid",
+      accountId: "acct1",
+    });
+
+    expect(result.ok).toBe(true);
+    // Same-channel DM read — no cross-channel wrapper
+    const data = result.data as any;
+    expect(data.header).toBeUndefined();
+    // The API receives channel_id=bare uid, channel_type=DM
+    expect(fetchBody.channel_id).toBe("uid");
+    expect(fetchBody.channel_type).toBe(ChannelType.DM);
+  });
+
+  it("react: injected octo:user:<space>:<uid> resolves DM + bare uid", async () => {
+    let body: any = null;
+    globalThis.fetch = mockFetch({
+      "/reactions": async (_u, init) => {
+        body = init?.body ? JSON.parse(init.body as string) : null;
+        return jsonResponse({}, 200);
+      },
+    });
+
+    const { handleOctoMessageAction } = await import("./actions.js");
+    const result = await handleOctoMessageAction({
+      action: "react",
+      args: { emoji: "👀", messageId: "m1", target: injected },
+      apiUrl: "http://localhost:8090",
+      botToken: "test-token",
+      currentChannelId: injected,
+      requesterSenderId: "uid",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(body.channel_type).toBe(ChannelType.DM);
+    expect(body.channel_id).toBe("uid");
+  });
+});

--- a/src/actions.test.ts
+++ b/src/actions.test.ts
@@ -3279,6 +3279,97 @@ describe("handleOctoMessageAction", () => {
   });
 
   // -----------------------------------------------------------------------
+  // Task 4: handleRead DM same-channel (kind-aware)
+  // -----------------------------------------------------------------------
+  describe("read — DM same-channel (kind-aware)", () => {
+    const fakeMessages = {
+      messages: [
+        {
+          from_uid: "peer-uid",
+          message_id: "m1",
+          timestamp: 1709654400,
+          payload: Buffer.from(JSON.stringify({ type: 1, content: "DM msg" })).toString("base64"),
+        },
+      ],
+    };
+
+    it("reads current DM without permission check (target matches octo:user:<space>:<uid>)", async () => {
+      registerBotGroupIds(["someGroup"]); // peer-uid is NOT a known group
+
+      globalThis.fetch = mockFetch({
+        "/v1/bot/messages/sync": async () => jsonResponse(fakeMessages),
+      });
+
+      const { handleOctoMessageAction } = await import("./actions.js");
+      // currentChannelId uses the runtime's octo:user:<space>:<uid> shape
+      const result = await handleOctoMessageAction({
+        action: "read",
+        args: { target: "user:peer-uid" },
+        apiUrl: "http://localhost:8090",
+        botToken: "test-token",
+        currentChannelId: "octo:user:space123:peer-uid",
+        requesterSenderId: "peer-uid",
+        accountId: "acct1",
+      });
+
+      expect(result.ok).toBe(true);
+      // Same-channel → no prompt-injection wrapper (cross-channel would add one)
+      const data = result.data as any;
+      expect(data.header).toBeUndefined();
+      expect(data.messages[0].content).toBe("DM msg");
+    });
+
+    it("currentChannelType honours user: kind even if uid collides with a known group", async () => {
+      // Scenario: currentChannelId = octo:user:grp1 where "grp1" is ALSO in knownGroupIds
+      // The kind-aware logic should treat this as DM (because kind=user), not Group.
+      // Without the fix, bareCurrentChannelId would be "grp1" which is in knownGroups,
+      // so currentChannelType would be Group → mismatch with parsed DM → cross-channel.
+      registerBotGroupIds(["grp1"]);
+
+      globalThis.fetch = mockFetch({
+        "/v1/bot/messages/sync": async () => jsonResponse(fakeMessages),
+      });
+
+      const { handleOctoMessageAction } = await import("./actions.js");
+      const result = await handleOctoMessageAction({
+        action: "read",
+        args: { target: "user:grp1" },
+        apiUrl: "http://localhost:8090",
+        botToken: "test-token",
+        currentChannelId: "octo:user:grp1",
+        requesterSenderId: "grp1",
+        accountId: "acct1",
+      });
+
+      expect(result.ok).toBe(true);
+      const data = result.data as any;
+      // Same-channel DM → no cross-channel wrapper
+      expect(data.header).toBeUndefined();
+    });
+
+    it("still denies cross-channel DM when uid differs", async () => {
+      globalThis.fetch = mockFetch({
+        "/v1/bot/messages/sync": async () => jsonResponse(fakeMessages),
+      });
+
+      const { handleOctoMessageAction } = await import("./actions.js");
+      const result = await handleOctoMessageAction({
+        action: "read",
+        args: { target: "user:different-peer" },
+        apiUrl: "http://localhost:8090",
+        botToken: "test-token",
+        currentChannelId: "octo:user:space123:peer-uid",
+        requesterSenderId: "peer-uid", // different from target
+        accountId: "acct1",
+      });
+
+      // Cross-channel DM to another user's DM → denied (not owner, not own DM)
+      expect(result.ok).toBe(false);
+      expect(result.error).toContain("无权查询他人");
+    });
+  });
+
+  // -----------------------------------------------------------------------
   // read — isSameChannel channelType bypass prevention
   // -----------------------------------------------------------------------
   describe("read — channelType mismatch prevents same-channel bypass", () => {

--- a/src/actions.test.ts
+++ b/src/actions.test.ts
@@ -2341,9 +2341,57 @@ describe("handleOctoMessageAction", () => {
       expect(data.count).toBe(2);
       expect(data.messages[0].content).toBe("Hello");
       expect(data.messages[1].content).toBe("Hi there");
+      // #111 — read must expose each message id so the agent can target an
+      // earlier message with `react` (see read→react chain test below).
+      expect(data.messages[0].messageId).toBe("m1");
+      expect(data.messages[1].messageId).toBe("m2");
       expect(data.hasMore).toBe(false);
       // Same-channel should NOT have prompt injection wrapper
       expect(data.header).toBeUndefined();
+    });
+
+    it("read messageId feeds react — agent can react to an earlier message", async () => {
+      registerBotGroupIds(["grp1"]);
+      const fakeMessages = {
+        messages: [
+          {
+            from_uid: "user1",
+            message_id: "earlier-99",
+            timestamp: 1709654400,
+            payload: Buffer.from(JSON.stringify({ type: 1, content: "Hello" })).toString("base64"),
+          },
+        ],
+      };
+      let reactUrl = "";
+      globalThis.fetch = mockFetch({
+        "/v1/bot/messages/sync": async () => jsonResponse(fakeMessages),
+        "/reactions": async (u) => {
+          reactUrl = u;
+          return jsonResponse({}, 200);
+        },
+      });
+
+      const { handleOctoMessageAction } = await import("./actions.js");
+      const read = await handleOctoMessageAction({
+        action: "read",
+        args: { target: "group:grp1" },
+        apiUrl: "http://localhost:8090",
+        botToken: "test-token",
+        currentChannelId: "grp1",
+      });
+      const earlierId = (read.data as any).messages[0].messageId as string;
+      expect(earlierId).toBe("earlier-99");
+
+      // Feed the id straight back into react — this is the loop the prompt
+      // advertises and that was impossible before read exposed messageId.
+      const react = await handleOctoMessageAction({
+        action: "react",
+        args: { target: "group:grp1", messageId: earlierId, emoji: "👍" },
+        apiUrl: "http://localhost:8090",
+        botToken: "test-token",
+      });
+      expect(react.ok).toBe(true);
+      expect(reactUrl).toContain("/v1/bot/messages/earlier-99/reactions");
     });
   });
 

--- a/src/actions.test.ts
+++ b/src/actions.test.ts
@@ -3482,6 +3482,36 @@ describe("parseTarget", () => {
     expect(result.channelId).toBe("grp1____topicA");
     expect(result.channelType).toBe(ChannelType.CommunityTopic);
   });
+
+  // Task 2: kind-aware parseTarget — root fix for not_group_member
+  describe("kind-aware (root-fix)", () => {
+    it("DM with space-scoped kind-tagged id → DM + bare uid", async () => {
+      const { parseTarget } = await import("./actions.js");
+      expect(parseTarget("octo:user:42:uid")).toEqual({ channelId: "uid", channelType: ChannelType.DM });
+      expect(parseTarget("octo:user:uid")).toEqual({ channelId: "uid", channelType: ChannelType.DM });
+      expect(parseTarget("user:42:uid")).toEqual({ channelId: "uid", channelType: ChannelType.DM });
+    });
+
+    it("group / topic unchanged", async () => {
+      const { parseTarget } = await import("./actions.js");
+      const known = new Set<string>(["grp1"]);
+      expect(parseTarget("octo:group:grp1", undefined, known)).toEqual({ channelId: "grp1", channelType: ChannelType.Group });
+      expect(parseTarget("group:grp1____x", undefined, known)).toEqual({ channelId: "grp1____x", channelType: ChannelType.CommunityTopic });
+    });
+
+    it("stacked prefixes route to group without inner-prefix residue", async () => {
+      const { parseTarget } = await import("./actions.js");
+      expect(parseTarget("group:octo:grp1")).toEqual({ channelId: "grp1", channelType: ChannelType.Group });
+      expect(parseTarget("octo:channel:group:grp1____x")).toEqual({ channelId: "grp1____x", channelType: ChannelType.CommunityTopic });
+    });
+
+    it("bare id still uses knownGroupIds", async () => {
+      const { parseTarget } = await import("./actions.js");
+      const known = new Set<string>(["grp1"]);
+      expect(parseTarget("octo:grp1", undefined, known)).toEqual({ channelId: "grp1", channelType: ChannelType.Group });
+      expect(parseTarget("octo:loneuid", undefined, known)).toEqual({ channelId: "loneuid", channelType: ChannelType.DM });
+    });
+  });
 });
 
 describe("resolveOutboundOctoTarget", () => {

--- a/src/actions.test.ts
+++ b/src/actions.test.ts
@@ -4101,12 +4101,9 @@ describe("handleOctoMessageAction — react", () => {
     expect(url).toContain("/v1/bot/messages/inbound-msg-77/reactions");
   });
 
-  it("react in a DM corrects target to user:<peer> (DM currentChannelId is octo:<peer>)", async () => {
-    // Regression (real DM shape, confirmed in runtime): the runtime hands
-    // currentChannelId as `octo:<peerUid>`. resolveOutboundOctoTarget's prefix
-    // normalization would turn that into `group:<peerUid>` → channel_type=2 →
-    // server not_group_member. The fix detects bare==peer (requesterSenderId)
-    // and forces `user:<peer>` so it routes as a DM (channel_type=1).
+  it("react in a DM via kind-tagged currentChannelId (no after-the-fact correction)", async () => {
+    // After Task 6: parseTarget/resolveOutboundOctoTarget already handle
+    // octo:user:<space>:<uid> → DM + bare uid. No requesterSenderId correction needed.
     let body: any = null;
     globalThis.fetch = mockFetch({
       "/reactions": async (_u, init) => {
@@ -4120,20 +4117,17 @@ describe("handleOctoMessageAction — react", () => {
       args: { emoji: "👀", messageId: "m-dm-1" },
       apiUrl: "http://localhost:8090",
       botToken: "test-token",
-      currentChannelId: "octo:peerUid", // real DM shape from runtime
-      requesterSenderId: "peerUid",
+      currentChannelId: "octo:user:42:uid",
+      requesterSenderId: "uid",
     });
     expect(result.ok).toBe(true);
     expect(body.channel_type).toBe(ChannelType.DM); // 1, not group(2)
-    expect(body.channel_id).toBe("peerUid"); // routed to the peer as a DM
+    expect(body.channel_id).toBe("uid"); // routed to the peer as a DM
   });
 
-  it("react in a DM when the runtime ALSO fills args.target with the ambient octo:<peer> (real case)", async () => {
-    // Confirmed in runtime: the message tool fills args.target with the current
-    // conversation id, so explicitTarget="octo:<peer>" is set even though the
-    // agent didn't deliberately pick a cross-channel target. The DM correction
-    // must NOT be gated on `!explicitTarget` — it must still rewrite to
-    // user:<peer>. (This is the exact failure that returned not_group_member.)
+  it("react in a DM when the runtime ALSO fills args.target with the ambient octo:user:42:uid (real case)", async () => {
+    // After Task 6: parseTarget/resolveOutboundOctoTarget already handle
+    // kind-tagged currentChannelId. No requesterSenderId correction needed.
     let body: any = null;
     globalThis.fetch = mockFetch({
       "/reactions": async (_u, init) => {
@@ -4144,18 +4138,19 @@ describe("handleOctoMessageAction — react", () => {
     const { handleOctoMessageAction } = await import("./actions.js");
     const result = await handleOctoMessageAction({
       action: "react",
-      args: { emoji: "👀", messageId: "m-dm-real", target: "octo:peerUid" },
+      args: { emoji: "👀", messageId: "m-dm-real", target: "octo:user:42:uid" },
       apiUrl: "http://localhost:8090",
       botToken: "test-token",
-      currentChannelId: "octo:peerUid",
-      requesterSenderId: "peerUid",
+      currentChannelId: "octo:user:42:uid",
+      requesterSenderId: "uid",
     });
     expect(result.ok).toBe(true);
     expect(body.channel_type).toBe(ChannelType.DM); // 1, not group(2)
-    expect(body.channel_id).toBe("peerUid");
+    expect(body.channel_id).toBe("uid");
   });
 
-  it("react in a DM with space-prefixed currentChannelId (octo:<space>:<peer>) still corrects", async () => {
+  it("react in a DM with space-prefixed currentChannelId (octo:user:<space>:<peer>) still corrects", async () => {
+    // After Task 6: kind-tagged form already handled by resolveOutboundOctoTarget.
     let body: any = null;
     globalThis.fetch = mockFetch({
       "/reactions": async (_u, init) => {
@@ -4169,12 +4164,12 @@ describe("handleOctoMessageAction — react", () => {
       args: { emoji: "👀", messageId: "m-dm-1b" },
       apiUrl: "http://localhost:8090",
       botToken: "test-token",
-      currentChannelId: "octo:space123:peerUid",
-      requesterSenderId: "peerUid",
+      currentChannelId: "octo:user:space123:uid",
+      requesterSenderId: "uid",
     });
     expect(result.ok).toBe(true);
     expect(body.channel_type).toBe(ChannelType.DM);
-    expect(body.channel_id).toBe("peerUid");
+    expect(body.channel_id).toBe("uid");
   });
 
   it("react with an explicit DM target is NOT overridden by the peer correction", async () => {

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -18,6 +18,8 @@ import {
   getGroupInfo,
   getGroupMd,
   updateGroupMd,
+  addReaction,
+  removeReaction,
 } from "./api-fetch.js";
 import { uploadAndSendMedia, uploadMedia, resolveRichTextContent, type UploadedMedia } from "./inbound.js";
 import { buildEntitiesFromFallback, parseStructuredMentions, convertStructuredMentions, sanitizeOutboundMentions } from "./mention-utils.js";
@@ -257,11 +259,12 @@ export async function handleOctoMessageAction(params: {
   groupMdCache?: Map<string, { content: string; version: number }>;
   currentChannelId?: string;
   threadId?: string | number | null;
+  currentMessageId?: string;
   requesterSenderId?: string;
   accountId?: string;
   log?: LogSink;
 }): Promise<MessageActionResult> {
-  const { action, args, apiUrl, botToken, memberMap, uidToNameMap, groupMdCache, currentChannelId, threadId, requesterSenderId, accountId, log } =
+  const { action, args, apiUrl, botToken, memberMap, uidToNameMap, groupMdCache, currentChannelId, threadId, currentMessageId, requesterSenderId, accountId, log } =
     params;
 
   if (!botToken) {
@@ -285,10 +288,101 @@ export async function handleOctoMessageAction(params: {
       return handleGroupMdRead({ args, apiUrl, botToken, groupMdCache, currentChannelId, log });
     case "group-md-update":
       return handleGroupMdUpdate({ args, apiUrl, botToken, groupMdCache, currentChannelId, log });
+    case "react":
+      return handleReact({ args, apiUrl, botToken, currentChannelId, threadId, currentMessageId, requesterSenderId, log });
     // 群管理操作（create-group/update-group/add-members/remove-members）
     // 统一通过 octo_management tool 入口，不走 message action
     default:
       return { ok: false, error: `Unknown action: ${action}` };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// react (#111 Sprint B) — add/remove the bot's reaction on a message
+// ---------------------------------------------------------------------------
+
+async function handleReact(params: {
+  args: Record<string, unknown>;
+  apiUrl: string;
+  botToken: string;
+  currentChannelId?: string;
+  threadId?: string | number | null;
+  currentMessageId?: string;
+  requesterSenderId?: string;
+  log?: LogSink;
+}): Promise<MessageActionResult> {
+  const { args, apiUrl, botToken, currentChannelId, threadId, currentMessageId, requesterSenderId, log } = params;
+
+  // messageId: explicit arg wins; otherwise fall back to the current inbound
+  // turn's message id (forwarded from toolContext.currentMessageId). The id is
+  // not surfaced in history/read output, so without this fallback "react to the
+  // message I'm replying to" would be impossible for the agent.
+  const messageId = (args.messageId as string | undefined)?.trim()
+    ?? (args.message_id as string | undefined)?.trim()
+    ?? currentMessageId?.trim();
+  if (!messageId) {
+    return { ok: false, error: "Missing required parameter: messageId (the id of the message to react to)" };
+  }
+  const emoji = (args.emoji as string | undefined)?.trim();
+  if (!emoji) {
+    return { ok: false, error: "Missing required parameter: emoji" };
+  }
+  const remove = args.remove === true;
+
+  // Target defaults to the current conversation (react in place). An explicit
+  // target is accepted for cross-channel reactions. Resolution reuses the
+  // outbound resolver so thread routing (#98) and empty/prefix-only fail-fast
+  // (#138) behave exactly like a send.
+  const explicitTarget = (args.target as string | undefined)?.trim();
+  let target = explicitTarget || currentChannelId;
+  if (!target || !stripAllChannelPrefixes(target.trim()).trim()) {
+    return { ok: false, error: "Missing or empty required parameter: target (and no current channel context)" };
+  }
+
+  // DM peer correction — MUST run BEFORE resolveOutboundOctoTarget.
+  //
+  // In a DM the runtime hands us currentChannelId as `octo:<peerUid>` (or
+  // `octo:<spaceId>:<peerUid>`) — it's the conversation's `To`, derived from
+  // the inbound from_uid. resolveOutboundOctoTarget → normalizeOutboundChannelPrefix
+  // turns ANY `octo:`/`channel:`-prefixed bare id that isn't `user:`-prefixed
+  // into `group:<bare>`, so `octo:<peer>` becomes `group:<peer>` and parseTarget
+  // returns channelType=Group → the server runs a group-membership check and
+  // rejects with not_group_member. (A post-resolve DM check can't help: the
+  // mis-classification already happened at the prefix step.)
+  //
+  // Fix: when the agent didn't pin an explicit target and the bare
+  // currentChannelId resolves to the trusted requesterSenderId (the DM peer for
+  // this turn — bare == peer, or `<space>:<peer>`), force the canonical DM form
+  // `user:<peer>` so the resolver routes it as a DM (channel_type=1) to the peer.
+  const peer = requesterSenderId?.trim();
+  if (!explicitTarget && peer && currentChannelId) {
+    const bare = stripAllChannelPrefixes(currentChannelId.trim());
+    if (bare === peer || bare.endsWith(`:${peer}`)) {
+      log?.info?.(`octo: react DM target corrected ${currentChannelId} → user:${peer}`);
+      target = `user:${peer}`;
+    }
+  }
+
+  let channelId: string;
+  let channelType: ChannelType;
+  try {
+    ({ channelId, channelType } = resolveOutboundOctoTarget(target, threadId));
+  } catch (err) {
+    return { ok: false, error: (err as Error).message };
+  }
+
+  try {
+    if (remove) {
+      await removeReaction({ apiUrl, botToken, channelId, channelType, messageId, emoji });
+      log?.info?.(`octo: removed reaction ${emoji} from ${messageId}`);
+      return { ok: true, data: { removed: emoji, messageId } };
+    }
+    await addReaction({ apiUrl, botToken, channelId, channelType, messageId, emoji });
+    log?.info?.(`octo: added reaction ${emoji} to ${messageId}`);
+    return { ok: true, data: { added: emoji, messageId } };
+  } catch (err) {
+    log?.info?.(`octo: react failed — channelId=${channelId} channelType=${channelType} msg=${messageId}: ${(err as Error).message}`);
+    return { ok: false, error: (err as Error).message };
   }
 }
 

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -354,14 +354,36 @@ async function handleReact(params: {
   // currentChannelId resolves to the trusted requesterSenderId (the DM peer for
   // this turn — bare == peer, or `<space>:<peer>`), force the canonical DM form
   // `user:<peer>` so the resolver routes it as a DM (channel_type=1) to the peer.
+  // DM peer correction — MUST run BEFORE resolveOutboundOctoTarget, and must
+  // NOT be gated on "no explicit target". The runtime fills args.target with the
+  // current conversation id, which in a DM is `octo:<peer>` (or
+  // `octo:<space>:<peer>`) — so explicitTarget is set, but it's just the ambient
+  // DM, not a deliberate cross-channel target. resolveOutboundOctoTarget →
+  // normalizeOutboundChannelPrefix would rewrite that `octo:<peer>` into
+  // `group:<peer>` → channelType=Group → server not_group_member.
+  //
+  // Rule: whatever the resolved target is (explicit arg OR currentChannelId),
+  // if its bare form is the DM peer (requesterSenderId — bare==peer, or
+  // `<space>:<peer>`), force `user:<peer>` so it routes as a DM (channel_type=1)
+  // to the peer. A deliberate cross-target (`group:<gid>`, `user:<other>`) has a
+  // bare that != peer, so it's left untouched.
   const peer = requesterSenderId?.trim();
-  if (!explicitTarget && peer && currentChannelId) {
-    const bare = stripAllChannelPrefixes(currentChannelId.trim());
+  if (peer && target) {
+    const bare = stripAllChannelPrefixes(target.trim());
     if (bare === peer || bare.endsWith(`:${peer}`)) {
-      log?.info?.(`octo: react DM target corrected ${currentChannelId} → user:${peer}`);
+      log?.info?.(`octo: react DM target corrected ${target} → user:${peer}`);
       target = `user:${peer}`;
     }
   }
+
+  // TEMP diagnostic — surface the REAL currentChannelId/peer so the DM
+  // correction can be tuned to the actual runtime shape.
+  console.log(
+    `[octo] react DM-check — currentChannelId=${JSON.stringify(currentChannelId)} ` +
+    `requesterSenderId=${JSON.stringify(requesterSenderId)} ` +
+    `bare=${JSON.stringify(currentChannelId ? stripAllChannelPrefixes(currentChannelId.trim()) : null)} ` +
+    `explicitTarget=${JSON.stringify(explicitTarget)} → target=${JSON.stringify(target)}`,
+  );
 
   let channelId: string;
   let channelType: ChannelType;
@@ -370,6 +392,7 @@ async function handleReact(params: {
   } catch (err) {
     return { ok: false, error: (err as Error).message };
   }
+  console.log(`[octo] react resolved → channelId=${channelId} channelType=${channelType} (1=DM,2=Group,5=Topic)`);
 
   try {
     if (remove) {
@@ -381,7 +404,7 @@ async function handleReact(params: {
     log?.info?.(`octo: added reaction ${emoji} to ${messageId}`);
     return { ok: true, data: { added: emoji, messageId } };
   } catch (err) {
-    log?.info?.(`octo: react failed — channelId=${channelId} channelType=${channelType} msg=${messageId}: ${(err as Error).message}`);
+    console.log(`[octo] react FAILED — channelId=${channelId} channelType=${channelType} msg=${messageId}: ${(err as Error).message}`);
     return { ok: false, error: (err as Error).message };
   }
 }

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -210,6 +210,26 @@ export function resolveOutboundOctoTarget(
 }
 
 /**
+ * Resolve a group target from args, falling back to currentChannelId.
+ * Returns the group ID and whether it's a DM target (for rejection).
+ *
+ * Accepts: args.groupId, args.target (with optional prefix), or bare currentChannelId.
+ * Uses parseConversationRef for kind-aware parsing: explicit `user:` targets
+ * are identified as DMs and return isDm=true so callers can reject them.
+ */
+function resolveGroupTarget(
+  args: Record<string, unknown>,
+  currentChannelId?: string,
+): { groupNo: string; isDm: boolean } | undefined {
+  const raw = (args.groupId ?? args.target ?? args.to) as string | undefined;
+  const source = raw?.trim() || currentChannelId?.trim();
+  if (!source) return undefined;
+  const ref = parseConversationRef(source);
+  if (ref.kind === "user") return { groupNo: "", isDm: true };
+  return { groupNo: ref.id, isDm: false };
+}
+
+/**
  * Resolve the group ID from args, falling back to currentChannelId.
  * Accepts: args.groupId, args.target (with group: prefix), or bare currentChannelId.
  */
@@ -1235,12 +1255,10 @@ async function handleMemberInfo(params: {
 }): Promise<MessageActionResult> {
   const { args, apiUrl, botToken, log } = params;
 
-  const target = args.target as string | undefined;
-  if (!target) {
-    return { ok: false, error: "Missing required parameter: target" };
-  }
-
-  const { channelId } = parseTarget(target);
+  const gt = resolveGroupTarget(args);
+  if (!gt) return { ok: false, error: "Missing required parameter: groupId (or target the current group chat)" };
+  if (gt.isDm) return { ok: false, error: "This action requires a group target, not a DM (user) target" };
+  const channelId = gt.groupNo;
 
   let members;
   try {
@@ -1299,12 +1317,10 @@ async function handleChannelInfo(params: {
 }): Promise<MessageActionResult> {
   const { args, apiUrl, botToken, log } = params;
 
-  const target = args.target as string | undefined;
-  if (!target) {
-    return { ok: false, error: "Missing required parameter: target" };
-  }
-
-  const { channelId } = parseTarget(target);
+  const gt = resolveGroupTarget(args);
+  if (!gt) return { ok: false, error: "Missing required parameter: groupId (or target the current group chat)" };
+  if (gt.isDm) return { ok: false, error: "This action requires a group target, not a DM (user) target" };
+  const channelId = gt.groupNo;
 
   const info = await getGroupInfo({
     apiUrl,
@@ -1335,10 +1351,10 @@ async function handleGroupMdRead(params: {
 }): Promise<MessageActionResult> {
   const { args, apiUrl, botToken, groupMdCache, currentChannelId, log } = params;
 
-  const channelId = resolveGroupId(args, currentChannelId);
-  if (!channelId) {
-    return { ok: false, error: "Missing required parameter: groupId (or target the current group chat)" };
-  }
+  const gt = resolveGroupTarget(args, currentChannelId);
+  if (!gt) return { ok: false, error: "Missing required parameter: groupId (or target the current group chat)" };
+  if (gt.isDm) return { ok: false, error: "This action requires a group target, not a DM (user) target" };
+  const channelId = gt.groupNo;
 
   // Try cache first
   const cached = groupMdCache?.get(channelId);
@@ -1383,10 +1399,10 @@ async function handleGroupMdUpdate(params: {
 }): Promise<MessageActionResult> {
   const { args, apiUrl, botToken, groupMdCache, currentChannelId, log } = params;
 
-  const channelId = resolveGroupId(args, currentChannelId);
-  if (!channelId) {
-    return { ok: false, error: "Missing required parameter: groupId (or target the current group chat)" };
-  }
+  const gt = resolveGroupTarget(args, currentChannelId);
+  if (!gt) return { ok: false, error: "Missing required parameter: groupId (or target the current group chat)" };
+  if (gt.isDm) return { ok: false, error: "This action requires a group target, not a DM (user) target" };
+  const channelId = gt.groupNo;
 
   const content = (args.content ?? args.message ?? args.topic ?? args.desc) as string | undefined;
   if (content == null) {

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -7,7 +7,7 @@
 
 import { ChannelType, MessageType, RICH_TEXT_BLOCK_IMAGE, RICH_TEXT_BLOCK_TEXT, RICH_TEXT_IMAGE_PLACEHOLDER } from "./types.js";
 import type { MentionEntity, LogSink, RichTextBlock } from "./types.js";
-import { stripAllChannelPrefixes } from "./constants.js";
+import { stripAllChannelPrefixes, parseConversationRef, dmPeerUid } from "./constants.js";
 import {
   sendMessage,
   sendMediaMessage,
@@ -46,42 +46,25 @@ export function parseTarget(
   knownGroupIds?: Set<string>,
 ): { channelId: string; channelType: ChannelType } {
   const THREAD_SEP = "____";
+  const ref = parseConversationRef(target);
 
-  // Explicit prefixes always win
-  if (target.startsWith("group:")) {
-    const channelId = target.slice(6);
-    // groupNo____shortId → CommunityTopic
-    if (channelId.includes(THREAD_SEP)) {
-      return { channelId, channelType: ChannelType.CommunityTopic };
+  if (ref.kind === "user") {
+    // DM: delivery channelId is the bare peer uid (space-scoped id is the
+    // session identity, not the wire channel_id the server wants).
+    return { channelId: dmPeerUid(ref.id), channelType: ChannelType.DM };
+  }
+  if (ref.kind === "group") {
+    if (ref.id.includes(THREAD_SEP)) {
+      return { channelId: ref.id, channelType: ChannelType.CommunityTopic };
     }
-    return { channelId, channelType: ChannelType.Group };
+    return { channelId: ref.id, channelType: ChannelType.Group };
   }
-  // OpenClaw's delivery pipeline can emit `channel:<id>` as a parallel alias
-  // for group channels (#232 review: "channel: 支持下沉到 parseTarget"). Handle
-  // it here so every caller — outbound adapter, message tool, etc — sees
-  // consistent routing without having to normalise upstream first.
-  if (target.startsWith("channel:")) {
-    const channelId = target.slice(8);
-    if (channelId.includes(THREAD_SEP)) {
-      return { channelId, channelType: ChannelType.CommunityTopic };
-    }
-    return { channelId, channelType: ChannelType.Group };
+  // kind undefined → bare id. Thread id wins; else knownGroupIds decides.
+  if (ref.id.includes(THREAD_SEP)) {
+    return { channelId: ref.id, channelType: ChannelType.CommunityTopic };
   }
-  if (target.startsWith("user:"))
-    return { channelId: target.slice(5), channelType: ChannelType.DM };
-
-  // Strip octo: channel-namespace prefix if present
-  let bareId = target;
-  if (bareId.startsWith("octo:")) bareId = bareId.slice(5);
-
-  // Thread channel ID (groupNo____shortId)
-  if (bareId.includes(THREAD_SEP)) {
-    return { channelId: bareId, channelType: ChannelType.CommunityTopic };
-  }
-
-  // Bare ID: check knownGroupIds, also check parent group for thread context
-  const isGroup = knownGroupIds?.has(bareId) ?? false;
-  return { channelId: bareId, channelType: isGroup ? ChannelType.Group : ChannelType.DM };
+  const isGroup = knownGroupIds?.has(ref.id) ?? false;
+  return { channelId: ref.id, channelType: isGroup ? ChannelType.Group : ChannelType.DM };
 }
 
 /** Strip common prefixes to get the raw group_no */

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -1003,18 +1003,32 @@ async function handleRead(params: {
   const { channelId, channelType } = parseTarget(target, currentChannelId, getKnownGroupIds());
 
   // ====== Permission check ======
-  // Strip channel-namespace prefix from currentChannelId for comparison.
-  // Uses the shared helper so all three runtime prefixes (octo:/channel:/group:)
-  // are handled — see src/constants.ts. Pre-fix this only stripped "octo:",
-  // so prefixed forms (channel:grp1____x, group:grp1____x) mis-compared
-  // against the prefix-stripped parsed channelId and treated legitimate
-  // same-channel reads as cross-channel queries. Fix tracked in #102.
-  const bareCurrentChannelId = currentChannelId ? stripAllChannelPrefixes(currentChannelId) : currentChannelId;
-  // Infer the current channel type
+  // Compare the target channel against the current session's channel using
+  // kind-aware parsing. parseConversationRef extracts {kind, id} from the
+  // runtime's canonical form (e.g. "octo:user:<space>:<uid>" for DMs). The bare
+  // comparison uses dmPeerUid for DM targets to match the delivery channelId, and
+  // ref.id directly for group/thread targets. currentChannelType honours the
+  // explicit kind first (user→DM, group→Group/Topic), falling back to shape-based
+  // inference only when kind is absent — this prevents a known-group uid collision
+  // from misclassifying a DM as a Group.
+  const currentRef = currentChannelId ? parseConversationRef(currentChannelId) : undefined;
+  // Bare id for comparison: DM uses dmPeerUid (extracts peer uid from space-scoped id),
+  // group/thread uses ref.id directly.
+  const bareCurrentChannelId = currentRef
+    ? (currentRef.kind === "user" ? dmPeerUid(currentRef.id) : currentRef.id)
+    : undefined;
+
+  // Infer current channel type: honour explicit kind first, then fall back to
+  // shape-based detection for legacy/bare forms.
   const knownGroups = getKnownGroupIds();
-  const currentChannelType = bareCurrentChannelId?.includes("____")
-    ? ChannelType.CommunityTopic
-    : knownGroups.has(bareCurrentChannelId ?? "") ? ChannelType.Group : ChannelType.DM;
+  const currentChannelType = currentRef?.kind === "user"
+    ? ChannelType.DM
+    : currentRef?.kind === "group"
+      ? (currentRef.id.includes("____") ? ChannelType.CommunityTopic : ChannelType.Group)
+      : bareCurrentChannelId?.includes("____")
+        ? ChannelType.CommunityTopic
+        : knownGroups.has(bareCurrentChannelId ?? "") ? ChannelType.Group : ChannelType.DM;
+
   // Must match both channelId AND channelType to be considered the same channel
   const isSameChannel = !!(bareCurrentChannelId && channelId === bareCurrentChannelId && channelType === currentChannelType);
 

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -359,10 +359,13 @@ async function handleReact(params: {
     log?.info?.(`octo: added reaction ${emoji} to ${messageId}`);
     return { ok: true, data: { added: emoji, messageId } };
   } catch (err) {
+    // Debug diagnostic: reaction failures are most often routing-misjudgment
+    // (wrong channelId/channelType resolved for the target), which is hard to
+    // triage from the bare error alone. Keep the resolved route context.
+    log?.debug?.(`octo: react failed emoji=${emoji} messageId=${messageId} channelId=${channelId} channelType=${channelType}: ${(err as Error).message}`);
     return { ok: false, error: (err as Error).message };
   }
 }
-
 // ---------------------------------------------------------------------------
 // send
 // ---------------------------------------------------------------------------

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -292,7 +292,7 @@ export async function handleOctoMessageAction(params: {
     case "group-md-update":
       return handleGroupMdUpdate({ args, apiUrl, botToken, groupMdCache, currentChannelId, log });
     case "react":
-      return handleReact({ args, apiUrl, botToken, currentChannelId, threadId, currentMessageId, requesterSenderId, log });
+      return handleReact({ args, apiUrl, botToken, currentChannelId, threadId, currentMessageId, log });
     // 群管理操作（create-group/update-group/add-members/remove-members）
     // 统一通过 octo_management tool 入口，不走 message action
     default:
@@ -311,10 +311,9 @@ async function handleReact(params: {
   currentChannelId?: string;
   threadId?: string | number | null;
   currentMessageId?: string;
-  requesterSenderId?: string;
   log?: LogSink;
 }): Promise<MessageActionResult> {
-  const { args, apiUrl, botToken, currentChannelId, threadId, currentMessageId, requesterSenderId, log } = params;
+  const { args, apiUrl, botToken, currentChannelId, threadId, currentMessageId, log } = params;
 
   // messageId: explicit arg wins; otherwise fall back to the current inbound
   // turn's message id (forwarded from toolContext.currentMessageId). The id is
@@ -342,52 +341,6 @@ async function handleReact(params: {
     return { ok: false, error: "Missing or empty required parameter: target (and no current channel context)" };
   }
 
-  // DM peer correction — MUST run BEFORE resolveOutboundOctoTarget.
-  //
-  // In a DM the runtime hands us currentChannelId as `octo:<peerUid>` (or
-  // `octo:<spaceId>:<peerUid>`) — it's the conversation's `To`, derived from
-  // the inbound from_uid. resolveOutboundOctoTarget → normalizeOutboundChannelPrefix
-  // turns ANY `octo:`/`channel:`-prefixed bare id that isn't `user:`-prefixed
-  // into `group:<bare>`, so `octo:<peer>` becomes `group:<peer>` and parseTarget
-  // returns channelType=Group → the server runs a group-membership check and
-  // rejects with not_group_member. (A post-resolve DM check can't help: the
-  // mis-classification already happened at the prefix step.)
-  //
-  // Fix: when the agent didn't pin an explicit target and the bare
-  // currentChannelId resolves to the trusted requesterSenderId (the DM peer for
-  // this turn — bare == peer, or `<space>:<peer>`), force the canonical DM form
-  // `user:<peer>` so the resolver routes it as a DM (channel_type=1) to the peer.
-  // DM peer correction — MUST run BEFORE resolveOutboundOctoTarget, and must
-  // NOT be gated on "no explicit target". The runtime fills args.target with the
-  // current conversation id, which in a DM is `octo:<peer>` (or
-  // `octo:<space>:<peer>`) — so explicitTarget is set, but it's just the ambient
-  // DM, not a deliberate cross-channel target. resolveOutboundOctoTarget →
-  // normalizeOutboundChannelPrefix would rewrite that `octo:<peer>` into
-  // `group:<peer>` → channelType=Group → server not_group_member.
-  //
-  // Rule: whatever the resolved target is (explicit arg OR currentChannelId),
-  // if its bare form is the DM peer (requesterSenderId — bare==peer, or
-  // `<space>:<peer>`), force `user:<peer>` so it routes as a DM (channel_type=1)
-  // to the peer. A deliberate cross-target (`group:<gid>`, `user:<other>`) has a
-  // bare that != peer, so it's left untouched.
-  const peer = requesterSenderId?.trim();
-  if (peer && target) {
-    const bare = stripAllChannelPrefixes(target.trim());
-    if (bare === peer || bare.endsWith(`:${peer}`)) {
-      log?.info?.(`octo: react DM target corrected ${target} → user:${peer}`);
-      target = `user:${peer}`;
-    }
-  }
-
-  // TEMP diagnostic — surface the REAL currentChannelId/peer so the DM
-  // correction can be tuned to the actual runtime shape.
-  console.log(
-    `[octo] react DM-check — currentChannelId=${JSON.stringify(currentChannelId)} ` +
-    `requesterSenderId=${JSON.stringify(requesterSenderId)} ` +
-    `bare=${JSON.stringify(currentChannelId ? stripAllChannelPrefixes(currentChannelId.trim()) : null)} ` +
-    `explicitTarget=${JSON.stringify(explicitTarget)} → target=${JSON.stringify(target)}`,
-  );
-
   let channelId: string;
   let channelType: ChannelType;
   try {
@@ -395,7 +348,6 @@ async function handleReact(params: {
   } catch (err) {
     return { ok: false, error: (err as Error).message };
   }
-  console.log(`[octo] react resolved → channelId=${channelId} channelType=${channelType} (1=DM,2=Group,5=Topic)`);
 
   try {
     if (remove) {
@@ -407,7 +359,6 @@ async function handleReact(params: {
     log?.info?.(`octo: added reaction ${emoji} to ${messageId}`);
     return { ok: true, data: { added: emoji, messageId } };
   } catch (err) {
-    console.log(`[octo] react FAILED — channelId=${channelId} channelType=${channelType} msg=${messageId}: ${(err as Error).message}`);
     return { ok: false, error: (err as Error).message };
   }
 }

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -1083,6 +1083,11 @@ async function handleRead(params: {
       from_uid: m.from_uid,
       content,
       timestamp: m.timestamp,
+      // Expose the message id so the agent can target an earlier message with
+      // the `react` action (handleReact resolves args.messageId). Without this
+      // only the current inbound message was reachable, so "react to an earlier
+      // message" — which the read/react prompts advertise — was not possible.
+      ...(m.message_id ? { messageId: m.message_id } : {}),
     };
   });
 

--- a/src/api-fetch.test.ts
+++ b/src/api-fetch.test.ts
@@ -2217,3 +2217,122 @@ describe("#138 — send functions reject empty channelId", () => {
     expect(fetchSpy).toHaveBeenCalledTimes(1);
   });
 });
+
+// #111 Sprint B — reaction helpers
+describe("addReaction / removeReaction", () => {
+  const originalFetch = global.fetch;
+  let fetchSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: vi.fn().mockResolvedValue(""),
+      json: vi.fn().mockResolvedValue({}),
+    });
+    global.fetch = fetchSpy as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it("addReaction POSTs to the reactions endpoint with emoji in the body", async () => {
+    const { addReaction } = await import("./api-fetch.js");
+    await addReaction({
+      apiUrl: "http://localhost:8090",
+      botToken: "bf_t",
+      channelId: "chan1",
+      channelType: ChannelType.Group,
+      messageId: "m123",
+      emoji: "👍",
+    });
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, opts] = fetchSpy.mock.calls[0];
+    expect(url).toContain("/v1/bot/messages/m123/reactions");
+    expect(opts.method).toBe("POST");
+    const body = JSON.parse(opts.body);
+    expect(body.emoji).toBe("👍");
+    expect(body.channel_id).toBe("chan1");
+    expect(body.channel_type).toBe(ChannelType.Group);
+  });
+
+  it("removeReaction DELETEs with the emoji URL-encoded in the path", async () => {
+    const { removeReaction } = await import("./api-fetch.js");
+    await removeReaction({
+      apiUrl: "http://localhost:8090",
+      botToken: "bf_t",
+      channelId: "chan1",
+      channelType: ChannelType.Group,
+      messageId: "m123",
+      emoji: "👍",
+    });
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, opts] = fetchSpy.mock.calls[0];
+    expect(opts.method).toBe("DELETE");
+    expect(url).toContain("/v1/bot/messages/m123/reactions/");
+    // emoji must be percent-encoded, never raw, in the path
+    expect(url).toContain(encodeURIComponent("👍"));
+    expect(url).not.toContain("👍");
+  });
+
+  it("addReaction rejects an empty channelId (fail-fast, #138 style)", async () => {
+    const { addReaction } = await import("./api-fetch.js");
+    await expect(
+      addReaction({
+        apiUrl: "http://localhost:8090",
+        botToken: "bf_t",
+        channelId: "  ",
+        channelType: ChannelType.Group,
+        messageId: "m123",
+        emoji: "👍",
+      }),
+    ).rejects.toThrow();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("addReaction rejects an empty messageId / emoji", async () => {
+    const { addReaction } = await import("./api-fetch.js");
+    await expect(
+      addReaction({
+        apiUrl: "http://localhost:8090",
+        botToken: "bf_t",
+        channelId: "chan1",
+        channelType: ChannelType.Group,
+        messageId: "",
+        emoji: "👍",
+      }),
+    ).rejects.toThrow();
+    await expect(
+      addReaction({
+        apiUrl: "http://localhost:8090",
+        botToken: "bf_t",
+        channelId: "chan1",
+        channelType: ChannelType.Group,
+        messageId: "m1",
+        emoji: "  ",
+      }),
+    ).rejects.toThrow();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("propagates a non-2xx error", async () => {
+    fetchSpy.mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      text: vi.fn().mockResolvedValue("forbidden"),
+      statusText: "Forbidden",
+    });
+    const { addReaction } = await import("./api-fetch.js");
+    await expect(
+      addReaction({
+        apiUrl: "http://localhost:8090",
+        botToken: "bf_t",
+        channelId: "chan1",
+        channelType: ChannelType.Group,
+        messageId: "m123",
+        emoji: "👍",
+      }),
+    ).rejects.toThrow(/403/);
+  });
+});

--- a/src/api-fetch.ts
+++ b/src/api-fetch.ts
@@ -417,6 +417,85 @@ export async function sendHeartbeat(params: {
   await postJson(params.apiUrl, params.botToken, "/v1/bot/heartbeat", {}, params.signal);
 }
 
+// ---- Reactions (#111 Sprint B) ----
+
+/**
+ * Add (or change) the bot's reaction on a message.
+ * POST /v1/bot/messages/{messageId}/reactions  body {channel_id, channel_type, emoji}
+ *
+ * The server treats the bot as a single-reaction actor per message: posting a
+ * different emoji replaces the bot's previous one (see server reaction_store
+ * state machine). channelId / messageId / emoji are validated client-side
+ * (fail-fast, #138 style) so an unroutable request never leaves the process.
+ */
+export async function addReaction(params: {
+  apiUrl: string;
+  botToken: string;
+  channelId: string;
+  channelType: ChannelType;
+  messageId: string;
+  emoji: string;
+  signal?: AbortSignal;
+}): Promise<void> {
+  if (!params.channelId || !params.channelId.trim()) {
+    throw new Error("octo: channelId is required to add a reaction");
+  }
+  if (!params.messageId || !params.messageId.trim()) {
+    throw new Error("octo: messageId is required to add a reaction");
+  }
+  if (!params.emoji || !params.emoji.trim()) {
+    throw new Error("octo: emoji is required to add a reaction");
+  }
+  await postJson(
+    params.apiUrl,
+    params.botToken,
+    `/v1/bot/messages/${encodeURIComponent(params.messageId)}/reactions`,
+    {
+      channel_id: params.channelId,
+      channel_type: params.channelType,
+      emoji: params.emoji,
+    },
+    // Symmetric with removeReaction (botFetchJson): bound the request so a
+    // stalled server can't hang an add indefinitely. A caller-supplied signal
+    // takes precedence.
+    params.signal ?? AbortSignal.timeout(DEFAULT_TIMEOUT_MS),
+  );
+}
+
+/**
+ * Remove the bot's reaction (matching `emoji`) from a message.
+ * DELETE /v1/bot/messages/{messageId}/reactions/{emoji}?channel_id&channel_type
+ *
+ * The emoji is percent-encoded into the path (multi-byte unicode). Removing an
+ * emoji the bot didn't set is a server-side no-op success.
+ */
+export async function removeReaction(params: {
+  apiUrl: string;
+  botToken: string;
+  channelId: string;
+  channelType: ChannelType;
+  messageId: string;
+  emoji: string;
+  signal?: AbortSignal;
+}): Promise<void> {
+  if (!params.channelId || !params.channelId.trim()) {
+    throw new Error("octo: channelId is required to remove a reaction");
+  }
+  if (!params.messageId || !params.messageId.trim()) {
+    throw new Error("octo: messageId is required to remove a reaction");
+  }
+  if (!params.emoji || !params.emoji.trim()) {
+    throw new Error("octo: emoji is required to remove a reaction");
+  }
+  const qs = `channel_id=${encodeURIComponent(params.channelId)}&channel_type=${params.channelType}`;
+  await botFetchJson({
+    apiUrl: params.apiUrl,
+    botToken: params.botToken,
+    path: `/v1/bot/messages/${encodeURIComponent(params.messageId)}/reactions/${encodeURIComponent(params.emoji)}?${qs}`,
+    method: "DELETE",
+  });
+}
+
 
 
 export async function registerBot(params: {

--- a/src/channel-message-adapter.test.ts
+++ b/src/channel-message-adapter.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock api-fetch so the send paths don't hit the network. Mirrors the
+// mocking style used by channel.test.ts.
+vi.mock("./api-fetch.js", async () => {
+  const actual = await vi.importActual<any>("./api-fetch.js");
+  return {
+    ...actual,
+    sendMessage: vi.fn().mockResolvedValue({
+      message_id: "msg-text-1",
+      client_msg_no: "cli-1",
+      message_seq: 1,
+    }),
+    sendMediaMessage: vi.fn().mockResolvedValue({
+      message_id: "msg-media-1",
+      client_msg_no: "cli-2",
+      message_seq: 2,
+    }),
+    getUploadPresign: vi.fn().mockResolvedValue({
+      uploadUrl: "https://upload.example/put",
+      downloadUrl: "https://cdn.example/file.png",
+      contentType: "image/png",
+      contentDisposition: "inline",
+    }),
+    uploadFileToPresignedUrl: vi.fn().mockResolvedValue({ url: "https://cdn.example/file.png" }),
+    registerBot: vi.fn(),
+    sendHeartbeat: vi.fn(),
+    fetchBotGroups: vi.fn().mockResolvedValue([]),
+    getGroupMd: vi.fn(),
+  };
+});
+
+import { octoPlugin } from "./channel.js";
+import { CHANNEL_ID } from "./constants.js";
+
+/**
+ * Sprint A (#111): migrate octo from the legacy `outbound` slot to the new
+ * `message` (ChannelMessageAdapterShape) slot via
+ * createChannelMessageAdapterFromOutbound, keeping `outbound` as the
+ * presentation-layer fallback (chunker/sanitize/pin are read from `outbound`
+ * by the runtime; send.* prefers `message`). See
+ * node_modules/openclaw/dist/deliver-*.js createPluginHandler.
+ */
+
+const baseCfg = {
+  channels: {
+    octo: {
+      accounts: {
+        default: { botToken: "bf_test", apiUrl: "https://octo.example" },
+      },
+    },
+  },
+};
+
+describe("#111 Sprint A — message adapter slot", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("declares a message slot with send.text and send.media", () => {
+    expect(octoPlugin.message).toBeDefined();
+    expect(typeof octoPlugin.message?.send?.text).toBe("function");
+    expect(typeof octoPlugin.message?.send?.media).toBe("function");
+  });
+
+  it("declares durableFinal capabilities for text and media", () => {
+    expect(octoPlugin.message?.durableFinal?.capabilities?.text).toBe(true);
+    expect(octoPlugin.message?.durableFinal?.capabilities?.media).toBe(true);
+  });
+
+  it("keeps the legacy outbound slot for presentation-layer fallback", () => {
+    // Runtime still reads chunker/sanitizeText/pin from outbound even when
+    // message.send.* is present; removing outbound would drop those hooks.
+    expect(octoPlugin.outbound).toBeDefined();
+    expect(typeof octoPlugin.outbound?.sendText).toBe("function");
+    expect(typeof octoPlugin.outbound?.sendMedia).toBe("function");
+  });
+
+  it("message.send.text returns a MessageReceipt carrying the real message_id", async () => {
+    const result = await octoPlugin.message!.send!.text!({
+      cfg: baseCfg as any,
+      to: "user:u123",
+      text: "hello",
+      accountId: "default",
+    } as any);
+    // ChannelMessageSendResult = { receipt: MessageReceipt; messageId? }
+    expect(result.receipt).toBeDefined();
+    expect(result.receipt.primaryPlatformMessageId ?? result.receipt.platformMessageIds[0]).toBe(
+      "msg-text-1",
+    );
+  });
+
+  it("message.send.text on empty text yields no platform message id (noop)", async () => {
+    const result = await octoPlugin.message!.send!.text!({
+      cfg: baseCfg as any,
+      to: "user:u123",
+      text: "",
+      accountId: "default",
+    } as any);
+    const id = result.receipt?.primaryPlatformMessageId ?? result.receipt?.platformMessageIds?.[0] ?? "";
+    expect(id).toBe("");
+  });
+
+  it("outbound and message share the same send behavior (parity)", async () => {
+    const viaOutbound = await octoPlugin.outbound!.sendText!({
+      cfg: baseCfg as any,
+      to: "user:u123",
+      text: "hello",
+      accountId: "default",
+    } as any);
+    expect(viaOutbound.channel).toBe(CHANNEL_ID);
+    expect(viaOutbound.messageId).toBe("msg-text-1");
+  });
+});

--- a/src/channel.test.ts
+++ b/src/channel.test.ts
@@ -1192,3 +1192,116 @@ describe("resolveSessionConversation", () => {
     expect(rsc("grp1____")).toBeNull();  // missing shortId
   });
 });
+
+// ─── resolveOutboundSessionRoute — outbound/inbound session isomorphism ──────
+//
+// The whole point of this hook is that an outbound send computes the SAME
+// session key the inbound router would compute for that conversation, so a
+// proactive reply lands in the existing thread rather than spawning a fresh
+// session. The contract: outbound `baseSessionKey` === inbound route sessionKey
+// for the same peer. Both sides go through the SAME `buildAgentSessionKey`
+// (inbound's resolveAgentRoute calls it; our hook does via
+// buildChannelOutboundSessionRoute), so isomorphism ⟺ identical `peer`.
+//
+// `testCfg` uses dmScope "per-channel-peer" so DM peer IDs are actually encoded
+// into the session key — otherwise the default "main" scope collapses every DM
+// to `agent:<id>:main` and the bare-uid recover path can't be exercised.
+describe("resolveOutboundSessionRoute", () => {
+  // Inbound oracle: the real SDK key builder. Inbound peer.id == octo sessionId
+  // (DM: <space>:<uid> or bare <uid>; group/topic: channel_id incl grp1____abc).
+  const realResolveAgentRoute = (p: {
+    cfg: any; channel: string; accountId: string;
+    peer: { kind: "direct" | "group" | "channel"; id: string };
+  }) => {
+    const { buildAgentSessionKey } = require("openclaw/plugin-sdk/core");
+    return {
+      sessionKey: buildAgentSessionKey({
+        agentId: "a1",
+        channel: p.channel,
+        accountId: p.accountId,
+        peer: p.peer,
+        dmScope: p.cfg.session?.dmScope,
+        identityLinks: p.cfg.session?.identityLinks,
+      }),
+    };
+  };
+
+  const testCfg: any = { session: { dmScope: "per-channel-peer" } };
+
+  // Generate a real DM currentSessionKey for a (uid, space) pair through the
+  // SAME cfg + key builder the runtime uses — never hand-built, so the recover
+  // test can't be more optimistic than production. space "" → bare-uid DM.
+  const someDmSessionKeyForUid = (uid: string, space: string) => {
+    const id = space ? `${space}:${uid}` : uid;
+    return realResolveAgentRoute({
+      cfg: testCfg, channel: "octo", accountId: "acc",
+      peer: { kind: "direct", id },
+    }).sessionKey;
+  };
+
+  let ros: (target: string, extra?: Record<string, unknown>) => Promise<any>;
+  beforeEach(async () => {
+    vi.resetModules();
+    const { octoPlugin } = await import("./channel.js");
+    ros = (target: string, extra: Record<string, unknown> = {}) =>
+      octoPlugin.messaging!.resolveOutboundSessionRoute!({
+        cfg: testCfg, agentId: "a1", accountId: "acc", channel: "octo", target, ...extra,
+      } as any);
+  });
+
+  it("DM: to=bare uid, peer.id=space-scoped, chatType=direct", async () => {
+    const r = await ros("octo:user:42:uid");
+    expect(r!.to).toBe("uid");          // delivery target = bare uid
+    expect(r!.peer.id).toBe("42:uid");  // session identity = space-scoped
+    expect(r!.chatType).toBe("direct");
+  });
+
+  it("group / topic → group chatType", async () => {
+    expect((await ros("octo:group:grp1"))!.chatType).toBe("group");
+    expect((await ros("octo:group:grp1____abc"))!.chatType).toBe("group");
+  });
+
+  it("topic: BOTH encoded id and separate threadId give peer.id=grp1____abc + route.threadId=abc", async () => {
+    const a = await ros("octo:group:grp1____abc");        // thread encoded in target
+    const b = await ros("octo:group:grp1", { threadId: "abc" }); // parent + separate threadId
+    expect(a!.peer.id).toBe("grp1____abc");
+    expect(b!.peer.id).toBe("grp1____abc");
+    expect(a!.threadId).toBe("abc");
+    expect(b!.threadId).toBe("abc");
+    expect(a!.baseSessionKey).toBe(b!.baseSessionKey); // same session
+  });
+
+  it("isomorphic with inbound resolveAgentRoute (real SDK, no mock)", async () => {
+    const cases: Array<{ sessionId: string; isGroup: boolean; target: string; extra?: any }> = [
+      { sessionId: "uid",         isGroup: false, target: "octo:user:uid",
+        extra: { currentSessionKey: someDmSessionKeyForUid("uid", "") } }, // single-space bare uid
+      { sessionId: "42:uid",      isGroup: false, target: "octo:user:42:uid" },
+      { sessionId: "grp1",        isGroup: true,  target: "octo:group:grp1" },
+      { sessionId: "grp1____abc", isGroup: true,  target: "octo:group:grp1____abc" },
+      { sessionId: "grp1____abc", isGroup: true,  target: "octo:group:grp1", extra: { threadId: "abc" } },
+    ];
+    for (const c of cases) {
+      const inboundKey = realResolveAgentRoute({
+        cfg: testCfg, channel: "octo", accountId: "acc",
+        peer: { kind: c.isGroup ? "group" : "direct", id: c.sessionId },
+      }).sessionKey;
+      const out = await ros(c.target, c.extra ?? {});
+      expect(out, `case ${c.target}`).not.toBeNull();
+      expect(out!.baseSessionKey, `case ${c.target}`).toBe(inboundKey);
+    }
+  });
+
+  it("DM returns null when bare-uid target cannot recover space from currentSessionKey", async () => {
+    // bare user:other, no currentSessionKey → cannot determine space-scoped id → null
+    expect(await ros("user:other")).toBeNull();
+    // currentSessionKey belongs to a different peer (uid, space 42); dmPeerUid
+    // of the recovered identity != "other" → still null (never write a wrong session)
+    expect(await ros("user:other", { currentSessionKey: someDmSessionKeyForUid("uid", "42") })).toBeNull();
+  });
+
+  it("DM recovers space from currentSessionKey when bare-uid target IS the current peer", async () => {
+    const r = await ros("user:uid", { currentSessionKey: someDmSessionKeyForUid("uid", "42") });
+    expect(r!.peer.id).toBe("42:uid");
+    expect(r!.to).toBe("uid");
+  });
+});

--- a/src/channel.test.ts
+++ b/src/channel.test.ts
@@ -1204,8 +1204,9 @@ describe("resolveSessionConversation", () => {
 // buildChannelOutboundSessionRoute), so isomorphism ⟺ identical `peer`.
 //
 // `testCfg` uses dmScope "per-channel-peer" so DM peer IDs are actually encoded
-// into the session key — otherwise the default "main" scope collapses every DM
-// to `agent:<id>:main` and the bare-uid recover path can't be exercised.
+// into the session key, exercising the bare-uid recover path. A second
+// main-scope cfg (the default) is also tested below, where the peer is dropped
+// from the key and the bare-uid DM stays isomorphic with `agent:<id>:main`.
 describe("resolveOutboundSessionRoute", () => {
   // Inbound oracle: the real SDK key builder. Inbound peer.id == octo sessionId
   // (DM: <space>:<uid> or bare <uid>; group/topic: channel_id incl grp1____abc).
@@ -1227,6 +1228,7 @@ describe("resolveOutboundSessionRoute", () => {
   };
 
   const testCfg: any = { session: { dmScope: "per-channel-peer" } };
+  const mainScopeCfg: any = { session: { dmScope: "main" } };
 
   // Generate a real DM currentSessionKey for a (uid, space) pair through the
   // SAME cfg + key builder the runtime uses — never hand-built, so the recover
@@ -1237,6 +1239,16 @@ describe("resolveOutboundSessionRoute", () => {
       cfg: testCfg, channel: "octo", accountId: "acc",
       peer: { kind: "direct", id },
     }).sessionKey;
+  };
+
+  // Invoke the hook with an explicit cfg (so the main-scope cases below don't
+  // have to mutate the per-channel-peer default).
+  const rosWith = async (cfg: any, target: string, extra: Record<string, unknown> = {}) => {
+    vi.resetModules();
+    const { octoPlugin } = await import("./channel.js");
+    return octoPlugin.messaging!.resolveOutboundSessionRoute!({
+      cfg, agentId: "a1", accountId: "acc", channel: "octo", target, ...extra,
+    } as any);
   };
 
   let ros: (target: string, extra?: Record<string, unknown>) => Promise<any>;
@@ -1276,6 +1288,9 @@ describe("resolveOutboundSessionRoute", () => {
       { sessionId: "uid",         isGroup: false, target: "octo:user:uid",
         extra: { currentSessionKey: someDmSessionKeyForUid("uid", "") } }, // single-space bare uid
       { sessionId: "42:uid",      isGroup: false, target: "octo:user:42:uid" },
+      // mixed-case space-scoped DM. Inbound lowercases the peerId in the key;
+      // outbound must yield the SAME key (BotFather mixed-case bot ids, issue #33).
+      { sessionId: "42:UidUpper", isGroup: false, target: "octo:user:42:UidUpper" },
       { sessionId: "grp1",        isGroup: true,  target: "octo:group:grp1" },
       { sessionId: "grp1____abc", isGroup: true,  target: "octo:group:grp1____abc" },
       { sessionId: "grp1____abc", isGroup: true,  target: "octo:group:grp1", extra: { threadId: "abc" } },
@@ -1291,12 +1306,42 @@ describe("resolveOutboundSessionRoute", () => {
     }
   });
 
-  it("DM returns null when bare-uid target cannot recover space from currentSessionKey", async () => {
-    // bare user:other, no currentSessionKey → cannot determine space-scoped id → null
-    expect(await ros("user:other")).toBeNull();
-    // currentSessionKey belongs to a different peer (uid, space 42); dmPeerUid
-    // of the recovered identity != "other" → still null (never write a wrong session)
-    expect(await ros("user:other", { currentSessionKey: someDmSessionKeyForUid("uid", "42") })).toBeNull();
+  // The default dmScope is "main", not "per-channel-peer". Under main the DM peer
+  // is dropped from the key, so a bare-uid DM outbound (no recoverable space)
+  // still produces `agent:<id>:main` and is isomorphic with inbound. This pins
+  // the contract that the DM branch NEVER returns null: it falls back to the bare
+  // uid, which under main scope is fully isomorphic.
+  it("main-scope DM: bare-uid built with bare uid, isomorphic with agent:<id>:main", async () => {
+    const inboundKey = realResolveAgentRoute({
+      cfg: mainScopeCfg, channel: "octo", accountId: "acc",
+      peer: { kind: "direct", id: "other" },
+    }).sessionKey;
+    expect(inboundKey).toBe("agent:a1:main");
+    // No currentSessionKey at all — recover yields nothing, falls back to bare uid.
+    const out = await rosWith(mainScopeCfg, "user:other");
+    expect(out).not.toBeNull();
+    expect(out!.peer.id).toBe("other");          // built with the bare uid
+    expect(out!.to).toBe("other");
+    expect(out!.baseSessionKey).toBe(inboundKey); // still lands the same session
+  });
+
+  // Even when the bare-uid target can't recover a space (different-peer
+  // currentSessionKey, or none), the DM hook returns a route built with the bare
+  // uid — it does NOT return null. Returning null would make the SDK skip the
+  // mirror entirely (no fallback resolver), dropping a session main-scope would
+  // otherwise land correctly.
+  it("DM bare-uid that can't recover space falls back to bare uid (never null)", async () => {
+    // No currentSessionKey.
+    const r1 = await ros("user:other");
+    expect(r1).not.toBeNull();
+    expect(r1!.peer.id).toBe("other");
+    expect(r1!.to).toBe("other");
+    // currentSessionKey belongs to a different peer (uid, space 42); dmPeerUid of
+    // the recovered identity != "other" → still fall back to the bare uid.
+    const r2 = await ros("user:other", { currentSessionKey: someDmSessionKeyForUid("uid", "42") });
+    expect(r2).not.toBeNull();
+    expect(r2!.peer.id).toBe("other");
+    expect(r2!.to).toBe("other");
   });
 
   it("DM recovers space from currentSessionKey when bare-uid target IS the current peer", async () => {

--- a/src/channel.test.ts
+++ b/src/channel.test.ts
@@ -1161,3 +1161,29 @@ describe("messaging.normalizeTarget canonical output", () => {
     expect(p.channelId).toBe("uid");
   });
 });
+
+// ─── resolveSessionConversation — thread id parsing ──────────────────────
+
+describe("resolveSessionConversation", () => {
+  let rsc: (rawId: string) => ReturnType<NonNullable<NonNullable<typeof octoPlugin.messaging>["resolveSessionConversation"]>> | null;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    const { octoPlugin } = await import("./channel.js");
+    rsc = (rawId: string) => octoPlugin.messaging!.resolveSessionConversation!({ kind: "group", rawId });
+  });
+
+  it("parses thread id into parent + short", () => {
+    expect(rsc("grp1____abc")).toEqual({
+      id: "grp1",
+      threadId: "abc",
+      baseConversationId: "grp1",
+      parentConversationCandidates: ["grp1"],
+    });
+  });
+
+  it("returns null for non-thread / empty", () => {
+    expect(rsc("grp1")).toBeNull();
+    expect(rsc("")).toBeNull();
+  });
+});

--- a/src/channel.test.ts
+++ b/src/channel.test.ts
@@ -1186,4 +1186,9 @@ describe("resolveSessionConversation", () => {
     expect(rsc("grp1")).toBeNull();
     expect(rsc("")).toBeNull();
   });
+
+  it("returns null for malformed thread-id with missing parts", () => {
+    expect(rsc("____abc")).toBeNull();   // missing groupNo
+    expect(rsc("grp1____")).toBeNull();  // missing shortId
+  });
 });

--- a/src/channel.test.ts
+++ b/src/channel.test.ts
@@ -1116,3 +1116,48 @@ describe("octoSetupAdapter.validateInput token prefix", () => {
     expect(validate({ baseUrl: "https://im.example.com/api" })).toBeUndefined();
   });
 });
+
+describe("messaging.normalizeTarget canonical output", () => {
+  let nt: (s: string) => string;
+  beforeEach(async () => {
+    const { octoPlugin } = await import("./channel.js");
+    nt = (s: string) => octoPlugin.messaging!.normalizeTarget!(s);
+  });
+
+  it("canonicalises kind-tagged targets, strips octo namespace, channel→group", () => {
+    expect(nt("octo:user:42:uid")).toBe("user:42:uid");
+    expect(nt("octo:group:grp1")).toBe("group:grp1");
+    expect(nt("channel:grp1____x")).toBe("group:grp1____x");
+    expect(nt("group:octo:grp1")).toBe("group:grp1");
+  });
+
+  it("leaves a bare id as-is (knownGroupIds decides later)", () => {
+    expect(nt("grp1")).toBe("grp1");
+  });
+
+  it("integration: normalizeTarget → parseTarget stable for group forms", async () => {
+    const { parseTarget } = await import("./actions.js");
+    // Both octo:group:grp1 and group:octo:grp1 should normalize to group:grp1
+    // and parseTarget should recognise them as Group
+    const norm1 = nt("octo:group:grp1");
+    const norm2 = nt("group:octo:grp1");
+    expect(norm1).toBe("group:grp1");
+    expect(norm2).toBe("group:grp1");
+    const p1 = parseTarget(norm1, undefined, new Set(["grp1"]));
+    const p2 = parseTarget(norm2, undefined, new Set(["grp1"]));
+    expect(p1.channelType).toBe(2); // ChannelType.Group
+    expect(p2.channelType).toBe(2);
+    expect(p1.channelId).toBe("grp1");
+    expect(p2.channelId).toBe("grp1");
+  });
+
+  it("integration: normalizeTarget octo:user:42:uid → DM + bare uid", async () => {
+    const { parseTarget } = await import("./actions.js");
+    const norm = nt("octo:user:42:uid");
+    expect(norm).toBe("user:42:uid");
+    const p = parseTarget(norm, undefined, new Set());
+    expect(p.channelType).toBe(1); // ChannelType.DM
+    // dmPeerUid extracts the last colon segment: "42:uid" → "uid"
+    expect(p.channelId).toBe("uid");
+  });
+});

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -5,9 +5,14 @@ import type {
 } from "openclaw/plugin-sdk";
 import type { ChannelOutboundContext } from "openclaw/plugin-sdk/channel-contract";
 import { createChannelMessageAdapterFromOutbound } from "openclaw/plugin-sdk/channel-message";
+// Outbound session route helper — same buildAgentSessionKey path inbound routing
+// uses, so an outbound send computes the identical session key (isomorphism).
+// NOT buildThreadAwareOutboundSessionRoute: that encodes threads as
+// `group:grp1:thread:abc`, which would NOT match inbound's `grp1____abc` peer id.
+import { buildChannelOutboundSessionRoute } from "openclaw/plugin-sdk/core";
 import { DEFAULT_ACCOUNT_ID } from "./sdk-compat.js";
 import { OctoConfigJsonSchema, type OctoConfig } from "./config-schema.js";
-import { CHANNEL_ID, MAX_UPLOAD_SIZE, stripAllChannelPrefixes, getChannelConfig, parseConversationRef, THREAD_ID_SEPARATOR } from "./constants.js";
+import { CHANNEL_ID, MAX_UPLOAD_SIZE, stripAllChannelPrefixes, getChannelConfig, parseConversationRef, dmPeerUid, THREAD_ID_SEPARATOR } from "./constants.js";
 import { streamToFileWithCap } from "./stream-helpers.js";
 import {
   listOctoAccountIds,
@@ -514,6 +519,36 @@ function getAvailableActions(cfg: any): string[] {
   return ["send", "read", "search", "react"];
 }
 
+/**
+ * Recover a DM peer's space-scoped identity (`"<space>:<uid>"` or bare `"<uid>"`)
+ * from an existing Octo DM `sessionKey`.
+ *
+ * Used by `resolveOutboundSessionRoute` for the bare-uid DM case: the outbound
+ * target may carry only the wire uid (no space), but the session peer.id must be
+ * the SAME space-scoped identity inbound routing keyed the conversation under,
+ * or the proactive reply spawns a fresh session.
+ *
+ * The key is built by the SDK's `buildAgentSessionKey` (same path inbound uses).
+ * Under the peer-encoding dmScopes the DM peerId is the tail after the LAST
+ * `:direct:` segment — `agent:<id>:direct:<peerId>` (per-peer),
+ * `agent:<id>:<channel>:direct:<peerId>` (per-channel-peer),
+ * `agent:<id>:<channel>:<account>:direct:<peerId>` (per-account-channel-peer).
+ * The peerId itself may contain a `:` (the `<space>:<uid>` joiner), so we split
+ * on the `:direct:` marker and keep the whole remainder verbatim.
+ *
+ * Returns undefined when the key encodes no peer — e.g. dmScope "main" collapses
+ * every DM to `agent:<id>:main`. The caller treats undefined as "cannot recover"
+ * and skips the mirror rather than writing a wrong session.
+ */
+const DM_DIRECT_MARKER = ":direct:";
+function recoverDmPeerFromSessionKey(sessionKey: string | undefined): string | undefined {
+  if (!sessionKey) return undefined;
+  const i = sessionKey.lastIndexOf(DM_DIRECT_MARKER);
+  if (i < 0) return undefined;
+  const peerId = sessionKey.slice(i + DM_DIRECT_MARKER.length).trim();
+  return peerId || undefined;
+}
+
 const meta = {
   id: "octo",
   label: "Octo",
@@ -905,6 +940,59 @@ export const octoPlugin: ChannelPlugin<ResolvedOctoAccount> = {
       const shortId = extractThreadShortId(id);
       if (!groupNo || !shortId) return null;
       return { id: groupNo, threadId: shortId, baseConversationId: groupNo, parentConversationCandidates: [groupNo] };
+    },
+    resolveOutboundSessionRoute: (params: any) => {
+      const ref = parseConversationRef(params.target);
+      const { channelType } = parseTarget(params.target, undefined, getKnownGroupIds());
+      const isDm = channelType === ChannelType.DM;
+
+      if (isDm) {
+        // peer.id must equal the inbound DM sessionId (`<space>:<uid>`) for the
+        // outbound key to be isomorphic with the inbound route.
+        let peerId: string;
+        if (ref.id.includes(":")) {
+          // Target already carries the space — runtime-injected current DM.
+          peerId = ref.id;
+        } else {
+          // Bare-uid target (explicit cross-DM): the space is unknown. Only the
+          // current conversation's sessionKey can supply the space-scoped
+          // identity, and only when it actually belongs to THIS peer. If it
+          // can't be recovered, or recovers a different peer, return null to
+          // skip the mirror — never write a bare-uid (wrong) session.
+          const recovered = recoverDmPeerFromSessionKey(params.currentSessionKey);
+          if (!recovered || dmPeerUid(recovered) !== ref.id) return null;
+          peerId = recovered;
+        }
+        return buildChannelOutboundSessionRoute({
+          cfg: params.cfg,
+          agentId: params.agentId,
+          channel: CHANNEL_ID,
+          accountId: params.accountId,
+          peer: { kind: "direct", id: peerId },
+          chatType: "direct",
+          from: `octo:${peerId}`,
+          to: dmPeerUid(peerId), // deliver to the bare wire uid
+        });
+      }
+
+      // group / topic: synthesize Octo's `grp1____abc` identity (parent +
+      // optional separate threadId) and use it AS the peer id, so the outbound
+      // key matches inbound (whose peer.id is the channel_id incl. `grp1____abc`).
+      // resolveOutboundOctoTarget already owns the separator-merge rules.
+      const { channelId: groupPeerId } = resolveOutboundOctoTarget(params.target, params.threadId);
+      const sep = groupPeerId.indexOf(THREAD_ID_SEPARATOR);
+      const shortId = sep >= 0 ? groupPeerId.slice(sep + THREAD_ID_SEPARATOR.length) : undefined;
+      return buildChannelOutboundSessionRoute({
+        cfg: params.cfg,
+        agentId: params.agentId,
+        channel: CHANNEL_ID,
+        accountId: params.accountId,
+        peer: { kind: "group", id: groupPeerId },
+        chatType: "group",
+        from: `octo:group:${groupPeerId}`,
+        to: groupPeerId,
+        ...(shortId ? { threadId: shortId } : {}),
+      });
     },
   },
   outbound: {

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -7,7 +7,7 @@ import type { ChannelOutboundContext } from "openclaw/plugin-sdk/channel-contrac
 import { createChannelMessageAdapterFromOutbound } from "openclaw/plugin-sdk/channel-message";
 import { DEFAULT_ACCOUNT_ID } from "./sdk-compat.js";
 import { OctoConfigJsonSchema, type OctoConfig } from "./config-schema.js";
-import { CHANNEL_ID, MAX_UPLOAD_SIZE, stripAllChannelPrefixes, getChannelConfig } from "./constants.js";
+import { CHANNEL_ID, MAX_UPLOAD_SIZE, stripAllChannelPrefixes, getChannelConfig, parseConversationRef } from "./constants.js";
 import { streamToFileWithCap } from "./stream-helpers.js";
 import {
   listOctoAccountIds,
@@ -888,7 +888,12 @@ export const octoPlugin: ChannelPlugin<ResolvedOctoAccount> = {
     }),
   },
   messaging: {
-    normalizeTarget: (target) => target.trim(),
+    normalizeTarget: (target) => {
+      const ref = parseConversationRef(target);
+      if (ref.kind === "user") return `user:${ref.id}`;
+      if (ref.kind === "group") return `group:${ref.id}`;
+      return ref.id; // bare id, let parseTarget/knownGroupIds decide
+    },
     targetResolver: {
       looksLikeId: (input) => Boolean(input.trim()),
       hint: "<userId or channelId>",

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -4,6 +4,7 @@ import type {
   ChannelMessageActionAdapter,
 } from "openclaw/plugin-sdk";
 import type { ChannelOutboundContext } from "openclaw/plugin-sdk/channel-contract";
+import { createChannelMessageAdapterFromOutbound } from "openclaw/plugin-sdk/channel-message";
 import { DEFAULT_ACCOUNT_ID } from "./sdk-compat.js";
 import { OctoConfigJsonSchema, type OctoConfig } from "./config-schema.js";
 import { CHANNEL_ID, MAX_UPLOAD_SIZE, stripAllChannelPrefixes, getChannelConfig } from "./constants.js";
@@ -506,7 +507,11 @@ function getAvailableActions(cfg: any): string[] {
   } catch {
     return [];
   }
-  return ["send", "read", "search"];
+  // "react" is exposed (add/remove a single reaction); "reactions" (list) is
+  // intentionally NOT exposed yet — it needs a server-side bot query endpoint
+  // that isn't shipping this round, so advertising it would surface an
+  // unimplemented action on the shared message tool (#111 B3).
+  return ["send", "read", "search", "react"];
 }
 
 const meta = {
@@ -691,7 +696,7 @@ export const octoPlugin: ChannelPlugin<ResolvedOctoAccount> = {
   capabilities: {
     chatTypes: ["direct", "group"],
     media: true,
-    reactions: false,
+    reactions: true,
     threads: true,
   },
   reload: { configPrefixes: [`channels.${CHANNEL_ID}`] },
@@ -833,6 +838,13 @@ export const octoPlugin: ChannelPlugin<ResolvedOctoAccount> = {
         groupMdCache,
         currentChannelId: ctx.toolContext?.currentChannelId ?? undefined,
         threadId: ctx.toolContext?.threadId ?? ctx.params?.threadId ?? undefined,
+        // Forward the inbound turn's message id so `react` can target the
+        // current message without the agent having to source an id that isn't
+        // surfaced anywhere LLM-visible (history/read both omit it). Runtime
+        // populates currentMessageId from the inbound MessageSid.
+        currentMessageId: ctx.toolContext?.currentMessageId != null
+          ? String(ctx.toolContext.currentMessageId)
+          : undefined,
         requesterSenderId: ctx.requesterSenderId ?? undefined,
         accountId,
         log: ctx.log,
@@ -850,7 +862,12 @@ export const octoPlugin: ChannelPlugin<ResolvedOctoAccount> = {
         `For searching: use action="search" with query="shared-groups" to find groups that the bot and the current user both belong to.`,
         `For @mentions in a group: FIRST look up the target member's real uid + display name with octo_management action="group-members" (target="group:<groupId>"). ${MENTION_FORMAT_HINT}`,
         `When the user names a target by NAME (not id), e.g. "forward to 'XXX' group/chat", FIRST call octo_management action="resolve" with name:"XXX" to resolve it. If multiple candidates are returned, ask the user which group/thread; if exactly one, use its channelId to send. Never hand-build a "group:" address from a name.`,
+        `To react to a message with an emoji: use action="react" with emoji="👍" (any emoji). To react to the message that triggered the current turn, you may omit messageId — it defaults to the current inbound message. To react to a specific earlier message, pass its messageId. Pass remove:true to take your reaction back. Target defaults to the current conversation.`,
       ];
+    },
+    reactionGuidance: ({ accountId }: { cfg: any; accountId?: string | null }) => {
+      void accountId;
+      return { level: "minimal" as const, channelLabel: "Octo" };
     },
   },
   configSchema: OctoConfigJsonSchema,
@@ -1617,3 +1634,28 @@ export const octoPlugin: ChannelPlugin<ResolvedOctoAccount> = {
     },
   },
 };
+
+// ---------------------------------------------------------------------------
+// #111 Sprint A — new `message` (ChannelMessageAdapterShape) slot.
+//
+// OpenClaw's runtime (deliver-*.js createPluginHandler) prefers
+// `message.send.{text,media}` over `outbound.send*`, but still reads the
+// presentation-layer hooks (chunker / sanitizeText / normalizePayload /
+// renderPresentation / pinDeliveredMessage) ONLY from `outbound`. So the
+// migration ADDS a message slot and KEEPS outbound — it is not a replacement.
+//
+// We wrap the existing, well-tested outbound sendText/sendMedia via
+// createChannelMessageAdapterFromOutbound (the Discord pattern): the factory
+// normalizes our legacy `{channel,to,messageId}` results into
+// ChannelMessageSendResult { receipt, messageId }. durableFinal advertises the
+// content types we can durably deliver; we do not implement reconcileUnknownSend
+// yet (opt-in enhancement).
+// ---------------------------------------------------------------------------
+octoPlugin.message = createChannelMessageAdapterFromOutbound({
+  id: CHANNEL_ID,
+  outbound: {
+    sendText: (ctx) => octoPlugin.outbound!.sendText!(ctx as unknown as ChannelOutboundContext),
+    sendMedia: (ctx) => octoPlugin.outbound!.sendMedia!(ctx as unknown as ChannelOutboundContext),
+    deliveryCapabilities: { durableFinal: { text: true, media: true } },
+  },
+}) as any;

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -7,7 +7,7 @@ import type { ChannelOutboundContext } from "openclaw/plugin-sdk/channel-contrac
 import { createChannelMessageAdapterFromOutbound } from "openclaw/plugin-sdk/channel-message";
 import { DEFAULT_ACCOUNT_ID } from "./sdk-compat.js";
 import { OctoConfigJsonSchema, type OctoConfig } from "./config-schema.js";
-import { CHANNEL_ID, MAX_UPLOAD_SIZE, stripAllChannelPrefixes, getChannelConfig, parseConversationRef } from "./constants.js";
+import { CHANNEL_ID, MAX_UPLOAD_SIZE, stripAllChannelPrefixes, getChannelConfig, parseConversationRef, THREAD_ID_SEPARATOR } from "./constants.js";
 import { streamToFileWithCap } from "./stream-helpers.js";
 import {
   listOctoAccountIds,
@@ -35,7 +35,7 @@ import { ChannelType, MessageType, type BotMessage, type MessagePayload, type Se
 import { buildEntitiesFromFallback, parseStructuredMentions, convertStructuredMentions, sanitizeOutboundMentions, MENTION_FORMAT_HINT } from "./mention-utils.js";
 import type { MentionEntity } from "./types.js";
 import { handleOctoMessageAction, parseTarget, resolveOutboundOctoTarget, normalizeOutboundChannelPrefix, extractInlineMentionUids } from "./actions.js";
-import { getOrCreateGroupMdCache, registerBotGroupIds, getKnownGroupIds, writeGroupMdToDisk, extractParentGroupNo } from "./group-md.js";
+import { getOrCreateGroupMdCache, registerBotGroupIds, getKnownGroupIds, writeGroupMdToDisk, extractParentGroupNo, extractThreadShortId } from "./group-md.js";
 import { registerOwnerUid } from "./owner-registry.js";
 import { registerKnownBot, isKnownBot } from "./bot-registry.js";
 import { preloadGroupMemberCache, getGroupMembersFromCache } from "./member-cache.js";
@@ -897,6 +897,14 @@ export const octoPlugin: ChannelPlugin<ResolvedOctoAccount> = {
     targetResolver: {
       looksLikeId: (input) => Boolean(input.trim()),
       hint: "<userId or channelId>",
+    },
+    resolveSessionConversation: ({ rawId }: { kind: "group" | "channel"; rawId: string }) => {
+      const id = stripAllChannelPrefixes((rawId ?? "").trim());
+      if (!id.includes(THREAD_ID_SEPARATOR)) return null;
+      const groupNo = extractParentGroupNo(id);
+      const shortId = extractThreadShortId(id);
+      if (!groupNo || !shortId) return null;
+      return { id: groupNo, threadId: shortId, baseConversationId: groupNo, parentConversationCandidates: [groupNo] };
     },
   },
   outbound: {

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -538,7 +538,8 @@ function getAvailableActions(cfg: any): string[] {
  *
  * Returns undefined when the key encodes no peer — e.g. dmScope "main" collapses
  * every DM to `agent:<id>:main`. The caller treats undefined as "cannot recover"
- * and skips the mirror rather than writing a wrong session.
+ * and falls back to the bare wire uid (which under main scope is dropped from the
+ * key anyway, staying isomorphic with inbound's `agent:<id>:main`).
  */
 const DM_DIRECT_MARKER = ":direct:";
 function recoverDmPeerFromSessionKey(sessionKey: string | undefined): string | undefined {
@@ -947,21 +948,32 @@ export const octoPlugin: ChannelPlugin<ResolvedOctoAccount> = {
       const isDm = channelType === ChannelType.DM;
 
       if (isDm) {
-        // peer.id must equal the inbound DM sessionId (`<space>:<uid>`) for the
-        // outbound key to be isomorphic with the inbound route.
+        // peer.id must equal the inbound DM sessionId for the outbound key to be
+        // isomorphic with the inbound route. This hook NEVER returns null for a
+        // DM: when a plugin resolver returns null the SDK does NOT fall back to
+        // its default session resolver — it leaves the route unmirrored and never
+        // sets __sessionKey — so returning null would DROP the mirror that the
+        // default (main) dmScope would otherwise land correctly.
         let peerId: string;
         if (ref.id.includes(":")) {
           // Target already carries the space — runtime-injected current DM.
           peerId = ref.id;
         } else {
-          // Bare-uid target (explicit cross-DM): the space is unknown. Only the
+          // Bare-uid target (explicit cross-DM): the space is unknown. The
           // current conversation's sessionKey can supply the space-scoped
-          // identity, and only when it actually belongs to THIS peer. If it
-          // can't be recovered, or recovers a different peer, return null to
-          // skip the mirror — never write a bare-uid (wrong) session.
-          const recovered = recoverDmPeerFromSessionKey(params.currentSessionKey);
-          if (!recovered || dmPeerUid(recovered) !== ref.id) return null;
-          peerId = recovered;
+          // identity, but only when it actually belongs to THIS peer. The SDK
+          // lowercases the encoded peerId while ref.id comes from the raw target,
+          // so compare case-insensitively. If it can't be recovered (or recovers
+          // a different peer), fall back to the bare uid: under peer-encoding
+          // dmScopes this equals the legacy SDK fallback, and under the default
+          // main scope the peer is dropped from the key anyway — fully isomorphic
+          // with inbound's `agent:<id>:main`.
+          const recovered = params.currentSessionKey
+            ? recoverDmPeerFromSessionKey(params.currentSessionKey)
+            : undefined;
+          peerId = recovered && dmPeerUid(recovered).toLowerCase() === ref.id.toLowerCase()
+            ? recovered
+            : ref.id;
         }
         return buildChannelOutboundSessionRoute({
           cfg: params.cfg,
@@ -980,8 +992,9 @@ export const octoPlugin: ChannelPlugin<ResolvedOctoAccount> = {
       // key matches inbound (whose peer.id is the channel_id incl. `grp1____abc`).
       // resolveOutboundOctoTarget already owns the separator-merge rules.
       const { channelId: groupPeerId } = resolveOutboundOctoTarget(params.target, params.threadId);
-      const sep = groupPeerId.indexOf(THREAD_ID_SEPARATOR);
-      const shortId = sep >= 0 ? groupPeerId.slice(sep + THREAD_ID_SEPARATOR.length) : undefined;
+      // Reuse the shared separator parser so the `____` split rule lives in one
+      // place (group-md.ts) rather than re-implemented here.
+      const shortId = extractThreadShortId(groupPeerId) ?? undefined;
       return buildChannelOutboundSessionRoute({
         cfg: params.cfg,
         agentId: params.agentId,

--- a/src/constants.test.ts
+++ b/src/constants.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { stripAllChannelPrefixes } from "./constants.js";
+import { stripAllChannelPrefixes, stripOctoNamespacePrefix, parseConversationRef, dmPeerUid } from "./constants.js";
 
 describe("stripAllChannelPrefixes", () => {
   it("strips octo: prefix", () => {
@@ -52,5 +52,41 @@ describe("stripAllChannelPrefixes", () => {
     for (const id of ["grp1", "octo:grp1", "channel:grp1____topicA", "octo:group:grp1"]) {
       expect(stripAllChannelPrefixes(stripAllChannelPrefixes(id))).toBe(stripAllChannelPrefixes(id));
     }
+  });
+});
+
+describe("stripOctoNamespacePrefix", () => {
+  it("strips only octo: namespace, keeps kind prefixes", () => {
+    expect(stripOctoNamespacePrefix("octo:group:grp1")).toBe("group:grp1");
+    expect(stripOctoNamespacePrefix("octo:octo:x")).toBe("x");
+    expect(stripOctoNamespacePrefix("group:grp1")).toBe("group:grp1");
+    expect(stripOctoNamespacePrefix("octo:user:42:uid")).toBe("user:42:uid");
+  });
+});
+
+describe("parseConversationRef", () => {
+  it("parses DM keeping space in id", () => {
+    expect(parseConversationRef("octo:user:42:uid")).toEqual({ kind: "user", id: "42:uid" });
+    expect(parseConversationRef("octo:user:uid")).toEqual({ kind: "user", id: "uid" });
+  });
+  it("parses group / topic", () => {
+    expect(parseConversationRef("octo:group:grp1")).toEqual({ kind: "group", id: "grp1" });
+    expect(parseConversationRef("group:grp1____x")).toEqual({ kind: "group", id: "grp1____x" });
+  });
+  it("normalises channel→group and peels stacked prefixes", () => {
+    expect(parseConversationRef("channel:octo:grp1")).toEqual({ kind: "group", id: "grp1" });
+    expect(parseConversationRef("group:octo:grp1")).toEqual({ kind: "group", id: "grp1" });
+    expect(parseConversationRef("octo:channel:group:grp1____x")).toEqual({ kind: "group", id: "grp1____x" });
+  });
+  it("returns undefined kind for bare id", () => {
+    expect(parseConversationRef("octo:grp1")).toEqual({ kind: undefined, id: "grp1" });
+    expect(parseConversationRef("")).toEqual({ kind: undefined, id: "" });
+  });
+});
+
+describe("dmPeerUid", () => {
+  it("takes the last colon segment (uid is colon-free in octo)", () => {
+    expect(dmPeerUid("42:uid")).toBe("uid");
+    expect(dmPeerUid("uid")).toBe("uid");
   });
 });

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -96,3 +96,61 @@ export function ensureChannelConfigObject(cfg: any): any {
   cfg.channels[CHANNEL_ID].accounts ??= {};
   return cfg.channels[CHANNEL_ID];
 }
+
+/** Conversation kind used by routing / session helpers. */
+export type ConversationKind = "user" | "group";
+
+/**
+ * Strip ONLY the provider namespace `octo:` (incl. stacked `octo:octo:`).
+ * Unlike stripAllChannelPrefixes this deliberately does NOT strip kind
+ * prefixes (`user:`/`group:`/`channel:`), so kind-aware parsing can read the
+ * kind afterwards instead of losing it.
+ */
+export function stripOctoNamespacePrefix(s: string): string {
+  let out = (s ?? "").trim();
+  while (true) {
+    const next = out.replace(/^octo:/i, "");
+    if (next === out) return out;
+    out = next;
+  }
+}
+
+/**
+ * Parse a channelId / target into its conversation kind + bare id.
+ *
+ * Loop-peels leading recognised tokens to canonicalise stacked runtime forms
+ * (multi-bot / agent-tool routing can produce `group:octo:grp1`,
+ * `octo:channel:group:grp1____x`): each iteration drops a leading `octo:`
+ * (namespace) or consumes a kind prefix. The FIRST kind seen wins (the
+ * outermost prefix expresses intent); `channel` is a group-class alias and
+ * normalises to `group`. `id` is the remaining tail kept verbatim — for a DM
+ * that is the space-scoped `<space>:<uid>` session identity, for a thread the
+ * `<groupNo>____<shortId>`. Bare uid extraction is a separate step (dmPeerUid).
+ */
+export function parseConversationRef(s: string): { kind: ConversationKind | undefined; id: string } {
+  let rest = (s ?? "").trim();
+  let kind: ConversationKind | undefined;
+  while (true) {
+    const m = /^(octo|user|group|channel):/i.exec(rest);
+    if (!m) break;
+    const tok = m[1].toLowerCase();
+    rest = rest.slice(m[0].length);
+    if (tok !== "octo" && kind === undefined) {
+      kind = tok === "user" ? "user" : "group"; // channel → group alias
+    }
+  }
+  return { kind, id: rest };
+}
+
+/**
+ * Extract the bare delivery uid from a DM id. Octo uids are colon-free
+ * (32-hex user uids, `<prefix>_bot` bot uids, fixed system uids like
+ * `botfather`); the only colon in a DM id comes from the `${spaceId}:${uid}`
+ * session joiner (src/inbound.ts), so the peer uid is the last colon segment.
+ * Used for the server delivery target + same-channel comparison ONLY — NOT for
+ * the WS2 session peer.id, which must keep the space-scoped identity.
+ */
+export function dmPeerUid(id: string): string {
+  const i = id.lastIndexOf(":");
+  return i >= 0 ? id.slice(i + 1) : id;
+}

--- a/src/inbound.test.ts
+++ b/src/inbound.test.ts
@@ -26,6 +26,7 @@ import {
   resolveInboundMediaList,
   resolveInboundMediaPaths,
   isRemoteMediaUrl,
+  buildConversationAddress,
   type ResolveFileResult,
 } from "./inbound.js";
 import { extractMentionUids, parseStructuredMentions } from "./mention-utils.js";
@@ -3700,5 +3701,42 @@ describe("/fork command history leak filter (regression)", () => {
     expect(() => filterApiMsgs(apiMessages)).not.toThrow();
     // None of them are fork commands, so all survive the fork filter.
     expect(filterApiMsgs(apiMessages)).toHaveLength(3);
+  });
+});
+
+/**
+ * Tests for buildConversationAddress — DM session address encoding (Task 3).
+ *
+ * DM: octo:user:<sessionId> where sessionId may be "<space>:<uid>" or "<uid>",
+ *     preserving the space prefix as-is.
+ * Group/thread: octo:<sessionId> (unchanged from current behavior).
+ */
+describe("buildConversationAddress", () => {
+  const CHANNEL_ID = "octo";
+
+  it("DM with space-scoped sessionId preserves space and adds user: kind tag", () => {
+    // spaceId=42, from_uid=uid → sessionId="42:uid"
+    const addr = buildConversationAddress(CHANNEL_ID, false, "42:uid");
+    expect(addr).toBe("octo:user:42:uid");
+  });
+
+  it("DM without space uses plain uid with user: kind tag", () => {
+    const addr = buildConversationAddress(CHANNEL_ID, false, "some_uid");
+    expect(addr).toBe("octo:user:some_uid");
+  });
+
+  it("Group uses octo: prefix without user: kind tag", () => {
+    const addr = buildConversationAddress(CHANNEL_ID, true, "grp123");
+    expect(addr).toBe("octo:grp123");
+  });
+
+  it("Community topic thread keeps groupNo____shortId format", () => {
+    const addr = buildConversationAddress(CHANNEL_ID, true, "12345____abc");
+    expect(addr).toBe("octo:12345____abc");
+  });
+
+  it("DM with complex space-id (alphanumeric) preserves full sessionId", () => {
+    const addr = buildConversationAddress(CHANNEL_ID, false, "space123:uid456");
+    expect(addr).toBe("octo:user:space123:uid456");
   });
 });

--- a/src/inbound.test.ts
+++ b/src/inbound.test.ts
@@ -27,6 +27,7 @@ import {
   resolveInboundMediaPaths,
   isRemoteMediaUrl,
   buildConversationAddress,
+  resolveReplyTarget,
   type ResolveFileResult,
 } from "./inbound.js";
 import { extractMentionUids, parseStructuredMentions } from "./mention-utils.js";
@@ -3738,5 +3739,40 @@ describe("buildConversationAddress", () => {
   it("DM with complex space-id (alphanumeric) preserves full sessionId", () => {
     const addr = buildConversationAddress(CHANNEL_ID, false, "space123:uid456");
     expect(addr).toBe("octo:user:space123:uid456");
+  });
+});
+
+/**
+ * Tests for resolveReplyTarget — reply target resolution for non-OBO messages (Task 7).
+ *
+ * Task 3 changed DM session address encoding (To/OriginatingTo), but the reply
+ * path must remain unaffected: DM inbound replyChannelId stays bare from_uid,
+ * replyChannelType stays DM.
+ */
+describe("resolveReplyTarget", () => {
+  it("DM (isGroup=false) replies to bare from_uid with ChannelType.DM", () => {
+    const result = resolveReplyTarget(false, "some-channel-id", "user123", undefined);
+    expect(result.replyChannelId).toBe("user123");
+    expect(result.replyChannelType).toBe(ChannelType.DM);
+  });
+
+  it("group (isGroup=true) replies to channel_id with provided channel_type", () => {
+    const result = resolveReplyTarget(true, "grp456", "user789", ChannelType.Group);
+    expect(result.replyChannelId).toBe("grp456");
+    expect(result.replyChannelType).toBe(ChannelType.Group);
+  });
+
+  it("group falls back to ChannelType.Group when channel_type is undefined", () => {
+    const result = resolveReplyTarget(true, "grp456", "user789", undefined);
+    expect(result.replyChannelId).toBe("grp456");
+    expect(result.replyChannelType).toBe(ChannelType.Group);
+  });
+
+  it("group preserves thread channel_type (not overridden)", () => {
+    // Community topic threads use a different numeric type; ensure we pass it through.
+    const threadType = 3; // hypothetical thread-specific type
+    const result = resolveReplyTarget(true, "12345____abc", "user789", threadType);
+    expect(result.replyChannelId).toBe("12345____abc");
+    expect(result.replyChannelType).toBe(threadType as ChannelType);
   });
 });

--- a/src/inbound.test.ts
+++ b/src/inbound.test.ts
@@ -3750,7 +3750,7 @@ describe("buildConversationAddress", () => {
  * replyChannelType stays DM.
  */
 describe("resolveReplyTarget", () => {
-  it("DM (isGroup=false) replies to bare from_uid with ChannelType.DM", () => {
+  it("DM inbound replyChannelId stays bare from_uid + DM type (unaffected by conversation-id encoding)", () => {
     const result = resolveReplyTarget(false, "some-channel-id", "user123", undefined);
     expect(result.replyChannelId).toBe("user123");
     expect(result.replyChannelType).toBe(ChannelType.DM);

--- a/src/inbound.ts
+++ b/src/inbound.ts
@@ -222,6 +222,29 @@ export function buildConversationAddress(
   return `${channelPrefix}:user:${sessionId}`;
 }
 
+/**
+ * Resolve the base reply target for a non-OBO inbound message.
+ *
+ * DM messages reply to the bare from_uid with ChannelType.DM.
+ * Group messages reply to channel_id with the group type fallback.
+ *
+ * This is extracted as a pure function so the reply-routing logic can be
+ * unit-tested in isolation (Task 7 — assert Task 3 conversation-id encoding
+ * does not affect reply paths).
+ */
+export function resolveReplyTarget(isGroup: boolean, channelId: string | undefined, fromUid: string, channelType?: number): { replyChannelId: string; replyChannelType: ChannelType } {
+  if (isGroup) {
+    return {
+      replyChannelId: channelId!,
+      replyChannelType: (channelType ?? ChannelType.Group) as ChannelType,
+    };
+  }
+  return {
+    replyChannelId: fromUid,
+    replyChannelType: ChannelType.DM,
+  };
+}
+
 export type OctoStatusSink = (patch: {
   lastInboundAt?: number;
   lastOutboundAt?: number;
@@ -2521,8 +2544,9 @@ export async function handleInboundMessage(params: {
     }
     log?.info?.(`octo: OBO v2 detected — reply target=${replyChannelId} type=${replyChannelType} respondAs=${effectiveOnBehalfOf} payloadRespondAs=${oboV2RespondAs} originFrom=${oboV2OriginFromUid}`);
   } else {
-    replyChannelId = isGroup ? message.channel_id! : message.from_uid;
-    replyChannelType = isGroup ? (message.channel_type ?? ChannelType.Group) : ChannelType.DM;
+    const replyTarget = resolveReplyTarget(isGroup, message.channel_id, message.from_uid, message.channel_type);
+    replyChannelId = replyTarget.replyChannelId;
+    replyChannelType = replyTarget.replyChannelType;
     // Persona clone: only reply as grantor when triggered by @所有人 (mention.humans=1).
     // When the bot is directly mentioned (@James, @AI), respond as itself.
     effectiveOnBehalfOf = (isGroup && triggeredByMentionHumans && account.config.onBehalfOf) ? account.config.onBehalfOf : undefined;

--- a/src/inbound.ts
+++ b/src/inbound.ts
@@ -198,6 +198,30 @@ export function recordSessionAccount(accountId: string, sessionKey: string): voi
   sessionAccountMap.set(buildSessionAccountKey(id, sessionKey), id);
 }
 
+/**
+ * Build the conversation address used for To / OriginatingTo in inbound ctxPayload.
+ *
+ * - DM (isGroup=false): `${channelPrefix}:user:${sessionId}` — kind-tagged so
+ *   downstream routing can distinguish from group addresses; sessionId is kept
+ *   verbatim (may be `<space>:<uid>` or plain `<uid>`), preserving any space
+ *   prefix for multi-tenant isolation.
+ * - Group/thread (isGroup=true): `${channelPrefix}:${sessionId}` — unchanged
+ *   from current behavior.
+ *
+ * Centralized here so both To and OriginatingTo use identical logic, and tests
+ * can verify the encoding without mocking the full inbound pipeline.
+ */
+export function buildConversationAddress(
+  channelPrefix: string,
+  isGroup: boolean,
+  sessionId: string,
+): string {
+  if (isGroup) {
+    return `${channelPrefix}:${sessionId}`;
+  }
+  return `${channelPrefix}:user:${sessionId}`;
+}
+
 export type OctoStatusSink = (patch: {
   lastInboundAt?: number;
   lastOutboundAt?: number;
@@ -2422,7 +2446,7 @@ export async function handleInboundMessage(params: {
       return resolved.mediaType ? [resolved.mediaType] : undefined;
     })(),
     From: `${CHANNEL_ID}:${message.from_uid}`,
-    To: `${CHANNEL_ID}:${sessionId}`,
+    To: buildConversationAddress(CHANNEL_ID, isGroup, sessionId),
     SessionKey: route.sessionKey,
     AccountId: route.accountId,
     ChatType: isGroup ? "group" : "direct",
@@ -2438,7 +2462,7 @@ export async function handleInboundMessage(params: {
     Provider: CHANNEL_ID,
     Surface: CHANNEL_ID,
     OriginatingChannel: CHANNEL_ID,
-    OriginatingTo: `${CHANNEL_ID}:${sessionId}`,
+    OriginatingTo: buildConversationAddress(CHANNEL_ID, isGroup, sessionId),
   });
 
   await core.channel.session.recordInboundSession({


### PR DESCRIPTION
## Summary

Plugin side of the three-end #111 reactions feature (message-adapter migration + `react` action) together with the session-routing root-fix. Both live on this branch because routing builds on the adapter migration.

## Related Issue

#111

## Changes

### #111 reactions / message adapter
- Migrate to the official message adapter slot and add a `react` action (`handleReact`); `api-fetch` gains `addReaction` / `removeReaction` (POST body, DELETE with percent-encoded emoji + query, timeout, `currentMessageId` fallback).
- `read` now returns each message's `messageId` so an agent can react to an earlier message (closes the read→react loop); the react failure path logs the resolved route at debug level for triage.

### session-routing root-fix
- Kind-aware conversation-ref parsing (`parseConversationRef` as the single source of truth); DM outbound recovers a space-scoped identity from `currentSessionKey` only when the recovered peer matches, else falls back to the bare uid to avoid cross-DM leakage (covered by tests).
- `handleRead` same-channel comparison is kind-aware (channelId + channelType must both match), closing a known-group-uid vs DM misclassification that leaked cross-channel reads.
- Outbound and inbound share the same `buildChannelOutboundSessionRoute` (isomorphic); the "DM hook never returns null" invariant is preserved (returning null would drop the mirror).

## Testing

- [x] Unit tests added/updated
- [x] Manually verified

`vitest run` — 36 files / 1368 tests pass; `tsc --noEmit` clean. Routing tests cover `parseConversationRef` / `resolveOutboundSessionRoute` / `resolveSessionConversation` / `dmPeerUid` / `normalizeTarget` plus the cross-peer mismatch fallback. Three-end e2e verified (bot reaction rendered in chat).

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Followed commit message conventions (Conventional Commits)

> Draft: reactions part ships with octo-server + octo-web. Routing depends on the adapter migration, so it is delivered in this same PR (it was reviewed independently as its own commit range).