### PR TITLE
fix: add Octo fallback and image-only delivery evidence

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -857,8 +857,15 @@ async function handleSend(params: {
     .map(m => m.messageId)
     .filter((id): id is string => Boolean(id));
 
+  // Surface the sent media URLs at the top level of the result so that
+  // openclaw core's collectMessagingMediaUrlsFromToolResult can populate
+  // messagingToolSentMediaUrls for delivery-evidence accounting (required
+  // for image-only turns to pass hasCommittedMessagingDeliveryEvidence).
+  const sentMediaUrls = sentMedia.map(m => m.url);
+
   return {
     ok: true,
+    ...(sentMediaUrls.length > 0 ? { mediaUrls: sentMediaUrls } : {}),
     data: {
       sent: true,
       target,

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -784,7 +784,12 @@ export const octoPlugin: ChannelPlugin<ResolvedOctoAccount> = {
     },
     extractToolSend: ({ args }: { args: Record<string, unknown> }) => {
       const target = args.target as string | undefined;
-      return target ? { target } : {};
+      // Return the canonical `to` field that openclaw core uses in
+      // isMessagingToolSendAction to recognise Octo sends as committed
+      // delivery evidence.  Without `to`, isDeliveredMessagingToolResult
+      // is false → messagingToolSentMediaUrls is never populated →
+      // image-only agent turns are classified as non_deliverable_terminal_turn.
+      return target ? { to: target } : {};
     },
     handleAction: async (ctx: any) => {
       // Resolve correct accountId: framework may pass wrong one when agent has multiple accounts.

--- a/src/inbound-dispatch-timeout.test.ts
+++ b/src/inbound-dispatch-timeout.test.ts
@@ -362,6 +362,87 @@ describe("dispatch timeout guard (issue #75)", () => {
   });
 });
 
+describe("dispatch-reject fallback guard (PR #152 regression)", () => {
+  it("blocks-only turn: dispatch rejects → delivers buffered block text, NOT error message", async () => {
+    // Regression: the fallback branch unconditionally cleared deliverBuffer
+    // before sending the error message, discarding a valid blocks-only reply
+    // and sending a contradictory error instead. The fix: if deliverBuffer
+    // has buffered text, deliver it and skip the error message.
+    const dispatch = vi.fn(async (args: any) => {
+      await args.dispatcherOptions.deliver({ text: "block-content-reply" }, { kind: "block" });
+      throw new Error("non_deliverable_terminal_turn");
+    });
+    setOctoRuntime({
+      config: { loadConfig: () => ({}) },
+      channel: {
+        reply: {
+          dispatchReplyWithBufferedBlockDispatcher: dispatch,
+          resolveEnvelopeFormatOptions: () => ({}),
+          formatAgentEnvelope: ({ body }: any) => body,
+          finalizeInboundContext: (ctx: any) => ctx,
+        },
+        routing: {
+          resolveAgentRoute: () => ({ agentId: "agent1", sessionKey: "sk1", accountId: "acct1" }),
+        },
+        session: {
+          resolveStorePath: () => "/tmp/store",
+          readSessionUpdatedAt: () => undefined,
+          recordInboundSession: async () => {},
+        },
+      },
+    } as any);
+    const { sends } = installFetchStub();
+
+    await expect(
+      runInbound({ log: { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} } }),
+    ).rejects.toThrow();
+
+    const actualReplies = sends.filter((s) => typeof s?.payload?.content === "string");
+    const blockReply = actualReplies.find((s) => s.payload.content === "block-content-reply");
+    const errorApology = actualReplies.find((s) => typeof s?.payload?.content === "string" && s.payload.content.includes("⚠️"));
+
+    expect(blockReply, "buffered block text must be delivered").toBeDefined();
+    expect(errorApology, "error apology must NOT be sent when buffered text exists").toBeUndefined();
+  });
+
+  it("no-content turn: dispatch rejects with no buffered text → sends error fallback", async () => {
+    // When dispatch rejects and no block text was buffered (and no reply
+    // succeeded), the error fallback should still fire as before.
+    const dispatch = vi.fn(async () => {
+      throw new Error("non_deliverable_terminal_turn");
+    });
+    setOctoRuntime({
+      config: { loadConfig: () => ({}) },
+      channel: {
+        reply: {
+          dispatchReplyWithBufferedBlockDispatcher: dispatch,
+          resolveEnvelopeFormatOptions: () => ({}),
+          formatAgentEnvelope: ({ body }: any) => body,
+          finalizeInboundContext: (ctx: any) => ctx,
+        },
+        routing: {
+          resolveAgentRoute: () => ({ agentId: "agent1", sessionKey: "sk1", accountId: "acct1" }),
+        },
+        session: {
+          resolveStorePath: () => "/tmp/store",
+          readSessionUpdatedAt: () => undefined,
+          recordInboundSession: async () => {},
+        },
+      },
+    } as any);
+    const { sends } = installFetchStub();
+
+    await expect(
+      runInbound({ log: { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} } }),
+    ).rejects.toThrow();
+
+    const errorApology = sends.find(
+      (s) => typeof s?.payload?.content === "string" && s.payload.content.includes("\u26a0\ufe0f"),
+    );
+    expect(errorApology, "error apology must be sent when no content was buffered").toBeDefined();
+  });
+});
+
 describe("dispatch timeout derivation from config (issue #113)", () => {
   // These tests exercise the real resolution chain, so clear the test
   // override that the outer beforeEach installs.

--- a/src/inbound.ts
+++ b/src/inbound.ts
@@ -2853,6 +2853,29 @@ export async function handleInboundMessage(params: {
       } catch (sendErr) {
         log?.error?.(`octo: failed to send timeout message: ${String(sendErr)}`);
       }
+    } else if (!deliveryErrorOccurred) {
+      // Dispatch itself rejected (e.g. non_deliverable_terminal_turn) and the
+      // onError callback was never invoked, so no fallback has been sent yet.
+      // Send one now so the user is not left with a silent failure.
+      clearInterval(typingInterval);
+      log?.error?.(
+        `octo: dispatch rejected (not a timeout), sending fallback message: ${String(err)}`,
+      );
+      deliverBuffer.lastText = null;
+      deliverBuffer.textSent = true;
+      try {
+        await sendMessage({
+          apiUrl,
+          botToken,
+          channelId: replyChannelId,
+          channelType: replyChannelType,
+          content: "Something went wrong while processing your request. Please try again.",
+          ...(effectiveOnBehalfOf ? { onBehalfOf: effectiveOnBehalfOf } : {}),
+          signal: AbortSignal.timeout(DISPATCH_TIMEOUT_APOLOGY_MS),
+        });
+      } catch (sendErr) {
+        log?.error?.(`octo: failed to send dispatch-error fallback: ${String(sendErr)}`);
+      }
     }
     throw err;
   } finally {

--- a/src/inbound.ts
+++ b/src/inbound.ts
@@ -2857,29 +2857,48 @@ export async function handleInboundMessage(params: {
       // Dispatch itself rejected (e.g. non_deliverable_terminal_turn) and the
       // onError callback was never invoked, AND no visible reply has been
       // delivered to the user yet, so no fallback has been sent yet.
-      // Send one now so the user is not left with a silent failure.
       // Guard on !replySucceeded prevents a spurious error message when the
       // dispatcher already sent a visible reply before the top-level rejection
       // (e.g. a post-delivery terminal throw): without this guard the user
       // would receive both a real answer and a contradictory error message.
       clearInterval(typingInterval);
-      log?.error?.(
-        `octo: dispatch rejected (not a timeout), sending fallback message: ${String(err)}`,
-      );
-      deliverBuffer.lastText = null;
-      deliverBuffer.textSent = true;
-      try {
-        await sendMessage({
-          apiUrl,
-          botToken,
-          channelId: replyChannelId,
-          channelType: replyChannelType,
-          content: "⚠️ 抱歉，处理您的消息时遇到了问题，请稍后重试。",
-          ...(effectiveOnBehalfOf ? { onBehalfOf: effectiveOnBehalfOf } : {}),
-          signal: AbortSignal.timeout(DISPATCH_TIMEOUT_APOLOGY_MS),
-        });
-      } catch (sendErr) {
-        log?.error?.(`octo: failed to send dispatch-error fallback: ${String(sendErr)}`);
+      if (deliverBuffer.lastText && !deliverBuffer.textSent) {
+        // A blocks-only reply was buffered (replySucceeded is not set for block
+        // kind until the finally flush). Deliver the buffered text instead of
+        // sending a contradictory error message: the agent produced a real
+        // answer and the user should see it.
+        const bufferedText = deliverBuffer.lastText;
+        deliverBuffer.lastText = null;
+        deliverBuffer.textSent = true;
+        log?.info?.(
+          `octo: dispatch rejected but buffered block text exists; delivering instead of error fallback (${bufferedText.length} chars)`,
+        );
+        try {
+          await resolveAndSendText(bufferedText, AbortSignal.timeout(DISPATCH_TIMEOUT_APOLOGY_MS));
+          replySucceeded = true;
+        } catch (sendErr) {
+          log?.error?.(`octo: failed to deliver buffered block text on dispatch error: ${String(sendErr)}`);
+        }
+      } else {
+        // No buffered content and no reply delivered — send the error fallback.
+        log?.error?.(
+          `octo: dispatch rejected (not a timeout), sending fallback message: ${String(err)}`,
+        );
+        deliverBuffer.lastText = null;
+        deliverBuffer.textSent = true;
+        try {
+          await sendMessage({
+            apiUrl,
+            botToken,
+            channelId: replyChannelId,
+            channelType: replyChannelType,
+            content: "⚠️ 抱歉，处理您的消息时遇到了问题，请稍后重试。",
+            ...(effectiveOnBehalfOf ? { onBehalfOf: effectiveOnBehalfOf } : {}),
+            signal: AbortSignal.timeout(DISPATCH_TIMEOUT_APOLOGY_MS),
+          });
+        } catch (sendErr) {
+          log?.error?.(`octo: failed to send dispatch-error fallback: ${String(sendErr)}`);
+        }
       }
     }
     throw err;

--- a/src/inbound.ts
+++ b/src/inbound.ts
@@ -2853,10 +2853,15 @@ export async function handleInboundMessage(params: {
       } catch (sendErr) {
         log?.error?.(`octo: failed to send timeout message: ${String(sendErr)}`);
       }
-    } else if (!deliveryErrorOccurred) {
+    } else if (!deliveryErrorOccurred && !replySucceeded) {
       // Dispatch itself rejected (e.g. non_deliverable_terminal_turn) and the
-      // onError callback was never invoked, so no fallback has been sent yet.
+      // onError callback was never invoked, AND no visible reply has been
+      // delivered to the user yet, so no fallback has been sent yet.
       // Send one now so the user is not left with a silent failure.
+      // Guard on !replySucceeded prevents a spurious error message when the
+      // dispatcher already sent a visible reply before the top-level rejection
+      // (e.g. a post-delivery terminal throw): without this guard the user
+      // would receive both a real answer and a contradictory error message.
       clearInterval(typingInterval);
       log?.error?.(
         `octo: dispatch rejected (not a timeout), sending fallback message: ${String(err)}`,
@@ -2869,7 +2874,7 @@ export async function handleInboundMessage(params: {
           botToken,
           channelId: replyChannelId,
           channelType: replyChannelType,
-          content: "Something went wrong while processing your request. Please try again.",
+          content: "⚠️ 抱歉，处理您的消息时遇到了问题，请稍后重试。",
           ...(effectiveOnBehalfOf ? { onBehalfOf: effectiveOnBehalfOf } : {}),
           signal: AbortSignal.timeout(DISPATCH_TIMEOUT_APOLOGY_MS),
         });


### PR DESCRIPTION
## 修改内容

- 在 Octo inbound dispatch reject 且 `onError` 未发送兜底时，补发错误兜底消息，避免 agent terminal failure 静默失败。
- 将 Octo message tool 的 `extractToolSend` 返回字段从 `target` 调整为 core 识别的 `to`。
- 在 message tool send 成功结果顶层补充 `mediaUrls`，让 image-only turn 能被 core 收集为 delivery evidence。

## 根因

- `dispatchReplyWithBufferedBlockDispatcher` reject 时，外层 catch 只处理 timeout；非 timeout 的 terminal dispatch error 会继续抛出，但 Octo 未发任何用户可见消息。
- image-only 发送依赖 core 的 committed delivery evidence 校验；Octo 返回的 send action 缺少 core 识别的 `to` 字段，且结果 envelope 未显式暴露已发送媒体 URL，导致纯图片 turn 可能被判定为 `non_deliverable_terminal_turn`。

## 测试验证

- `npm run build`
- `npm test`（35 files / 1300 tests passed）
