### PR TITLE
feat: InteractiveCard(17) — inbound + progress card + static display foundation

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -27,6 +27,7 @@ import { setOctoRuntime } from "./src/runtime.js";
 import { octoPlugin } from "./src/channel.js";
 import { createOctoManagementTools } from "./src/agent-tools.js";
 import { CHANNEL_ID } from "./src/constants.js";
+import { registerCardProgress } from "./src/card-progress.js";
 
 // ---------------------------------------------------------------------------
 // Tool-availability self-diagnostic (issue #137)
@@ -236,5 +237,9 @@ export default defineBundledChannelEntry({
         ...(systemSections.length > 0 ? { prependSystemContext: systemSections.join('\n\n') } : {}),
       };
     });
+
+    // 波 B:注册卡片进度 hook(before/after_tool_call、model_call_started)。
+    // 只处理 dispatch 经 setCardContext 登记的 octo session(见 src/card-progress.ts)。
+    registerCardProgress(api);
   },
 });

--- a/index.ts
+++ b/index.ts
@@ -26,7 +26,8 @@ import { resolvePersonaHintForSession } from "./src/persona-prompt.js";
 import { setOctoRuntime } from "./src/runtime.js";
 import { octoPlugin } from "./src/channel.js";
 import { createOctoManagementTools } from "./src/agent-tools.js";
-import { CHANNEL_ID } from "./src/constants.js";
+import { createDisplayCardTool } from "./src/card-display-tool.js";
+import { CHANNEL_ID, DISPLAY_CARD_TOOL_NAME } from "./src/constants.js";
 import { registerCardProgress } from "./src/card-progress.js";
 
 // ---------------------------------------------------------------------------
@@ -141,6 +142,21 @@ export default defineBundledChannelEntry({
         });
       },
       { names: ['octo_management'] },
+    );
+
+    // P1-e:agent 展示卡工具(顶层无 actions、不回流,发展示型 InteractiveCard 17)。
+    // 与 octo_management 一样,tool-discovery 阶段就注册,便于 profile 过滤评估。
+    api.registerTool(
+      (ctx: OpenClawPluginToolContext) => {
+        const cfg = ctx.getRuntimeConfig?.() ?? ctx.runtimeConfig ?? ctx.config;
+        if (!cfg) return null;
+        return createDisplayCardTool({
+          cfg,
+          agentAccountId: ctx.agentAccountId,
+          agentId: ctx.agentId,
+        });
+      },
+      { names: [DISPLAY_CARD_TOOL_NAME] },
     );
 
     // Manual setOctoRuntime + registerChannel — kept as a defensive call even

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -9,7 +9,7 @@
     "./skills"
   ],
   "contracts": {
-    "tools": ["octo_management"]
+    "tools": ["octo_management", "octo_send_display_card"]
   },
   "activation": {
     "onStartup": true

--- a/skills/octo-bot-api/SKILL.md
+++ b/skills/octo-bot-api/SKILL.md
@@ -153,6 +153,122 @@ curl -X POST <apiUrl>/v1/bot/sendMessage \
 
 When replying, always use the `channel_id` and `channel_type` from the received event. Do not modify or split the channel_id.
 
+### Sending Cards (Interactive Card, payload.type=17)
+
+**When to use cards vs plain text**
+
+- Plain text (`payload.type=1`) — conversational replies, short answers, follow-ups.
+- **Display card** (`payload.type=17`, `profile="octo/v1"`) — rich, structured, **NON-INTERACTIVE** output: status reports, structured answers, key-value summaries, images, collapsible detail sections. The card **has no clickable buttons and does not trigger any callback event**. Use for anything a plain paragraph cannot express cleanly.
+- Interactive card with Submit buttons (`profile="octo/v2"`) — user clicks a button, server pushes a `card_action` event, your bot processes it and continues. Only use when you actually need a click-back. Requires the bot to poll `/v1/bot/events` for the callback.
+
+**Discover what the deployment supports (feature detection)**
+
+```bash
+curl <apiUrl>/v1/bot/card/profile -H "Authorization: Bearer $TOKEN"
+```
+
+Response (fields your bot should read):
+```jsonc
+{
+  "enabled": true,                             // deployment-level rollout switch
+  "card_version": "1.5",
+  "profiles": ["octo/v1", "octo/v2"],
+  "elements": ["TextBlock","RichTextBlock","Container","ColumnSet","Column",
+               "FactSet","Image","ImageSet","Table","ActionSet"],
+  "inputs":   ["Input.Text","Input.Toggle","Input.ChoiceSet",
+               "Input.Number","Input.Date","Input.Time"],
+  "limits": { "max_payload_bytes": 524288, "max_nodes": 200, "max_depth": 16,
+              "max_input_text_bytes": 4096, "max_inputs_bytes": 16384 }
+}
+```
+
+- If `available` is false (404) or `enabled` is false → **do not send cards**; fall back to text.
+- `elements`/`inputs` are the authoritative whitelists — send only what the server advertises. Element not in the list → server responds 400.
+- Old deployments may omit `elements`/`inputs` — fall back to the conservative baseline: `TextBlock`/`Container`/`ColumnSet`/`Column`/`FactSet`/`Image`.
+- Respect `limits.max_nodes` / `max_depth` — cards over the cap are rejected.
+
+**Payload shape for a display card**
+
+```jsonc
+POST /v1/bot/sendMessage
+{
+  "channel_id": "<groupId or uid>",
+  "channel_type": 2,
+  "payload": {
+    "type": 17,
+    "profile": "octo/v1",       // display; use octo/v2 only for Submit-interactive
+    "card_version": "1.5",
+    "card": {
+      "type": "AdaptiveCard",
+      "version": "1.5",
+      "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+      "body": [
+        { "type": "TextBlock", "text": "报告", "weight": "Bolder", "size": "Medium", "wrap": true },
+        { "type": "FactSet", "facts": [
+            { "title": "状态", "value": "已完成" },
+            { "title": "耗时", "value": "30ms" }
+        ]}
+      ]
+    },
+    "plain": "报告 · 状态:已完成 · 耗时:30ms"    // fallback text for non-card clients
+  }
+}
+```
+
+**Recommended DisplayBlock building blocks** (this plugin's `buildDisplayCard` translates these to AC JSON, negotiates degradation, and sanitizes content — same behavior you should implement in a hand-written bot):
+
+| Block | Renders to | Purpose | Degrades to when server does not advertise |
+|---|---|---|---|
+| `heading` (text, size?) | Bolder TextBlock (optional Medium/Large) | Section title | (always available) |
+| `text` (text) | TextBlock | Body paragraph | (always available) |
+| `rich` (segments[]) | RichTextBlock + TextRun inlines (bold / color) | One-line multi-style | TextBlock, segments joined |
+| `facts` (items[]) | FactSet | Key-value pairs | Rows of TextBlock `label:value` |
+| `group` (blocks[], style?) | Container with `style: good/warning/attention` | Grouped/tinted section | Flattened (color lost, content kept) |
+| `collapsible` (summary, blocks[]) | Container `isVisible:false` + ActionSet `Action.ToggleVisibility` | Fold long details behind a click | Summary as heading + inner blocks expanded below |
+
+The `collapsible` upgrade requires **three** capability flags together: `elements` contains `Container` AND `ActionSet`, AND `actions` (once the server advertises it) contains `Action.ToggleVisibility`. Any one missing → falls back to the expanded form; the content is never lost.
+
+**Security & safety**
+
+- **Cards are visible to every member of the group.** Never render tokens, API keys, webhook URLs, or `Authorization` values into any card field, even inside a "hidden" collapsible — the raw JSON is stored server-side and can be pulled back by `/v1/message/get`. `buildDisplayCard` in this plugin auto-degrades embedded URLs to `scheme://<registrable-domain>` (including scheme-less and protocol-relative webhook URLs) and drops blocks that match secret shapes (`AKIA…`, `gh[pous]_…`, `xox[bap]-…`/`xapp-…`, `sk-…`, Stripe `sk_live_…`, `glpat-…`, Google `AIza…`, `npm_…`, `shpat_…`, `dop_v1_…`, JWTs, 32+ hex/base64 blobs), but hand-rolled clients must implement the same guardrails.
+- The `plain` field is what non-card clients (and history search) see — keep it a truthful summary. Do not put anything in `plain` that isn't already visible in `card`.
+
+**Editing a card (progress frames, live status)**
+
+```bash
+POST /v1/bot/message/edit
+{ "message_id":"<original>", "channel_id":"…",
+  "content_edit": "<JSON.stringify({ type:17, card:…, profile, card_version, transient:true })>" }
+```
+
+`transient` lives **inside** the stringified `content_edit` envelope (a sibling of `type`/`card`/`card_seq`), **not** as a top-level field of the edit body — the server reads it from the parsed `content_edit`, so a top-level `transient` would be silently ignored. Set `transient: true` for intermediate progress frames so they don't clutter the message audit trail (revision history); omit it (or set to false) for the terminal frame that should persist.
+
+**Visual styling recipes (rich look — use freely, the deployment supports it)**
+
+The im-test deployment renders Adaptive Cards 1.5 rich styling end-to-end: `Container.style` tinted backgrounds, `TextRun` colors and weights, `heading.size`, `RichTextBlock` multi-inline layouts. Use them to reduce cognitive load, not for decoration. Rules of thumb:
+
+1. **Layer status with `group.style`.** Wrap sections in a `group` block with `style: "good"` (success/completed), `"warning"` (待办/degraded), or `"attention"` (error/风险). The tinted background lets users spot the important zone at a glance. Example — a status summary:
+   ```jsonc
+   { "type": "group", "style": "good",       "blocks": [ /* heading + facts of what worked */ ] }
+   { "type": "group", "style": "warning",    "blocks": [ /* heading + facts of what's pending */ ] }
+   { "type": "group", "style": "attention",  "blocks": [ /* heading + facts of risks */ ] }
+   ```
+2. **Emphasize key tokens with `rich` segment colors.** Don't recolor a whole line — just the critical span. Example — a totals line:
+   ```jsonc
+   { "type": "rich", "segments": [
+       { "text": "总计: " },
+       { "text": "5 项已完成", "bold": true, "color": "good" },
+       { "text": " · 1 项待联调 · 1 项风险" }
+   ]}
+   ```
+   Available colors: `default | good | warning | attention | accent`. Applied to a `TextRun`, not to a whole block.
+3. **Use `heading.size` for cross-section hierarchy.** The card's outer title uses `size: "large"` or `"medium"`; section-level headings inside groups leave `size` unset (default bold is enough — resist the urge to size every heading).
+4. **Prefer `facts` for stable key→value.** `facts` renders as a two-column table (label ⇢ value). Great for "status" / "耗时" / "总计" panels. Do NOT use it for rich text — use `text` or `rich` instead.
+5. **Keep a lid on it.** One `heading` + 1-2 tinted `group`s + one closing `rich` line is usually enough. Three tinted groups is the ceiling; more starts to feel like a Christmas tree.
+6. **Automatic degradation is free.** `buildDisplayCard` negotiates against the server's advertised elements: a deployment that doesn't advertise `RichTextBlock` will silently render your `rich` segments as a joined `TextBlock`, `FactSet` degrades to text rows, `Container.style` flattens to plain items. **You don't need to check compatibility — just describe the intent and the builder degrades gracefully.**
+
+Anti-pattern: rendering a "success ✅ / warning ⚠️ / error ❌" prefix in every row instead of grouping them by tint — the icons carry the signal but rows still bleed into each other. Group them; the tint does the layout work for you.
+
 ## Real-time Features
 
 ### Typing Indicator

--- a/skills/octo-bot-api/SKILL.md
+++ b/skills/octo-bot-api/SKILL.md
@@ -352,16 +352,16 @@ POST /v1/bot/sendMessage
 |---|---|---|---|
 | `heading` (text, size?) | Bolder TextBlock (optional Medium/Large) | Section title | (always available) |
 | `text` (text) | TextBlock | Body paragraph | (always available) |
-| `rich` (segments[]) | RichTextBlock + TextRun inlines (bold / color) | One-line multi-style | TextBlock, segments joined |
+| `rich` (segments[]) | RichTextBlock + TextRun inlines (bold / color / `fontType:"Monospace"`) | One-line multi-style | TextBlock, segments joined |
 | `facts` (items[]) | FactSet | Key-value pairs | Rows of TextBlock `label:value` |
 | `columns` (columns[].blocks[]) | ColumnSet, with Column children inside `columns[]` | Summary/KPI strip, e.g. weather / temperature / rain chance | One TextBlock line joined with pipe separators |
-| `table` (rows[].cells[].text) | Table, with TableRow/TableCell children inside `rows[]` / `cells[]` | Dense matrix data | TextBlock rows with pipe separators |
+| `table` (columns?, rows[].cells[]) | Table, with TableRow/TableCell children inside `rows[]` / `cells[]` | Dense matrix data; producer controls column widths, header row, and cell display blocks | TextBlock rows with pipe separators |
 | `link` (text, url) | ActionSet with `Action.OpenUrl`; falls back to TextBlock `selectAction` only when `ActionSet` is absent | Visible local/navigation link, no bot callback | TextBlock `text: url` |
-| `group` (blocks[], style?) | Container with `style: good/warning/attention` | Grouped/tinted section | Flattened (color lost, content kept) |
-| `collapsible` (summary, actionLabel?, blocks[]) | Container `isVisible:false` + ActionSet `Action.ToggleVisibility` | Fold long details behind a click; use `actionLabel:"查看过程"` for card-message process sections | Summary as heading + inner blocks expanded below |
+| `group` (blocks[], style?) | Container with `style: good/warning/attention/emphasis` | Grouped/tinted section | Flattened (color lost, content kept) |
+| `collapsible` (summary, actionLabel?/expandLabel?/collapseLabel?/defaultVisible?, blocks[]) | Summary ColumnSet + right-side ActionSet buttons + Container `isVisible` | Fold long details behind a click; progress sections use two buttons so labels can switch | Summary as heading + inner blocks expanded below |
 | `copy` (label?, text) | ActionSet with `Action.CopyToClipboard` | Local clipboard copy, no bot callback | TextBlock containing the copy text |
 
-The `collapsible` upgrade requires **three** capability flags together: `elements` contains `Container` AND `ActionSet`, AND `actions` contains `Action.ToggleVisibility`. Any one missing → falls back to the expanded form; the content is never lost.
+The `collapsible` upgrade requires all related capability flags together: `elements` contains `Container`, `ColumnSet`, and `ActionSet`, AND `actions` contains `Action.ToggleVisibility`. Any one missing → falls back to the expanded form; the content is never lost.
 
 For a card-message process section, prepend one `collapsible` block with a short summary and `actionLabel: "查看过程"`:
 ```jsonc
@@ -388,6 +388,10 @@ The `copy` upgrade requires `elements` contains `ActionSet` AND `actions` contai
 
 The `link` block should render a visible `ActionSet` button when `ActionSet` and `Action.OpenUrl` are both advertised. Use TextBlock `selectAction` only as a compatibility fallback because it is clickable but not visually obvious. Never put `Action.Submit` in `selectAction`; Submit belongs to `octo/v2` callback cards.
 
+For `table`, producers may provide `columns: [{ "width": 1 }, { "width": 2 }]`, `firstRowAsHeader`, and either simple cells (`{ "text": "..." }`) or rich cells (`{ "blocks": [...] }`). Rich cell blocks may include `text`, `rich`, or `group` with `style: "good" | "warning" | "attention" | "emphasis"` when supported by the client. Keep table cells compact; use `wrap`, `weight`, `color`, and `isSubtle` semantics rather than long paragraphs.
+
+For agent progress cards, mark the root card with `metadata: { "octo_layout": "agent_progress_v1" }`; renderers should match known layout values and treat unknown values as ordinary Adaptive Cards. The top-level `body` structure must be `[ColumnSet, Container#timeline_detail]`: put summary/toggle controls in the first `ColumnSet`, and put all timeline rows inside `Container` with `id: "timeline_detail"`. Running cards keep `timeline_detail.isVisible: true`; terminal cards (`done` / `error`) should default collapsed when toggle is available (`timeline_detail:false`, `btn_collapse:false`, `btn_expand:true`). Do not set `style` on `timeline_detail`; put `style: "warning"` / `"attention"` only on child step containers so the client can override inline backgrounds cleanly. Put toggle buttons inside the right-side `ColumnSet` column, not root `actions`. Adaptive Cards does not auto-switch a single button label, so emit two `ActionSet`s and toggle all three targets: detail `Container`, `btn_collapse`, and `btn_expand`. Continuous timeline lines/dots can only be approximated in pure AC; producer should send structured rows, while precise line/dot/tool-row styling belongs in the client renderer.
+
 **Security & safety**
 
 - **Cards are visible to every member of the group.** Never render tokens, API keys, webhook URLs, or `Authorization` values into any card field, even inside a "hidden" collapsible — the raw JSON is stored server-side and can be pulled back by `/v1/message/get`. `buildDisplayCard` in this plugin auto-degrades embedded URLs to `scheme://<registrable-domain>` (including scheme-less and protocol-relative webhook URLs) and drops blocks that match secret shapes (`AKIA…`, `gh[pous]_…`, `xox[bap]-…`/`xapp-…`, `sk-…`, Stripe `sk_live_…`, `glpat-…`, Google `AIza…`, `npm_…`, `shpat_…`, `dop_v1_…`, JWTs, 32+ hex/base64 blobs), but hand-rolled clients must implement the same guardrails.
@@ -410,7 +414,7 @@ POST /v1/bot/message/edit
 The im-test deployment renders Adaptive Cards 1.5 rich styling end-to-end: `Container.style` tinted backgrounds, `TextRun` colors and weights, `heading.size`, `RichTextBlock` multi-inline layouts. Use them to reduce cognitive load, not for decoration. Rules of thumb:
 
 1. **Design for the IM first screen.** One title + one compact process summary + answer summary content is the default. Put reasoning sections behind `查看过程`; do not make the first screen a log viewer.
-2. **Layer status with `group.style`.** Wrap sections in a `group` block with `style: "good"` (success/completed), `"warning"` (待办/degraded), or `"attention"` (error/风险). The tinted background lets users spot the important zone at a glance. Example — a status summary:
+2. **Layer status with `group.style`.** Wrap sections in a `group` block with `style: "good"` (success/completed), `"warning"` (待办/degraded), `"attention"` (error/风险), or `"emphasis"` (neutral emphasis). The tinted background lets users spot the important zone at a glance. Example — a status summary:
    ```jsonc
    { "type": "group", "style": "good",       "blocks": [ /* heading + facts of what worked */ ] }
    { "type": "group", "style": "warning",    "blocks": [ /* heading + facts of what's pending */ ] }
@@ -579,6 +583,13 @@ if message.channel_id is present               → Group  → reply to (channel_
 - **Never end a turn on a tool call.** Tools (including `octo_send_display_card`, `exec`, version checks, etc.) are *actions*, not your reply. After the last tool returns, you **must** still emit a short text message to the user.
 - Sending a display card is a **side effect**, not a conversational answer. If the user asked a question (e.g. "check the versions"), a card alone does not answer it — follow the card with a one-line text reply that states the result (the version numbers, the outcome, or a next step).
 - A turn that finishes with zero text output is judged **incomplete** by the runtime and rendered to the user as an interrupted/failed turn (⚠️ 已中断), even though the tools ran. Always leave a closing sentence so the turn completes cleanly.
+
+#### Never End on a Preamble — Announce Then Actually Do It (CRITICAL)
+
+- A filler / preamble sentence — "我先看看…", "让我查一下…", "稍等，我来处理", "I'll take a look", "let me check" — **must never be the last thing you say in a turn.** It is a promise, not an answer.
+- If you announce an action, you **must** actually perform it **in the same turn**: call the tool(s), then deliver the real result (the file contents, the answer, the outcome). Announcing "我先看看 README" and then ending the turn without reading the file leaves the user staring at an empty promise and asking "然后呢?".
+- Rule of thumb: **either just do it silently and report the result, or say one short "on it" line AND immediately follow with the tool calls + result — never stop after the "on it" line.** When unsure whether more work remains, do the work; do not hand the turn back on a preamble.
+- This is the mirror image of the rule above: there, a turn ended on a tool call with no text; here, a turn ends on text with no follow-through. Both leave the user without the answer they asked for.
 
 ### Conversation Style — Talk Like a Person, Not a Document
 

--- a/skills/octo-bot-api/SKILL.md
+++ b/skills/octo-bot-api/SKILL.md
@@ -158,7 +158,7 @@ When replying, always use the `channel_id` and `channel_type` from the received 
 **When to use cards vs plain text**
 
 - Plain text (`payload.type=1`) — conversational replies, short answers, follow-ups.
-- **Display card** (`payload.type=17`, `profile="octo/v1"`) — rich, structured, **NON-INTERACTIVE** output: status reports, structured answers, key-value summaries, images, collapsible detail sections. The card **has no clickable buttons and does not trigger any callback event**. Use for anything a plain paragraph cannot express cleanly.
+- **Display card** (`payload.type=17`, `profile="octo/v1"`) — rich, structured, **NON-INTERACTIVE** output: status reports, structured answers, key-value summaries, collapsible detail sections, and local copy-to-clipboard buttons. The card **has no callback buttons and does not trigger any callback event**. Use for anything a plain paragraph cannot express cleanly. The underlying octo/v1 protocol can render `Image`/`ImageSet`, but the `octo_send_display_card` helper currently exposes the safer DisplayBlock subset listed below.
 - Interactive card with Submit buttons (`profile="octo/v2"`) — user clicks a button, server pushes a `card_action` event, your bot processes it and continues. Only use when you actually need a click-back. Requires the bot to poll `/v1/bot/events` for the callback.
 
 **Discover what the deployment supports (feature detection)**
@@ -173,21 +173,138 @@ Response (fields your bot should read):
   "enabled": true,                             // deployment-level rollout switch
   "card_version": "1.5",
   "profiles": ["octo/v1", "octo/v2"],
-  "elements": ["TextBlock","RichTextBlock","Container","ColumnSet","Column",
+  "elements": ["TextBlock","RichTextBlock","Container","ColumnSet",
                "FactSet","Image","ImageSet","Table","ActionSet"],
   "inputs":   ["Input.Text","Input.Toggle","Input.ChoiceSet",
                "Input.Number","Input.Date","Input.Time"],
+  "actions":  ["Action.OpenUrl","Action.ToggleVisibility","Action.CopyToClipboard"],
   "limits": { "max_payload_bytes": 524288, "max_nodes": 200, "max_depth": 16,
               "max_input_text_bytes": 4096, "max_inputs_bytes": 16384 }
 }
 ```
 
 - If `available` is false (404) or `enabled` is false → **do not send cards**; fall back to text.
-- `elements`/`inputs` are the authoritative whitelists — send only what the server advertises. Element not in the list → server responds 400.
-- Old deployments may omit `elements`/`inputs` — fall back to the conservative baseline: `TextBlock`/`Container`/`ColumnSet`/`Column`/`FactSet`/`Image`.
+- `elements`/`inputs`/`actions` are the authoritative whitelists — send only what the server advertises. Missing support → server responds 400.
+- `elements` lists renderable card elements such as `ColumnSet` and `Table`. It does **not** need to list schema child structures such as `Column`, `TableRow`, or `TableCell`; those are valid only inside their parent element.
+- Old deployments may omit `elements`/`inputs`/`actions` — fall back to the conservative baseline: `TextBlock`/`Container`/`ColumnSet`/`FactSet`/`Image`, and no actions.
 - Respect `limits.max_nodes` / `max_depth` — cards over the cap are rejected.
 
-**Payload shape for a display card**
+**Canonical card-message structure**
+
+The producer's job is not to make a pretty UI; it is to generate Adaptive Card JSON that reads well in IM. Think **IM summary card + expandable details**, not "logs converted into a card".
+
+For final answers, prefer **one display card message**. If the answer needs a "查看过程" affordance, put the process as the **first block inside that same display card**; do **not** send or leave a separate final process-only card.
+
+Keep the visible first screen short: normally **3-6 lines** total. If execution/process information is included, the first screen shows only a compact process summary plus the answer card content; the detailed process opens under `查看过程`.
+
+Inside the `查看过程` detail, use this fixed shape:
+
+1. Status line: completed / running / failed + step count + elapsed time.
+2. Summary line: reasoning stages, tool calls, failures.
+3. Reasoning sections: show **2-3** human-readable stage summaries; fold overflow stages and raw details.
+
+Do not send an engineering event stream as the card structure. Convert `tool_events` into `reasoning_sections`: each section has one natural-language reasoning sentence and optional tool evidence. Make tool names prominent, but keep parameters subtle and shortened. Put full tool calls, raw parameters, long paths, stack traces, and verbose logs behind `collapsible` / `Action.ToggleVisibility`. Summarize errors by default: show "2 个工具调用失败" plus one short line per failed operation; put raw error text in a folded detail block. Truncate long paths, queries, and error messages to roughly **80-120 characters** in visible rows. Use at most one status symbol; prefer text labels such as `阶段`, `工具`, `读取文件`, `失败`.
+
+`plain` is first-class output. Generate it from the same source as the card, keep exactly one title, and do not dump raw logs into `plain`.
+
+When using `octo_send_display_card`, this is the preferred shape:
+
+```jsonc
+{
+  "title": "天气卡片（模拟）",
+  "blocks": [
+    {
+      "type": "collapsible",
+      "summary": "已深度思考 · 12.3s · 3 段推理 · 4 次工具调用",
+      "actionLabel": "查看过程",
+      "blocks": [
+        { "type": "text", "text": "先确认用户要天气摘要卡，而不是额外发送过程卡或日志卡。" },
+        { "type": "rich", "segments": [
+          { "text": "fetch_weather", "bold": true, "color": "accent" },
+          { "text": "  city=上海 fields=weather,temp,rain_chance · 171ms", "color": "default" }
+        ] },
+        { "type": "text", "text": "再把首屏组织成天气、温度、降水概率三块摘要，明细只保留城市、时间、来源。" },
+        { "type": "rich", "segments": [
+          { "text": "read_profile", "bold": true, "color": "accent" },
+          { "text": "  .../bot/card/profile · 102ms", "color": "default" }
+        ] }
+      ]
+    },
+    {
+      "type": "columns",
+      "columns": [
+        { "blocks": [{ "type": "heading", "text": "天气" }, { "type": "text", "text": "多云转晴" }] },
+        { "blocks": [{ "type": "heading", "text": "温度" }, { "type": "text", "text": "28°C / 35°C" }] },
+        { "blocks": [{ "type": "heading", "text": "降水概率" }, { "type": "text", "text": "12%" }] }
+      ]
+    },
+    {
+      "type": "facts",
+      "items": [
+        { "label": "城市", "value": "上海" },
+        { "label": "更新时间", "value": "2026-07-10 06:57 UTC" },
+        { "label": "数据源", "value": "模拟数据" }
+      ]
+    },
+    { "type": "rich", "segments": [
+      { "text": "提示：", "bold": true, "color": "accent" },
+      { "text": "出门记得带伞，午后注意防晒。" }
+    ] },
+    { "type": "copy", "label": "复制天气摘要", "text": "上海：多云转晴，28°C / 35°C，降水概率 12%。" }
+  ]
+}
+```
+
+Rules this example is meant to enforce:
+
+- Process, if shown, is part of the card message (`collapsible` first block), not a separate process card.
+- The process block uses stage-level reasoning summaries, not raw `tool_events`. Tool calls are evidence under a stage.
+- The visible card starts with a short process summary, not full logs. After `查看过程` is opened, show only 2-3 reasoning stages and fold the rest.
+- Keep exactly one title. Do not repeat the same title as the first `heading`.
+- Use `columns` for top summary strips such as weather / temperature / rain chance.
+- Use `facts` for detail fields, not for the whole card body.
+- Use `copy` for local clipboard copy; it does not call back to the bot.
+
+Recommended producer-side shape before rendering:
+
+```text
+status: completed | running | failed | interrupted
+title: 已深度思考 | 正在思考 | 已中断 | 处理失败
+duration_text: 用时 12 秒
+summary: 3 段推理 · 13 次工具调用
+reasoning_sections[]:
+  - text: natural-language reasoning summary; never a raw log line
+  - tools[]:
+      name: query_metrics
+      args_preview: channel=B range=90d group=stage
+      count: 2
+      status: success | failed | running
+collapsed_section_ids[]: stages hidden by default
+plain: same-source summary text; never the full log
+```
+
+Anti-pattern:
+
+```text
+思考 · 2.8s
+执行命令 × 2 · 共 1.4s — 最近: openclaw
+思考 · 4.5s
+执行命令 × 2 · 共 82ms — 最近: node
+```
+
+Preferred:
+
+```text
+先定位下降发生在哪个漏斗阶段。
+  query_metrics channel=B range=90d group=stage
+  read_file ~/analytics/funnel_definition.sql
+
+再复核口径和行业结构，判断是不是数据口径问题。
+  query_metrics dims=industry metric=activation_rate
+  run_sql SELECT industry, activation_rate ...
+```
+
+**Low-level payload shape for a display card**
 
 ```jsonc
 POST /v1/bot/sendMessage
@@ -203,14 +320,28 @@ POST /v1/bot/sendMessage
       "version": "1.5",
       "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
       "body": [
-        { "type": "TextBlock", "text": "报告", "weight": "Bolder", "size": "Medium", "wrap": true },
+        { "type": "TextBlock", "text": "天气卡片（模拟）", "weight": "Bolder", "size": "Medium", "wrap": true },
+        { "type": "ColumnSet", "columns": [
+          { "type": "Column", "items": [
+            { "type": "TextBlock", "text": "天气", "weight": "Bolder", "wrap": true },
+            { "type": "TextBlock", "text": "多云转晴", "wrap": true }
+          ]},
+          { "type": "Column", "items": [
+            { "type": "TextBlock", "text": "温度", "weight": "Bolder", "wrap": true },
+            { "type": "TextBlock", "text": "28°C / 35°C", "wrap": true }
+          ]},
+          { "type": "Column", "items": [
+            { "type": "TextBlock", "text": "降水概率", "weight": "Bolder", "wrap": true },
+            { "type": "TextBlock", "text": "12%", "wrap": true }
+          ]}
+        ]},
         { "type": "FactSet", "facts": [
-            { "title": "状态", "value": "已完成" },
-            { "title": "耗时", "value": "30ms" }
+          { "title": "城市", "value": "上海" },
+          { "title": "更新时间", "value": "2026-07-10 06:57 UTC" }
         ]}
       ]
     },
-    "plain": "报告 · 状态:已完成 · 耗时:30ms"    // fallback text for non-card clients
+    "plain": "天气卡片（模拟）\n天气：多云转晴 · 温度：28°C / 35°C · 降水概率：12%\n城市：上海"
   }
 }
 ```
@@ -223,15 +354,46 @@ POST /v1/bot/sendMessage
 | `text` (text) | TextBlock | Body paragraph | (always available) |
 | `rich` (segments[]) | RichTextBlock + TextRun inlines (bold / color) | One-line multi-style | TextBlock, segments joined |
 | `facts` (items[]) | FactSet | Key-value pairs | Rows of TextBlock `label:value` |
+| `columns` (columns[].blocks[]) | ColumnSet, with Column children inside `columns[]` | Summary/KPI strip, e.g. weather / temperature / rain chance | One TextBlock line joined with pipe separators |
+| `table` (rows[].cells[].text) | Table, with TableRow/TableCell children inside `rows[]` / `cells[]` | Dense matrix data | TextBlock rows with pipe separators |
+| `link` (text, url) | ActionSet with `Action.OpenUrl`; falls back to TextBlock `selectAction` only when `ActionSet` is absent | Visible local/navigation link, no bot callback | TextBlock `text: url` |
 | `group` (blocks[], style?) | Container with `style: good/warning/attention` | Grouped/tinted section | Flattened (color lost, content kept) |
-| `collapsible` (summary, blocks[]) | Container `isVisible:false` + ActionSet `Action.ToggleVisibility` | Fold long details behind a click | Summary as heading + inner blocks expanded below |
+| `collapsible` (summary, actionLabel?, blocks[]) | Container `isVisible:false` + ActionSet `Action.ToggleVisibility` | Fold long details behind a click; use `actionLabel:"查看过程"` for card-message process sections | Summary as heading + inner blocks expanded below |
+| `copy` (label?, text) | ActionSet with `Action.CopyToClipboard` | Local clipboard copy, no bot callback | TextBlock containing the copy text |
 
-The `collapsible` upgrade requires **three** capability flags together: `elements` contains `Container` AND `ActionSet`, AND `actions` (once the server advertises it) contains `Action.ToggleVisibility`. Any one missing → falls back to the expanded form; the content is never lost.
+The `collapsible` upgrade requires **three** capability flags together: `elements` contains `Container` AND `ActionSet`, AND `actions` contains `Action.ToggleVisibility`. Any one missing → falls back to the expanded form; the content is never lost.
+
+For a card-message process section, prepend one `collapsible` block with a short summary and `actionLabel: "查看过程"`:
+```jsonc
+{
+  "type": "collapsible",
+  "summary": "已深度思考 · 12.3s · 3 段推理 · 4 次工具调用",
+  "actionLabel": "查看过程",
+  "blocks": [
+    { "type": "text", "text": "先定位下降发生在哪个漏斗阶段。" },
+    { "type": "rich", "segments": [
+      { "text": "query_metrics", "bold": true, "color": "accent" },
+      { "text": "  channel=B range=90d group=stage · 171ms", "color": "default" }
+    ] },
+    { "type": "text", "text": "再复核口径和行业结构，判断是不是数据口径问题。" },
+    { "type": "rich", "segments": [
+      { "text": "run_sql", "bold": true, "color": "accent" },
+      { "text": "  SELECT industry, activation_rate ... · 102ms", "color": "default" }
+    ] }
+  ]
+}
+```
+
+The `copy` upgrade requires `elements` contains `ActionSet` AND `actions` contains `Action.CopyToClipboard`. `copy.text` is limited to 4KiB measured as UTF-8 bytes; larger text should be shortened before sending.
+
+The `link` block should render a visible `ActionSet` button when `ActionSet` and `Action.OpenUrl` are both advertised. Use TextBlock `selectAction` only as a compatibility fallback because it is clickable but not visually obvious. Never put `Action.Submit` in `selectAction`; Submit belongs to `octo/v2` callback cards.
 
 **Security & safety**
 
 - **Cards are visible to every member of the group.** Never render tokens, API keys, webhook URLs, or `Authorization` values into any card field, even inside a "hidden" collapsible — the raw JSON is stored server-side and can be pulled back by `/v1/message/get`. `buildDisplayCard` in this plugin auto-degrades embedded URLs to `scheme://<registrable-domain>` (including scheme-less and protocol-relative webhook URLs) and drops blocks that match secret shapes (`AKIA…`, `gh[pous]_…`, `xox[bap]-…`/`xapp-…`, `sk-…`, Stripe `sk_live_…`, `glpat-…`, Google `AIza…`, `npm_…`, `shpat_…`, `dop_v1_…`, JWTs, 32+ hex/base64 blobs), but hand-rolled clients must implement the same guardrails.
+- Hidden collapsible content and copy text are still stored in card JSON. Treat them as public group-visible data.
 - The `plain` field is what non-card clients (and history search) see — keep it a truthful summary. Do not put anything in `plain` that isn't already visible in `card`.
+- Keep exactly one title. If you set the tool/card `title`, do not repeat the same text as the first `heading`; the builder deduplicates this, but producers should avoid creating the duplicate in the first place.
 
 **Editing a card (progress frames, live status)**
 
@@ -247,13 +409,14 @@ POST /v1/bot/message/edit
 
 The im-test deployment renders Adaptive Cards 1.5 rich styling end-to-end: `Container.style` tinted backgrounds, `TextRun` colors and weights, `heading.size`, `RichTextBlock` multi-inline layouts. Use them to reduce cognitive load, not for decoration. Rules of thumb:
 
-1. **Layer status with `group.style`.** Wrap sections in a `group` block with `style: "good"` (success/completed), `"warning"` (待办/degraded), or `"attention"` (error/风险). The tinted background lets users spot the important zone at a glance. Example — a status summary:
+1. **Design for the IM first screen.** One title + one compact process summary + answer summary content is the default. Put reasoning sections behind `查看过程`; do not make the first screen a log viewer.
+2. **Layer status with `group.style`.** Wrap sections in a `group` block with `style: "good"` (success/completed), `"warning"` (待办/degraded), or `"attention"` (error/风险). The tinted background lets users spot the important zone at a glance. Example — a status summary:
    ```jsonc
    { "type": "group", "style": "good",       "blocks": [ /* heading + facts of what worked */ ] }
    { "type": "group", "style": "warning",    "blocks": [ /* heading + facts of what's pending */ ] }
    { "type": "group", "style": "attention",  "blocks": [ /* heading + facts of risks */ ] }
    ```
-2. **Emphasize key tokens with `rich` segment colors.** Don't recolor a whole line — just the critical span. Example — a totals line:
+3. **Emphasize key tokens with `rich` segment colors.** Don't recolor a whole line — just the critical span. Example — a totals line:
    ```jsonc
    { "type": "rich", "segments": [
        { "text": "总计: " },
@@ -262,10 +425,25 @@ The im-test deployment renders Adaptive Cards 1.5 rich styling end-to-end: `Cont
    ]}
    ```
    Available colors: `default | good | warning | attention | accent`. Applied to a `TextRun`, not to a whole block.
-3. **Use `heading.size` for cross-section hierarchy.** The card's outer title uses `size: "large"` or `"medium"`; section-level headings inside groups leave `size` unset (default bold is enough — resist the urge to size every heading).
-4. **Prefer `facts` for stable key→value.** `facts` renders as a two-column table (label ⇢ value). Great for "status" / "耗时" / "总计" panels. Do NOT use it for rich text — use `text` or `rich` instead.
-5. **Keep a lid on it.** One `heading` + 1-2 tinted `group`s + one closing `rich` line is usually enough. Three tinted groups is the ceiling; more starts to feel like a Christmas tree.
-6. **Automatic degradation is free.** `buildDisplayCard` negotiates against the server's advertised elements: a deployment that doesn't advertise `RichTextBlock` will silently render your `rich` segments as a joined `TextBlock`, `FactSet` degrades to text rows, `Container.style` flattens to plain items. **You don't need to check compatibility — just describe the intent and the builder degrades gracefully.**
+4. **Use `heading.size` for cross-section hierarchy.** The card's outer title uses `size: "large"` or `"medium"`; section-level headings inside groups leave `size` unset (default bold is enough — resist the urge to size every heading).
+5. **Prefer `facts` for stable key→value.** `facts` renders as a two-column table (label ⇢ value). Great for "status" / "耗时" / "总计" panels. Do NOT use it for rich text or whole-card layout — use `columns`, `text`, or `rich` instead.
+6. **Use `columns` for three-part summaries; reserve `facts` for details.** Weather cards should not be a single FactSet. Use one `columns` block for the top summary, e.g. `天气` / `温度` / `降水概率`, then a small `facts` block for details like `城市` / `日期` / `风力` / `湿度`.
+   ```jsonc
+   {
+     "type": "columns",
+     "columns": [
+       { "blocks": [{ "type": "heading", "text": "天气" }, { "type": "text", "text": "多云转晴" }] },
+       { "blocks": [{ "type": "heading", "text": "温度" }, { "type": "text", "text": "28°C / 19°C" }] },
+       { "blocks": [{ "type": "heading", "text": "降水概率" }, { "type": "text", "text": "20%" }] }
+     ]
+   }
+   ```
+7. **Keep a lid on it.** One title + one summary strip + 1-2 detail groups is usually enough. Three tinted groups is the ceiling; more starts to compete with the answer.
+8. **Put process inside the card message when needed.** If the answer needs a "查看过程" affordance, make it the first block of the display card as a `collapsible` with `actionLabel: "查看过程"`; do not send a separate process-only card for the final answer. Structure it as `reasoning_sections`, not raw `tool_events`.
+9. **Use fewer emoji.** A single status symbol is acceptable, but do not prefix every row with mixed emoji. Tool/process rows should read as text: `阶段`, `工具`, `读取文件`, `失败`.
+10. **Automatic degradation is free.** `buildDisplayCard` negotiates against the server's advertised elements/actions: a deployment that doesn't advertise `RichTextBlock` will silently render your `rich` segments as a joined `TextBlock`; `ColumnSet`, `FactSet`, and `Table` degrade to text rows; `Container.style` flattens to plain items; local actions degrade to text. **You don't need to check compatibility — just describe the intent and the builder degrades gracefully.**
+
+RichTextBlock parity note: always emit `inlines` as objects like `{ "type": "TextRun", "text": "..." }`. The current frontend validator does not accept Adaptive Cards string shorthand in `RichTextBlock.inlines`.
 
 Anti-pattern: rendering a "success ✅ / warning ⚠️ / error ❌" prefix in every row instead of grouping them by tint — the icons carry the signal but rows still bleed into each other. Group them; the tint does the layout work for you.
 
@@ -395,6 +573,12 @@ if message.channel_id is present               → Group  → reply to (channel_
 - The conversation is casual chatter you weren't asked about — stay out.
 - Someone just said "thanks" or "ok" — no need to respond.
 - You were mentioned but the message is clearly for another user — ignore.
+
+#### Always Close the Turn with Text (CRITICAL)
+
+- **Never end a turn on a tool call.** Tools (including `octo_send_display_card`, `exec`, version checks, etc.) are *actions*, not your reply. After the last tool returns, you **must** still emit a short text message to the user.
+- Sending a display card is a **side effect**, not a conversational answer. If the user asked a question (e.g. "check the versions"), a card alone does not answer it — follow the card with a one-line text reply that states the result (the version numbers, the outcome, or a next step).
+- A turn that finishes with zero text output is judged **incomplete** by the runtime and rendered to the user as an interrupted/failed turn (⚠️ 已中断), even though the tools ran. Always leave a closing sentence so the turn completes cleanly.
 
 ### Conversation Style — Talk Like a Person, Not a Document
 

--- a/src/api-fetch.ts
+++ b/src/api-fetch.ts
@@ -518,6 +518,11 @@ export interface CardProfileManifest {
    */
   elements?: string[];
   inputs?: string[];
+  /**
+   * 动作白名单(pkg/cardmsg 权威;server 目前未 advertise,消费方保守视为 undefined)。
+   * 覆盖不回流展示交互(`Action.ToggleVisibility`/`ShowCard`/`OpenUrl`)与回流 `Action.Submit`。
+   */
+  actions?: string[];
   /** 尺寸/结构上限（node/depth/body caps 等）。 */
   limits?: Record<string, unknown>;
 }
@@ -555,11 +560,13 @@ export async function getCardProfile(params: {
   if (!raw || typeof raw !== "object") return { available: true, enabled: false };
   return {
     available: true,
-    enabled: raw.enabled === true,
-    ...(Array.isArray(raw.profiles) ? { profiles: raw.profiles as string[] } : {}),
+    // 兼容布尔与 1/0 序列化(与本仓 GroupMember.robot / getMentionPref 的 flag 惯例一致)。
+    enabled: raw.enabled === true || raw.enabled === 1,
+    ...(Array.isArray(raw.profiles) ? { profiles: (raw.profiles as unknown[]).filter((e): e is string => typeof e === "string") } : {}),
     ...(typeof raw.card_version === "string" ? { card_version: raw.card_version } : {}),
     ...(Array.isArray(raw.elements) ? { elements: (raw.elements as unknown[]).filter((e): e is string => typeof e === "string") } : {}),
     ...(Array.isArray(raw.inputs) ? { inputs: (raw.inputs as unknown[]).filter((e): e is string => typeof e === "string") } : {}),
+    ...(Array.isArray(raw.actions) ? { actions: (raw.actions as unknown[]).filter((e): e is string => typeof e === "string") } : {}),
     ...(raw.limits && typeof raw.limits === "object" ? { limits: raw.limits as Record<string, unknown> } : {}),
   };
 }

--- a/src/api-fetch.ts
+++ b/src/api-fetch.ts
@@ -519,8 +519,10 @@ export interface CardProfileManifest {
   elements?: string[];
   inputs?: string[];
   /**
-   * 动作白名单(pkg/cardmsg 权威;server 目前未 advertise,消费方保守视为 undefined)。
-   * 覆盖不回流展示交互(`Action.ToggleVisibility`/`ShowCard`/`OpenUrl`)与回流 `Action.Submit`。
+   * 动作白名单(pkg/cardmsg 权威)。octo/v1 展示卡只消费本地/导航动作
+   * (`Action.ToggleVisibility`/`Action.CopyToClipboard`/`Action.OpenUrl`);回流 `Action.Submit`
+   * 属于 octo/v2 交互卡路径,不得放进展示卡 selectAction。
+   * 旧部署不返该字段(undefined) → 消费方保守视为不支持任何 action。
    */
   actions?: string[];
   /** 尺寸/结构上限（node/depth/body caps 等）。 */

--- a/src/api-fetch.ts
+++ b/src/api-fetch.ts
@@ -3,7 +3,7 @@
  * These are used by inbound/outbound where the full OctoAPI class is not available.
  */
 
-import { ChannelType, MessageType, type MentionEntity, type RichTextBlock, type SendMessageResult, type TargetCandidate } from "./types.js";
+import { ChannelType, MessageType, CARD_PROFILE, CARD_VERSION, type MentionEntity, type RichTextBlock, type SendMessageResult, type TargetCandidate } from "./types.js";
 import path from "path";
 import { open } from "node:fs/promises";
 import { randomUUID } from "node:crypto";
@@ -377,6 +377,182 @@ export async function sendRichTextMessage(params: {
     client_msg_no: params.clientMsgNo ?? generateClientMsgNo(),
     ...(params.onBehalfOf ? { on_behalf_of: params.onBehalfOf } : {}),
   }, params.signal);
+}
+
+/**
+ * 发送一条 InteractiveCard(=17) 卡片消息（octo-server PR #525 P1）。
+ *
+ * 复用现有 `/v1/bot/sendMessage`，`payload.type=17`，`card` 为标准 Adaptive Cards
+ * 1.5 JSON（`octo/v1` profile）。契约要点：
+ *   - `card` 由调用方组装为合法 AC1.5 JSON；schema 校验由服务端 `pkg/cardmsg` 权威，
+ *     本函数只组包不校验。
+ *   - `plain` 出站可附带（老客户端降级用），server 在 dispatch 出口权威重算覆盖。
+ *   - `profile`/`card_version` 固定 `octo/v1`/`1.5`（Decision 10；不匹配 server 400）。
+ *   - `onBehalfOf` 透传保证 persona-clone 身份一致（C3）；注意 OBO + type17 会被
+ *     server 在 P1 拒绝（Decision 2b），故仅用于普通 bot 发卡场景。
+ *   - 发卡前应先 `getCardProfile` feature-detect（D12）。
+ */
+export async function sendCardMessage(params: {
+  apiUrl: string;
+  botToken: string;
+  channelId: string;
+  channelType: ChannelType;
+  card: Record<string, unknown>;
+  plain?: string;
+  mentionUids?: string[];
+  mentionEntities?: MentionEntity[];
+  mentionAll?: boolean;
+  replyMsgId?: string;
+  onBehalfOf?: string;
+  clientMsgNo?: string;
+  signal?: AbortSignal;
+}): Promise<SendMessageResult | undefined> {
+  if (!params.channelId || !params.channelId.trim()) {
+    throw new Error("octo: channelId is required to send a message");
+  }
+  const payload: Record<string, unknown> = {
+    type: MessageType.InteractiveCard,
+    card: params.card,
+    profile: CARD_PROFILE,
+    card_version: CARD_VERSION,
+  };
+  if (typeof params.plain === "string") {
+    payload.plain = params.plain;
+  }
+  if (
+    (params.mentionUids && params.mentionUids.length > 0) ||
+    (params.mentionEntities && params.mentionEntities.length > 0) ||
+    params.mentionAll
+  ) {
+    const mention: Record<string, unknown> = {};
+    if (params.mentionUids && params.mentionUids.length > 0) mention.uids = params.mentionUids;
+    if (params.mentionEntities && params.mentionEntities.length > 0) mention.entities = params.mentionEntities;
+    if (params.mentionAll) mention.all = 1;
+    payload.mention = mention;
+  }
+  if (params.replyMsgId) {
+    payload.reply = { message_id: params.replyMsgId };
+  }
+  return await postJson<SendMessageResult>(params.apiUrl, params.botToken, "/v1/bot/sendMessage", {
+    channel_id: params.channelId,
+    channel_type: params.channelType,
+    payload,
+    client_msg_no: params.clientMsgNo ?? generateClientMsgNo(),
+    ...(params.onBehalfOf ? { on_behalf_of: params.onBehalfOf } : {}),
+  }, params.signal);
+}
+
+/**
+ * 就地编辑一条 InteractiveCard(=17) 消息（D6 帧 rewrite，octo-server PR#548）。
+ *
+ * `POST /v1/bot/message/edit`，`content_edit` 是**完整 type-17 信封的 JSON 字符串**
+ * （与 send 对称）。服务端 `cardmsg` 校验 + 权威重算 `plain` + `message_extra` upsert +
+ * `SendCMD(CMDSyncMessageExtra)` 扇出;仅能编辑 bot 自己发的、未撤回的卡。
+ *
+ *   - 不传 `message_seq`（canonical flow，服务端解析）。
+ *   - 不带 `card_seq`:adapter dispatch per-group 串行 = 单写者，服务端 last-write-wins;
+ *     并发多副本才需 CAS（届时 `card_seq` 需 string/BigInt 以免 JS number 精度丢失）。
+ *   - `onBehalfOf` 透传（C3 身份一致）;注意 OBO + type-17 被 P1 Decision 2b 拒，
+ *     故调用方应在 persona-clone 场景跳过卡片(见 `card-progress.ts`)。
+ */
+export async function editCardMessage(params: {
+  apiUrl: string;
+  botToken: string;
+  messageId: string;
+  channelId: string;
+  channelType: ChannelType;
+  card: Record<string, unknown>;
+  plain?: string;
+  /** 进度中间帧标 true → D10 不进修订历史(避免 cap 20 被进度噪音刷屏);终态帧不带 → 进历史。 */
+  transient?: boolean;
+  onBehalfOf?: string;
+  signal?: AbortSignal;
+}): Promise<void> {
+  if (!params.messageId) {
+    throw new Error("octo: messageId is required to edit a card");
+  }
+  if (!params.channelId || !params.channelId.trim()) {
+    throw new Error("octo: channelId is required to edit a card");
+  }
+  const envelope: Record<string, unknown> = {
+    type: MessageType.InteractiveCard,
+    card: params.card,
+    profile: CARD_PROFILE,
+    card_version: CARD_VERSION,
+  };
+  if (typeof params.plain === "string") {
+    envelope.plain = params.plain;
+  }
+  // D10:transient 帧不进修订历史侧表(进度中间帧用,避免 cap 20 被刷屏)。
+  if (params.transient) {
+    envelope.transient = true;
+  }
+  await postJson(params.apiUrl, params.botToken, "/v1/bot/message/edit", {
+    message_id: params.messageId,
+    channel_id: params.channelId,
+    channel_type: params.channelType,
+    content_edit: JSON.stringify(envelope),
+    ...(params.onBehalfOf ? { on_behalf_of: params.onBehalfOf } : {}),
+  }, params.signal);
+}
+
+/**
+ * D12 生产者能力发现 manifest（octo-server PR #525 P2 D12，additive-only）。
+ */
+export interface CardProfileManifest {
+  /**
+   * D12 manifest 端点是否**已部署并响应**（非 404）。
+   * `false` 表示端点尚未上线（PR-D 未落地）—— 调用方应回退到 adapter 侧 config
+   * 显式开关决定是否发卡,**不可**把它等同于「服务端明确关闭」。
+   */
+  available: boolean;
+  /** 卡片消息是否启用（OCTO_CARD_MESSAGE_ENABLED）。禁用时 server 仍返 200 + manifest。 */
+  enabled: boolean;
+  /** 支持的 profile 列表，如 `["octo/v1"]`（P2 增 `"octo/v2"`）。 */
+  profiles?: string[];
+  card_version?: string;
+  /** 尺寸/结构上限（node/depth/body caps 等）。 */
+  limits?: Record<string, unknown>;
+}
+
+/**
+ * GET /v1/bot/card/profile — D12 能力发现。发卡前 feature-detect，避免用发送试探
+ * （一个 400 无法区分「disabled」与「invalid」）。
+ *
+ * 返回 `available` 区分两种「不发」语义（避免 gate 死锁）:
+ *   - 端点未部署（404）→ `{ available:false }`：调用方回退 adapter config 显式开关，
+ *     **不可**当作服务端明确关闭（octo-server PR-D 上线前 R2 未落地即此情形）。
+ *   - 端点已部署但 `enabled:false` → `{ available:true, enabled:false }`：服务端明确关，不发。
+ * 传输 / 5xx 抛错，交由调用方重试节奏处理。
+ */
+export async function getCardProfile(params: {
+  apiUrl: string;
+  botToken: string;
+  signal?: AbortSignal;
+}): Promise<CardProfileManifest> {
+  const url = `${params.apiUrl.replace(/\/+$/, "")}/v1/bot/card/profile`;
+  const resp = await fetch(url, {
+    method: "GET",
+    headers: { Authorization: `Bearer ${params.botToken}` },
+    signal: params.signal ?? AbortSignal.timeout(DEFAULT_TIMEOUT_MS),
+  });
+  // 端点尚未部署（PR-D 未落地）→ available:false，调用方回退 config 显式开关，
+  // 不可当作「服务端明确关闭」硬降级不发。
+  if (resp.status === 404) return { available: false, enabled: false };
+  if (!resp.ok) {
+    const text = await resp.text().catch(() => "");
+    throw new Error(`Bot API GET /v1/bot/card/profile failed (${resp.status}): ${text || resp.statusText}`);
+  }
+  // 端点已部署（available:true）；manifest 内容异常时保守视作 enabled:false。
+  const raw = (await resp.json().catch(() => null)) as Record<string, unknown> | null;
+  if (!raw || typeof raw !== "object") return { available: true, enabled: false };
+  return {
+    available: true,
+    enabled: raw.enabled === true,
+    ...(Array.isArray(raw.profiles) ? { profiles: raw.profiles as string[] } : {}),
+    ...(typeof raw.card_version === "string" ? { card_version: raw.card_version } : {}),
+    ...(raw.limits && typeof raw.limits === "object" ? { limits: raw.limits as Record<string, unknown> } : {}),
+  };
 }
 
 export async function sendTyping(params: {

--- a/src/api-fetch.ts
+++ b/src/api-fetch.ts
@@ -511,6 +511,13 @@ export interface CardProfileManifest {
   /** 支持的 profile 列表，如 `["octo/v1"]`（P2 增 `"octo/v2"`）。 */
   profiles?: string[];
   card_version?: string;
+  /**
+   * 服务端 advertise 的元素/输入白名单（源自 pkg/cardmsg 权威，additive）。producer 据此按
+   * 元素/输入粒度协商 —— 即便 card_version 停在 1.5，也能探测该部署到底吃不吃某元素/输入。
+   * 旧部署不返这两字段（undefined）→ 消费方回退保守基线。
+   */
+  elements?: string[];
+  inputs?: string[];
   /** 尺寸/结构上限（node/depth/body caps 等）。 */
   limits?: Record<string, unknown>;
 }
@@ -551,6 +558,8 @@ export async function getCardProfile(params: {
     enabled: raw.enabled === true,
     ...(Array.isArray(raw.profiles) ? { profiles: raw.profiles as string[] } : {}),
     ...(typeof raw.card_version === "string" ? { card_version: raw.card_version } : {}),
+    ...(Array.isArray(raw.elements) ? { elements: (raw.elements as unknown[]).filter((e): e is string => typeof e === "string") } : {}),
+    ...(Array.isArray(raw.inputs) ? { inputs: (raw.inputs as unknown[]).filter((e): e is string => typeof e === "string") } : {}),
     ...(raw.limits && typeof raw.limits === "object" ? { limits: raw.limits as Record<string, unknown> } : {}),
   };
 }

--- a/src/card-adaptation.test.ts
+++ b/src/card-adaptation.test.ts
@@ -95,18 +95,58 @@ describe("getCardProfile (D12 feature-detect)", () => {
     vi.restoreAllMocks();
   });
 
-  it("200 → 解析 manifest", async () => {
+  it("200 → 解析 manifest(完整能力清单:elements/inputs/actions/limits;真实服务端形状)", async () => {
     global.fetch = vi.fn().mockResolvedValue({
       ok: true,
       status: 200,
-      json: vi.fn().mockResolvedValue({ enabled: true, profiles: ["octo/v1"], card_version: "1.5" }),
+      json: vi.fn().mockResolvedValue({
+        enabled: true,
+        card_version: "1.5",
+        profiles: ["octo/v1", "octo/v2"],
+        elements: [
+          "TextBlock", "RichTextBlock", "Image", "ImageSet",
+          "Container", "ColumnSet", "Column", "FactSet",
+          "Table", "ActionSet",
+        ],
+        inputs: [
+          "Input.Text", "Input.Toggle", "Input.ChoiceSet",
+          "Input.Number", "Input.Date", "Input.Time",
+        ],
+        // Action 白名单目前 server 未 advertise(附加式提议),消费方按 undefined 保守处理。
+        // 显式给一份用于验证解析器路径(P1-a 打通,forward-compat)。
+        actions: ["Action.Submit", "Action.ToggleVisibility", "Action.OpenUrl"],
+        limits: {
+          max_payload_bytes: 524288,
+          max_nodes: 200,
+          max_depth: 16,
+          max_input_text_bytes: 4096,
+          max_inputs_bytes: 16384,
+        },
+      }),
     }) as unknown as typeof fetch;
 
     const m = await getCardProfile({ apiUrl: "https://api.test", botToken: "bf_x" });
     expect(m.available).toBe(true);
     expect(m.enabled).toBe(true);
-    expect(m.profiles).toEqual(["octo/v1"]);
     expect(m.card_version).toBe("1.5");
+    expect(m.profiles).toEqual(["octo/v1", "octo/v2"]);
+    expect(m.elements).toEqual([
+      "TextBlock", "RichTextBlock", "Image", "ImageSet",
+      "Container", "ColumnSet", "Column", "FactSet",
+      "Table", "ActionSet",
+    ]);
+    expect(m.inputs).toEqual([
+      "Input.Text", "Input.Toggle", "Input.ChoiceSet",
+      "Input.Number", "Input.Date", "Input.Time",
+    ]);
+    expect(m.actions).toEqual(["Action.Submit", "Action.ToggleVisibility", "Action.OpenUrl"]);
+    expect(m.limits).toEqual({
+      max_payload_bytes: 524288,
+      max_nodes: 200,
+      max_depth: 16,
+      max_input_text_bytes: 4096,
+      max_inputs_bytes: 16384,
+    });
   });
 
   it("404(端点未部署)→ available:false(调用方回退 config)", async () => {
@@ -130,6 +170,24 @@ describe("getCardProfile (D12 feature-detect)", () => {
     const m = await getCardProfile({ apiUrl: "https://api.test", botToken: "bf_x" });
     expect(m.available).toBe(true);
     expect(m.enabled).toBe(false);
+  });
+
+  it("F5: enabled 序列化为 1/0 也兼容(与仓库 flag 惯例一致)", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: vi.fn().mockResolvedValue({ enabled: 1, profiles: ["octo/v1"] }),
+    }) as unknown as typeof fetch;
+    const m = await getCardProfile({ apiUrl: "https://api.test", botToken: "bf_x" });
+    expect(m.enabled).toBe(true);
+
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: vi.fn().mockResolvedValue({ enabled: 0 }),
+    }) as unknown as typeof fetch;
+    const m0 = await getCardProfile({ apiUrl: "https://api.test", botToken: "bf_x" });
+    expect(m0.enabled).toBe(false);
   });
 
   it("5xx → 抛错(交给调用方重试节奏)", async () => {

--- a/src/card-adaptation.test.ts
+++ b/src/card-adaptation.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { ChannelType, MessageType, CARD_PLACEHOLDER } from "./types.js";
+import { resolveCardPlain, resolveInnerMessageText, resolveApiMessagePlaceholder } from "./inbound.js";
+import { sendCardMessage, getCardProfile, editCardMessage } from "./api-fetch.js";
+
+/**
+ * InteractiveCard(=17) 适配 — 波 0 入站派生 + 波 A 出站原语。
+ * 契约来源:octo-server PR #525 P1(card-message-protocol)。
+ */
+
+describe("InteractiveCard(17) 入站派生 plain", () => {
+  it("resolveCardPlain: 有 plain 取原文(trim)", () => {
+    expect(resolveCardPlain({ plain: "任务完成 ✅" })).toBe("任务完成 ✅");
+    expect(resolveCardPlain({ plain: "  spaced  " })).toBe("spaced");
+  });
+
+  it("resolveCardPlain: 空/空白/非字符串/缺失 → [卡片](never empty)", () => {
+    expect(resolveCardPlain({ plain: "" })).toBe(CARD_PLACEHOLDER);
+    expect(resolveCardPlain({ plain: "   " })).toBe(CARD_PLACEHOLDER);
+    expect(resolveCardPlain({ plain: 123 as unknown })).toBe(CARD_PLACEHOLDER);
+    expect(resolveCardPlain({})).toBe(CARD_PLACEHOLDER);
+    expect(resolveCardPlain(undefined)).toBe(CARD_PLACEHOLDER);
+  });
+
+  it("resolveInnerMessageText: type=17 取服务端 plain / 回退 [卡片]", () => {
+    expect(
+      resolveInnerMessageText({ type: MessageType.InteractiveCard, plain: "卡片正文" } as never),
+    ).toBe("卡片正文");
+    expect(
+      resolveInnerMessageText({ type: MessageType.InteractiveCard } as never),
+    ).toBe(CARD_PLACEHOLDER);
+  });
+
+  it("resolveApiMessagePlaceholder: type=17 → [卡片]", () => {
+    expect(resolveApiMessagePlaceholder(MessageType.InteractiveCard)).toBe(CARD_PLACEHOLDER);
+  });
+});
+
+describe("sendCardMessage 出站组包", () => {
+  const originalFetch = global.fetch;
+  afterEach(() => {
+    global.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it("payload.type=17 + card + profile/card_version + on_behalf_of 透传(C3)", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: vi.fn().mockResolvedValue('{"message_id":"m1"}'),
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const res = await sendCardMessage({
+      apiUrl: "https://api.test",
+      botToken: "bf_x",
+      channelId: "g1",
+      channelType: ChannelType.Group,
+      card: { type: "AdaptiveCard", body: [] },
+      plain: "seed",
+      onBehalfOf: "u_grantor",
+    });
+    expect(res).toEqual({ message_id: "m1" });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(String(url)).toContain("/v1/bot/sendMessage");
+    const body = JSON.parse(init.body as string);
+    expect(body.payload.type).toBe(MessageType.InteractiveCard);
+    expect(body.payload.card).toEqual({ type: "AdaptiveCard", body: [] });
+    expect(body.payload.profile).toBe("octo/v1");
+    expect(body.payload.card_version).toBe("1.5");
+    expect(body.payload.plain).toBe("seed");
+    expect(body.on_behalf_of).toBe("u_grantor");
+    expect(typeof body.client_msg_no).toBe("string");
+  });
+
+  it("空 channelId 抛错", async () => {
+    await expect(
+      sendCardMessage({
+        apiUrl: "https://api.test",
+        botToken: "bf_x",
+        channelId: "  ",
+        channelType: ChannelType.Group,
+        card: {},
+      }),
+    ).rejects.toThrow(/channelId is required/);
+  });
+});
+
+describe("getCardProfile (D12 feature-detect)", () => {
+  const originalFetch = global.fetch;
+  afterEach(() => {
+    global.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it("200 → 解析 manifest", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: vi.fn().mockResolvedValue({ enabled: true, profiles: ["octo/v1"], card_version: "1.5" }),
+    }) as unknown as typeof fetch;
+
+    const m = await getCardProfile({ apiUrl: "https://api.test", botToken: "bf_x" });
+    expect(m.available).toBe(true);
+    expect(m.enabled).toBe(true);
+    expect(m.profiles).toEqual(["octo/v1"]);
+    expect(m.card_version).toBe("1.5");
+  });
+
+  it("404(端点未部署)→ available:false(调用方回退 config)", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 404,
+      text: vi.fn().mockResolvedValue(""),
+    }) as unknown as typeof fetch;
+
+    const m = await getCardProfile({ apiUrl: "https://api.test", botToken: "bf_x" });
+    expect(m).toEqual({ available: false, enabled: false });
+  });
+
+  it("200 enabled:false → available:true(服务端明确关,区别于 404 未部署)", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: vi.fn().mockResolvedValue({ enabled: false }),
+    }) as unknown as typeof fetch;
+
+    const m = await getCardProfile({ apiUrl: "https://api.test", botToken: "bf_x" });
+    expect(m.available).toBe(true);
+    expect(m.enabled).toBe(false);
+  });
+
+  it("5xx → 抛错(交给调用方重试节奏)", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: "err",
+      text: vi.fn().mockResolvedValue("boom"),
+    }) as unknown as typeof fetch;
+
+    await expect(
+      getCardProfile({ apiUrl: "https://api.test", botToken: "bf_x" }),
+    ).rejects.toThrow(/card\/profile failed \(500\)/);
+  });
+});
+
+describe("editCardMessage 出站组包", () => {
+  const originalFetch = global.fetch;
+  afterEach(() => {
+    global.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it("POST /v1/bot/message/edit,content_edit=stringify 的 type-17 信封 + onBehalfOf(C3)", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: vi.fn().mockResolvedValue(""),
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    await editCardMessage({
+      apiUrl: "https://api.test",
+      botToken: "bf_x",
+      messageId: "m1",
+      channelId: "g1",
+      channelType: ChannelType.Group,
+      card: { type: "AdaptiveCard" },
+      plain: "进度",
+      onBehalfOf: "u_grantor",
+    });
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(String(url)).toContain("/v1/bot/message/edit");
+    const body = JSON.parse(init.body as string);
+    expect(body.message_id).toBe("m1");
+    expect(body.channel_id).toBe("g1");
+    expect(body.on_behalf_of).toBe("u_grantor");
+    expect(body.message_seq).toBeUndefined();
+    const env = JSON.parse(body.content_edit);
+    expect(env.type).toBe(MessageType.InteractiveCard);
+    expect(env.profile).toBe("octo/v1");
+    expect(env.card_version).toBe("1.5");
+    expect(env.card).toEqual({ type: "AdaptiveCard" });
+    expect(env.plain).toBe("进度");
+    expect(env.card_seq).toBeUndefined();
+    expect(env.transient).toBeUndefined(); // 不传 transient → 默认进修订历史
+  });
+
+  it("空 messageId 抛错", async () => {
+    await expect(
+      editCardMessage({
+        apiUrl: "https://api.test",
+        botToken: "bf_x",
+        messageId: "",
+        channelId: "g1",
+        channelType: ChannelType.Group,
+        card: {},
+      }),
+    ).rejects.toThrow(/messageId is required/);
+  });
+});

--- a/src/card-adaptation.test.ts
+++ b/src/card-adaptation.test.ts
@@ -105,16 +105,14 @@ describe("getCardProfile (D12 feature-detect)", () => {
         profiles: ["octo/v1", "octo/v2"],
         elements: [
           "TextBlock", "RichTextBlock", "Image", "ImageSet",
-          "Container", "ColumnSet", "Column", "FactSet",
+          "Container", "ColumnSet", "FactSet",
           "Table", "ActionSet",
         ],
         inputs: [
           "Input.Text", "Input.Toggle", "Input.ChoiceSet",
           "Input.Number", "Input.Date", "Input.Time",
         ],
-        // Action 白名单目前 server 未 advertise(附加式提议),消费方按 undefined 保守处理。
-        // 显式给一份用于验证解析器路径(P1-a 打通,forward-compat)。
-        actions: ["Action.Submit", "Action.ToggleVisibility", "Action.OpenUrl"],
+        actions: ["Action.OpenUrl", "Action.ToggleVisibility", "Action.CopyToClipboard"],
         limits: {
           max_payload_bytes: 524288,
           max_nodes: 200,
@@ -132,14 +130,14 @@ describe("getCardProfile (D12 feature-detect)", () => {
     expect(m.profiles).toEqual(["octo/v1", "octo/v2"]);
     expect(m.elements).toEqual([
       "TextBlock", "RichTextBlock", "Image", "ImageSet",
-      "Container", "ColumnSet", "Column", "FactSet",
+      "Container", "ColumnSet", "FactSet",
       "Table", "ActionSet",
     ]);
     expect(m.inputs).toEqual([
       "Input.Text", "Input.Toggle", "Input.ChoiceSet",
       "Input.Number", "Input.Date", "Input.Time",
     ]);
-    expect(m.actions).toEqual(["Action.Submit", "Action.ToggleVisibility", "Action.OpenUrl"]);
+    expect(m.actions).toEqual(["Action.OpenUrl", "Action.ToggleVisibility", "Action.CopyToClipboard"]);
     expect(m.limits).toEqual({
       max_payload_bytes: 524288,
       max_nodes: 200,

--- a/src/card-blocks.test.ts
+++ b/src/card-blocks.test.ts
@@ -1,0 +1,452 @@
+import { describe, it, expect } from "vitest";
+import { buildDisplayCard, validateDisplayBlocks, type DisplayBlock } from "./card-blocks.js";
+import type { CardCaps } from "./card-render.js";
+
+/**
+ * 展示卡构建器 —— 方案乙契约测试:DisplayBlock → AC 1.5 JSON,按 caps 协商降级,
+ * 每 block 产 plain 兜底,脱敏与 card-render 同套(URL 降级 + secret 命中隐藏)。
+ */
+
+/** 便利:advertise 全套元素(RichTextBlock/FactSet/Container 都可用)。 */
+const FULL_CAPS: CardCaps = {
+  elements: new Set(["TextBlock", "RichTextBlock", "FactSet", "Container", "ColumnSet", "Column", "Image"]),
+};
+
+/** 便利:仅基线(相当于旧部署不 advertise elements,card-render baseline)。 */
+const BASELINE_CAPS: CardCaps | undefined = undefined;
+
+/** 类型窄化:取 body 元素。 */
+type Element = Record<string, unknown>;
+function body(res: { card: Record<string, unknown> }): Element[] {
+  return (res.card.body as Element[]) ?? [];
+}
+
+describe("buildDisplayCard 骨架", () => {
+  it("最小卡:type=AdaptiveCard + version=1.5 + $schema + body 数组", () => {
+    const { card } = buildDisplayCard({ blocks: [] });
+    expect(card.type).toBe("AdaptiveCard");
+    expect(card.version).toBe("1.5");
+    expect(card.$schema).toBe("http://adaptivecards.io/schemas/adaptive-card.json");
+    expect(Array.isArray(card.body)).toBe(true);
+  });
+
+  it("title 渲染成置顶 Bolder TextBlock,plain 首行是 title", () => {
+    const { card, plain } = buildDisplayCard({ title: "审批请求", blocks: [] });
+    const els = body({ card });
+    expect(els[0]).toEqual({ type: "TextBlock", text: "审批请求", wrap: true, weight: "Bolder" });
+    expect(plain.split("\n")[0]).toBe("审批请求");
+  });
+
+  it("plain 每个 block 一行,与视觉降级无关", () => {
+    const { plain } = buildDisplayCard({
+      blocks: [
+        { type: "heading", text: "H" },
+        { type: "text", text: "L1" },
+        { type: "text", text: "L2" },
+      ],
+    });
+    expect(plain.split("\n")).toEqual(["H", "L1", "L2"]);
+  });
+});
+
+describe("heading / text block", () => {
+  it("heading → Bolder TextBlock", () => {
+    const { card } = buildDisplayCard({ blocks: [{ type: "heading", text: "标题" }] });
+    expect(body({ card })[0]).toEqual({ type: "TextBlock", text: "标题", wrap: true, weight: "Bolder" });
+  });
+
+  it("text → 普通 TextBlock(wrap)", () => {
+    const { card } = buildDisplayCard({ blocks: [{ type: "text", text: "正文" }] });
+    expect(body({ card })[0]).toEqual({ type: "TextBlock", text: "正文", wrap: true });
+  });
+
+  it("text 内嵌 URL 降级到 scheme://注册域(webhook/隧道/预签名主机都吃)", () => {
+    const { card } = buildDisplayCard({
+      blocks: [{ type: "text", text: "回调 https://hooks.slack.com/services/T00/B00/xy → 500" }],
+    });
+    // Slack webhook path 里嵌的密钥被 URL 降级抹掉,只留 slack.com 主机
+    expect((body({ card })[0] as { text: string }).text).toContain("https://slack.com");
+    expect((body({ card })[0] as { text: string }).text).not.toContain("xy");
+    expect((body({ card })[0] as { text: string }).text).not.toContain("services");
+  });
+
+  it("text 命中 secret shape → 整个 block 不渲染(fail-closed)", () => {
+    const { card, plain } = buildDisplayCard({
+      blocks: [
+        { type: "text", text: "token=AKIAIOSFODNN7EXAMPLE" }, // AWS key shape
+        { type: "text", text: "正常正文" },
+      ],
+    });
+    const texts = body({ card }).map((e) => (e as { text?: string }).text);
+    expect(texts).toContain("正常正文");
+    expect(texts).not.toContain("token=AKIAIOSFODNN7EXAMPLE");
+    // plain 也应隐藏,保持一致
+    expect(plain).not.toContain("AKIA");
+  });
+});
+
+describe("rich block(高价值:一行多样式,顺带解决 ColumnSet plain 分行)", () => {
+  it("advertise RichTextBlock → RichTextBlock + inlines(bold/color 逐段)", () => {
+    const { card } = buildDisplayCard({
+      caps: FULL_CAPS,
+      blocks: [{ type: "rich", segments: [
+        { text: "📖 " },
+        { text: "读取文件", bold: true },
+        { text: "：/a.md" },
+        { text: " · 30ms", color: "good" },
+      ]}],
+    });
+    const el = body({ card })[0] as { type: string; inlines: Array<Record<string, unknown>> };
+    expect(el.type).toBe("RichTextBlock");
+    expect(el.inlines).toHaveLength(4);
+    expect(el.inlines[1]).toEqual({ type: "TextRun", text: "读取文件", weight: "Bolder" });
+    expect(el.inlines[3]).toEqual({ type: "TextRun", text: " · 30ms", color: "good" });
+  });
+
+  it("不 advertise RichTextBlock → 段拼成单个 TextBlock(降级,零回归)", () => {
+    const { card, plain } = buildDisplayCard({
+      caps: { elements: new Set(["TextBlock"]) }, // 只 baseline TextBlock
+      blocks: [{ type: "rich", segments: [
+        { text: "📖 " },
+        { text: "读取文件" },
+        { text: "：/a.md · 30ms" },
+      ]}],
+    });
+    const el = body({ card })[0] as { type: string; text: string };
+    expect(el.type).toBe("TextBlock");
+    expect(el.text).toBe("📖 读取文件：/a.md · 30ms"); // 一行,顺带解决 ColumnSet plain 分行
+    expect(plain).toBe("📖 读取文件：/a.md · 30ms");
+  });
+
+  it("rich 段命中 secret → 整块隐藏", () => {
+    const { card } = buildDisplayCard({
+      caps: FULL_CAPS,
+      blocks: [{ type: "rich", segments: [
+        { text: "Bearer sk-1234567890abcdef" },
+      ]}],
+    });
+    expect(body({ card })).toEqual([]);
+  });
+
+  it("F1: rich 段内 URL 也降级 —— card 绝不多于 plain(webhook 密钥不进 TextRun)", () => {
+    const { card, plain } = buildDisplayCard({
+      caps: FULL_CAPS,
+      blocks: [{ type: "rich", segments: [
+        { text: "Webhook: " },
+        { text: "https://hooks.slack.com/services/T00000000/B11111111/AbCdEfSecretTokenXyz123" }, // gitleaks:allow (fake fixture)
+      ]}],
+    });
+    const cardStr = JSON.stringify(card);
+    expect(cardStr).not.toContain("AbCdEfSecretTokenXyz123");
+    expect(cardStr).not.toContain("/services/");
+    expect(cardStr).toContain("https://slack.com");
+    expect(plain).toBe("Webhook: https://slack.com");
+    // 含 URL → 降级为单个 TextBlock(不再逐段 TextRun,防跨段拆开的 URL 漏出)
+    expect((body({ card })[0] as { type: string }).type).toBe("TextBlock");
+  });
+
+  it("前缀式密钥被词字符粘连(含 rich 段空串拼接)也不漏进卡体", () => {
+    // 回归 yujiawei P1:renderRich 用空串拼 segments,相邻段会把 `foo` 与 `sk-…` 粘成 `foosk-…`,
+    // 抹掉词界 → 若前缀检测带 `\b` 就漏。text 单字段粘连同理。
+    const text = buildDisplayCard({ blocks: [{ type: "text", text: "KeyAKIA1234567890ABCDEF" }], caps: FULL_CAPS });
+    expect(JSON.stringify(text.card)).not.toContain("AKIA1234567890ABCDEF");
+    expect(text.plain).not.toContain("AKIA1234567890ABCDEF");
+    const rich = buildDisplayCard({
+      caps: FULL_CAPS,
+      blocks: [{ type: "rich", segments: [{ text: "foo" }, { text: "sk-liveABCDEFGHIJKLMNOP" }] }],
+    });
+    expect(JSON.stringify(rich.card)).not.toContain("sk-liveABCDEFGHIJKLMNOP");
+    expect(rich.plain).not.toContain("sk-liveABCDEFGHIJKLMNOP");
+  });
+
+  it("F1: URL 跨 segment 拆开也不漏(joined 降级 + 降级为 TextBlock)", () => {
+    const { card, plain } = buildDisplayCard({
+      caps: FULL_CAPS,
+      blocks: [{ type: "rich", segments: [
+        { text: "https://hooks.slack.com/services/T00" },
+        { text: "/B00/SuperSecretTail99" },
+      ]}],
+    });
+    const cardStr = JSON.stringify(card);
+    expect(cardStr).not.toContain("SuperSecretTail99");
+    expect(plain).toBe("https://slack.com");
+  });
+});
+
+describe("facts block(键值对)", () => {
+  it("advertise FactSet → FactSet + facts[]", () => {
+    const { card } = buildDisplayCard({
+      caps: FULL_CAPS,
+      blocks: [{ type: "facts", items: [
+        { label: "状态", value: "已完成" },
+        { label: "耗时", value: "30ms" },
+      ]}],
+    });
+    const el = body({ card })[0] as { type: string; facts: Array<{ title: string; value: string }> };
+    expect(el.type).toBe("FactSet");
+    expect(el.facts).toEqual([
+      { title: "状态", value: "已完成" },
+      { title: "耗时", value: "30ms" },
+    ]);
+  });
+
+  it("不 advertise FactSet → 降级为多行 TextBlock 「label:value」", () => {
+    const { card, plain } = buildDisplayCard({
+      caps: { elements: new Set(["TextBlock"]) },
+      blocks: [{ type: "facts", items: [
+        { label: "状态", value: "已完成" },
+        { label: "耗时", value: "30ms" },
+      ]}],
+    });
+    const els = body({ card });
+    expect(els).toHaveLength(2);
+    expect((els[0] as { text: string }).text).toBe("状态：已完成");
+    expect((els[1] as { text: string }).text).toBe("耗时：30ms");
+    expect(plain).toBe("状态：已完成\n耗时：30ms");
+  });
+
+  it("facts.value 内嵌 URL 降级;命中 secret → 该条隐藏,不影响其它条", () => {
+    const { card, plain } = buildDisplayCard({
+      caps: FULL_CAPS,
+      blocks: [{ type: "facts", items: [
+        { label: "webhook", value: "https://hooks.slack.com/services/T/B/xy" },
+        { label: "token", value: "AKIAIOSFODNN7EXAMPLE" }, // secret shape
+        { label: "状态", value: "ok" },
+      ]}],
+    });
+    const el = body({ card })[0] as { facts: Array<{ title: string; value: string }> };
+    // 3 条剩下 2 条:webhook 只留主机;token 整条被抹;状态原样
+    expect(el.facts).toHaveLength(2);
+    expect(el.facts[0].value).toBe("https://slack.com");
+    expect(el.facts[1].title).toBe("状态");
+    expect(plain).not.toContain("AKIA");
+  });
+});
+
+describe("group block(分组着色)", () => {
+  it("advertise Container → Container(style)包住子 block", () => {
+    const { card } = buildDisplayCard({
+      caps: FULL_CAPS,
+      blocks: [{ type: "group", style: "good", blocks: [
+        { type: "text", text: "成功" },
+      ]}],
+    });
+    const el = body({ card })[0] as { type: string; style: string; items: Element[] };
+    expect(el.type).toBe("Container");
+    expect(el.style).toBe("good");
+    expect(el.items).toHaveLength(1);
+    expect((el.items[0] as { text: string }).text).toBe("成功");
+  });
+
+  it("baseline(无 caps)含 Container → 走 Container 路径(零回归)", () => {
+    const { card } = buildDisplayCard({
+      caps: BASELINE_CAPS,
+      blocks: [{ type: "group", blocks: [{ type: "text", text: "内" }] }],
+    });
+    expect((body({ card })[0] as { type: string }).type).toBe("Container");
+  });
+
+  it("不 advertise Container → 平铺子 block(降级不丢内容,只丢着色)", () => {
+    const { card } = buildDisplayCard({
+      caps: { elements: new Set(["TextBlock"]) },
+      blocks: [{ type: "group", style: "warning", blocks: [
+        { type: "text", text: "a" },
+        { type: "text", text: "b" },
+      ]}],
+    });
+    const els = body({ card });
+    expect(els).toHaveLength(2); // 平铺,无 Container 外壳
+    expect((els[0] as { text: string }).text).toBe("a");
+    expect((els[1] as { text: string }).text).toBe("b");
+  });
+});
+
+describe("collapsible block(forward-compat 折叠/展开)", () => {
+  /**
+   * 升级 = advertise Container + advertise ActionSet + advertise Action.ToggleVisibility。
+   * 任一不满足 → 降级为平铺(summary 当 heading,inner 全部展开在下方 —— 零回归)。
+   */
+  const CAPS_WITH_TOGGLE: CardCaps = {
+    elements: new Set(["TextBlock", "Container", "ActionSet"]),
+    actions: new Set(["Action.ToggleVisibility"]),
+  };
+
+  it("advertise ToggleVisibility+ActionSet+Container → 升级:summary+隐藏 Container", () => {
+    const { card } = buildDisplayCard({
+      caps: CAPS_WITH_TOGGLE,
+      blocks: [{ type: "collapsible", summary: "详情", blocks: [
+        { type: "text", text: "机密上下文 A" },
+        { type: "text", text: "机密上下文 B" },
+      ]}],
+    });
+    const els = body({ card });
+    // 应有:summary(TextBlock)+ toggle 触发器(ActionSet)+ 目标 Container(isVisible:false)
+    const container = els.find((e) => e.type === "Container") as { id: string; isVisible: boolean; items: Element[] };
+    expect(container).toBeTruthy();
+    expect(container.isVisible).toBe(false);
+    expect(container.id).toBeTruthy(); // 有 id 才能 target
+    expect(container.items).toHaveLength(2);
+
+    const actionSet = els.find((e) => e.type === "ActionSet") as { actions: Array<Record<string, unknown>> };
+    expect(actionSet).toBeTruthy();
+    expect(actionSet.actions[0]).toMatchObject({
+      type: "Action.ToggleVisibility",
+      title: "详情",
+      targetElements: [container.id],
+    });
+  });
+
+  it("plain 兜底:summary + 详情行(全展开,与折叠无关 —— 服务端 Finalize 权威重算)", () => {
+    const { plain } = buildDisplayCard({
+      caps: CAPS_WITH_TOGGLE,
+      blocks: [{ type: "collapsible", summary: "详情", blocks: [
+        { type: "text", text: "行1" },
+        { type: "text", text: "行2" },
+      ]}],
+    });
+    expect(plain).toBe("详情\n行1\n行2");
+  });
+
+  it("未 advertise Action.ToggleVisibility → 降级平铺(summary 当 heading,inner 展开)", () => {
+    // Container/ActionSet 有,但缺 actions 白名单 → 保守降级。
+    const { card } = buildDisplayCard({
+      caps: { elements: new Set(["TextBlock", "Container", "ActionSet"]) }, // 无 actions
+      blocks: [{ type: "collapsible", summary: "详情", blocks: [
+        { type: "text", text: "行1" },
+      ]}],
+    });
+    const els = body({ card });
+    // 无 ActionSet / 无 isVisible:false 的 Container(全展开,heading + text)
+    expect(els.some((e) => e.type === "ActionSet")).toBe(false);
+    expect(els.some((e) => (e as { isVisible?: boolean }).isVisible === false)).toBe(false);
+    // 至少有:summary heading + inner 行
+    const texts = els.map((e) => (e as { text?: string }).text).filter(Boolean);
+    expect(texts).toEqual(expect.arrayContaining(["详情", "行1"]));
+  });
+
+  it("未 advertise ActionSet → 同样降级(缺哪一维都退回展开)", () => {
+    const { card } = buildDisplayCard({
+      caps: {
+        elements: new Set(["TextBlock", "Container"]), // 缺 ActionSet
+        actions: new Set(["Action.ToggleVisibility"]),
+      },
+      blocks: [{ type: "collapsible", summary: "S", blocks: [{ type: "text", text: "inner" }] }],
+    });
+    const els = body({ card });
+    expect(els.some((e) => e.type === "ActionSet")).toBe(false);
+  });
+
+  it("summary 命中 secret 整块隐藏(fail-closed);summary 空 → 整块跳过", () => {
+    const { card: c1 } = buildDisplayCard({
+      caps: CAPS_WITH_TOGGLE,
+      blocks: [{ type: "collapsible", summary: "Bearer sk-1234567890abcdef", blocks: [
+        { type: "text", text: "inner" },
+      ]}],
+    });
+    expect(body({ card: c1 })).toEqual([]);
+
+    const { card: c2 } = buildDisplayCard({
+      caps: CAPS_WITH_TOGGLE,
+      blocks: [{ type: "collapsible", summary: "", blocks: [{ type: "text", text: "inner" }] }],
+    });
+    expect(body({ card: c2 })).toEqual([]);
+  });
+
+  it("inner 全部空/被脱敏抹掉 → 整个 collapsible 不渲染(避免产生「点击展开发现空」的死块)", () => {
+    const { card } = buildDisplayCard({
+      caps: CAPS_WITH_TOGGLE,
+      blocks: [{ type: "collapsible", summary: "标题", blocks: [
+        { type: "text", text: "" },
+        { type: "text", text: "AKIAIOSFODNN7EXAMPLE" }, // secret shape → 隐藏
+      ]}],
+    });
+    expect(body({ card })).toEqual([]);
+  });
+
+  it("多个 collapsible 各自 target 独立 id(不串扰)", () => {
+    const { card } = buildDisplayCard({
+      caps: CAPS_WITH_TOGGLE,
+      blocks: [
+        { type: "collapsible", summary: "A", blocks: [{ type: "text", text: "a" }] },
+        { type: "collapsible", summary: "B", blocks: [{ type: "text", text: "b" }] },
+      ],
+    });
+    const containers = body({ card }).filter((e) => e.type === "Container") as Array<{ id: string }>;
+    expect(containers).toHaveLength(2);
+    expect(containers[0].id).not.toBe(containers[1].id);
+  });
+});
+
+describe("组合与边界", () => {
+  it("多种 block 依序 + title,plain 逐行", () => {
+    const blocks: DisplayBlock[] = [
+      { type: "heading", text: "报告" },
+      { type: "facts", items: [{ label: "总数", value: "3" }] },
+      { type: "text", text: "尾注" },
+    ];
+    const { plain } = buildDisplayCard({ title: "T", blocks, caps: FULL_CAPS });
+    expect(plain).toBe("T\n报告\n总数：3\n尾注");
+  });
+
+  it("空 blocks + 空 title → 空 body,plain 为空串", () => {
+    const { card, plain } = buildDisplayCard({ blocks: [] });
+    expect(body({ card })).toEqual([]);
+    expect(plain).toBe("");
+  });
+
+  it("空白 text 自动跳过(不产元素也不产 plain 行)", () => {
+    const { card, plain } = buildDisplayCard({
+      blocks: [
+        { type: "text", text: "" },
+        { type: "text", text: "   " },
+        { type: "text", text: "有内容" },
+      ],
+    });
+    expect(body({ card })).toHaveLength(1);
+    expect(plain).toBe("有内容");
+  });
+
+  it("F3: 超 max_nodes → 截断 body 并附省略提示(不产出会被服务端 400 的结构)", () => {
+    const many: DisplayBlock[] = Array.from({ length: 10 }, (_, i) => ({ type: "text", text: `行${i}` }));
+    const { card, plain } = buildDisplayCard({ blocks: many, caps: { elements: new Set(["TextBlock"]), maxNodes: 3 } });
+    const b = body({ card }) as Array<{ type: string; text: string }>;
+    expect(b).toHaveLength(3);
+    expect(b[2].text).toContain("省略");
+    // plain 与 card 同步:被卡片丢弃的项(行2..行9)不得出现在 plain 里(P2-1)
+    expect(plain.split("\n")).toHaveLength(3);
+    expect(plain).not.toContain("行2");
+    expect(plain).not.toContain("行9");
+    expect(plain).toContain("行0");
+  });
+});
+
+describe("validateDisplayBlocks 结构上限(不可信输入)", () => {
+  it("F6: 超深嵌套不 RangeError(深度耗尽 → 该层丢弃)", () => {
+    let deep: unknown = { type: "text", text: "leaf" };
+    for (let i = 0; i < 5000; i++) deep = { type: "group", blocks: [deep] };
+    expect(() => validateDisplayBlocks([deep])).not.toThrow();
+  });
+
+  it("F6: 超大数组按总数上限截断", () => {
+    const huge = Array.from({ length: 100000 }, (_, i) => ({ type: "text", text: `t${i}` }));
+    const out = validateDisplayBlocks(huge);
+    expect(out.length).toBeLessThanOrEqual(200);
+  });
+
+  it("合法浅结构照常通过", () => {
+    const out = validateDisplayBlocks([
+      { type: "heading", text: "H" },
+      { type: "group", blocks: [{ type: "text", text: "x" }] },
+    ]);
+    expect(out).toHaveLength(2);
+  });
+
+  it("facts.items 计入总节点预算 —— facts-heavy 卡被截断(防服务端 node 上限 400)", () => {
+    const bigFacts = { type: "facts", items: Array.from({ length: 1000 }, (_, i) => ({ label: `k${i}`, value: `v${i}` })) };
+    const out = validateDisplayBlocks([bigFacts]);
+    expect(out).toHaveLength(1);
+    expect(out[0].type).toBe("facts");
+    const items = (out[0] as { items: unknown[] }).items;
+    expect(items.length).toBeLessThanOrEqual(200); // 受 MAX_TOTAL_BLOCKS 约束
+  });
+});

--- a/src/card-blocks.test.ts
+++ b/src/card-blocks.test.ts
@@ -9,7 +9,21 @@ import type { CardCaps } from "./card-render.js";
 
 /** 便利:advertise 全套元素(RichTextBlock/FactSet/Container 都可用)。 */
 const FULL_CAPS: CardCaps = {
-  elements: new Set(["TextBlock", "RichTextBlock", "FactSet", "Container", "ColumnSet", "Column", "Image"]),
+  elements: new Set([
+    "TextBlock", "RichTextBlock", "FactSet", "Container", "ColumnSet",
+    "Image", "Table", "ActionSet",
+  ]),
+  actions: new Set(["Action.OpenUrl", "Action.ToggleVisibility", "Action.CopyToClipboard"]),
+};
+
+const CAPS_WITH_COPY: CardCaps = {
+  elements: new Set(["TextBlock", "ActionSet"]),
+  actions: new Set(["Action.CopyToClipboard"]),
+};
+
+const CAPS_WITH_OPEN_URL: CardCaps = {
+  elements: new Set(["TextBlock"]),
+  actions: new Set(["Action.OpenUrl"]),
 };
 
 /** 便利:仅基线(相当于旧部署不 advertise elements,card-render baseline)。 */
@@ -99,6 +113,7 @@ describe("rich block(高价值:一行多样式,顺带解决 ColumnSet plain 分�
     const el = body({ card })[0] as { type: string; inlines: Array<Record<string, unknown>> };
     expect(el.type).toBe("RichTextBlock");
     expect(el.inlines).toHaveLength(4);
+    expect(el.inlines.every((i) => i.type === "TextRun")).toBe(true); // 前端 validator 不接受 string shorthand
     expect(el.inlines[1]).toEqual({ type: "TextRun", text: "读取文件", weight: "Bolder" });
     expect(el.inlines[3]).toEqual({ type: "TextRun", text: " · 30ms", color: "good" });
   });
@@ -170,6 +185,147 @@ describe("rich block(高价值:一行多样式,顺带解决 ColumnSet plain 分�
     const cardStr = JSON.stringify(card);
     expect(cardStr).not.toContain("SuperSecretTail99");
     expect(plain).toBe("https://slack.com");
+  });
+});
+
+describe("table block(Table)", () => {
+  it("advertise Table → 渲染原生 Table,Row/Cell 作为 Table 内部子结构生成", () => {
+    const { card, plain } = buildDisplayCard({
+      caps: FULL_CAPS,
+      blocks: [{ type: "table", rows: [
+        { cells: [{ text: "阶段" }, { text: "状态" }] },
+        { cells: [{ text: "联调" }, { text: "完成" }] },
+      ]}],
+    });
+    const el = body({ card })[0] as {
+      type: string;
+      firstRowAsHeader: boolean;
+      rows: Array<{ type: string; cells: Array<{ type: string; items: Array<{ type: string; text: string }> }> }>;
+    };
+    expect(el.type).toBe("Table");
+    expect(el.firstRowAsHeader).toBe(true);
+    expect(el).toMatchObject({ columns: [{ width: 1 }, { width: 1 }] });
+    expect(el.rows[0].type).toBe("TableRow");
+    expect(el.rows[0].cells[0].type).toBe("TableCell");
+    expect(el.rows[0].cells[0].items[0]).toMatchObject({ type: "TextBlock", text: "阶段" });
+    expect(plain).toBe("阶段 | 状态\n联调 | 完成");
+  });
+
+  it("未 advertise Table → 降级为管道分隔文本行", () => {
+    const { card, plain } = buildDisplayCard({
+      caps: { elements: new Set(["TextBlock"]) },
+      blocks: [{ type: "table", rows: [
+        { cells: [{ text: "A" }, { text: "B" }] },
+      ]}],
+    });
+    expect((body({ card })[0] as { type: string; text: string }).type).toBe("TextBlock");
+    expect((body({ card })[0] as { text: string }).text).toBe("A | B");
+    expect(plain).toBe("A | B");
+  });
+
+  it("table cell 内容逐格脱敏,敏感 cell 被跳过", () => {
+    const { card, plain } = buildDisplayCard({
+      caps: FULL_CAPS,
+      blocks: [{ type: "table", rows: [
+        { cells: [{ text: "safe" }, { text: "AKIAIOSFODNN7EXAMPLE" }] },
+      ]}],
+    });
+    const cardStr = JSON.stringify(card);
+    expect(cardStr).toContain("safe");
+    expect(cardStr).not.toContain("AKIA");
+    expect(plain).toBe("safe");
+  });
+});
+
+describe("columns block(ColumnSet 摘要区)", () => {
+  it("advertise ColumnSet → 三块摘要渲染为 ColumnSet,Column 作为 ColumnSet 内部子结构生成", () => {
+    const { card, plain } = buildDisplayCard({
+      title: "北京天气",
+      caps: FULL_CAPS,
+      blocks: [
+        { type: "heading", text: "北京天气" }, // 与 title 重复,应去掉
+        { type: "columns", columns: [
+          { blocks: [{ type: "heading", text: "天气" }, { type: "text", text: "多云转晴" }] },
+          { blocks: [{ type: "heading", text: "温度" }, { type: "text", text: "28°C / 19°C" }] },
+          { blocks: [{ type: "heading", text: "降水概率" }, { type: "text", text: "20%" }] },
+        ]},
+        { type: "facts", items: [
+          { label: "城市", value: "北京" },
+          { label: "日期", value: "2026-07-11" },
+        ]},
+      ],
+    });
+    const b = body({ card });
+    expect((b[0] as { text: string }).text).toBe("北京天气");
+    expect(b.filter((e) => (e as { text?: string }).text === "北京天气")).toHaveLength(1);
+    const colSet = b.find((e) => e.type === "ColumnSet") as {
+      type: string;
+      columns: Array<{ type: string; items: Array<{ text?: string }> }>;
+    };
+    expect(colSet).toBeTruthy();
+    expect(colSet.columns).toHaveLength(3);
+    expect(colSet.columns[0].type).toBe("Column");
+    expect(colSet.columns[0].items.map((i) => i.text)).toEqual(["天气", "多云转晴"]);
+    expect(plain.split("\n")).toEqual([
+      "北京天气",
+      "天气；多云转晴 | 温度；28°C / 19°C | 降水概率；20%",
+      "城市：北京",
+      "日期：2026-07-11",
+    ]);
+  });
+
+  it("未 advertise ColumnSet → 摘要降级为单行 TextBlock", () => {
+    const { card, plain } = buildDisplayCard({
+      caps: { elements: new Set(["TextBlock"]) },
+      blocks: [{ type: "columns", columns: [
+        { blocks: [{ type: "text", text: "天气：晴" }] },
+        { blocks: [{ type: "text", text: "温度：28°C" }] },
+      ]}],
+    });
+    const el = body({ card })[0] as { type: string; text: string };
+    expect(el.type).toBe("TextBlock");
+    expect(el.text).toBe("天气：晴 | 温度：28°C");
+    expect(plain).toBe("天气：晴 | 温度：28°C");
+  });
+});
+
+describe("link block(Action.OpenUrl)", () => {
+  it("advertise ActionSet+Action.OpenUrl → 用可见 ActionSet 按钮,且不会生成 Submit", () => {
+    const { card, plain } = buildDisplayCard({
+      caps: FULL_CAPS,
+      blocks: [{ type: "link", text: "打开控制台", url: "https://admin.example.com/path?token=abc" }],
+    });
+    const el = body({ card })[0] as { type: string; actions: Array<Record<string, unknown>> };
+    expect(el.type).toBe("ActionSet");
+    expect(el.actions[0]).toEqual({
+      type: "Action.OpenUrl",
+      title: "打开控制台",
+      url: "https://example.com",
+    });
+    expect(JSON.stringify(card)).not.toContain("Action.Submit");
+    expect(plain).toBe("打开控制台：https://example.com");
+  });
+
+  it("advertise Action.OpenUrl 但缺 ActionSet → 退回 TextBlock.selectAction", () => {
+    const { card } = buildDisplayCard({
+      caps: CAPS_WITH_OPEN_URL,
+      blocks: [{ type: "link", text: "打开控制台", url: "https://admin.example.com/path?token=abc" }],
+    });
+    const el = body({ card })[0] as { type: string; text: string; selectAction: Record<string, unknown> };
+    expect(el.type).toBe("TextBlock");
+    expect(el.text).toBe("打开控制台");
+    expect(el.selectAction).toMatchObject({ type: "Action.OpenUrl" });
+  });
+
+  it("未 advertise Action.OpenUrl → 降级为普通文本", () => {
+    const { card } = buildDisplayCard({
+      caps: { elements: new Set(["TextBlock"]) },
+      blocks: [{ type: "link", text: "Docs", url: "https://docs.example.com/a" }],
+    });
+    const el = body({ card })[0] as { type: string; text: string; selectAction?: unknown };
+    expect(el.type).toBe("TextBlock");
+    expect(el.text).toBe("Docs：https://example.com");
+    expect(el.selectAction).toBeUndefined();
   });
 });
 
@@ -271,7 +427,7 @@ describe("collapsible block(forward-compat 折叠/展开)", () => {
     actions: new Set(["Action.ToggleVisibility"]),
   };
 
-  it("advertise ToggleVisibility+ActionSet+Container → 升级:summary+隐藏 Container", () => {
+  it("advertise ToggleVisibility+ActionSet+Container → 升级:summary+短按钮+隐藏 Container", () => {
     const { card } = buildDisplayCard({
       caps: CAPS_WITH_TOGGLE,
       blocks: [{ type: "collapsible", summary: "详情", blocks: [
@@ -280,18 +436,23 @@ describe("collapsible block(forward-compat 折叠/展开)", () => {
       ]}],
     });
     const els = body({ card });
-    // 应有:summary(TextBlock)+ toggle 触发器(ActionSet)+ 目标 Container(isVisible:false)
+    // 应有:summary(TextBlock)+ 短按钮(ActionSet)+ 目标 Container(isVisible:false),按钮不重复长 summary。
+    expect(els).toHaveLength(3);
     const container = els.find((e) => e.type === "Container") as { id: string; isVisible: boolean; items: Element[] };
     expect(container).toBeTruthy();
     expect(container.isVisible).toBe(false);
-    expect(container.id).toBeTruthy(); // 有 id 才能 target
+    expect(container.id).toMatch(/^octo_disp_clp_\d+$/); // 展示元素 id 统一命名空间,避免与 input/action 撞名
     expect(container.items).toHaveLength(2);
 
-    const actionSet = els.find((e) => e.type === "ActionSet") as { actions: Array<Record<string, unknown>> };
-    expect(actionSet).toBeTruthy();
+    const summary = els[0] as { text: string; selectAction?: unknown };
+    expect(summary.text).toBe("详情");
+    expect(summary.selectAction).toBeUndefined();
+
+    const actionSet = els[1] as { type: string; actions: Array<Record<string, unknown>> };
+    expect(actionSet.type).toBe("ActionSet");
     expect(actionSet.actions[0]).toMatchObject({
       type: "Action.ToggleVisibility",
-      title: "详情",
+      title: "展开/收起",
       targetElements: [container.id],
     });
   });
@@ -305,6 +466,36 @@ describe("collapsible block(forward-compat 折叠/展开)", () => {
       ]}],
     });
     expect(plain).toBe("详情\n行1\n行2");
+  });
+
+  it("actionLabel 可自定义为展示卡过程入口文案", () => {
+    const { card } = buildDisplayCard({
+      caps: CAPS_WITH_TOGGLE,
+      blocks: [{ type: "collapsible", summary: "✓ 已思考 12 秒 · 6 次工具调用", actionLabel: "查看过程", blocks: [
+        { type: "text", text: "先拆分线索" },
+      ]}],
+    });
+    const actionSet = body({ card }).find((e) => e.type === "ActionSet") as { actions: Array<Record<string, unknown>> };
+    expect(actionSet.actions[0]).toMatchObject({
+      type: "Action.ToggleVisibility",
+      title: "查看过程",
+    });
+  });
+
+  it("summary 与 actionLabel 同名时只保留按钮,避免截图里标题/按钮重复", () => {
+    const { card, plain } = buildDisplayCard({
+      caps: CAPS_WITH_TOGGLE,
+      blocks: [{ type: "collapsible", summary: "查看过程", actionLabel: "查看过程", blocks: [
+        { type: "text", text: "先定位问题" },
+      ]}],
+    });
+    const els = body({ card });
+    expect(els).toHaveLength(2);
+    expect(els[0].type).toBe("ActionSet");
+    expect((els[0] as { actions: Array<Record<string, unknown>> }).actions[0].title).toBe("查看过程");
+    expect(els[1].type).toBe("Container");
+    expect(JSON.stringify(card).match(/查看过程/g)).toHaveLength(1);
+    expect(plain).toBe("查看过程\n先定位问题");
   });
 
   it("未 advertise Action.ToggleVisibility → 降级平铺(summary 当 heading,inner 展开)", () => {
@@ -377,6 +568,72 @@ describe("collapsible block(forward-compat 折叠/展开)", () => {
   });
 });
 
+describe("copy block(Action.CopyToClipboard 本地动作)", () => {
+  it("advertise Action.CopyToClipboard+ActionSet → 渲染复制按钮,不产生顶层 callback action", () => {
+    const { card, plain } = buildDisplayCard({
+      caps: CAPS_WITH_COPY,
+      blocks: [{ type: "copy", label: "复制 SQL", text: "SELECT 1;" }],
+    });
+    const el = body({ card })[0] as { type: string; actions: Array<Record<string, unknown>> };
+    expect(el.type).toBe("ActionSet");
+    expect(el.actions[0]).toEqual({
+      type: "Action.CopyToClipboard",
+      title: "复制 SQL",
+      text: "SELECT 1;",
+    });
+    expect(card).not.toHaveProperty("actions");
+    expect(plain).toBe("SELECT 1;");
+  });
+
+  it("未 advertise CopyToClipboard 或 ActionSet → 降级为普通文本(不 400,内容不丢)", () => {
+    const noAction = buildDisplayCard({
+      caps: { elements: new Set(["TextBlock", "ActionSet"]) },
+      blocks: [{ type: "copy", label: "复制", text: "abc" }],
+    });
+    expect((body(noAction)[0] as { type: string; text: string }).type).toBe("TextBlock");
+    expect((body(noAction)[0] as { text: string }).text).toBe("abc");
+
+    const noActionSet = buildDisplayCard({
+      caps: { elements: new Set(["TextBlock"]), actions: new Set(["Action.CopyToClipboard"]) },
+      blocks: [{ type: "copy", label: "复制", text: "abc" }],
+    });
+    expect((body(noActionSet)[0] as { type: string; text: string }).type).toBe("TextBlock");
+    expect((body(noActionSet)[0] as { text: string }).text).toBe("abc");
+  });
+
+  it("CopyToClipboard.text 按 UTF-8 4KiB 限制,超限降级为说明而不是发非法 action", () => {
+    const ok = buildDisplayCard({
+      caps: CAPS_WITH_COPY,
+      blocks: [{ type: "copy", text: "中".repeat(1365) }], // 4095 bytes
+    });
+    expect((body(ok)[0] as { type: string }).type).toBe("ActionSet");
+
+    const tooLong = buildDisplayCard({
+      caps: CAPS_WITH_COPY,
+      blocks: [{ type: "copy", text: "中".repeat(1366) }], // 4098 bytes
+    });
+    const el = body(tooLong)[0] as { type: string; text: string };
+    expect(el.type).toBe("TextBlock");
+    expect(el.text).toContain("4KiB");
+    expect(JSON.stringify(tooLong.card)).not.toContain("Action.CopyToClipboard");
+  });
+
+  it("copy text / label 仍走脱敏;label 命中敏感时退回默认标题", () => {
+    const hidden = buildDisplayCard({
+      caps: CAPS_WITH_COPY,
+      blocks: [{ type: "copy", label: "复制", text: "AKIAIOSFODNN7EXAMPLE" }],
+    });
+    expect(body(hidden)).toEqual([]);
+
+    const defaultLabel = buildDisplayCard({
+      caps: CAPS_WITH_COPY,
+      blocks: [{ type: "copy", label: "token=AKIAIOSFODNN7EXAMPLE", text: "safe" }],
+    });
+    const action = (body(defaultLabel)[0] as { actions: Array<Record<string, unknown>> }).actions[0];
+    expect(action.title).toBe("复制");
+  });
+});
+
 describe("组合与边界", () => {
   it("多种 block 依序 + title,plain 逐行", () => {
     const blocks: DisplayBlock[] = [
@@ -436,9 +693,15 @@ describe("validateDisplayBlocks 结构上限(不可信输入)", () => {
   it("合法浅结构照常通过", () => {
     const out = validateDisplayBlocks([
       { type: "heading", text: "H" },
+      { type: "table", rows: [{ cells: [{ text: "a" }] }] },
+      { type: "columns", columns: [{ blocks: [{ type: "text", text: "c" }] }] },
+      { type: "link", text: "Docs", url: "https://example.com/a" },
       { type: "group", blocks: [{ type: "text", text: "x" }] },
+      { type: "collapsible", summary: "过程", actionLabel: "查看过程", blocks: [{ type: "text", text: "p" }] },
+      { type: "copy", label: "复制", text: "y" },
     ]);
-    expect(out).toHaveLength(2);
+    expect(out).toHaveLength(7);
+    expect(out[5]).toMatchObject({ type: "collapsible", actionLabel: "查看过程" });
   });
 
   it("facts.items 计入总节点预算 —— facts-heavy 卡被截断(防服务端 node 上限 400)", () => {

--- a/src/card-blocks.test.ts
+++ b/src/card-blocks.test.ts
@@ -118,6 +118,18 @@ describe("rich block(高价值:一行多样式,顺带解决 ColumnSet plain 分�
     expect(el.inlines[3]).toEqual({ type: "TextRun", text: " · 30ms", color: "good" });
   });
 
+  it("rich segment 支持 Monospace 字体,用于工具参数/命令片段", () => {
+    const { card } = buildDisplayCard({
+      caps: FULL_CAPS,
+      blocks: [{ type: "rich", segments: [
+        { text: "query_metrics", bold: true },
+        { text: " channel=B range=90d", fontType: "Monospace" },
+      ] }],
+    });
+    const el = body({ card })[0] as { inlines: Array<Record<string, unknown>> };
+    expect(el.inlines[1]).toMatchObject({ text: " channel=B range=90d", fontType: "Monospace" });
+  });
+
   it("不 advertise RichTextBlock → 段拼成单个 TextBlock(降级,零回归)", () => {
     const { card, plain } = buildDisplayCard({
       caps: { elements: new Set(["TextBlock"]) }, // 只 baseline TextBlock
@@ -200,6 +212,7 @@ describe("table block(Table)", () => {
     const el = body({ card })[0] as {
       type: string;
       firstRowAsHeader: boolean;
+      columns: Array<{ width: number }>;
       rows: Array<{ type: string; cells: Array<{ type: string; items: Array<{ type: string; text: string }> }> }>;
     };
     expect(el.type).toBe("Table");
@@ -209,6 +222,43 @@ describe("table block(Table)", () => {
     expect(el.rows[0].cells[0].type).toBe("TableCell");
     expect(el.rows[0].cells[0].items[0]).toMatchObject({ type: "TextBlock", text: "阶段" });
     expect(plain).toBe("阶段 | 状态\n联调 | 完成");
+  });
+
+  it("producer 可控制列宽、表头开关,并在 cell 内放 rich/group 等展示块", () => {
+    const { card, plain } = buildDisplayCard({
+      caps: FULL_CAPS,
+      blocks: [{
+        type: "table",
+        firstRowAsHeader: false,
+        columns: [{ width: 1 }, { width: 2 }],
+        rows: [
+          { cells: [
+            { blocks: [{ type: "rich", segments: [{ text: "模块", bold: true }] }] },
+            { text: "内容" },
+          ] },
+          { cells: [
+            { text: "状态" },
+            { blocks: [{ type: "group", style: "emphasis", blocks: [{ type: "text", text: "可用" }] }] },
+          ] },
+        ],
+      }],
+    });
+    const table = body({ card })[0] as {
+      firstRowAsHeader: boolean;
+      columns: Array<{ width: number }>;
+      rows: Array<{ cells: Array<{ items: Array<Record<string, unknown>> }> }>;
+    };
+    expect(table.firstRowAsHeader).toBe(false);
+    expect(table.columns).toEqual([{ width: 1 }, { width: 2 }]);
+    expect(table.rows[0].cells[0].items[0]).toMatchObject({
+      type: "RichTextBlock",
+      inlines: [{ type: "TextRun", text: "模块", weight: "Bolder" }],
+    });
+    expect(table.rows[1].cells[1].items[0]).toMatchObject({
+      type: "Container",
+      style: "emphasis",
+    });
+    expect(plain).toBe("模块 | 内容\n状态 | 可用");
   });
 
   it("未 advertise Table → 降级为管道分隔文本行", () => {
@@ -423,11 +473,11 @@ describe("collapsible block(forward-compat 折叠/展开)", () => {
    * 任一不满足 → 降级为平铺(summary 当 heading,inner 全部展开在下方 —— 零回归)。
    */
   const CAPS_WITH_TOGGLE: CardCaps = {
-    elements: new Set(["TextBlock", "Container", "ActionSet"]),
+    elements: new Set(["TextBlock", "RichTextBlock", "Container", "ColumnSet", "ActionSet"]),
     actions: new Set(["Action.ToggleVisibility"]),
   };
 
-  it("advertise ToggleVisibility+ActionSet+Container → 升级:summary+短按钮+隐藏 Container", () => {
+  it("advertise ToggleVisibility+ActionSet+Container+ColumnSet → 升级:summary 左侧 + 右侧展开/收起按钮 + 隐藏 Container", () => {
     const { card } = buildDisplayCard({
       caps: CAPS_WITH_TOGGLE,
       blocks: [{ type: "collapsible", summary: "详情", blocks: [
@@ -436,24 +486,40 @@ describe("collapsible block(forward-compat 折叠/展开)", () => {
       ]}],
     });
     const els = body({ card });
-    // 应有:summary(TextBlock)+ 短按钮(ActionSet)+ 目标 Container(isVisible:false),按钮不重复长 summary。
-    expect(els).toHaveLength(3);
+    expect(els).toHaveLength(2);
+    const header = els[0] as { type: string; columns: Array<{ width: string; items: Array<Record<string, unknown>> }> };
+    expect(header.type).toBe("ColumnSet");
+    expect(header.columns[0].width).toBe("stretch");
+    expect(header.columns[0].items[0]).toMatchObject({ type: "TextBlock", text: "详情" });
+    expect(header.columns[1].width).toBe("auto");
+    const collapseBtn = header.columns[1].items[0] as { id: string; isVisible: boolean; actions: Array<Record<string, unknown>> };
+    const expandBtn = header.columns[1].items[1] as { id: string; isVisible: boolean; actions: Array<Record<string, unknown>> };
+    expect(collapseBtn.isVisible).toBe(false);
+    expect(expandBtn.isVisible).toBe(true);
+
     const container = els.find((e) => e.type === "Container") as { id: string; isVisible: boolean; items: Element[] };
     expect(container).toBeTruthy();
     expect(container.isVisible).toBe(false);
     expect(container.id).toMatch(/^octo_disp_clp_\d+$/); // 展示元素 id 统一命名空间,避免与 input/action 撞名
     expect(container.items).toHaveLength(2);
 
-    const summary = els[0] as { text: string; selectAction?: unknown };
-    expect(summary.text).toBe("详情");
-    expect(summary.selectAction).toBeUndefined();
-
-    const actionSet = els[1] as { type: string; actions: Array<Record<string, unknown>> };
-    expect(actionSet.type).toBe("ActionSet");
-    expect(actionSet.actions[0]).toMatchObject({
+    expect(expandBtn.actions[0]).toMatchObject({
       type: "Action.ToggleVisibility",
-      title: "展开/收起",
-      targetElements: [container.id],
+      title: "展开",
+      targetElements: [
+        { elementId: container.id, isVisible: true },
+        { elementId: collapseBtn.id, isVisible: true },
+        { elementId: expandBtn.id, isVisible: false },
+      ],
+    });
+    expect(collapseBtn.actions[0]).toMatchObject({
+      type: "Action.ToggleVisibility",
+      title: "收起",
+      targetElements: [
+        { elementId: container.id, isVisible: false },
+        { elementId: collapseBtn.id, isVisible: false },
+        { elementId: expandBtn.id, isVisible: true },
+      ],
     });
   });
 
@@ -475,8 +541,9 @@ describe("collapsible block(forward-compat 折叠/展开)", () => {
         { type: "text", text: "先拆分线索" },
       ]}],
     });
-    const actionSet = body({ card }).find((e) => e.type === "ActionSet") as { actions: Array<Record<string, unknown>> };
-    expect(actionSet.actions[0]).toMatchObject({
+    const header = body({ card })[0] as { columns: Array<{ items: Array<{ actions: Array<Record<string, unknown>> }> }> };
+    const expandBtn = header.columns[1].items[1];
+    expect(expandBtn.actions[0]).toMatchObject({
       type: "Action.ToggleVisibility",
       title: "查看过程",
     });
@@ -491,8 +558,9 @@ describe("collapsible block(forward-compat 折叠/展开)", () => {
     });
     const els = body({ card });
     expect(els).toHaveLength(2);
-    expect(els[0].type).toBe("ActionSet");
-    expect((els[0] as { actions: Array<Record<string, unknown>> }).actions[0].title).toBe("查看过程");
+    expect(els[0].type).toBe("ColumnSet");
+    const header = els[0] as { columns: Array<{ items: Array<Record<string, unknown>> }> };
+    expect((header.columns[1].items[1] as { actions: Array<Record<string, unknown>> }).actions[0].title).toBe("展开");
     expect(els[1].type).toBe("Container");
     expect(JSON.stringify(card).match(/查看过程/g)).toHaveLength(1);
     expect(plain).toBe("查看过程\n先定位问题");
@@ -693,7 +761,7 @@ describe("validateDisplayBlocks 结构上限(不可信输入)", () => {
   it("合法浅结构照常通过", () => {
     const out = validateDisplayBlocks([
       { type: "heading", text: "H" },
-      { type: "table", rows: [{ cells: [{ text: "a" }] }] },
+      { type: "table", columns: [{ width: 1 }, { width: 2 }], rows: [{ cells: [{ text: "a" }, { blocks: [{ type: "rich", segments: [{ text: "b", bold: true, fontType: "Monospace" }] }] }] }] },
       { type: "columns", columns: [{ blocks: [{ type: "text", text: "c" }] }] },
       { type: "link", text: "Docs", url: "https://example.com/a" },
       { type: "group", blocks: [{ type: "text", text: "x" }] },
@@ -701,6 +769,8 @@ describe("validateDisplayBlocks 结构上限(不可信输入)", () => {
       { type: "copy", label: "复制", text: "y" },
     ]);
     expect(out).toHaveLength(7);
+    expect(out[1]).toMatchObject({ type: "table", columns: [{ width: 1 }, { width: 2 }] });
+    expect(JSON.stringify(out[1])).toContain("Monospace");
     expect(out[5]).toMatchObject({ type: "collapsible", actionLabel: "查看过程" });
   });
 

--- a/src/card-blocks.ts
+++ b/src/card-blocks.ts
@@ -1,0 +1,451 @@
+/**
+ * 展示卡构建器 —— 方案乙:agent / 进度卡用受控的 DisplayBlock 描述展示意图,构建器翻译成
+ * Adaptive Cards 1.5 JSON,按服务端下放的能力清单(CardCaps)协商降级,统一脱敏(与 card-render
+ * 同套 helper:URL 降级到 scheme://注册域、命中 secret shape 整块隐藏)。绝不产出会被服务端
+ * 400 的结构,消费者无需自己判断白名单。
+ *
+ * 本轮支持的 block:heading / text / rich / facts / group(高价值子集)。
+ * collapsible 在 P1-c 引入(依赖 caps.actions 里 Action.ToggleVisibility);
+ * table/image/gallery/columns 后续轮次。
+ *
+ * 纯函数、无副作用、无 I/O —— hook 进度卡与 agent 展示卡工具共享这一层。
+ */
+
+import { cardSupports, isSensitive, reduceUrlsInText, type CardCaps } from "./card-render.js";
+import { CARD_VERSION } from "./types.js";
+
+// ── DisplayBlock:展示意图 ──────────────────────────────────
+/** 富文本行内片段(rich block 用)。 */
+export interface RichSegment {
+  text: string;
+  bold?: boolean;
+  color?: "default" | "good" | "warning" | "attention" | "accent";
+}
+
+/** 一条键值(facts block 用)。 */
+export interface Fact {
+  label: string;
+  value: string;
+}
+
+/** Container 语义着色(group block 用)。 */
+export type GroupStyle = "default" | "good" | "warning" | "attention";
+
+/**
+ * 展示 block —— agent / 进度卡用它表达「想展示什么」,不直接写 AC element JSON。
+ * 构建器负责翻译成受能力约束的 AC element,并在不支持时降级。
+ */
+export type DisplayBlock =
+  | { type: "heading"; text: string; size?: "medium" | "large" }
+  | { type: "text"; text: string }
+  | { type: "rich"; segments: RichSegment[] }
+  | { type: "facts"; items: Fact[] }
+  | { type: "group"; style?: GroupStyle; blocks: DisplayBlock[] }
+  | { type: "collapsible"; summary: string; blocks: DisplayBlock[] };
+
+export interface BuildDisplayCardOptions {
+  /** 卡片标题(渲染成置顶的 Bolder TextBlock)。 */
+  title?: string;
+  blocks: DisplayBlock[];
+  /** 服务端能力清单;缺省用 card-render 的保守 baseline。 */
+  caps?: CardCaps;
+  /**
+   * 内容是否**可信/已脱敏**。默认 false(不可信 agent 输入 → sanitize 用最严 generic=true)。
+   * 进度卡文案上游已逐 sink 脱敏 → 传 true(sanitize 用 generic=false,不再二次误删 git SHA 等)。
+   */
+  trusted?: boolean;
+}
+
+export interface BuildDisplayCardResult {
+  card: Record<string, unknown>;
+  plain: string;
+}
+
+// ── 文本清洗(与 card-render 的参数摘要/错误脱敏同套)────────
+/**
+ * 群卡片全员可见 → 与 summarizeToolParams/sanitizeErrorText 同套:
+ *   1. 折叠空白;
+ *   2. 内嵌 URL 降级为 `scheme://注册域`(丢子域/path/query/userinfo,杀 webhook/预签名/隧道
+ *      场景里的密钥);
+ *   3. 命中 secret 关键词/形状 → 返回 null(整个 block 不渲染,fail-closed)。
+ *
+ * `generic`:
+ *   - `true`(默认,**不可信** agent 展示卡输入)—— 额外套用长 hex/高熵检测,最严;
+ *   - `false`(**可信**、上游已逐 sink 脱敏的进度卡文案)—— 只走关键词 + 明确前缀,避免把
+ *     git SHA / docker digest / 缓存哈希等正常内容二次误删(见 renderProgressCard 的 trusted)。
+ * 返回 null 表示"敏感,不该展示";空串同 null(text-only block 无内容也不渲染)。
+ */
+function sanitize(text: string, generic = true): string | null {
+  let s = text.replace(/\s+/g, " ").trim();
+  if (!s) return null;
+  s = reduceUrlsInText(s).replace(/\s+/g, " ").trim();
+  if (!s) return null;
+  if (isSensitive(s, generic)) return null;
+  return s;
+}
+
+// ── 单 block → { elements, plainLines }─────────────────────
+interface Rendered {
+  elements: Record<string, unknown>[];
+  plainLines: string[];
+}
+
+const EMPTY: Rendered = { elements: [], plainLines: [] };
+
+/**
+ * 渲染上下文 —— collapsible 需要在整卡内生成唯一 id 用于 Action.ToggleVisibility 的
+ * targetElements。用 counter 而非 Math.random(),便于测试且不引入非确定性。
+ */
+interface RenderCtx {
+  caps?: CardCaps;
+  uid: { n: number };
+  /** 传给 sanitize 的 generic 档位:false=可信(进度卡),true=不可信(agent 展示卡,默认最严)。 */
+  generic: boolean;
+}
+
+function nextId(ctx: RenderCtx, prefix: string): string {
+  return `${prefix}_${ctx.uid.n++}`;
+}
+
+function textBlock(text: string, opts?: { bold?: boolean; size?: "medium" | "large" }): Record<string, unknown> {
+  return {
+    type: "TextBlock",
+    text,
+    wrap: true,
+    ...(opts?.bold ? { weight: "Bolder" } : {}),
+    ...(opts?.size ? { size: opts.size === "medium" ? "Medium" : "Large" } : {}),
+  };
+}
+
+function renderHeading(text: string, size: "medium" | "large" | undefined, ctx: RenderCtx): Rendered {
+  const clean = sanitize(text, ctx.generic);
+  if (!clean) return EMPTY;
+  return { elements: [textBlock(clean, { bold: true, size })], plainLines: [clean] };
+}
+
+function renderText(text: string, ctx: RenderCtx): Rendered {
+  const clean = sanitize(text, ctx.generic);
+  if (!clean) return EMPTY;
+  return { elements: [textBlock(clean)], plainLines: [clean] };
+}
+
+function renderRich(segments: RichSegment[], ctx: RenderCtx): Rendered {
+  const joined = segments.map((s) => s.text).join("");
+  // clean 走完整 sanitize:对**整段 joined** 做 URL 降级(能抓到跨 segment 拆开的 URL)+ secret 检查。
+  const clean = sanitize(joined, ctx.generic);
+  if (!clean) return EMPTY;
+  // 关键(F1 修复):仅当 joined 里**没有任何可降级 URL** 时,才保留逐段 TextRun 的富样式 ——
+  // 否则某个 segment(或跨段拆开)的 URL 会以原文进 TextRun,而 plain 已降级 → card ⊋ plain 泄露。
+  // 含 URL 时降级为单个 TextBlock(用已降级的 clean),card 与 plain 一致、绝不多出密钥。
+  const noReducibleUrl = reduceUrlsInText(joined) === joined;
+  if (noReducibleUrl && cardSupports(ctx.caps, "RichTextBlock")) {
+    return {
+      elements: [
+        {
+          type: "RichTextBlock",
+          inlines: segments.map((s) => ({
+            type: "TextRun",
+            text: s.text,
+            ...(s.bold ? { weight: "Bolder" } : {}),
+            ...(s.color && s.color !== "default" ? { color: s.color } : {}),
+          })),
+        },
+      ],
+      plainLines: [clean],
+    };
+  }
+  // 降级:段拼成单个 TextBlock(已 URL 降级;顺带解决 ColumnSet plain 分行:一行完整而非按列拆行)。
+  return { elements: [textBlock(clean)], plainLines: [clean] };
+}
+
+function renderFacts(items: Fact[], ctx: RenderCtx): Rendered {
+  // 每条键值独立过 sanitize:label 或 value 命中 secret → 该条隐藏,不影响其它条(细粒度)。
+  const cleaned: Array<{ label: string; value: string }> = [];
+  for (const f of items) {
+    const label = sanitize(f.label, ctx.generic);
+    const value = sanitize(f.value, ctx.generic);
+    if (!label || !value) continue;
+    cleaned.push({ label, value });
+  }
+  if (cleaned.length === 0) return EMPTY;
+  const plainLines = cleaned.map((f) => `${f.label}：${f.value}`);
+  if (cardSupports(ctx.caps, "FactSet")) {
+    return {
+      elements: [
+        {
+          type: "FactSet",
+          facts: cleaned.map((f) => ({ title: f.label, value: f.value })),
+        },
+      ],
+      plainLines,
+    };
+  }
+  // 降级:每条键值一行 TextBlock。
+  return {
+    elements: cleaned.map((f) => textBlock(`${f.label}：${f.value}`)),
+    plainLines,
+  };
+}
+
+function renderGroup(
+  style: GroupStyle | undefined,
+  blocks: DisplayBlock[],
+  ctx: RenderCtx,
+): Rendered {
+  const inner = renderBlocks(blocks, ctx);
+  if (inner.elements.length === 0) return EMPTY;
+  if (cardSupports(ctx.caps, "Container")) {
+    return {
+      elements: [
+        {
+          type: "Container",
+          ...(style && style !== "default" ? { style } : {}),
+          items: inner.elements,
+        },
+      ],
+      plainLines: inner.plainLines,
+    };
+  }
+  // 降级:平铺子 block(不丢内容,只丢着色/分组视觉)。
+  return inner;
+}
+
+/**
+ * 折叠/展开 —— 升级条件三维齐备(forward-compat,任一未 advertise 就降级平铺):
+ *   1. `caps.elements` 含 `Container` —— 用来包 hidden 内容 + `isVisible:false`;
+ *   2. `caps.elements` 含 `ActionSet` —— 触发器容器(比 selectAction 更少属性依赖);
+ *   3. `caps.actions` 含 `Action.ToggleVisibility` —— 具体动作被服务端接受(旧部署无该 advertise
+ *      → 保守 fail-closed,避免乐观发出被 400)。
+ *
+ * summary 是永远可见的"点我展开"入口,inner 是默认隐藏的正文。降级形态 = summary 当 heading +
+ * inner 全部展开在下方(视觉上等同"已展开",信息不丢)。
+ *
+ * 若 summary 被脱敏或空 / inner 全被脱敏或空,整个 collapsible 不渲染 —— 避免展开后是空块。
+ */
+function renderCollapsible(summary: string, blocks: DisplayBlock[], ctx: RenderCtx): Rendered {
+  const cleanSummary = sanitize(summary, ctx.generic);
+  if (!cleanSummary) return EMPTY;
+  const inner = renderBlocks(blocks, ctx);
+  if (inner.elements.length === 0) return EMPTY;
+
+  const canToggle =
+    cardSupports(ctx.caps, "Container") &&
+    cardSupports(ctx.caps, "ActionSet") &&
+    cardSupports(ctx.caps, "Action.ToggleVisibility");
+
+  if (canToggle) {
+    const targetId = nextId(ctx, "clp");
+    return {
+      elements: [
+        textBlock(cleanSummary, { bold: true }),
+        {
+          type: "ActionSet",
+          actions: [
+            {
+              type: "Action.ToggleVisibility",
+              title: cleanSummary,
+              targetElements: [targetId],
+            },
+          ],
+        },
+        {
+          type: "Container",
+          id: targetId,
+          isVisible: false,
+          items: inner.elements,
+        },
+      ],
+      // plain 全展开,与折叠视觉无关。服务端 Finalize 会权威重算 plain。
+      plainLines: [cleanSummary, ...inner.plainLines],
+    };
+  }
+
+  // 降级:summary 当 heading + inner 全部展开在下方(零回归展开态)。
+  return {
+    elements: [textBlock(cleanSummary, { bold: true }), ...inner.elements],
+    plainLines: [cleanSummary, ...inner.plainLines],
+  };
+}
+
+function renderBlock(block: DisplayBlock, ctx: RenderCtx): Rendered {
+  switch (block.type) {
+    case "heading":
+      return renderHeading(block.text, block.size, ctx);
+    case "text":
+      return renderText(block.text, ctx);
+    case "rich":
+      return renderRich(block.segments, ctx);
+    case "facts":
+      return renderFacts(block.items, ctx);
+    case "group":
+      return renderGroup(block.style, block.blocks, ctx);
+    case "collapsible":
+      return renderCollapsible(block.summary, block.blocks, ctx);
+  }
+}
+
+function renderBlocks(blocks: DisplayBlock[], ctx: RenderCtx): Rendered {
+  const elements: Record<string, unknown>[] = [];
+  const plainLines: string[] = [];
+  for (const b of blocks) {
+    const r = renderBlock(b, ctx);
+    elements.push(...r.elements);
+    plainLines.push(...r.plainLines);
+  }
+  return { elements, plainLines };
+}
+
+/**
+ * 构建展示卡。返回 `{ card, plain }`:card = AC 1.5 JSON(按 caps 协商降级、逐 block 脱敏),
+ * plain = 纯文本兜底(与布局无关,服务端 Finalize 会权威重算)。
+ */
+export function buildDisplayCard(opts: BuildDisplayCardOptions): BuildDisplayCardResult {
+  const { title, blocks, caps, trusted } = opts;
+  const ctx: RenderCtx = { caps, uid: { n: 0 }, generic: !trusted };
+  const body: Record<string, unknown>[] = [];
+  const plainLines: string[] = [];
+
+  if (title) {
+    const cleanTitle = sanitize(title, ctx.generic);
+    if (cleanTitle) {
+      body.push(textBlock(cleanTitle, { bold: true }));
+      plainLines.push(cleanTitle);
+    }
+  }
+
+  const rendered = renderBlocks(blocks, ctx);
+  body.push(...rendered.elements);
+  plainLines.push(...rendered.plainLines);
+
+  // 服务端 max_nodes 权威约束:顶层 body 元素数超上限时截断并附一行说明,避免 edit/send 撞 400
+  // (card-blocks.ts 契约「绝不产出会被服务端 400 的结构」)。节点计数取顶层元素的保守近似。
+  const maxNodes = caps?.maxNodes;
+  if (typeof maxNodes === "number" && maxNodes > 0 && body.length > maxNodes) {
+    const keep = Math.max(1, maxNodes - 1); // 留一格给「截断」提示
+    const dropped = body.length - keep;
+    body.length = keep;
+    // 同步截断 plainLines,保持「plain 与 card 同步」不变量:否则 plain 会列出 card 已丢弃的项。
+    // flat 卡片下 body/plainLines 一一对应,截断精确;嵌套卡片下为近似(plain 本就是 advisory,
+    // 服务端 Finalize 会权威重算),至少不再多列一整串被丢弃的内容。
+    plainLines.length = Math.min(plainLines.length, keep);
+    body.push(textBlock(`… 省略 ${dropped} 项(超出服务端节点上限)`));
+    plainLines.push(`… 省略 ${dropped} 项`);
+  }
+
+  const card: Record<string, unknown> = {
+    type: "AdaptiveCard",
+    version: CARD_VERSION,
+    $schema: "http://adaptivecards.io/schemas/adaptive-card.json",
+    body,
+  };
+  return { card, plain: plainLines.join("\n") };
+}
+
+// ── 不可信输入验证 ────────────────────────────────────────────
+/**
+ * 白名单校验 agent / 外部输入的 DisplayBlock —— 每 block:
+ *   - `type` 在支持集内(heading/text/rich/facts/group/collapsible);
+ *   - 关键字段类型正确(text 是 string;facts.items 是 [{label,value}];rich.segments 是 [{text}];
+ *     group.blocks / collapsible.blocks 递归校验;heading.size 若给则限于 medium/large)。
+ * 任何字段类型错的整块**静默丢弃**(不 fail 整个构建),避免 agent 单个字段错就完全无回复。
+ * 内容脱敏由 buildDisplayCard/sanitize 兜底,此处只做结构校验。
+ */
+/**
+ * 不可信输入的结构上限 —— 防止深嵌套(RangeError 栈溢出)/超大数组(node 爆炸 → 服务端 400),
+ * 与服务端 limits(max_depth≈16 / max_nodes)对齐的保守本地预检。超限静默截断,不 fail 整卡。
+ */
+const MAX_BLOCK_DEPTH = 12; // group/collapsible 嵌套深度
+const MAX_TOTAL_BLOCKS = 200; // 整棵树累计 block 数(近似 node 上限)
+
+export function validateDisplayBlocks(input: unknown): DisplayBlock[] {
+  return validateBlockList(input, MAX_BLOCK_DEPTH, { count: 0 });
+}
+
+/** 带深度/总数预算的递归校验。深度耗尽 → 该层丢弃;总数耗尽 → 停止收集。 */
+function validateBlockList(
+  input: unknown,
+  depth: number,
+  budget: { count: number },
+): DisplayBlock[] {
+  if (!Array.isArray(input) || depth <= 0) return [];
+  const out: DisplayBlock[] = [];
+  for (const raw of input) {
+    if (budget.count >= MAX_TOTAL_BLOCKS) break;
+    budget.count++;
+    const b = validateOneBlock(raw, depth, budget);
+    if (b) out.push(b);
+  }
+  return out;
+}
+
+const HEADING_SIZES = new Set(["medium", "large"]);
+const GROUP_STYLES = new Set(["default", "good", "warning", "attention"]);
+const RICH_COLORS = new Set(["default", "good", "warning", "attention", "accent"]);
+
+function validateOneBlock(raw: unknown, depth: number, budget: { count: number }): DisplayBlock | null {
+  if (!raw || typeof raw !== "object") return null;
+  const r = raw as Record<string, unknown>;
+  switch (r.type) {
+    case "heading": {
+      if (typeof r.text !== "string") return null;
+      const size = r.size;
+      if (size !== undefined && (typeof size !== "string" || !HEADING_SIZES.has(size))) return null;
+      return size ? { type: "heading", text: r.text, size: size as "medium" | "large" } : { type: "heading", text: r.text };
+    }
+    case "text": {
+      if (typeof r.text !== "string") return null;
+      return { type: "text", text: r.text };
+    }
+    case "rich": {
+      if (!Array.isArray(r.segments)) return null;
+      const segs: RichSegment[] = [];
+      for (const s of r.segments) {
+        if (!s || typeof s !== "object") continue;
+        const seg = s as Record<string, unknown>;
+        if (typeof seg.text !== "string") continue;
+        const color = seg.color;
+        if (color !== undefined && (typeof color !== "string" || !RICH_COLORS.has(color))) continue;
+        segs.push({
+          text: seg.text,
+          ...(seg.bold === true ? { bold: true } : {}),
+          ...(typeof color === "string" ? { color: color as RichSegment["color"] } : {}),
+        });
+      }
+      if (segs.length === 0) return null;
+      return { type: "rich", segments: segs };
+    }
+    case "facts": {
+      if (!Array.isArray(r.items)) return null;
+      const items: Fact[] = [];
+      for (const it of r.items) {
+        // facts.items 也计入总节点预算 —— 服务端按 fact 递归计 node,一个 facts 块可膨胀成
+        // 上千节点撞 max_nodes(400)。这里连同 block 一起受 MAX_TOTAL_BLOCKS 约束,超预算即停止收集。
+        if (budget.count >= MAX_TOTAL_BLOCKS) break;
+        if (!it || typeof it !== "object") continue;
+        const f = it as Record<string, unknown>;
+        if (typeof f.label !== "string" || typeof f.value !== "string") continue;
+        budget.count++;
+        items.push({ label: f.label, value: f.value });
+      }
+      if (items.length === 0) return null;
+      return { type: "facts", items };
+    }
+    case "group": {
+      const inner = validateBlockList(r.blocks, depth - 1, budget);
+      if (inner.length === 0) return null;
+      const style = r.style;
+      if (style !== undefined && (typeof style !== "string" || !GROUP_STYLES.has(style))) return null;
+      return style
+        ? { type: "group", style: style as GroupStyle, blocks: inner }
+        : { type: "group", blocks: inner };
+    }
+    case "collapsible": {
+      if (typeof r.summary !== "string") return null;
+      const inner = validateBlockList(r.blocks, depth - 1, budget);
+      if (inner.length === 0) return null;
+      return { type: "collapsible", summary: r.summary, blocks: inner };
+    }
+    default:
+      return null;
+  }
+}

--- a/src/card-blocks.ts
+++ b/src/card-blocks.ts
@@ -22,6 +22,7 @@ export interface RichSegment {
   text: string;
   bold?: boolean;
   subtle?: boolean;
+  fontType?: "Default" | "Monospace";
   color?: "default" | "good" | "warning" | "attention" | "accent";
 }
 
@@ -31,10 +32,16 @@ export interface Fact {
   value: string;
 }
 
-/** 表格单元格。 */
-export interface TableCell {
-  text: string;
+/** 表格列定义。 */
+export interface TableColumn {
+  /** Adaptive Cards TableColumnDefinition.width;当前 helper 暴露数字权重。 */
+  width?: number;
 }
+
+/** 表格单元格。text 是简写;blocks 可放 text/rich/group 等展示块。 */
+export type TableCell =
+  | { text: string; blocks?: never }
+  | { blocks: DisplayBlock[]; text?: never };
 
 /** 表格行。 */
 export interface TableRow {
@@ -47,7 +54,7 @@ export interface Column {
 }
 
 /** Container 语义着色(group block 用)。 */
-export type GroupStyle = "default" | "good" | "warning" | "attention";
+export type GroupStyle = "default" | "good" | "warning" | "attention" | "emphasis";
 
 /**
  * 展示 block —— agent / 进度卡用它表达「想展示什么」,不直接写 AC element JSON。
@@ -58,11 +65,20 @@ export type DisplayBlock =
   | { type: "text"; text: string }
   | { type: "rich"; segments: RichSegment[] }
   | { type: "facts"; items: Fact[] }
-  | { type: "table"; rows: TableRow[]; firstRowAsHeader?: boolean }
+  | { type: "table"; rows: TableRow[]; columns?: TableColumn[]; firstRowAsHeader?: boolean }
   | { type: "columns"; columns: Column[] }
   | { type: "link"; text: string; url: string }
   | { type: "group"; style?: GroupStyle; blocks: DisplayBlock[] }
-  | { type: "collapsible"; summary: string; summarySegments?: RichSegment[]; actionLabel?: string; blocks: DisplayBlock[] }
+  | {
+      type: "collapsible";
+      summary: string;
+      summarySegments?: RichSegment[];
+      actionLabel?: string;
+      expandLabel?: string;
+      collapseLabel?: string;
+      defaultVisible?: boolean;
+      blocks: DisplayBlock[];
+    }
   | { type: "copy"; label?: string; text: string };
 
 export interface BuildDisplayCardOptions {
@@ -213,6 +229,7 @@ function renderRich(segments: RichSegment[], ctx: RenderCtx): Rendered {
             text: s.text,
             ...(s.bold ? { weight: "Bolder" } : {}),
             ...(s.subtle ? { isSubtle: true } : {}),
+            ...(s.fontType ? { fontType: s.fontType } : {}),
             ...(s.color && s.color !== "default" ? { color: s.color } : {}),
           })),
         },
@@ -224,30 +241,52 @@ function renderRich(segments: RichSegment[], ctx: RenderCtx): Rendered {
   return { elements: [textBlock(clean)], plainLines: [clean] };
 }
 
-function renderTable(rows: TableRow[], firstRowAsHeader: boolean | undefined, ctx: RenderCtx): Rendered {
-  const cleanedRows: string[][] = [];
+function renderTableCell(cell: TableCell, ctx: RenderCtx): Rendered {
+  if (Array.isArray(cell.blocks)) return renderBlocks(cell.blocks, ctx);
+  return typeof cell.text === "string" ? renderText(cell.text, ctx) : EMPTY;
+}
+
+function renderTableColumns(columns: TableColumn[] | undefined, columnCount: number): Array<{ width: number }> {
+  return Array.from({ length: columnCount }, (_, i) => {
+    const width = columns?.[i]?.width;
+    return { width: typeof width === "number" && Number.isFinite(width) && width > 0 ? width : 1 };
+  });
+}
+
+function renderTable(
+  rows: TableRow[],
+  columns: TableColumn[] | undefined,
+  firstRowAsHeader: boolean | undefined,
+  ctx: RenderCtx,
+): Rendered {
+  const renderedRows: Array<{ cells: Rendered[]; plainLine: string }> = [];
   for (const row of rows) {
     const cells = row.cells
-      .map((c) => sanitize(c.text, ctx.generic))
-      .filter((c): c is string => !!c);
-    if (cells.length > 0) cleanedRows.push(cells);
+      .map((c) => renderTableCell(c, ctx))
+      .filter((c) => c.elements.length > 0);
+    if (cells.length > 0) {
+      renderedRows.push({
+        cells,
+        plainLine: cells.map((cell) => cell.plainLines.join("；")).filter(Boolean).join(" | "),
+      });
+    }
   }
-  if (cleanedRows.length === 0) return EMPTY;
+  if (renderedRows.length === 0) return EMPTY;
 
-  const plainLines = cleanedRows.map((cells) => cells.join(" | "));
+  const plainLines = renderedRows.map((row) => row.plainLine);
   if (cardSupports(ctx.caps, "Table")) {
-    const columnCount = Math.max(...cleanedRows.map((cells) => cells.length));
+    const columnCount = Math.max(columns?.length ?? 0, ...renderedRows.map((row) => row.cells.length));
     return {
       elements: [
         {
           type: "Table",
           firstRowAsHeader: firstRowAsHeader !== false,
-          columns: Array.from({ length: columnCount }, () => ({ width: 1 })),
-          rows: cleanedRows.map((cells) => ({
+          columns: renderTableColumns(columns, columnCount),
+          rows: renderedRows.map((row) => ({
             type: "TableRow",
-            cells: cells.map((text) => ({
+            cells: row.cells.map((cell) => ({
               type: "TableCell",
-              items: [textBlock(text)],
+              items: cell.elements,
             })),
           })),
         },
@@ -344,21 +383,22 @@ function renderGroup(
 }
 
 /**
- * 折叠/展开 —— 升级条件三维齐备(forward-compat,任一未 advertise 就降级平铺):
+ * 折叠/展开 —— 升级条件齐备(forward-compat,任一未 advertise 就降级平铺):
  *   1. `caps.elements` 含 `Container` —— 用来包 hidden 内容 + `isVisible:false`;
- *   2. `caps.elements` 含 `ActionSet` —— 触发器容器,避免部分前端对 TextBlock.selectAction
+ *   2. `caps.elements` 含 `ColumnSet` —— 摘要左列 + 右侧按钮列;
+ *   3. `caps.elements` 含 `ActionSet` —— 触发器容器,避免部分前端对 TextBlock.selectAction
  *      的 ToggleVisibility 支持不完整;
- *   3. `caps.actions` 含 `Action.ToggleVisibility` —— 具体动作被服务端接受(旧部署无该 advertise
+ *   4. `caps.actions` 含 `Action.ToggleVisibility` —— 具体动作被服务端接受(旧部署无该 advertise
  *      → 保守 fail-closed,避免乐观发出被 400)。
  *
- * summary 是永远可见的摘要,ActionSet 用短标题承载 ToggleVisibility,避免重复展示整段 summary。
- * inner 是默认隐藏的正文。降级形态 = summary 当 heading + inner 全部展开在下方(视觉上等同
- * "已展开",信息不丢)。
+ * summary 是永远可见的摘要,右侧 Column 放两个 ActionSet 互相切换可见性,避免单按钮文案无法
+ * 从"展开"自动变"收起"。inner 可默认隐藏或展开。降级形态 = summary 当 heading + inner
+ * 全部展开在下方(视觉上等同"已展开",信息不丢)。
  *
  * 若 summary 被脱敏或空 / inner 全被脱敏或空,整个 collapsible 不渲染 —— 避免展开后是空块。
  */
 function renderCollapsible(summary: string, blocks: DisplayBlock[], ctx: RenderCtx): Rendered {
-  return renderCollapsibleWithSummary(summary, undefined, undefined, blocks, ctx);
+  return renderCollapsibleWithSummary(summary, undefined, undefined, undefined, undefined, false, blocks, ctx);
 }
 
 function renderCollapsibleWithActionLabel(
@@ -367,20 +407,25 @@ function renderCollapsibleWithActionLabel(
   blocks: DisplayBlock[],
   ctx: RenderCtx,
 ): Rendered {
-  return renderCollapsibleWithSummary(summary, undefined, actionLabel, blocks, ctx);
+  return renderCollapsibleWithSummary(summary, undefined, actionLabel, undefined, undefined, false, blocks, ctx);
 }
 
 function renderCollapsibleWithSummary(
   summary: string,
   summarySegments: RichSegment[] | undefined,
   actionLabel: string | undefined,
+  expandLabel: string | undefined,
+  collapseLabel: string | undefined,
+  defaultVisible: boolean | undefined,
   blocks: DisplayBlock[],
   ctx: RenderCtx,
 ): Rendered {
   const rawSummary = summarySegments ? summarySegments.map((s) => s.text).join("") : summary;
   const cleanSummary = sanitize(rawSummary, ctx.generic);
   if (!cleanSummary) return EMPTY;
-  const cleanActionLabel = sanitize(actionLabel ?? "展开/收起", ctx.generic) ?? "展开/收起";
+  const rawExpandLabel = expandLabel ?? (actionLabel && actionLabel !== cleanSummary ? actionLabel : "展开");
+  const cleanExpandLabel = sanitize(rawExpandLabel, ctx.generic) ?? "展开";
+  const cleanCollapseLabel = sanitize(collapseLabel ?? "收起", ctx.generic) ?? "收起";
   const inner = renderBlocks(blocks, ctx);
   if (inner.elements.length === 0) return EMPTY;
   const summaryElements = summarySegments
@@ -390,29 +435,69 @@ function renderCollapsibleWithSummary(
 
   const canToggle =
     cardSupports(ctx.caps, "Container") &&
+    cardSupports(ctx.caps, "ColumnSet") &&
     cardSupports(ctx.caps, "ActionSet") &&
     cardSupports(ctx.caps, "Action.ToggleVisibility");
 
   if (canToggle) {
-    const targetId = nextId(ctx, "clp");
-    const visibleSummaryElements = cleanSummary === cleanActionLabel ? [] : summaryElements;
+    const detailId = nextId(ctx, "clp");
+    const expandId = nextId(ctx, "btn_expand");
+    const collapseId = nextId(ctx, "btn_collapse");
+    const startVisible = defaultVisible === true;
     return {
       elements: [
-        ...visibleSummaryElements,
         {
-          type: "ActionSet",
-          actions: [
+          type: "ColumnSet",
+          columns: [
             {
-              type: "Action.ToggleVisibility",
-              title: cleanActionLabel,
-              targetElements: [targetId],
+              type: "Column",
+              width: "stretch",
+              items: summaryElements,
+            },
+            {
+              type: "Column",
+              width: "auto",
+              items: [
+                {
+                  type: "ActionSet",
+                  id: collapseId,
+                  isVisible: startVisible,
+                  actions: [
+                    {
+                      type: "Action.ToggleVisibility",
+                      title: cleanCollapseLabel,
+                      targetElements: [
+                        { elementId: detailId, isVisible: false },
+                        { elementId: collapseId, isVisible: false },
+                        { elementId: expandId, isVisible: true },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  type: "ActionSet",
+                  id: expandId,
+                  isVisible: !startVisible,
+                  actions: [
+                    {
+                      type: "Action.ToggleVisibility",
+                      title: cleanExpandLabel,
+                      targetElements: [
+                        { elementId: detailId, isVisible: true },
+                        { elementId: collapseId, isVisible: true },
+                        { elementId: expandId, isVisible: false },
+                      ],
+                    },
+                  ],
+                },
+              ],
             },
           ],
         },
         {
           type: "Container",
-          id: targetId,
-          isVisible: false,
+          id: detailId,
+          isVisible: startVisible,
           items: inner.elements,
         },
       ],
@@ -484,7 +569,7 @@ function renderBlock(block: DisplayBlock, ctx: RenderCtx): Rendered {
     case "facts":
       return renderFacts(block.items, ctx);
     case "table":
-      return renderTable(block.rows, block.firstRowAsHeader, ctx);
+      return renderTable(block.rows, block.columns, block.firstRowAsHeader, ctx);
     case "columns":
       return renderColumns(block.columns, ctx);
     case "link":
@@ -492,7 +577,16 @@ function renderBlock(block: DisplayBlock, ctx: RenderCtx): Rendered {
     case "group":
       return renderGroup(block.style, block.blocks, ctx);
     case "collapsible":
-      return renderCollapsibleWithSummary(block.summary, block.summarySegments, block.actionLabel, block.blocks, ctx);
+      return renderCollapsibleWithSummary(
+        block.summary,
+        block.summarySegments,
+        block.actionLabel,
+        block.expandLabel,
+        block.collapseLabel,
+        block.defaultVisible,
+        block.blocks,
+        ctx,
+      );
     case "copy":
       return renderCopy(block.label, block.text, ctx);
   }
@@ -571,8 +665,8 @@ export function buildDisplayCard(opts: BuildDisplayCardOptions): BuildDisplayCar
  * 白名单校验 agent / 外部输入的 DisplayBlock —— 每 block:
  *   - `type` 在支持集内(heading/text/rich/facts/table/columns/link/group/collapsible/copy);
  *   - 关键字段类型正确(text 是 string;facts.items 是 [{label,value}];rich.segments 是 [{text}];
- *     table.rows 是 rows/cells/text;columns/group/collapsible 递归校验;heading.size 若给则限于 medium/large;
- *     collapsible.actionLabel/copy.label 可选)。
+ *     table 支持 columns[].width 与 cell.text/cell.blocks;columns/group/collapsible 递归校验;heading.size 若给则限于 medium/large;
+ *     rich.fontType 限 Default/Monospace;collapsible labels/defaultVisible/copy.label 可选)。
  * 任何字段类型错的整块**静默丢弃**(不 fail 整个构建),避免 agent 单个字段错就完全无回复。
  * 内容脱敏由 buildDisplayCard/sanitize 兜底,此处只做结构校验。
  */
@@ -605,8 +699,9 @@ function validateBlockList(
 }
 
 const HEADING_SIZES = new Set(["medium", "large"]);
-const GROUP_STYLES = new Set(["default", "good", "warning", "attention"]);
+const GROUP_STYLES = new Set(["default", "good", "warning", "attention", "emphasis"]);
 const RICH_COLORS = new Set(["default", "good", "warning", "attention", "accent"]);
+const FONT_TYPES = new Set(["Default", "Monospace"]);
 
 function validateOneBlock(raw: unknown, depth: number, budget: { count: number }): DisplayBlock | null {
   if (!raw || typeof raw !== "object") return null;
@@ -631,10 +726,13 @@ function validateOneBlock(raw: unknown, depth: number, budget: { count: number }
         if (typeof seg.text !== "string") continue;
         const color = seg.color;
         if (color !== undefined && (typeof color !== "string" || !RICH_COLORS.has(color))) continue;
+        const fontType = seg.fontType;
+        if (fontType !== undefined && (typeof fontType !== "string" || !FONT_TYPES.has(fontType))) continue;
         segs.push({
           text: seg.text,
           ...(seg.bold === true ? { bold: true } : {}),
           ...(seg.subtle === true ? { subtle: true } : {}),
+          ...(typeof fontType === "string" ? { fontType: fontType as RichSegment["fontType"] } : {}),
           ...(typeof color === "string" ? { color: color as RichSegment["color"] } : {}),
         });
       }
@@ -659,6 +757,18 @@ function validateOneBlock(raw: unknown, depth: number, budget: { count: number }
     }
     case "table": {
       if (!Array.isArray(r.rows)) return null;
+      let columns: TableColumn[] | undefined;
+      if (Array.isArray(r.columns)) {
+        columns = [];
+        for (const col of r.columns) {
+          if (!col || typeof col !== "object") continue;
+          const width = (col as Record<string, unknown>).width;
+          columns.push({
+            ...(typeof width === "number" && Number.isFinite(width) && width > 0 ? { width } : {}),
+          });
+        }
+        if (columns.length === 0) columns = undefined;
+      }
       const rows: TableRow[] = [];
       for (const row of r.rows) {
         if (budget.count >= MAX_TOTAL_BLOCKS) break;
@@ -670,9 +780,17 @@ function validateOneBlock(raw: unknown, depth: number, budget: { count: number }
           if (budget.count >= MAX_TOTAL_BLOCKS) break;
           if (!cell || typeof cell !== "object") continue;
           const cc = cell as Record<string, unknown>;
-          if (typeof cc.text !== "string") continue;
-          budget.count++;
-          cells.push({ text: cc.text });
+          if (Array.isArray(cc.blocks)) {
+            const inner = validateBlockList(cc.blocks, depth - 1, budget);
+            if (inner.length === 0) continue;
+            budget.count++;
+            cells.push({ blocks: inner });
+            continue;
+          }
+          if (typeof cc.text === "string") {
+            budget.count++;
+            cells.push({ text: cc.text });
+          }
         }
         if (cells.length > 0) {
           budget.count++;
@@ -683,6 +801,7 @@ function validateOneBlock(raw: unknown, depth: number, budget: { count: number }
       return {
         type: "table",
         rows,
+        ...(columns ? { columns } : {}),
         ...(r.firstRowAsHeader === false ? { firstRowAsHeader: false } : {}),
       };
     }
@@ -718,6 +837,10 @@ function validateOneBlock(raw: unknown, depth: number, budget: { count: number }
       if (typeof r.summary !== "string") return null;
       const actionLabel = r.actionLabel;
       if (actionLabel !== undefined && typeof actionLabel !== "string") return null;
+      const expandLabel = r.expandLabel;
+      if (expandLabel !== undefined && typeof expandLabel !== "string") return null;
+      const collapseLabel = r.collapseLabel;
+      if (collapseLabel !== undefined && typeof collapseLabel !== "string") return null;
       let summarySegments: RichSegment[] | undefined;
       if (Array.isArray(r.summarySegments)) {
         summarySegments = [];
@@ -727,10 +850,13 @@ function validateOneBlock(raw: unknown, depth: number, budget: { count: number }
           if (typeof seg.text !== "string") continue;
           const color = seg.color;
           if (color !== undefined && (typeof color !== "string" || !RICH_COLORS.has(color))) continue;
+          const fontType = seg.fontType;
+          if (fontType !== undefined && (typeof fontType !== "string" || !FONT_TYPES.has(fontType))) continue;
           summarySegments.push({
             text: seg.text,
             ...(seg.bold === true ? { bold: true } : {}),
             ...(seg.subtle === true ? { subtle: true } : {}),
+            ...(typeof fontType === "string" ? { fontType: fontType as RichSegment["fontType"] } : {}),
             ...(typeof color === "string" ? { color: color as RichSegment["color"] } : {}),
           });
         }
@@ -738,9 +864,16 @@ function validateOneBlock(raw: unknown, depth: number, budget: { count: number }
       }
       const inner = validateBlockList(r.blocks, depth - 1, budget);
       if (inner.length === 0) return null;
-      return typeof actionLabel === "string"
-        ? { type: "collapsible", summary: r.summary, summarySegments, actionLabel, blocks: inner }
-        : { type: "collapsible", summary: r.summary, summarySegments, blocks: inner };
+      return {
+        type: "collapsible",
+        summary: r.summary,
+        summarySegments,
+        ...(typeof actionLabel === "string" ? { actionLabel } : {}),
+        ...(typeof expandLabel === "string" ? { expandLabel } : {}),
+        ...(typeof collapseLabel === "string" ? { collapseLabel } : {}),
+        ...(r.defaultVisible === true ? { defaultVisible: true } : {}),
+        blocks: inner,
+      };
     }
     case "copy": {
       if (typeof r.text !== "string") return null;

--- a/src/card-blocks.ts
+++ b/src/card-blocks.ts
@@ -4,9 +4,11 @@
  * 同套 helper:URL 降级到 scheme://注册域、命中 secret shape 整块隐藏)。绝不产出会被服务端
  * 400 的结构,消费者无需自己判断白名单。
  *
- * 本轮支持的 block:heading / text / rich / facts / group(高价值子集)。
+ * 本轮支持的 block:heading / text / rich / facts / table / columns / group(高价值子集)。
  * collapsible 在 P1-c 引入(依赖 caps.actions 里 Action.ToggleVisibility);
- * table/image/gallery/columns 后续轮次。
+ * copy 在 P1-j 引入(依赖 caps.actions 里 Action.CopyToClipboard,客户端本地动作,不回流)。
+ * link 在 P1-k 引入(依赖 caps.actions 里 Action.OpenUrl;优先可见 ActionSet,不回流)。
+ * image/gallery 后续轮次。
  *
  * 纯函数、无副作用、无 I/O —— hook 进度卡与 agent 展示卡工具共享这一层。
  */
@@ -19,6 +21,7 @@ import { CARD_VERSION } from "./types.js";
 export interface RichSegment {
   text: string;
   bold?: boolean;
+  subtle?: boolean;
   color?: "default" | "good" | "warning" | "attention" | "accent";
 }
 
@@ -26,6 +29,21 @@ export interface RichSegment {
 export interface Fact {
   label: string;
   value: string;
+}
+
+/** 表格单元格。 */
+export interface TableCell {
+  text: string;
+}
+
+/** 表格行。 */
+export interface TableRow {
+  cells: TableCell[];
+}
+
+/** ColumnSet 单列。 */
+export interface Column {
+  blocks: DisplayBlock[];
 }
 
 /** Container 语义着色(group block 用)。 */
@@ -40,8 +58,12 @@ export type DisplayBlock =
   | { type: "text"; text: string }
   | { type: "rich"; segments: RichSegment[] }
   | { type: "facts"; items: Fact[] }
+  | { type: "table"; rows: TableRow[]; firstRowAsHeader?: boolean }
+  | { type: "columns"; columns: Column[] }
+  | { type: "link"; text: string; url: string }
   | { type: "group"; style?: GroupStyle; blocks: DisplayBlock[] }
-  | { type: "collapsible"; summary: string; blocks: DisplayBlock[] };
+  | { type: "collapsible"; summary: string; summarySegments?: RichSegment[]; actionLabel?: string; blocks: DisplayBlock[] }
+  | { type: "copy"; label?: string; text: string };
 
 export interface BuildDisplayCardOptions {
   /** 卡片标题(渲染成置顶的 Bolder TextBlock)。 */
@@ -104,7 +126,7 @@ interface RenderCtx {
 }
 
 function nextId(ctx: RenderCtx, prefix: string): string {
-  return `${prefix}_${ctx.uid.n++}`;
+  return `octo_disp_${prefix}_${ctx.uid.n++}`;
 }
 
 function textBlock(text: string, opts?: { bold?: boolean; size?: "medium" | "large" }): Record<string, unknown> {
@@ -114,6 +136,14 @@ function textBlock(text: string, opts?: { bold?: boolean; size?: "medium" | "lar
     wrap: true,
     ...(opts?.bold ? { weight: "Bolder" } : {}),
     ...(opts?.size ? { size: opts.size === "medium" ? "Medium" : "Large" } : {}),
+  };
+}
+
+function openUrlAction(title: string, url: string): Record<string, unknown> {
+  return {
+    type: "Action.OpenUrl",
+    title,
+    url,
   };
 }
 
@@ -127,6 +157,41 @@ function renderText(text: string, ctx: RenderCtx): Rendered {
   const clean = sanitize(text, ctx.generic);
   if (!clean) return EMPTY;
   return { elements: [textBlock(clean)], plainLines: [clean] };
+}
+
+function sanitizeUrlForAction(url: string, ctx: RenderCtx): string | null {
+  const clean = sanitize(url, ctx.generic);
+  if (!clean) return null;
+  try {
+    const u = new URL(clean);
+    return u.protocol === "http:" || u.protocol === "https:" ? clean : null;
+  } catch {
+    return null;
+  }
+}
+
+function renderLink(text: string, url: string, ctx: RenderCtx): Rendered {
+  const cleanText = sanitize(text, ctx.generic);
+  const cleanUrl = sanitizeUrlForAction(url, ctx);
+  if (!cleanText || !cleanUrl) return EMPTY;
+  if (cardSupports(ctx.caps, "ActionSet") && cardSupports(ctx.caps, "Action.OpenUrl")) {
+    return {
+      elements: [
+        {
+          type: "ActionSet",
+          actions: [openUrlAction(cleanText, cleanUrl)],
+        },
+      ],
+      plainLines: [`${cleanText}：${cleanUrl}`],
+    };
+  }
+  if (cardSupports(ctx.caps, "Action.OpenUrl")) {
+    const el = textBlock(cleanText);
+    // selectAction 只承载本地/导航类动作。Submit 必须是回流交互卡路径,这里永不生成。
+    el.selectAction = openUrlAction(cleanText, cleanUrl);
+    return { elements: [el], plainLines: [`${cleanText}：${cleanUrl}`] };
+  }
+  return { elements: [textBlock(`${cleanText}：${cleanUrl}`)], plainLines: [`${cleanText}：${cleanUrl}`] };
 }
 
 function renderRich(segments: RichSegment[], ctx: RenderCtx): Rendered {
@@ -147,6 +212,7 @@ function renderRich(segments: RichSegment[], ctx: RenderCtx): Rendered {
             type: "TextRun",
             text: s.text,
             ...(s.bold ? { weight: "Bolder" } : {}),
+            ...(s.subtle ? { isSubtle: true } : {}),
             ...(s.color && s.color !== "default" ? { color: s.color } : {}),
           })),
         },
@@ -156,6 +222,73 @@ function renderRich(segments: RichSegment[], ctx: RenderCtx): Rendered {
   }
   // 降级:段拼成单个 TextBlock(已 URL 降级;顺带解决 ColumnSet plain 分行:一行完整而非按列拆行)。
   return { elements: [textBlock(clean)], plainLines: [clean] };
+}
+
+function renderTable(rows: TableRow[], firstRowAsHeader: boolean | undefined, ctx: RenderCtx): Rendered {
+  const cleanedRows: string[][] = [];
+  for (const row of rows) {
+    const cells = row.cells
+      .map((c) => sanitize(c.text, ctx.generic))
+      .filter((c): c is string => !!c);
+    if (cells.length > 0) cleanedRows.push(cells);
+  }
+  if (cleanedRows.length === 0) return EMPTY;
+
+  const plainLines = cleanedRows.map((cells) => cells.join(" | "));
+  if (cardSupports(ctx.caps, "Table")) {
+    const columnCount = Math.max(...cleanedRows.map((cells) => cells.length));
+    return {
+      elements: [
+        {
+          type: "Table",
+          firstRowAsHeader: firstRowAsHeader !== false,
+          columns: Array.from({ length: columnCount }, () => ({ width: 1 })),
+          rows: cleanedRows.map((cells) => ({
+            type: "TableRow",
+            cells: cells.map((text) => ({
+              type: "TableCell",
+              items: [textBlock(text)],
+            })),
+          })),
+        },
+      ],
+      plainLines,
+    };
+  }
+
+  return {
+    elements: plainLines.map((line) => textBlock(line)),
+    plainLines,
+  };
+}
+
+function renderColumns(columns: Column[], ctx: RenderCtx): Rendered {
+  const renderedColumns = columns
+    .map((col) => renderBlocks(col.blocks, ctx))
+    .filter((col) => col.elements.length > 0);
+  if (renderedColumns.length === 0) return EMPTY;
+
+  const plainLines = [renderedColumns.map((col) => col.plainLines.join("；")).filter(Boolean).join(" | ")];
+  if (cardSupports(ctx.caps, "ColumnSet")) {
+    return {
+      elements: [
+        {
+          type: "ColumnSet",
+          columns: renderedColumns.map((col) => ({
+            type: "Column",
+            width: "stretch",
+            items: col.elements,
+          })),
+        },
+      ],
+      plainLines,
+    };
+  }
+
+  return {
+    elements: [textBlock(plainLines[0])],
+    plainLines,
+  };
 }
 
 function renderFacts(items: Fact[], ctx: RenderCtx): Rendered {
@@ -213,20 +346,47 @@ function renderGroup(
 /**
  * 折叠/展开 —— 升级条件三维齐备(forward-compat,任一未 advertise 就降级平铺):
  *   1. `caps.elements` 含 `Container` —— 用来包 hidden 内容 + `isVisible:false`;
- *   2. `caps.elements` 含 `ActionSet` —— 触发器容器(比 selectAction 更少属性依赖);
+ *   2. `caps.elements` 含 `ActionSet` —— 触发器容器,避免部分前端对 TextBlock.selectAction
+ *      的 ToggleVisibility 支持不完整;
  *   3. `caps.actions` 含 `Action.ToggleVisibility` —— 具体动作被服务端接受(旧部署无该 advertise
  *      → 保守 fail-closed,避免乐观发出被 400)。
  *
- * summary 是永远可见的"点我展开"入口,inner 是默认隐藏的正文。降级形态 = summary 当 heading +
- * inner 全部展开在下方(视觉上等同"已展开",信息不丢)。
+ * summary 是永远可见的摘要,ActionSet 用短标题承载 ToggleVisibility,避免重复展示整段 summary。
+ * inner 是默认隐藏的正文。降级形态 = summary 当 heading + inner 全部展开在下方(视觉上等同
+ * "已展开",信息不丢)。
  *
  * 若 summary 被脱敏或空 / inner 全被脱敏或空,整个 collapsible 不渲染 —— 避免展开后是空块。
  */
 function renderCollapsible(summary: string, blocks: DisplayBlock[], ctx: RenderCtx): Rendered {
-  const cleanSummary = sanitize(summary, ctx.generic);
+  return renderCollapsibleWithSummary(summary, undefined, undefined, blocks, ctx);
+}
+
+function renderCollapsibleWithActionLabel(
+  summary: string,
+  actionLabel: string | undefined,
+  blocks: DisplayBlock[],
+  ctx: RenderCtx,
+): Rendered {
+  return renderCollapsibleWithSummary(summary, undefined, actionLabel, blocks, ctx);
+}
+
+function renderCollapsibleWithSummary(
+  summary: string,
+  summarySegments: RichSegment[] | undefined,
+  actionLabel: string | undefined,
+  blocks: DisplayBlock[],
+  ctx: RenderCtx,
+): Rendered {
+  const rawSummary = summarySegments ? summarySegments.map((s) => s.text).join("") : summary;
+  const cleanSummary = sanitize(rawSummary, ctx.generic);
   if (!cleanSummary) return EMPTY;
+  const cleanActionLabel = sanitize(actionLabel ?? "展开/收起", ctx.generic) ?? "展开/收起";
   const inner = renderBlocks(blocks, ctx);
   if (inner.elements.length === 0) return EMPTY;
+  const summaryElements = summarySegments
+    ? renderRich(summarySegments, ctx).elements
+    : [textBlock(cleanSummary, { bold: true })];
+  if (summaryElements.length === 0) return EMPTY;
 
   const canToggle =
     cardSupports(ctx.caps, "Container") &&
@@ -235,15 +395,16 @@ function renderCollapsible(summary: string, blocks: DisplayBlock[], ctx: RenderC
 
   if (canToggle) {
     const targetId = nextId(ctx, "clp");
+    const visibleSummaryElements = cleanSummary === cleanActionLabel ? [] : summaryElements;
     return {
       elements: [
-        textBlock(cleanSummary, { bold: true }),
+        ...visibleSummaryElements,
         {
           type: "ActionSet",
           actions: [
             {
               type: "Action.ToggleVisibility",
-              title: cleanSummary,
+              title: cleanActionLabel,
               targetElements: [targetId],
             },
           ],
@@ -262,8 +423,53 @@ function renderCollapsible(summary: string, blocks: DisplayBlock[], ctx: RenderC
 
   // 降级:summary 当 heading + inner 全部展开在下方(零回归展开态)。
   return {
-    elements: [textBlock(cleanSummary, { bold: true }), ...inner.elements],
+    elements: [...summaryElements, ...inner.elements],
     plainLines: [cleanSummary, ...inner.plainLines],
+  };
+}
+
+const COPY_TEXT_MAX_BYTES = 4096;
+const COPY_LABEL_DEFAULT = "复制";
+
+function utf8Bytes(s: string): number {
+  return new TextEncoder().encode(s).byteLength;
+}
+
+/**
+ * Action.CopyToClipboard 是客户端本地动作,不触发 bot callback。text 仍是群卡 JSON 的一部分,
+ * 所以与普通正文同样脱敏,并按服务端/客户端约定限制为 UTF-8 4KiB。
+ */
+function renderCopy(label: string | undefined, text: string, ctx: RenderCtx): Rendered {
+  const cleanText = sanitize(text, ctx.generic);
+  if (!cleanText) return EMPTY;
+  const cleanLabel = sanitize(label ?? COPY_LABEL_DEFAULT, ctx.generic) ?? COPY_LABEL_DEFAULT;
+  if (!cardSupports(ctx.caps, "Action.CopyToClipboard") || !cardSupports(ctx.caps, "ActionSet")) {
+    return {
+      elements: [textBlock(cleanText)],
+      plainLines: [cleanText],
+    };
+  }
+  if (utf8Bytes(cleanText) > COPY_TEXT_MAX_BYTES) {
+    const msg = "复制内容超过 4KiB，未渲染复制按钮";
+    return {
+      elements: [textBlock(msg)],
+      plainLines: [msg],
+    };
+  }
+  return {
+    elements: [
+      {
+        type: "ActionSet",
+        actions: [
+          {
+            type: "Action.CopyToClipboard",
+            title: cleanLabel,
+            text: cleanText,
+          },
+        ],
+      },
+    ],
+    plainLines: [cleanText],
   };
 }
 
@@ -277,10 +483,18 @@ function renderBlock(block: DisplayBlock, ctx: RenderCtx): Rendered {
       return renderRich(block.segments, ctx);
     case "facts":
       return renderFacts(block.items, ctx);
+    case "table":
+      return renderTable(block.rows, block.firstRowAsHeader, ctx);
+    case "columns":
+      return renderColumns(block.columns, ctx);
+    case "link":
+      return renderLink(block.text, block.url, ctx);
     case "group":
       return renderGroup(block.style, block.blocks, ctx);
     case "collapsible":
-      return renderCollapsible(block.summary, block.blocks, ctx);
+      return renderCollapsibleWithSummary(block.summary, block.summarySegments, block.actionLabel, block.blocks, ctx);
+    case "copy":
+      return renderCopy(block.label, block.text, ctx);
   }
 }
 
@@ -304,9 +518,10 @@ export function buildDisplayCard(opts: BuildDisplayCardOptions): BuildDisplayCar
   const ctx: RenderCtx = { caps, uid: { n: 0 }, generic: !trusted };
   const body: Record<string, unknown>[] = [];
   const plainLines: string[] = [];
+  let cleanTitle = "";
 
   if (title) {
-    const cleanTitle = sanitize(title, ctx.generic);
+    cleanTitle = sanitize(title, ctx.generic) ?? "";
     if (cleanTitle) {
       body.push(textBlock(cleanTitle, { bold: true }));
       plainLines.push(cleanTitle);
@@ -314,6 +529,16 @@ export function buildDisplayCard(opts: BuildDisplayCardOptions): BuildDisplayCar
   }
 
   const rendered = renderBlocks(blocks, ctx);
+  // Agent 常同时传 title + 首个同名 heading。展示面只保留一个标题,plain 同步去重。
+  if (
+    cleanTitle &&
+    rendered.plainLines[0] === cleanTitle &&
+    rendered.elements[0]?.type === "TextBlock" &&
+    rendered.elements[0]?.text === cleanTitle
+  ) {
+    rendered.elements.shift();
+    rendered.plainLines.shift();
+  }
   body.push(...rendered.elements);
   plainLines.push(...rendered.plainLines);
 
@@ -344,9 +569,10 @@ export function buildDisplayCard(opts: BuildDisplayCardOptions): BuildDisplayCar
 // ── 不可信输入验证 ────────────────────────────────────────────
 /**
  * 白名单校验 agent / 外部输入的 DisplayBlock —— 每 block:
- *   - `type` 在支持集内(heading/text/rich/facts/group/collapsible);
+ *   - `type` 在支持集内(heading/text/rich/facts/table/columns/link/group/collapsible/copy);
  *   - 关键字段类型正确(text 是 string;facts.items 是 [{label,value}];rich.segments 是 [{text}];
- *     group.blocks / collapsible.blocks 递归校验;heading.size 若给则限于 medium/large)。
+ *     table.rows 是 rows/cells/text;columns/group/collapsible 递归校验;heading.size 若给则限于 medium/large;
+ *     collapsible.actionLabel/copy.label 可选)。
  * 任何字段类型错的整块**静默丢弃**(不 fail 整个构建),避免 agent 单个字段错就完全无回复。
  * 内容脱敏由 buildDisplayCard/sanitize 兜底,此处只做结构校验。
  */
@@ -408,6 +634,7 @@ function validateOneBlock(raw: unknown, depth: number, budget: { count: number }
         segs.push({
           text: seg.text,
           ...(seg.bold === true ? { bold: true } : {}),
+          ...(seg.subtle === true ? { subtle: true } : {}),
           ...(typeof color === "string" ? { color: color as RichSegment["color"] } : {}),
         });
       }
@@ -430,6 +657,54 @@ function validateOneBlock(raw: unknown, depth: number, budget: { count: number }
       if (items.length === 0) return null;
       return { type: "facts", items };
     }
+    case "table": {
+      if (!Array.isArray(r.rows)) return null;
+      const rows: TableRow[] = [];
+      for (const row of r.rows) {
+        if (budget.count >= MAX_TOTAL_BLOCKS) break;
+        if (!row || typeof row !== "object") continue;
+        const rr = row as Record<string, unknown>;
+        if (!Array.isArray(rr.cells)) continue;
+        const cells: TableCell[] = [];
+        for (const cell of rr.cells) {
+          if (budget.count >= MAX_TOTAL_BLOCKS) break;
+          if (!cell || typeof cell !== "object") continue;
+          const cc = cell as Record<string, unknown>;
+          if (typeof cc.text !== "string") continue;
+          budget.count++;
+          cells.push({ text: cc.text });
+        }
+        if (cells.length > 0) {
+          budget.count++;
+          rows.push({ cells });
+        }
+      }
+      if (rows.length === 0) return null;
+      return {
+        type: "table",
+        rows,
+        ...(r.firstRowAsHeader === false ? { firstRowAsHeader: false } : {}),
+      };
+    }
+    case "columns": {
+      if (!Array.isArray(r.columns)) return null;
+      const columns: Column[] = [];
+      for (const col of r.columns) {
+        if (budget.count >= MAX_TOTAL_BLOCKS) break;
+        if (!col || typeof col !== "object") continue;
+        const cc = col as Record<string, unknown>;
+        const inner = validateBlockList(cc.blocks, depth - 1, budget);
+        if (inner.length === 0) continue;
+        budget.count++;
+        columns.push({ blocks: inner });
+      }
+      if (columns.length === 0) return null;
+      return { type: "columns", columns };
+    }
+    case "link": {
+      if (typeof r.text !== "string" || typeof r.url !== "string") return null;
+      return { type: "link", text: r.text, url: r.url };
+    }
     case "group": {
       const inner = validateBlockList(r.blocks, depth - 1, budget);
       if (inner.length === 0) return null;
@@ -441,9 +716,39 @@ function validateOneBlock(raw: unknown, depth: number, budget: { count: number }
     }
     case "collapsible": {
       if (typeof r.summary !== "string") return null;
+      const actionLabel = r.actionLabel;
+      if (actionLabel !== undefined && typeof actionLabel !== "string") return null;
+      let summarySegments: RichSegment[] | undefined;
+      if (Array.isArray(r.summarySegments)) {
+        summarySegments = [];
+        for (const s of r.summarySegments) {
+          if (!s || typeof s !== "object") continue;
+          const seg = s as Record<string, unknown>;
+          if (typeof seg.text !== "string") continue;
+          const color = seg.color;
+          if (color !== undefined && (typeof color !== "string" || !RICH_COLORS.has(color))) continue;
+          summarySegments.push({
+            text: seg.text,
+            ...(seg.bold === true ? { bold: true } : {}),
+            ...(seg.subtle === true ? { subtle: true } : {}),
+            ...(typeof color === "string" ? { color: color as RichSegment["color"] } : {}),
+          });
+        }
+        if (summarySegments.length === 0) summarySegments = undefined;
+      }
       const inner = validateBlockList(r.blocks, depth - 1, budget);
       if (inner.length === 0) return null;
-      return { type: "collapsible", summary: r.summary, blocks: inner };
+      return typeof actionLabel === "string"
+        ? { type: "collapsible", summary: r.summary, summarySegments, actionLabel, blocks: inner }
+        : { type: "collapsible", summary: r.summary, summarySegments, blocks: inner };
+    }
+    case "copy": {
+      if (typeof r.text !== "string") return null;
+      const label = r.label;
+      if (label !== undefined && typeof label !== "string") return null;
+      return typeof label === "string"
+        ? { type: "copy", label, text: r.text }
+        : { type: "copy", text: r.text };
     }
     default:
       return null;

--- a/src/card-display-tool.test.ts
+++ b/src/card-display-tool.test.ts
@@ -1,0 +1,216 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("./accounts.js", () => ({
+  listOctoAccountIds: vi.fn(),
+  resolveOctoAccount: vi.fn(),
+  resolveDefaultOctoAccountId: vi.fn(),
+}));
+
+vi.mock("./api-fetch.js", () => ({
+  sendCardMessage: vi.fn(),
+  getCardProfile: vi.fn(),
+}));
+
+import { createDisplayCardTool } from "./card-display-tool.js";
+import {
+  listOctoAccountIds,
+  resolveOctoAccount,
+} from "./accounts.js";
+import { sendCardMessage, getCardProfile } from "./api-fetch.js";
+
+const mockCfg = { channels: { octo: { botToken: "t" } } } as never;
+
+function setupOk(): void {
+  vi.mocked(listOctoAccountIds).mockReturnValue(["default"]);
+  vi.mocked(resolveOctoAccount).mockReturnValue({
+    accountId: "default",
+    enabled: true,
+    configured: true,
+    config: {
+      botToken: "tok",
+      apiUrl: "https://api.test",
+      pollIntervalMs: 2000,
+      heartbeatIntervalMs: 30000,
+    },
+  } as never);
+  vi.mocked(getCardProfile).mockResolvedValue({
+    available: true,
+    enabled: true,
+    profiles: ["octo/v1"],
+    card_version: "1.5",
+    elements: ["TextBlock", "RichTextBlock", "Container", "FactSet"],
+  } as never);
+  vi.mocked(sendCardMessage).mockResolvedValue({ message_id: "m1" } as never);
+}
+
+function getTool(): {
+  name: string;
+  description: string;
+  parameters: unknown;
+  execute: (id: string, args: Record<string, unknown>) => Promise<{ content: Array<{ text: string }>; details?: unknown }>;
+} {
+  const tools = createDisplayCardTool({ cfg: mockCfg, agentAccountId: "default" });
+  expect(tools).toHaveLength(1);
+  return tools[0];
+}
+
+describe("createDisplayCardTool 骨架", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupOk();
+  });
+
+  it("无 configured account → 空数组(tool discovery 阶段安全)", () => {
+    vi.mocked(listOctoAccountIds).mockReturnValue([]);
+    expect(createDisplayCardTool({ cfg: mockCfg })).toEqual([]);
+  });
+
+  it("cfg 缺失 → 空数组", () => {
+    expect(createDisplayCardTool({ cfg: undefined as never })).toEqual([]);
+  });
+
+  it("tool 元数据:name=octo_send_display_card,description 涵盖『展示型』『不回流』", () => {
+    const t = getTool();
+    expect(t.name).toBe("octo_send_display_card");
+    expect(t.description.length).toBeGreaterThan(20);
+    expect(t.description).toMatch(/display|展示|non[- ]?interactive|not interactive/i);
+  });
+
+  it("P1-i: description 明确指引富样式(group.style + rich color),引用 SKILL 文档", () => {
+    const t = getTool();
+    // 显式提到 group.style 三色和 rich color 才算引导到位
+    expect(t.description).toMatch(/group.*style/i);
+    expect(t.description).toMatch(/good.*warning.*attention|attention.*warning.*good/);
+    expect(t.description).toMatch(/rich.*color|color.*rich/i);
+    // 指向 SKILL 详细节
+    expect(t.description).toMatch(/SKILL(\.md)?/);
+  });
+});
+
+describe("execute:发展示卡", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupOk();
+  });
+
+  it("blocks + channelId → 调 sendCardMessage,payload.card 是 buildDisplayCard 产物,payload 无 actions(展示型)", async () => {
+    const t = getTool();
+    const res = await t.execute("call-1", {
+      channelId: "group:g1",
+      title: "报告",
+      blocks: [
+        { type: "text", text: "任务完成" },
+        { type: "facts", items: [{ label: "耗时", value: "30ms" }] },
+      ],
+    });
+    expect(sendCardMessage).toHaveBeenCalledTimes(1);
+    const call = vi.mocked(sendCardMessage).mock.calls[0][0];
+    expect(call.channelId).toBe("g1");
+    expect((call.card as { type: string }).type).toBe("AdaptiveCard");
+    expect((call.card as { version: string }).version).toBe("1.5");
+    // 展示型 → 顶层无 actions
+    expect(call.card).not.toHaveProperty("actions");
+    expect(res.content[0].text).toContain("m1"); // 返回 message_id
+  });
+
+  it("blocks 空 + title 空 → 拒绝(不发)", async () => {
+    const t = getTool();
+    const res = await t.execute("call-2", { channelId: "group:g1", blocks: [] });
+    expect(sendCardMessage).not.toHaveBeenCalled();
+    expect(res.content[0].text.toLowerCase()).toMatch(/error|empty|blocks/);
+  });
+
+  it("gate available:false + env 未开 → 拒绝(agent 由错误退回文本)", async () => {
+    vi.mocked(getCardProfile).mockResolvedValue({ available: false, enabled: false } as never);
+    delete process.env.OCTO_CARD_MESSAGE_ENABLED;
+    const t = getTool();
+    const res = await t.execute("c3", { channelId: "group:g1", title: "T", blocks: [{ type: "text", text: "a" }] });
+    expect(sendCardMessage).not.toHaveBeenCalled();
+    expect(res.content[0].text.toLowerCase()).toMatch(/error|not (available|enabled)|unavailable/);
+  });
+
+  it("gate enabled:false → 拒绝", async () => {
+    vi.mocked(getCardProfile).mockResolvedValue({ available: true, enabled: false } as never);
+    const t = getTool();
+    const res = await t.execute("c4", { channelId: "group:g1", title: "T", blocks: [{ type: "text", text: "a" }] });
+    expect(sendCardMessage).not.toHaveBeenCalled();
+    expect(res.content[0].text.toLowerCase()).toMatch(/error|disabled|not enabled/);
+  });
+
+  it("profile 不含 octo/v1 → 拒绝(避免 400)", async () => {
+    vi.mocked(getCardProfile).mockResolvedValue({
+      available: true,
+      enabled: true,
+      profiles: ["octo/v2"],
+      card_version: "1.5",
+    } as never);
+    const t = getTool();
+    const res = await t.execute("c5", { channelId: "group:g1", title: "T", blocks: [{ type: "text", text: "a" }] });
+    expect(sendCardMessage).not.toHaveBeenCalled();
+    expect(res.content[0].text.toLowerCase()).toMatch(/profile|不兼容/);
+  });
+
+  it("能力协商生效:advertise 不含 FactSet → 卡里 FactSet 被降级(不 400,不拒绝)", async () => {
+    vi.mocked(getCardProfile).mockResolvedValue({
+      available: true,
+      enabled: true,
+      profiles: ["octo/v1"],
+      card_version: "1.5",
+      elements: ["TextBlock"], // 无 FactSet
+    } as never);
+    const t = getTool();
+    await t.execute("c6", { channelId: "group:g1", blocks: [
+      { type: "facts", items: [{ label: "k", value: "v" }] },
+    ]});
+    const call = vi.mocked(sendCardMessage).mock.calls[0]?.[0];
+    expect(call).toBeTruthy();
+    const body = (call!.card as { body: Array<Record<string, unknown>> }).body;
+    // FactSet 降级为 TextBlock 罗列 —— 不会有 FactSet 元素
+    expect(body.some((e) => e.type === "FactSet")).toBe(false);
+    expect(body.some((e) => e.type === "TextBlock")).toBe(true);
+  });
+
+  it("安全:agent 传入的 onBehalfOf 被忽略(不接受不可信身份,防 persona 冒充)", async () => {
+    const t = getTool();
+    await t.execute("c7", {
+      channelId: "group:g1",
+      title: "T",
+      blocks: [{ type: "text", text: "a" }],
+      onBehalfOf: "u_grantor", // 不可信入参 —— 不应透传
+    });
+    // 展示卡始终以 bot 自身身份发出;OBO 绝不由模型输入指定(与进度卡路径一致)。
+    expect(vi.mocked(sendCardMessage).mock.calls[0][0].onBehalfOf).toBeUndefined();
+  });
+
+  it("非法 block 静默丢弃(不 fail;不合法字段类型的整块跳过)", async () => {
+    const t = getTool();
+    await t.execute("c8", {
+      channelId: "group:g1",
+      blocks: [
+        { type: "invalid_kind", stuff: "x" }, // 未知 type
+        { type: "text" }, // 缺 text
+        { type: "text", text: 42 }, // text 非 string
+        { type: "text", text: "存活" },
+      ],
+    });
+    const call = vi.mocked(sendCardMessage).mock.calls[0]?.[0];
+    expect(call).toBeTruthy();
+    const body = (call!.card as { body: Array<{ text?: string }> }).body;
+    // 只剩存活的
+    expect(body.some((e) => e.text === "存活")).toBe(true);
+    expect(body).toHaveLength(1);
+  });
+
+  it("blocks 全被验证/脱敏过滤空 + title 空 → 拒绝", async () => {
+    const t = getTool();
+    const res = await t.execute("c9", {
+      channelId: "group:g1",
+      blocks: [
+        { type: "invalid" },
+        { type: "text", text: "AKIAIOSFODNN7EXAMPLE" }, // 全被脱敏
+      ],
+    });
+    expect(sendCardMessage).not.toHaveBeenCalled();
+    expect(res.content[0].text.toLowerCase()).toMatch(/error|empty|blocks/);
+  });
+});

--- a/src/card-display-tool.test.ts
+++ b/src/card-display-tool.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 
 vi.mock("./accounts.js", () => ({
   listOctoAccountIds: vi.fn(),
@@ -9,6 +12,7 @@ vi.mock("./accounts.js", () => ({
 vi.mock("./api-fetch.js", () => ({
   sendCardMessage: vi.fn(),
   getCardProfile: vi.fn(),
+  generateClientMsgNo: vi.fn(),
 }));
 
 import { createDisplayCardTool } from "./card-display-tool.js";
@@ -17,10 +21,12 @@ import {
   resolveOctoAccount,
 } from "./accounts.js";
 import { sendCardMessage, getCardProfile } from "./api-fetch.js";
+import { generateClientMsgNo } from "./api-fetch.js";
 
 const mockCfg = { channels: { octo: { botToken: "t" } } } as never;
 
 function setupOk(): void {
+  vi.mocked(generateClientMsgNo).mockReturnValue("client-msg-no-1");
   vi.mocked(listOctoAccountIds).mockReturnValue(["default"]);
   vi.mocked(resolveOctoAccount).mockReturnValue({
     accountId: "default",
@@ -57,6 +63,7 @@ function getTool(): {
 describe("createDisplayCardTool 骨架", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    delete process.env.OCTO_CARD_REQUEST_LOG_DIR;
     setupOk();
   });
 
@@ -85,11 +92,31 @@ describe("createDisplayCardTool 骨架", () => {
     // 指向 SKILL 详细节
     expect(t.description).toMatch(/SKILL(\.md)?/);
   });
+
+  it("卡片过程指引:description 要求 reasoning_sections,避免 raw tool_events 日志卡", () => {
+    const t = getTool();
+    expect(t.description).toMatch(/reasoning_sections/);
+    expect(t.description).toMatch(/tool_events/);
+    expect(t.description).toMatch(/human-readable reasoning sentence/i);
+    expect(t.description).toMatch(/2-3 .*reasoning_sections/);
+    expect(t.description).toMatch(/查看过程/);
+  });
+
+  it("收尾约束:description 提醒发卡是 side-effect,turn 必须补文本收尾(否则被判 incomplete)", () => {
+    const t = getTool();
+    // 强调发卡不是对话回复
+    expect(t.description).toMatch(/side[- ]?effect/i);
+    // 要求调用后仍要输出文本 / 不要以工具调用结束 turn
+    expect(t.description).toMatch(/final text|text message|end your turn/i);
+    // 点明零文本收尾会被判 incomplete
+    expect(t.description).toMatch(/incomplete/i);
+  });
 });
 
 describe("execute:发展示卡", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    delete process.env.OCTO_CARD_REQUEST_LOG_DIR;
     setupOk();
   });
 
@@ -212,5 +239,38 @@ describe("execute:发展示卡", () => {
     });
     expect(sendCardMessage).not.toHaveBeenCalled();
     expect(res.content[0].text.toLowerCase()).toMatch(/error|empty|blocks/);
+  });
+
+  it("OCTO_CARD_REQUEST_LOG_DIR:记录脱敏后的请求参数,用 client_msg_no 关联实际消息", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "octo-card-req-"));
+    process.env.OCTO_CARD_REQUEST_LOG_DIR = dir;
+    try {
+      const t = getTool();
+      const res = await t.execute("trace-call-1", {
+        channelId: "group:g1",
+        title: "调试卡",
+        blocks: [
+          { type: "text", text: "safe text" },
+          { type: "text", text: "Authorization: Bearer sk-abcdefghijklmnop" },
+        ],
+      });
+      const sent = vi.mocked(sendCardMessage).mock.calls[0][0];
+      expect(typeof sent.clientMsgNo).toBe("string");
+      expect(sent.clientMsgNo).toBeTruthy();
+      expect(res.details).toMatchObject({ client_msg_no: sent.clientMsgNo });
+
+      const logText = await readFile(path.join(dir, "display-card-requests.jsonl"), "utf8");
+      const entry = JSON.parse(logText.trim());
+      expect(entry.tool_call_id).toBe("trace-call-1");
+      expect(entry.message_id).toBe("m1");
+      expect(entry.client_msg_no).toBe(sent.clientMsgNo);
+      expect(entry.args.title).toBe("调试卡");
+      expect(JSON.stringify(entry)).toContain("safe text");
+      expect(JSON.stringify(entry)).not.toContain("sk-abcdefghijklmnop");
+      expect(JSON.stringify(entry)).toContain("[redacted]");
+    } finally {
+      delete process.env.OCTO_CARD_REQUEST_LOG_DIR;
+      await rm(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/src/card-display-tool.ts
+++ b/src/card-display-tool.ts
@@ -172,7 +172,7 @@ export function createDisplayCardTool(params: Params): Array<{
       "automatically and unsupported types degrade to plain text — you never need to check " +
       "compatibility yourself. " +
       "For visual emphasis, wrap key sections in a `group` block with `style: 'good' | " +
-      "'warning' | 'attention'` (tinted background — the client renders them as green / " +
+      "'warning' | 'attention' | 'emphasis'` (tinted background — the client renders them as green / " +
       "amber / pink zones); highlight important tokens with `rich` segment colors instead " +
       "of recoloring whole lines. Design for IM: the visible first screen should be a " +
       "3-6 line summary, not a log dump. Prefer ONE title, one compact process summary, " +
@@ -217,13 +217,13 @@ export function createDisplayCardTool(params: Params): Array<{
             "Ordered list of DisplayBlock. Each block is one of: " +
             "{type:'heading', text, size?:'medium'|'large'} · " +
             "{type:'text', text} · " +
-            "{type:'rich', segments:[{text, bold?, color?:'good'|'warning'|'attention'|'accent'}]} · " +
+            "{type:'rich', segments:[{text, bold?, fontType?:'Monospace', color?:'good'|'warning'|'attention'|'accent'}]} · " +
             "{type:'facts', items:[{label, value}]} · " +
             "{type:'columns', columns:[{blocks:[…]}]} for summary blocks such as weather / temperature / rain chance · " +
-            "{type:'table', rows:[{cells:[{text}]}], firstRowAsHeader?:boolean} · " +
+            "{type:'table', columns?:[{width:number}], rows:[{cells:[{text}|{blocks:[…]}]}], firstRowAsHeader?:boolean} · " +
             "{type:'link', text:string, url:string} for selectAction Action.OpenUrl navigation · " +
-            "{type:'group', style?:'good'|'warning'|'attention', blocks:[…]} · " +
-            "{type:'collapsible', summary, actionLabel?:string, blocks:[…]} (use actionLabel:'查看过程' for a process section) · " +
+            "{type:'group', style?:'good'|'warning'|'attention'|'emphasis', blocks:[…]} · " +
+            "{type:'collapsible', summary, actionLabel?:string, expandLabel?:string, collapseLabel?:string, defaultVisible?:boolean, blocks:[…]} (process cards render the toggle in a right-side ColumnSet) · " +
             "{type:'copy', label?:string, text:string} for a local Action.CopyToClipboard button. " +
             "Unknown block types or missing fields are silently dropped.",
           items: { type: "object" },

--- a/src/card-display-tool.ts
+++ b/src/card-display-tool.ts
@@ -2,11 +2,11 @@
  * agent 展示卡工具 —— `octo_send_display_card`
  *
  * 让 agent 在一次 turn 内主动发一张**展示型** InteractiveCard(17)到当前会话:
- * 标题 + 富展示 block(TextBlock/RichTextBlock/FactSet/Container/collapsible …)。
+ * 标题 + 富展示 block(TextBlock/RichTextBlock/ColumnSet/FactSet/Table/Container/collapsible/copy/link …)。
  *
  * 与 P2 的 `octo_send_card`(带 Action.Submit 按钮、点击回流 card_action 触发新 turn)
- * 严格区分:本工具**顶层无 actions、不产生回流事件** —— agent 无需处理点击回调,
- * 结果类展示、通知、审批汇总、结构化答复的自然承载。
+ * 严格区分:本工具**顶层无回调 actions、不产生回流事件** —— agent 无需处理点击回调。
+ * block 内可包含客户端本地动作(如复制到剪贴板),但不会触发 bot callback。
  *
  * 安全:
  *   - 入参 `blocks` 是 agent 可控输入,经 `validateDisplayBlocks` 白名单结构校验;
@@ -20,8 +20,11 @@
 
 import type { OpenClawConfig } from "openclaw/plugin-sdk";
 import { listOctoAccountIds, resolveOctoAccount } from "./accounts.js";
-import { sendCardMessage, getCardProfile, type CardProfileManifest } from "./api-fetch.js";
+import { appendFile, mkdir } from "node:fs/promises";
+import path from "node:path";
+import { sendCardMessage, getCardProfile, generateClientMsgNo, type CardProfileManifest } from "./api-fetch.js";
 import { buildDisplayCard, validateDisplayBlocks } from "./card-blocks.js";
+import { isSensitive, reduceUrlsInText } from "./card-render.js";
 import { resolveOutboundOctoTarget } from "./actions.js";
 import type { CardCaps } from "./card-render.js";
 import { ChannelType, CARD_PROFILE, CARD_VERSION } from "./types.js";
@@ -29,6 +32,8 @@ import { DISPLAY_CARD_TOOL_NAME } from "./constants.js";
 
 /** 展示卡发送超时(postJson 无默认超时,防挂起的 POST 拖死 tool 调用)。 */
 const SEND_TIMEOUT_MS = 15_000;
+const REQUEST_LOG_FILE = "display-card-requests.jsonl";
+const DEBUG_STRING_MAX = 512;
 
 interface ToolResult {
   content: Array<{ type: "text"; text: string }>;
@@ -53,6 +58,53 @@ function deriveCaps(m: CardProfileManifest): CardCaps {
       ? { maxNodes: (m.limits as Record<string, unknown>).max_nodes as number }
       : {}),
   };
+}
+
+function redactDebugValue(value: unknown): unknown {
+  if (typeof value === "string") {
+    const reduced = reduceUrlsInText(value).replace(/\s+/g, " ").trim();
+    if (!reduced) return reduced;
+    if (isSensitive(reduced, true)) return "[redacted]";
+    return reduced.length > DEBUG_STRING_MAX ? `${reduced.slice(0, DEBUG_STRING_MAX)}…` : reduced;
+  }
+  if (Array.isArray(value)) return value.map((v) => redactDebugValue(v));
+  if (value && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      if (/token|secret|password|passwd|pwd|authorization|bearer|api[_-]?key|client[_-]?secret/i.test(k)) {
+        out[k] = "[redacted]";
+      } else {
+        out[k] = redactDebugValue(v);
+      }
+    }
+    return out;
+  }
+  return value;
+}
+
+function manifestForDebug(m: CardProfileManifest): Record<string, unknown> {
+  return {
+    available: m.available,
+    enabled: m.enabled,
+    profiles: m.profiles,
+    card_version: m.card_version,
+    elements: m.elements,
+    actions: m.actions,
+    limits: m.limits,
+  };
+}
+
+async function recordDisplayCardRequest(entry: Record<string, unknown>): Promise<void> {
+  const dir = process.env.OCTO_CARD_REQUEST_LOG_DIR;
+  if (!dir) return;
+  try {
+    await mkdir(dir, { recursive: true });
+    await appendFile(path.join(dir, REQUEST_LOG_FILE), `${JSON.stringify(entry)}\n`, "utf8");
+  } catch (e) {
+    // Debug recording must never affect message delivery.
+    // eslint-disable-next-line no-console -- env-gated diagnostic sink
+    console.warn(`[octo:display-card] failed to record request: ${e instanceof Error ? e.message : String(e)}`);
+  }
 }
 
 /**
@@ -111,21 +163,37 @@ export function createDisplayCardTool(params: Params): Array<{
     description:
       "Send a DISPLAY card (Adaptive Card 1.5) to an Octo conversation. Use this for rich, " +
       "structured, NON-INTERACTIVE output — status reports, structured answers, key-value " +
-      "summaries, collapsible detail sections. The card does NOT have clickable " +
-      "action buttons and will NOT trigger any callback event; if you need clickable buttons " +
-      "that call back to you, do not use this tool. " +
+      "summaries, three-column KPI/weather summary strips, tables, collapsible detail sections, local copy-to-clipboard buttons, and " +
+      "safe navigation links. The card " +
+      "does NOT have callback buttons and will NOT trigger any callback event; if you need " +
+      "buttons that call back to you, do not use this tool. " +
       "Provide `blocks`, an ordered list of typed display blocks (heading / text / rich / " +
-      "facts / group / collapsible); the server's advertised element set is negotiated " +
+      "facts / columns / table / link / group / collapsible / copy); the server's advertised element/action set is negotiated " +
       "automatically and unsupported types degrade to plain text — you never need to check " +
       "compatibility yourself. " +
       "For visual emphasis, wrap key sections in a `group` block with `style: 'good' | " +
       "'warning' | 'attention'` (tinted background — the client renders them as green / " +
       "amber / pink zones); highlight important tokens with `rich` segment colors instead " +
-      "of recoloring whole lines. Prefer ONE heading + at most 2-3 tinted groups + a " +
-      "closing `rich` summary line. See SKILL.md \"Visual styling recipes\" for full " +
-      "examples. " +
+      "of recoloring whole lines. Design for IM: the visible first screen should be a " +
+      "3-6 line summary, not a log dump. Prefer ONE title, one compact process summary, " +
+      "answer summary content, and folded details. Put 2-3 `reasoning_sections` inside " +
+      "the `查看过程` detail, not on the first screen. Convert raw `tool_events` into " +
+      "`reasoning_sections`: each stage needs a human-readable reasoning sentence, with " +
+      "tool names/short args only as evidence under the stage. Truncate long " +
+      "paths/errors/queries to roughly 80-120 characters and put full details behind " +
+      "`collapsible`. See SKILL.md \"Visual styling recipes\" for full " +
+      "examples. If you need to show the reasoning/tool process, put it as the first " +
+      "`collapsible` block in this same display card with actionLabel:'查看过程'; do not send " +
+      "a separate final process-only card. " +
+      "`plain` is first-class fallback/search text: generate it from the same source, keep " +
+      "the title deduped, and do not concatenate raw logs into it. " +
       "Content is fully visible to all group members: never put secrets or tokens into any " +
-      "field.",
+      "field. " +
+      "IMPORTANT — this tool is a side-effect that posts a card; it is NOT your conversational " +
+      "reply. After it returns you MUST still emit a short final text message to the user (a " +
+      "one-line summary, the answer to their question, or a next-step note). Never end your " +
+      "turn on this (or any) tool call with no text: a turn that finishes with zero text output " +
+      "is judged incomplete and shown to the user as an interrupted/failed turn.",
     parameters: {
       type: "object",
       properties: {
@@ -151,8 +219,12 @@ export function createDisplayCardTool(params: Params): Array<{
             "{type:'text', text} · " +
             "{type:'rich', segments:[{text, bold?, color?:'good'|'warning'|'attention'|'accent'}]} · " +
             "{type:'facts', items:[{label, value}]} · " +
+            "{type:'columns', columns:[{blocks:[…]}]} for summary blocks such as weather / temperature / rain chance · " +
+            "{type:'table', rows:[{cells:[{text}]}], firstRowAsHeader?:boolean} · " +
+            "{type:'link', text:string, url:string} for selectAction Action.OpenUrl navigation · " +
             "{type:'group', style?:'good'|'warning'|'attention', blocks:[…]} · " +
-            "{type:'collapsible', summary, blocks:[…]}. " +
+            "{type:'collapsible', summary, actionLabel?:string, blocks:[…]} (use actionLabel:'查看过程' for a process section) · " +
+            "{type:'copy', label?:string, text:string} for a local Action.CopyToClipboard button. " +
             "Unknown block types or missing fields are silently dropped.",
           items: { type: "object" },
         },
@@ -210,6 +282,7 @@ export function createDisplayCardTool(params: Params): Array<{
         // 模型输入指定,否则群可见卡片就成了 persona 冒充的 sink。与进度卡路径一致(OBO 一律跳过);
         // 展示卡始终以 bot 自身身份发出。若日后需要 persona 展示卡,应从 inbound 的可信 effectiveOnBehalfOf
         // 注入,而非工具参数,且需服务端确实支持 OBO + type-17。
+        const clientMsgNo = generateClientMsgNo();
         const result = await sendCardMessage({
           apiUrl,
           botToken,
@@ -217,14 +290,34 @@ export function createDisplayCardTool(params: Params): Array<{
           channelType: target.channelType as ChannelType,
           card,
           plain,
+          clientMsgNo,
           // postJson 无默认超时 —— 显式设超时,避免挂起的 POST 无限期占住这次 tool 调用。
           signal: AbortSignal.timeout(SEND_TIMEOUT_MS),
         });
 
         const messageId = result?.message_id ?? "";
+        await recordDisplayCardRequest({
+          ts: new Date().toISOString(),
+          tool: DISPLAY_CARD_TOOL_NAME,
+          tool_call_id: _toolCallId,
+          account_id: requestedAccountId,
+          channel_id: target.channelId,
+          channel_type: target.channelType,
+          thread_id: rawThread,
+          client_msg_no: clientMsgNo,
+          message_id: messageId,
+          manifest: manifestForDebug(manifest),
+          args: redactDebugValue({
+            channelId: rawChannelId,
+            threadId: rawThread,
+            title: rawTitle,
+            blocks: validated,
+          }),
+          rendered: redactDebugValue({ plain, card }),
+        });
         return ok(
           `sent display card message_id=${messageId} channel=${target.channelId} elements=${body.length}`,
-          { message_id: messageId, channel_id: target.channelId },
+          { message_id: messageId, channel_id: target.channelId, client_msg_no: clientMsgNo },
         );
       } catch (e) {
         return err(e instanceof Error ? e.message : String(e));

--- a/src/card-display-tool.ts
+++ b/src/card-display-tool.ts
@@ -1,0 +1,236 @@
+/**
+ * agent 展示卡工具 —— `octo_send_display_card`
+ *
+ * 让 agent 在一次 turn 内主动发一张**展示型** InteractiveCard(17)到当前会话:
+ * 标题 + 富展示 block(TextBlock/RichTextBlock/FactSet/Container/collapsible …)。
+ *
+ * 与 P2 的 `octo_send_card`(带 Action.Submit 按钮、点击回流 card_action 触发新 turn)
+ * 严格区分:本工具**顶层无 actions、不产生回流事件** —— agent 无需处理点击回调,
+ * 结果类展示、通知、审批汇总、结构化答复的自然承载。
+ *
+ * 安全:
+ *   - 入参 `blocks` 是 agent 可控输入,经 `validateDisplayBlocks` 白名单结构校验;
+ *   - 内容再由 `buildDisplayCard` 逐 block 脱敏(URL 降级、命中 secret 抹除);
+ *   - 出站前 D12 gate:manifest disabled / profile 不含 `octo/v1` / card_version 不兼容
+ *     → 拒绝(fail-closed),避免服务端 400。
+ *   - caps.elements 未 advertise 的元素自动降级,agent 无需自己判断白名单。
+ *   - **身份不接受 agent 入参**:展示卡始终以 bot 自身身份发出,OBO(persona-clone)绝不由
+ *     不可信模型输入指定(与进度卡路径一致,OBO 一律跳过),避免群可见卡片成为 persona 冒充 sink。
+ */
+
+import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import { listOctoAccountIds, resolveOctoAccount } from "./accounts.js";
+import { sendCardMessage, getCardProfile, type CardProfileManifest } from "./api-fetch.js";
+import { buildDisplayCard, validateDisplayBlocks } from "./card-blocks.js";
+import { resolveOutboundOctoTarget } from "./actions.js";
+import type { CardCaps } from "./card-render.js";
+import { ChannelType, CARD_PROFILE, CARD_VERSION } from "./types.js";
+import { DISPLAY_CARD_TOOL_NAME } from "./constants.js";
+
+/** 展示卡发送超时(postJson 无默认超时,防挂起的 POST 拖死 tool 调用)。 */
+const SEND_TIMEOUT_MS = 15_000;
+
+interface ToolResult {
+  content: Array<{ type: "text"; text: string }>;
+  details: unknown; // SDK ErasedAgentToolExecute requires this key present(可为 null)
+}
+
+function ok(msg: string, details?: unknown): ToolResult {
+  return { content: [{ type: "text", text: msg }], details: details ?? null };
+}
+
+function err(msg: string): ToolResult {
+  return { content: [{ type: "text", text: `Error: ${msg}` }], details: null };
+}
+
+/** manifest → CardCaps(限于本工具消费:elements + maxNodes)。 */
+function deriveCaps(m: CardProfileManifest): CardCaps {
+  return {
+    ...(m.elements ? { elements: new Set(m.elements) } : {}),
+    ...(m.inputs ? { inputs: new Set(m.inputs) } : {}),
+    ...(m.actions ? { actions: new Set(m.actions) } : {}),
+    ...(m.limits && typeof (m.limits as Record<string, unknown>).max_nodes === "number"
+      ? { maxNodes: (m.limits as Record<string, unknown>).max_nodes as number }
+      : {}),
+  };
+}
+
+/**
+ * gate 校验:manifest 明确 disabled / profile 不含 octo/v1 / card_version 不匹配 → 拒绝。
+ * `available:false`(端点未部署)时回退 env `OCTO_CARD_MESSAGE_ENABLED === "1"` —— 与 hook
+ * 进度卡的 gate 语义对齐,单一权威。
+ */
+function gateReason(m: CardProfileManifest): string | null {
+  if (!m.available) {
+    return process.env.OCTO_CARD_MESSAGE_ENABLED === "1"
+      ? null
+      : "card manifest endpoint not available and OCTO_CARD_MESSAGE_ENABLED is not set";
+  }
+  if (!m.enabled) return "card sending is disabled on this deployment (manifest.enabled=false)";
+  if (Array.isArray(m.profiles) && m.profiles.length > 0 && !m.profiles.includes(CARD_PROFILE)) {
+    return `profile ${CARD_PROFILE} not advertised by server (got: ${m.profiles.join(",")})`;
+  }
+  if (typeof m.card_version === "string" && m.card_version !== CARD_VERSION) {
+    return `card_version ${m.card_version} not compatible (need ${CARD_VERSION})`;
+  }
+  return null;
+}
+
+interface Params {
+  cfg?: OpenClawConfig;
+  agentAccountId?: string;
+  agentId?: string;
+}
+
+/**
+ * 创建 agent 展示卡工具。无 configured account → 返回空数组(tool-discovery 阶段安全)。
+ */
+export function createDisplayCardTool(params: Params): Array<{
+  name: string;
+  label: string;
+  description: string;
+  parameters: Record<string, unknown>;
+  execute: (toolCallId: string, args: Record<string, unknown>) => Promise<ToolResult>;
+}> {
+  const { cfg, agentAccountId } = params;
+  if (!cfg) return [];
+  try {
+    const ids = listOctoAccountIds(cfg);
+    const hasConfigured = ids.some((id) => {
+      const acct = resolveOctoAccount({ cfg, accountId: id });
+      return acct.enabled && acct.configured && !!acct.config.botToken;
+    });
+    if (!hasConfigured) return [];
+  } catch {
+    return [];
+  }
+
+  const tool = {
+    name: DISPLAY_CARD_TOOL_NAME,
+    label: "Octo Send Display Card",
+    description:
+      "Send a DISPLAY card (Adaptive Card 1.5) to an Octo conversation. Use this for rich, " +
+      "structured, NON-INTERACTIVE output — status reports, structured answers, key-value " +
+      "summaries, collapsible detail sections. The card does NOT have clickable " +
+      "action buttons and will NOT trigger any callback event; if you need clickable buttons " +
+      "that call back to you, do not use this tool. " +
+      "Provide `blocks`, an ordered list of typed display blocks (heading / text / rich / " +
+      "facts / group / collapsible); the server's advertised element set is negotiated " +
+      "automatically and unsupported types degrade to plain text — you never need to check " +
+      "compatibility yourself. " +
+      "For visual emphasis, wrap key sections in a `group` block with `style: 'good' | " +
+      "'warning' | 'attention'` (tinted background — the client renders them as green / " +
+      "amber / pink zones); highlight important tokens with `rich` segment colors instead " +
+      "of recoloring whole lines. Prefer ONE heading + at most 2-3 tinted groups + a " +
+      "closing `rich` summary line. See SKILL.md \"Visual styling recipes\" for full " +
+      "examples. " +
+      "Content is fully visible to all group members: never put secrets or tokens into any " +
+      "field.",
+    parameters: {
+      type: "object",
+      properties: {
+        channelId: {
+          type: "string",
+          description:
+            "Target channel (REQUIRED): 'group:<groupId>', 'user:<uid>', or an existing channelId. " +
+            "Use the channel_id from the event you are replying to.",
+        },
+        threadId: {
+          type: "string",
+          description: "Optional thread short_id when targeting a group topic.",
+        },
+        title: {
+          type: "string",
+          description: "Optional bold title rendered at the top of the card.",
+        },
+        blocks: {
+          type: "array",
+          description:
+            "Ordered list of DisplayBlock. Each block is one of: " +
+            "{type:'heading', text, size?:'medium'|'large'} · " +
+            "{type:'text', text} · " +
+            "{type:'rich', segments:[{text, bold?, color?:'good'|'warning'|'attention'|'accent'}]} · " +
+            "{type:'facts', items:[{label, value}]} · " +
+            "{type:'group', style?:'good'|'warning'|'attention', blocks:[…]} · " +
+            "{type:'collapsible', summary, blocks:[…]}. " +
+            "Unknown block types or missing fields are silently dropped.",
+          items: { type: "object" },
+        },
+      },
+      required: ["blocks", "channelId"],
+    },
+    execute: async (
+      _toolCallId: string,
+      args: Record<string, unknown>,
+    ): Promise<ToolResult> => {
+      try {
+        const validated = validateDisplayBlocks(args.blocks);
+        const rawTitle = typeof args.title === "string" ? args.title : "";
+
+        // Account 解析 —— 复用 octo_management 的选择路径:agentAccountId 优先,单账号回退。
+        const requestedAccountId = agentAccountId
+          ?? (listOctoAccountIds(cfg).length === 1 ? listOctoAccountIds(cfg)[0] : undefined);
+        if (!requestedAccountId) return err("no configured Octo account available");
+        const acct = resolveOctoAccount({ cfg, accountId: requestedAccountId });
+        if (!acct.enabled || !acct.configured || !acct.config.botToken) {
+          return err("Octo account is not fully configured");
+        }
+        const apiUrl = acct.config.apiUrl;
+        const botToken = acct.config.botToken;
+        if (!apiUrl) return err("apiUrl not configured");
+
+        // D12 能力探测(gate + caps)。
+        let manifest: CardProfileManifest;
+        try {
+          manifest = await getCardProfile({ apiUrl, botToken });
+        } catch (e) {
+          return err(`card profile probe failed: ${e instanceof Error ? e.message : String(e)}`);
+        }
+        const rejection = gateReason(manifest);
+        if (rejection) return err(`${rejection}. Send your reply as a plain text message instead.`);
+
+        // 构建 + 协商降级 + 脱敏 —— buildDisplayCard 单点权威。
+        const { card, plain } = buildDisplayCard({
+          title: rawTitle,
+          blocks: validated,
+          caps: deriveCaps(manifest),
+        });
+        // body 空 = 校验后无合法 block 且无有效 title → 空卡无意义。
+        const body = (card.body as unknown[]) ?? [];
+        if (body.length === 0) return err("card is empty (no valid blocks after validation)");
+
+        // 解析目标 channel。channelId 缺省时 agent 依赖 runtime 注入(此工具签名保留 channelId,
+        // 让 agent 显式给出;默认路由到当前会话由 channel.ts 侧的 outbound 完成,不在此层猜)。
+        const rawChannelId = typeof args.channelId === "string" ? args.channelId : "";
+        if (!rawChannelId.trim()) return err("channelId is required (use 'group:<id>' or 'user:<uid>')");
+        const rawThread = typeof args.threadId === "string" ? args.threadId : undefined;
+        const target = resolveOutboundOctoTarget(rawChannelId, rawThread);
+
+        // 身份**不**接受 agent 入参:OBO(persona-clone)是可信运行时/服务端授权语义,绝不能由不可信的
+        // 模型输入指定,否则群可见卡片就成了 persona 冒充的 sink。与进度卡路径一致(OBO 一律跳过);
+        // 展示卡始终以 bot 自身身份发出。若日后需要 persona 展示卡,应从 inbound 的可信 effectiveOnBehalfOf
+        // 注入,而非工具参数,且需服务端确实支持 OBO + type-17。
+        const result = await sendCardMessage({
+          apiUrl,
+          botToken,
+          channelId: target.channelId,
+          channelType: target.channelType as ChannelType,
+          card,
+          plain,
+          // postJson 无默认超时 —— 显式设超时,避免挂起的 POST 无限期占住这次 tool 调用。
+          signal: AbortSignal.timeout(SEND_TIMEOUT_MS),
+        });
+
+        const messageId = result?.message_id ?? "";
+        return ok(
+          `sent display card message_id=${messageId} channel=${target.channelId} elements=${body.length}`,
+          { message_id: messageId, channel_id: target.channelId },
+        );
+      } catch (e) {
+        return err(e instanceof Error ? e.message : String(e));
+      }
+    },
+  };
+
+  return [tool];
+}

--- a/src/card-e2e.test.ts
+++ b/src/card-e2e.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Tier-1 端到端联调（对真实 octo-server），env-gated —— 无 OCTO_E2E_* 环境变量时整组 skip，
+ * 不进 CI 默认路径、不含任何密钥（凭据只从环境读）。
+ *
+ * 用真实 fetch 直打 D12 端点与 send/edit，验证单测 mock 不到的两件事:
+ *   1. 真实 manifest 能解析出 elements/inputs/limits（wire 契约对得上 pkg/cardmsg 导出）;
+ *   2. 服务端 pkg/cardmsg 真的接受我们在 advertise 后发的 ColumnSet 卡（200 而非 400），
+ *      且 transient 中间帧 + 终态帧 edit 均 200。
+ *
+ * 跑法:
+ *   OCTO_E2E_API_URL=… OCTO_E2E_BOT_TOKEN=… [OCTO_E2E_CHANNEL=… [OCTO_E2E_CHANNEL_TYPE=2]] \
+ *     npx vitest run src/card-e2e.test.ts
+ *   仅给 API_URL+BOT_TOKEN → 只跑只读 manifest 探测（零副作用）;
+ *   再给 CHANNEL → 追加 send/edit 往返（会向该频道发一条真实进度卡）。
+ */
+import { describe, it, expect } from "vitest";
+import { getCardProfile, sendCardMessage, editCardMessage } from "./api-fetch.js";
+import { renderProgressCard, type CardCaps } from "./card-render.js";
+import { ChannelType } from "./types.js";
+
+const API = process.env.OCTO_E2E_API_URL;
+const TOKEN = process.env.OCTO_E2E_BOT_TOKEN;
+const CHANNEL = process.env.OCTO_E2E_CHANNEL;
+const CHANNEL_TYPE = Number(process.env.OCTO_E2E_CHANNEL_TYPE ?? ChannelType.Group);
+
+const suite = API && TOKEN ? describe : describe.skip;
+
+suite("card E2E（真实 octo-server）", () => {
+  it("getCardProfile:真实 manifest 可解析(elements/inputs/limits)", async () => {
+    const m = await getCardProfile({ apiUrl: API!, botToken: TOKEN! });
+    // eslint-disable-next-line no-console -- e2e 联调观测
+    console.log("[e2e] manifest =", JSON.stringify(m, null, 2));
+    expect(m.available).toBe(true);
+    if (m.elements !== undefined) expect(Array.isArray(m.elements)).toBe(true);
+    if (m.inputs !== undefined) expect(Array.isArray(m.inputs)).toBe(true);
+  });
+
+  const sendIt = API && TOKEN && CHANNEL ? it : it.skip;
+  sendIt("send/edit/terminal 往返 + 服务端接受渲染后的卡", async () => {
+    const m = await getCardProfile({ apiUrl: API!, botToken: TOKEN! });
+    const caps: CardCaps = {
+      ...(m.elements ? { elements: new Set(m.elements) } : {}),
+      ...(typeof m.limits?.max_nodes === "number" ? { maxNodes: m.limits.max_nodes as number } : {}),
+    };
+    // 探针:OCTO_E2E_FORCE_COLUMNS=1 时强制 advertise ColumnSet+Column,验证 octo/v1 是否接受
+    // 列布局(即便本部署 manifest 尚未 advertise elements)—— 回答"server 端上线 elements 后我们发
+    // ColumnSet 会不会 400"。
+    if (process.env.OCTO_E2E_FORCE_COLUMNS === "1") {
+      caps.elements = new Set([...(caps.elements ?? []), "TextBlock", "ColumnSet", "Column"]);
+    }
+    const steps = [
+      { tool: "read", status: "done" as const, summary: "/work/README.md", durationMs: 180 },
+      { tool: "exec", status: "done" as const, summary: "ls -la", durationMs: 220 },
+    ];
+    const { card, plain } = renderProgressCard({ phase: "tool", steps }, caps);
+    // eslint-disable-next-line no-console -- e2e 联调观测
+    console.log("[e2e] send card =", JSON.stringify(card));
+    const res = await sendCardMessage({
+      apiUrl: API!, botToken: TOKEN!, channelId: CHANNEL!, channelType: CHANNEL_TYPE, card, plain,
+    });
+    expect(res?.message_id).toBeTruthy();
+
+    // transient 中间帧（不进修订历史）
+    await editCardMessage({
+      apiUrl: API!, botToken: TOKEN!, messageId: res!.message_id!, channelId: CHANNEL!,
+      channelType: CHANNEL_TYPE, card, plain, transient: true,
+    });
+
+    // 终态帧（进修订历史）
+    const done = renderProgressCard({ phase: "done", steps, elapsedMs: 1600 }, caps);
+    await editCardMessage({
+      apiUrl: API!, botToken: TOKEN!, messageId: res!.message_id!, channelId: CHANNEL!,
+      channelType: CHANNEL_TYPE, card: done.card, plain: done.plain,
+    });
+    // eslint-disable-next-line no-console -- e2e 联调观测
+    console.log("[e2e] round-trip ok, message_id =", res!.message_id);
+  });
+});

--- a/src/card-e2e.test.ts
+++ b/src/card-e2e.test.ts
@@ -42,11 +42,11 @@ suite("card E2E（真实 octo-server）", () => {
       ...(m.elements ? { elements: new Set(m.elements) } : {}),
       ...(typeof m.limits?.max_nodes === "number" ? { maxNodes: m.limits.max_nodes as number } : {}),
     };
-    // 探针:OCTO_E2E_FORCE_COLUMNS=1 时强制 advertise ColumnSet+Column,验证 octo/v1 是否接受
+    // 探针:OCTO_E2E_FORCE_COLUMNS=1 时强制 advertise ColumnSet,验证 octo/v1 是否接受
     // 列布局(即便本部署 manifest 尚未 advertise elements)—— 回答"server 端上线 elements 后我们发
     // ColumnSet 会不会 400"。
     if (process.env.OCTO_E2E_FORCE_COLUMNS === "1") {
-      caps.elements = new Set([...(caps.elements ?? []), "TextBlock", "ColumnSet", "Column"]);
+      caps.elements = new Set([...(caps.elements ?? []), "TextBlock", "ColumnSet"]);
     }
     const steps = [
       { tool: "read", status: "done" as const, summary: "/work/README.md", durationMs: 180 },

--- a/src/card-progress.test.ts
+++ b/src/card-progress.test.ts
@@ -1,0 +1,279 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { ChannelType } from "./types.js";
+import {
+  setCardContext,
+  finalizeCard,
+  registerCardProgress,
+  _resetCardProgressForTests,
+} from "./card-progress.js";
+
+/** 收集 registerCardProgress 注册的 hook handler。 */
+function makeApi(): { handlers: Record<string, (e: unknown, c: unknown) => void> } {
+  const handlers: Record<string, (e: unknown, c: unknown) => void> = {};
+  const api = { on: (name: string, fn: (e: unknown, c: unknown) => void) => { handlers[name] = fn; } };
+  registerCardProgress(api as never);
+  return { handlers };
+}
+
+/** mock fetch,按 url 分派 getCardProfile / sendMessage / message-edit,记录请求。 */
+function mockFetch(opts: { enabled?: boolean; sendId?: string } = {}) {
+  const calls: Array<{ url: string; body: Record<string, unknown> | undefined }> = [];
+  const fn = vi.fn().mockImplementation(async (url: string, init?: { body?: string }) => {
+    calls.push({ url: String(url), body: init?.body ? JSON.parse(init.body) : undefined });
+    if (String(url).includes("/v1/bot/card/profile")) {
+      return { ok: true, status: 200, json: async () => ({ enabled: opts.enabled ?? true, profiles: ["octo/v1"] }) };
+    }
+    if (String(url).includes("/v1/bot/sendMessage")) {
+      return { ok: true, status: 200, text: async () => JSON.stringify({ message_id: opts.sendId ?? "card1" }) };
+    }
+    return { ok: true, status: 200, text: async () => "" }; // message/edit
+  });
+  return { fn, calls };
+}
+
+/** 可控 promise:用于把某个请求悬在 in-flight 状态。 */
+function makeDeferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((r) => { resolve = r; });
+  return { promise, resolve };
+}
+
+describe("card-progress 状态机 + hook + 节流", () => {
+  const originalFetch = global.fetch;
+  beforeEach(() => {
+    vi.useFakeTimers();
+    _resetCardProgressForTests();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    global.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it("首个 tool 事件懒发占位卡(gate+send),after_tool_call 触发 edit", async () => {
+    const { fn, calls } = mockFetch();
+    global.fetch = fn as unknown as typeof fetch;
+    const { handlers } = makeApi();
+
+    setCardContext("s1", { apiUrl: "https://a1.test", botToken: "bf", channelId: "g1", channelType: ChannelType.Group });
+    handlers.before_tool_call({ toolName: "read" }, { sessionKey: "s1" });
+    await vi.advanceTimersByTimeAsync(900);
+
+    expect(calls.some((c) => c.url.includes("/card/profile"))).toBe(true);
+    const send = calls.find((c) => c.url.includes("/sendMessage"));
+    expect(send).toBeTruthy();
+    expect((send!.body!.payload as { type: number }).type).toBe(17);
+
+    handlers.after_tool_call({ toolName: "read", durationMs: 30 }, { sessionKey: "s1" });
+    await vi.advanceTimersByTimeAsync(900);
+    const edit = calls.find((c) => c.url.includes("/message/edit"));
+    expect(edit).toBeTruthy();
+    const editEnv = JSON.parse(edit!.body!.content_edit as string);
+    expect(editEnv.type).toBe(17);
+    expect(editEnv.transient).toBe(true); // 进度中间帧不进修订历史(D10)
+  });
+
+  it("OBO 场景跳过(不发任何请求)", async () => {
+    const { fn, calls } = mockFetch();
+    global.fetch = fn as unknown as typeof fetch;
+    const { handlers } = makeApi();
+    setCardContext("s2", { apiUrl: "https://a2.test", botToken: "y", channelId: "g", channelType: ChannelType.Group, onBehalfOf: "grantor" });
+    handlers.before_tool_call({ toolName: "read" }, { sessionKey: "s2" });
+    await vi.advanceTimersByTimeAsync(900);
+    expect(calls.length).toBe(0);
+  });
+
+  it("未登记 session 的事件 no-op(天然过滤非 octo run)", async () => {
+    const { fn, calls } = mockFetch();
+    global.fetch = fn as unknown as typeof fetch;
+    const { handlers } = makeApi();
+    handlers.before_tool_call({ toolName: "read" }, { sessionKey: "unknown" });
+    await vi.advanceTimersByTimeAsync(900);
+    expect(calls.length).toBe(0);
+  });
+
+  it("D12 gate disabled → 不发卡", async () => {
+    const { fn, calls } = mockFetch({ enabled: false });
+    global.fetch = fn as unknown as typeof fetch;
+    const { handlers } = makeApi();
+    setCardContext("s3", { apiUrl: "https://a3.test", botToken: "y", channelId: "g", channelType: ChannelType.Group });
+    handlers.before_tool_call({ toolName: "read" }, { sessionKey: "s3" });
+    await vi.advanceTimersByTimeAsync(900);
+    expect(calls.some((c) => c.url.includes("/sendMessage"))).toBe(false);
+  });
+
+  it("finalizeCard 发终态帧(已有占位卡)", async () => {
+    const { fn, calls } = mockFetch();
+    global.fetch = fn as unknown as typeof fetch;
+    const { handlers } = makeApi();
+    setCardContext("s4", { apiUrl: "https://a4.test", botToken: "bf", channelId: "g1", channelType: ChannelType.Group });
+    handlers.before_tool_call({ toolName: "read" }, { sessionKey: "s4" });
+    await vi.advanceTimersByTimeAsync(900);
+    calls.length = 0;
+
+    await finalizeCard("s4", { success: true });
+    const edit = calls.find((c) => c.url.includes("/message/edit"));
+    expect(edit).toBeTruthy();
+    const env = JSON.parse(edit!.body!.content_edit as string);
+    expect((env.card.body as Array<{ text: string }>)[0].text).toContain("✅ 已完成");
+    expect(env.transient).toBeUndefined(); // 终态帧进修订历史(不带 transient)
+  });
+
+  it("finalizeCard 未发过占位卡 → 仅清理不发", async () => {
+    const { fn, calls } = mockFetch();
+    global.fetch = fn as unknown as typeof fetch;
+    makeApi();
+    setCardContext("s5", { apiUrl: "https://a5.test", botToken: "y", channelId: "g", channelType: ChannelType.Group });
+    await finalizeCard("s5", { success: true });
+    expect(calls.length).toBe(0);
+  });
+
+  it("P1: finalize 等待 in-flight 首帧 send,终态帧不丢失", async () => {
+    const calls: Array<{ url: string; body: Record<string, unknown> | undefined }> = [];
+    const sendGate = makeDeferred(); // 悬住首帧 send
+    const sendReached = makeDeferred(); // 通知 send 已进入
+    const fn = vi.fn().mockImplementation(async (url: string, init?: { body?: string }) => {
+      calls.push({ url: String(url), body: init?.body ? JSON.parse(init.body) : undefined });
+      if (String(url).includes("/card/profile")) {
+        return { ok: true, status: 200, json: async () => ({ enabled: true }) };
+      }
+      if (String(url).includes("/sendMessage")) {
+        sendReached.resolve();
+        await sendGate.promise; // 保持 send in-flight
+        return { ok: true, status: 200, text: async () => JSON.stringify({ message_id: "card1" }) };
+      }
+      return { ok: true, status: 200, text: async () => "" };
+    });
+    global.fetch = fn as unknown as typeof fetch;
+    const { handlers } = makeApi();
+
+    setCardContext("p1", { apiUrl: "https://p1.test", botToken: "bf", channelId: "g1", channelType: ChannelType.Group });
+    handlers.before_tool_call({ toolName: "read" }, { sessionKey: "p1" });
+    await vi.advanceTimersByTimeAsync(900); // flush 启动:gate 过,send 悬在 sendGate
+    await sendReached.promise;
+
+    // send 仍 in-flight(messageId 未就绪)时收尾 —— 旧实现会跳过终态帧。
+    const finalizing = finalizeCard("p1", { success: true });
+    sendGate.resolve(); // 放行 send 完成
+    await finalizing;
+
+    const edit = calls.find((c) => c.url.includes("/message/edit"));
+    expect(edit).toBeTruthy();
+    const env = JSON.parse(edit!.body!.content_edit as string);
+    expect((env.card.body as Array<{ text: string }>)[0].text).toContain("✅ 已完成");
+    expect(env.transient).toBeUndefined(); // 终态帧进修订历史
+  });
+
+  it("P1(重叠 flush): 首帧 send 在途时第二个 debounce 到期,finalize 仍等真实 send", async () => {
+    const calls: Array<{ url: string; body: Record<string, unknown> | undefined }> = [];
+    const sendGate = makeDeferred();
+    const sendReached = makeDeferred();
+    let sendCount = 0;
+    const fn = vi.fn().mockImplementation(async (url: string, init?: { body?: string }) => {
+      calls.push({ url: String(url), body: init?.body ? JSON.parse(init.body) : undefined });
+      if (String(url).includes("/card/profile")) {
+        return { ok: true, status: 200, json: async () => ({ enabled: true }) };
+      }
+      if (String(url).includes("/sendMessage")) {
+        sendCount++;
+        sendReached.resolve();
+        await sendGate.promise; // 首帧 send 一直悬着
+        return { ok: true, status: 200, text: async () => JSON.stringify({ message_id: "card1" }) };
+      }
+      return { ok: true, status: 200, text: async () => "" };
+    });
+    global.fetch = fn as unknown as typeof fetch;
+    const { handlers } = makeApi();
+
+    setCardContext("p1b", { apiUrl: "https://p1b.test", botToken: "bf", channelId: "g1", channelType: ChannelType.Group });
+    handlers.before_tool_call({ toolName: "read", toolCallId: "A" }, { sessionKey: "p1b" });
+    await vi.advanceTimersByTimeAsync(900); // 首帧 flush 启动,send 悬在 sendGate
+    await sendReached.promise;
+
+    // 首帧 send 仍在途,再来一个事件 → 第二个 debounce 窗口到期(旧实现会用空转 flush 覆盖 flushPromise)
+    handlers.after_tool_call({ toolName: "read", toolCallId: "A", durationMs: 20 }, { sessionKey: "p1b" });
+    await vi.advanceTimersByTimeAsync(900);
+
+    const finalizing = finalizeCard("p1b", { success: true });
+    sendGate.resolve();
+    await finalizing;
+
+    expect(sendCount).toBe(1); // 只发一次首帧(无重复 send)
+    const edit = calls.find((c) => c.url.includes("/message/edit"));
+    expect(edit).toBeTruthy(); // 终态帧未丢
+    const env = JSON.parse(edit!.body!.content_edit as string);
+    expect((env.card.body as Array<{ text: string }>)[0].text).toContain("✅ 已完成");
+  });
+
+  it("P2-a: gate 5xx 不缓存,下次 flush 重探成功仍能发卡", async () => {
+    const calls: Array<{ url: string }> = [];
+    let profileCall = 0;
+    const fn = vi.fn().mockImplementation(async (url: string) => {
+      calls.push({ url: String(url) });
+      if (String(url).includes("/card/profile")) {
+        profileCall++;
+        if (profileCall === 1) return { ok: false, status: 500, text: async () => "boom" };
+        return { ok: true, status: 200, json: async () => ({ enabled: true }) };
+      }
+      if (String(url).includes("/sendMessage")) {
+        return { ok: true, status: 200, text: async () => JSON.stringify({ message_id: "card1" }) };
+      }
+      return { ok: true, status: 200, text: async () => "" };
+    });
+    global.fetch = fn as unknown as typeof fetch;
+    const { handlers } = makeApi();
+
+    setCardContext("ga", { apiUrl: "https://ga.test", botToken: "bf", channelId: "g1", channelType: ChannelType.Group });
+    handlers.before_tool_call({ toolName: "read" }, { sessionKey: "ga" });
+    await vi.advanceTimersByTimeAsync(900); // 首次 gate 抛错 → 不缓存、不发卡
+    expect(calls.some((c) => c.url.includes("/sendMessage"))).toBe(false);
+
+    handlers.before_tool_call({ toolName: "read" }, { sessionKey: "ga" });
+    await vi.advanceTimersByTimeAsync(900); // 重探 gate → enabled → 发卡
+    expect(profileCall).toBe(2); // 未命中缓存,确实重探了
+    expect(calls.some((c) => c.url.includes("/sendMessage"))).toBe(true);
+  });
+
+  it("P2-b: 并发同名工具按 toolCallId 精确回填(不串到最后一个)", async () => {
+    const { fn, calls } = mockFetch();
+    global.fetch = fn as unknown as typeof fetch;
+    const { handlers } = makeApi();
+
+    setCardContext("tc", { apiUrl: "https://tc.test", botToken: "bf", channelId: "g1", channelType: ChannelType.Group });
+    // 两个并发 exec:A、B 都 running
+    handlers.before_tool_call({ toolName: "exec", toolCallId: "A", params: { command: "sleep 1" } }, { sessionKey: "tc" });
+    handlers.before_tool_call({ toolName: "exec", toolCallId: "B", params: { command: "sleep 2" } }, { sessionKey: "tc" });
+    // 先完成的是 A(不是最后 push 的 B)—— 旧逻辑会错标 B。
+    handlers.after_tool_call({ toolName: "exec", toolCallId: "A", durationMs: 50 }, { sessionKey: "tc" });
+    await vi.advanceTimersByTimeAsync(900);
+    await finalizeCard("tc", { success: true });
+
+    const edit = calls.filter((c) => c.url.includes("/message/edit")).pop();
+    expect(edit).toBeTruthy();
+    const env = JSON.parse(edit!.body!.content_edit as string);
+    const texts = (env.card.body as Array<{ text: string }>).map((b) => b.text);
+    expect(texts[1]).toBe("⌨️ 执行命令：sleep · 50ms"); // A 已完成
+    expect(texts[2]).toBe("⏳ 执行命令：sleep");          // B 仍 running
+  });
+
+  it("P2-b(重复投递): toolCallId 命中失败不回退按名匹配,不误标并发步骤", async () => {
+    const { fn, calls } = mockFetch();
+    global.fetch = fn as unknown as typeof fetch;
+    const { handlers } = makeApi();
+
+    setCardContext("dup", { apiUrl: "https://dup.test", botToken: "bf", channelId: "g1", channelType: ChannelType.Group });
+    handlers.before_tool_call({ toolName: "exec", toolCallId: "A", params: { command: "sleep 1" } }, { sessionKey: "dup" });
+    handlers.before_tool_call({ toolName: "exec", toolCallId: "B", params: { command: "sleep 2" } }, { sessionKey: "dup" });
+    handlers.after_tool_call({ toolName: "exec", toolCallId: "A", durationMs: 50 }, { sessionKey: "dup" }); // A → done
+    // 同一 after 事件重复投递(at-least-once):A 已非 running,旧逻辑会回退把 B 误标 done。
+    handlers.after_tool_call({ toolName: "exec", toolCallId: "A", durationMs: 50 }, { sessionKey: "dup" });
+    await vi.advanceTimersByTimeAsync(900);
+    await finalizeCard("dup", { success: true });
+
+    const edit = calls.filter((c) => c.url.includes("/message/edit")).pop();
+    const env = JSON.parse(edit!.body!.content_edit as string);
+    const texts = (env.card.body as Array<{ text: string }>).map((b) => b.text);
+    expect(texts[1]).toBe("⌨️ 执行命令：sleep · 50ms"); // A done(只被标一次)
+    expect(texts[2]).toBe("⏳ 执行命令：sleep");          // B 仍 running,未被重复事件误标
+  });
+});

--- a/src/card-progress.test.ts
+++ b/src/card-progress.test.ts
@@ -419,4 +419,36 @@ describe("card-progress 状态机 + hook + 节流", () => {
     expect(p1).toBe(1);
     expect(p2).toBe(1); // 不再自动重探,等下个工具事件
   });
+
+  it("波C: manifest advertise ColumnSet+Column → 进度卡按列渲染(缺省则 TextBlock)", async () => {
+    const calls: Array<{ url: string; body: Record<string, unknown> | undefined }> = [];
+    const fn = vi.fn().mockImplementation(async (url: string, init?: { body?: string }) => {
+      calls.push({ url: String(url), body: init?.body ? JSON.parse(init.body) : undefined });
+      if (String(url).includes("/card/profile")) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            enabled: true,
+            profiles: ["octo/v1"],
+            elements: ["TextBlock", "ColumnSet", "Column"],
+            limits: { max_nodes: 200 },
+          }),
+        };
+      }
+      if (String(url).includes("/sendMessage")) return { ok: true, status: 200, text: async () => JSON.stringify({ message_id: "card1" }) };
+      return { ok: true, status: 200, text: async () => "" };
+    });
+    global.fetch = fn as unknown as typeof fetch;
+    const { handlers } = makeApi();
+
+    setCardContext("wc", { apiUrl: "https://wc.test", botToken: "bf", channelId: "g1", channelType: ChannelType.Group });
+    handlers.before_tool_call({ toolName: "exec", params: { command: "ls" } }, { sessionKey: "wc" });
+    await vi.advanceTimersByTimeAsync(900);
+
+    const send = calls.find((c) => c.url.includes("/sendMessage"));
+    expect(send).toBeTruthy();
+    const card = (send!.body!.payload as { card: { body: Array<{ type: string }> } }).card;
+    expect(card.body[1].type).toBe("ColumnSet"); // manifest advertise → 列渲染
+  });
 });

--- a/src/card-progress.test.ts
+++ b/src/card-progress.test.ts
@@ -353,4 +353,50 @@ describe("card-progress 状态机 + hook + 节流", () => {
     await vi.advanceTimersByTimeAsync(900);
     expect(calls.length).toBe(0); // fail closed,两边都不发
   });
+
+  it("影响项#2: 首帧 send 持续 4xx → fail-closed,不再重试", async () => {
+    const calls: string[] = [];
+    const fn = vi.fn().mockImplementation(async (url: string) => {
+      calls.push(String(url));
+      if (String(url).includes("/card/profile")) return { ok: true, status: 200, json: async () => ({ enabled: true }) };
+      if (String(url).includes("/sendMessage")) return { ok: false, status: 403, text: async () => "forbidden" };
+      return { ok: true, status: 200, text: async () => "" };
+    });
+    global.fetch = fn as unknown as typeof fetch;
+    const { handlers } = makeApi();
+
+    setCardContext("e4", { apiUrl: "https://e4.test", botToken: "bf", channelId: "g1", channelType: ChannelType.Group });
+    handlers.before_tool_call({ toolName: "read" }, { sessionKey: "e4" });
+    await vi.advanceTimersByTimeAsync(900); // 首帧 send → 403 抛错
+    const sends1 = calls.filter((c) => c.includes("/sendMessage")).length;
+    handlers.after_tool_call({ toolName: "read", durationMs: 5 }, { sessionKey: "e4" });
+    await vi.advanceTimersByTimeAsync(900); // 未 skip 则会再试一次
+    const sends2 = calls.filter((c) => c.includes("/sendMessage")).length;
+    expect(sends1).toBe(1);
+    expect(sends2).toBe(1); // 4xx → skip,没有第二次 send
+  });
+
+  it("影响项#2: 首帧 send 429/5xx 仍可重试(不 fail-closed)", async () => {
+    const calls: string[] = [];
+    let sendN = 0;
+    const fn = vi.fn().mockImplementation(async (url: string) => {
+      calls.push(String(url));
+      if (String(url).includes("/card/profile")) return { ok: true, status: 200, json: async () => ({ enabled: true }) };
+      if (String(url).includes("/sendMessage")) {
+        sendN++;
+        if (sendN === 1) return { ok: false, status: 429, text: async () => "rate limited" };
+        return { ok: true, status: 200, text: async () => JSON.stringify({ message_id: "card1" }) };
+      }
+      return { ok: true, status: 200, text: async () => "" };
+    });
+    global.fetch = fn as unknown as typeof fetch;
+    const { handlers } = makeApi();
+
+    setCardContext("e5", { apiUrl: "https://e5.test", botToken: "bf", channelId: "g1", channelType: ChannelType.Group });
+    handlers.before_tool_call({ toolName: "read" }, { sessionKey: "e5" });
+    await vi.advanceTimersByTimeAsync(900); // 首帧 429 抛错 → 不 skip
+    handlers.after_tool_call({ toolName: "read", durationMs: 5 }, { sessionKey: "e5" });
+    await vi.advanceTimersByTimeAsync(900); // 重试成功
+    expect(calls.filter((c) => c.includes("/sendMessage")).length).toBe(2);
+  });
 });

--- a/src/card-progress.test.ts
+++ b/src/card-progress.test.ts
@@ -340,4 +340,17 @@ describe("card-progress 状态机 + hook + 节流", () => {
     await vi.advanceTimersByTimeAsync(900);
     expect(calls.some((c) => c.url.includes("/sendMessage"))).toBe(true);
   });
+
+  it("J2: 同 apiUrl+同频道但不同 botToken(两个账号同群回复)也 fail closed", async () => {
+    const { fn, calls } = mockFetch();
+    global.fetch = fn as unknown as typeof fetch;
+    const { handlers } = makeApi();
+
+    const base = { apiUrl: "https://a.test", channelId: "g1", channelType: ChannelType.Group };
+    setCardContext("Z", { ...base, botToken: "tokA" });
+    setCardContext("Z", { ...base, botToken: "tokB" }); // 仅 token 不同 → 仍视为跨身份碰撞
+    handlers.before_tool_call({ toolName: "read" }, { sessionKey: "Z" });
+    await vi.advanceTimersByTimeAsync(900);
+    expect(calls.length).toBe(0); // fail closed,两边都不发
+  });
 });

--- a/src/card-progress.test.ts
+++ b/src/card-progress.test.ts
@@ -399,4 +399,24 @@ describe("card-progress 状态机 + hook + 节流", () => {
     await vi.advanceTimersByTimeAsync(900); // 重试成功
     expect(calls.filter((c) => c.includes("/sendMessage")).length).toBe(2);
   });
+
+  it("影响项#P2-4: gate 瞬时失败后无新事件不再每 tick 重探", async () => {
+    const calls: string[] = [];
+    const fn = vi.fn().mockImplementation(async (url: string) => {
+      calls.push(String(url));
+      if (String(url).includes("/card/profile")) return { ok: false, status: 503, text: async () => "down" };
+      return { ok: true, status: 200, text: async () => "" };
+    });
+    global.fetch = fn as unknown as typeof fetch;
+    const { handlers } = makeApi();
+
+    setCardContext("g0", { apiUrl: "https://g0.test", botToken: "bf", channelId: "g1", channelType: ChannelType.Group });
+    handlers.before_tool_call({ toolName: "read" }, { sessionKey: "g0" });
+    await vi.advanceTimersByTimeAsync(900); // 首次 probe → 503 → null
+    const p1 = calls.filter((c) => c.includes("/card/profile")).length;
+    await vi.advanceTimersByTimeAsync(4000); // 无新事件,推进多个 debounce 周期
+    const p2 = calls.filter((c) => c.includes("/card/profile")).length;
+    expect(p1).toBe(1);
+    expect(p2).toBe(1); // 不再自动重探,等下个工具事件
+  });
 });

--- a/src/card-progress.test.ts
+++ b/src/card-progress.test.ts
@@ -276,4 +276,68 @@ describe("card-progress 状态机 + hook + 节流", () => {
     expect(texts[1]).toBe("⌨️ 执行命令：sleep · 50ms"); // A done(只被标一次)
     expect(texts[2]).toBe("⏳ 执行命令：sleep");          // B 仍 running,未被重复事件误标
   });
+
+  it("J1: finalize await 期间下一 run setCardContext,不误删新 run 的 entry", async () => {
+    const calls: Array<{ url: string; body: Record<string, unknown> | undefined }> = [];
+    const sendGate = makeDeferred();
+    const sendReached = makeDeferred();
+    let sendId = 0;
+    const fn = vi.fn().mockImplementation(async (url: string, init?: { body?: string }) => {
+      calls.push({ url: String(url), body: init?.body ? JSON.parse(init.body) : undefined });
+      if (String(url).includes("/card/profile")) {
+        return { ok: true, status: 200, json: async () => ({ enabled: true }) };
+      }
+      if (String(url).includes("/sendMessage")) {
+        sendId++;
+        if (sendId === 1) { sendReached.resolve(); await sendGate.promise; } // run1 首帧悬住
+        return { ok: true, status: 200, text: async () => JSON.stringify({ message_id: `card${sendId}` }) };
+      }
+      return { ok: true, status: 200, text: async () => "" };
+    });
+    global.fetch = fn as unknown as typeof fetch;
+    const { handlers } = makeApi();
+    const ctx = { apiUrl: "https://j1.test", botToken: "bf", channelId: "g1", channelType: ChannelType.Group };
+
+    setCardContext("S", ctx);
+    handlers.before_tool_call({ toolName: "read" }, { sessionKey: "S" });
+    await vi.advanceTimersByTimeAsync(900); // run1 flush 首帧 send 悬在 sendGate
+    await sendReached.promise;
+
+    const finalizing = finalizeCard("S", { success: true }); // 捕获 entry1,await 其 flushPromise
+    setCardContext("S", ctx);                                // 队列推进:同身份 run2 覆盖 Map
+    sendGate.resolve();                                       // 放行 run1 首帧完成 → finalize 恢复
+    await finalizing;
+
+    // run2 entry 未被误删:它的 before_tool_call 能发出自己的卡(否则无 entry → no-op)。
+    handlers.before_tool_call({ toolName: "read" }, { sessionKey: "S" });
+    await vi.advanceTimersByTimeAsync(900);
+    const sends = calls.filter((c) => c.url.includes("/sendMessage"));
+    expect(sends.length).toBe(2); // run1 card1 + run2 card2;若误删则仅 1
+  });
+
+  it("J2: 同 sessionKey 不同身份并发 → fail closed,两边都不发", async () => {
+    const { fn, calls } = mockFetch();
+    global.fetch = fn as unknown as typeof fetch;
+    const { handlers } = makeApi();
+
+    // 两个不同账号(不同频道)共享同一 sessionKey —— hook 侧无法区分。
+    setCardContext("X", { apiUrl: "https://a.test", botToken: "tA", channelId: "chA", channelType: ChannelType.Group });
+    setCardContext("X", { apiUrl: "https://a.test", botToken: "tB", channelId: "chB", channelType: ChannelType.Group });
+    handlers.before_tool_call({ toolName: "read" }, { sessionKey: "X" });
+    await vi.advanceTimersByTimeAsync(900);
+    expect(calls.length).toBe(0); // 碰撞 → 两边 skip,绝不发到任一频道
+  });
+
+  it("J2: 同 sessionKey 同身份(同账号下一 run)不算碰撞,正常发卡", async () => {
+    const { fn, calls } = mockFetch();
+    global.fetch = fn as unknown as typeof fetch;
+    const { handlers } = makeApi();
+    const ctx = { apiUrl: "https://same.test", botToken: "bf", channelId: "g1", channelType: ChannelType.Group };
+
+    setCardContext("Y", ctx);
+    setCardContext("Y", ctx); // 同身份重登记(如上一 run 尚未 finalize)→ 不 fail closed
+    handlers.before_tool_call({ toolName: "read" }, { sessionKey: "Y" });
+    await vi.advanceTimersByTimeAsync(900);
+    expect(calls.some((c) => c.url.includes("/sendMessage"))).toBe(true);
+  });
 });

--- a/src/card-progress.test.ts
+++ b/src/card-progress.test.ts
@@ -433,7 +433,7 @@ describe("card-progress 状态机 + hook + 节流", () => {
             profiles: ["octo/v1"],
             // 真实 im-test 部署 advertise 的元素超集(P1-d 起进度卡优先 RichTextBlock 而非 ColumnSet:
             // 解决服务端权威重算 plain 时 ColumnSet 图标/文本分行的问题)
-            elements: ["TextBlock", "RichTextBlock", "Container", "ColumnSet", "Column", "FactSet"],
+            elements: ["TextBlock", "RichTextBlock", "Container", "ColumnSet", "FactSet"],
             limits: { max_nodes: 200 },
           }),
         };
@@ -450,8 +450,60 @@ describe("card-progress 状态机 + hook + 节流", () => {
 
     const send = calls.find((c) => c.url.includes("/sendMessage"));
     expect(send).toBeTruthy();
-    const card = (send!.body!.payload as { card: { body: Array<{ type: string }> } }).card;
-    expect(card.body[1].type).toBe("RichTextBlock"); // manifest advertise → 富文本行渲染
+    const card = (send!.body!.payload as {
+      card: { body: Array<{ type: string; items?: Array<{ type: string }> }> };
+    }).card;
+    expect(card.body[1].type).toBe("Container"); // manifest advertise → timeline 分组容器
+    expect(card.body[1].items?.[0]?.type).toBe("RichTextBlock"); // 容器内仍是富文本行
+  });
+
+  it("波C: manifest advertise Action.ToggleVisibility → 终态 edit 折叠 thinking/tool 明细", async () => {
+    const calls: Array<{ url: string; body: Record<string, unknown> | undefined }> = [];
+    const fn = vi.fn().mockImplementation(async (url: string, init?: { body?: string }) => {
+      calls.push({ url: String(url), body: init?.body ? JSON.parse(init.body) : undefined });
+      if (String(url).includes("/card/profile")) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            enabled: true,
+            profiles: ["octo/v1"],
+            elements: ["TextBlock", "RichTextBlock", "Container", "ActionSet"],
+            actions: ["Action.ToggleVisibility"],
+            limits: { max_nodes: 200 },
+          }),
+        };
+      }
+      if (String(url).includes("/sendMessage")) return { ok: true, status: 200, text: async () => JSON.stringify({ message_id: "card1" }) };
+      return { ok: true, status: 200, text: async () => "" };
+    });
+    global.fetch = fn as unknown as typeof fetch;
+    const { handlers } = makeApi();
+
+    setCardContext("wc-toggle", { apiUrl: "https://wc-toggle.test", botToken: "bf", channelId: "g1", channelType: ChannelType.Group });
+    handlers.model_call_started({}, { sessionKey: "wc-toggle" });
+    await vi.advanceTimersByTimeAsync(100);
+    handlers.before_tool_call({ toolName: "exec", toolCallId: "e1", params: { command: "find src" } }, { sessionKey: "wc-toggle" });
+    handlers.after_tool_call({ toolName: "exec", toolCallId: "e1", durationMs: 50 }, { sessionKey: "wc-toggle" });
+    await vi.advanceTimersByTimeAsync(900);
+
+    await finalizeCard("wc-toggle", { success: true });
+    const edit = calls.filter((c) => c.url.includes("/message/edit")).pop();
+    expect(edit).toBeTruthy();
+    const env = JSON.parse(edit!.body!.content_edit as string);
+    const body = env.card.body as Array<Record<string, unknown>>;
+    expect(body[1].type).toBe("RichTextBlock");
+    const summaryInlines = body[1].inlines as Array<Record<string, unknown>>;
+    expect(summaryInlines[0]).toMatchObject({ text: "推理与工具调用", weight: "Bolder" });
+    expect(summaryInlines[1]).toMatchObject({ isSubtle: true });
+    expect((body[2] as { type: string }).type).toBe("ActionSet");
+    const action = (body[2] as { actions: Array<Record<string, unknown>> }).actions[0];
+    expect(action).toMatchObject({ type: "Action.ToggleVisibility", title: "展开/收起" });
+    expect(action.title).not.toBe("推理与工具调用");
+    expect((body[3] as { type: string; isVisible: boolean }).type).toBe("Container");
+    expect((body[3] as { isVisible: boolean }).isVisible).toBe(false);
+    expect(action.targetElements).toEqual([(body[3] as { id: string }).id]);
+    expect(JSON.stringify(body[3])).toContain("执行命令");
   });
 
   it("P1-g: model_call_started 产 running thinking step,before_tool_call 结束它(标 done + durationMs)", async () => {

--- a/src/card-progress.test.ts
+++ b/src/card-progress.test.ts
@@ -420,7 +420,7 @@ describe("card-progress 状态机 + hook + 节流", () => {
     expect(p2).toBe(1); // 不再自动重探,等下个工具事件
   });
 
-  it("波C: manifest advertise ColumnSet+Column → 进度卡按列渲染(缺省则 TextBlock)", async () => {
+  it("波C: manifest advertise RichTextBlock → 进度卡按富文本行渲染(缺省则 TextBlock 平铺)", async () => {
     const calls: Array<{ url: string; body: Record<string, unknown> | undefined }> = [];
     const fn = vi.fn().mockImplementation(async (url: string, init?: { body?: string }) => {
       calls.push({ url: String(url), body: init?.body ? JSON.parse(init.body) : undefined });
@@ -431,7 +431,9 @@ describe("card-progress 状态机 + hook + 节流", () => {
           json: async () => ({
             enabled: true,
             profiles: ["octo/v1"],
-            elements: ["TextBlock", "ColumnSet", "Column"],
+            // 真实 im-test 部署 advertise 的元素超集(P1-d 起进度卡优先 RichTextBlock 而非 ColumnSet:
+            // 解决服务端权威重算 plain 时 ColumnSet 图标/文本分行的问题)
+            elements: ["TextBlock", "RichTextBlock", "Container", "ColumnSet", "Column", "FactSet"],
             limits: { max_nodes: 200 },
           }),
         };
@@ -449,6 +451,209 @@ describe("card-progress 状态机 + hook + 节流", () => {
     const send = calls.find((c) => c.url.includes("/sendMessage"));
     expect(send).toBeTruthy();
     const card = (send!.body!.payload as { card: { body: Array<{ type: string }> } }).card;
-    expect(card.body[1].type).toBe("ColumnSet"); // manifest advertise → 列渲染
+    expect(card.body[1].type).toBe("RichTextBlock"); // manifest advertise → 富文本行渲染
+  });
+
+  it("P1-g: model_call_started 产 running thinking step,before_tool_call 结束它(标 done + durationMs)", async () => {
+    const { fn, calls } = mockFetch();
+    global.fetch = fn as unknown as typeof fetch;
+    const { handlers } = makeApi();
+    setCardContext("tk1", { apiUrl: "https://tk1.test", botToken: "bf", channelId: "g", channelType: ChannelType.Group });
+
+    // 起 thinking(agent 首次调 model 决定用哪个工具)
+    handlers.model_call_started({}, { sessionKey: "tk1" });
+    // 100ms 后开始调 tool —— thinking 结束
+    await vi.advanceTimersByTimeAsync(100);
+    handlers.before_tool_call({ toolName: "read", params: { path: "/a" }, toolCallId: "r1" }, { sessionKey: "tk1" });
+    handlers.after_tool_call({ toolName: "read", toolCallId: "r1", durationMs: 50 }, { sessionKey: "tk1" });
+    await vi.advanceTimersByTimeAsync(900);
+
+    const send = calls.find((c) => c.url.includes("/sendMessage"));
+    expect(send).toBeTruthy();
+    const body = (send!.body!.payload as { card: { body: Array<{ text?: string; inlines?: Array<{ text: string }> }> } }).card.body;
+    // 首帧应含:header + thinking(done) + read(running/done)
+    const asText = (e: { text?: string; inlines?: Array<{ text: string }> }) =>
+      e.text ?? (e.inlines ?? []).map((i) => i.text).join("");
+    const joined = body.map(asText).join(" | ");
+    expect(joined).toContain("💭 思考"); // thinking step 出现
+    expect(joined).toContain("读取文件");  // 后续 tool step 也在
+  });
+
+  it("P1-g: 多次 model_call_started 累积多步 thinking(同类合并压缩)", async () => {
+    const { fn, calls } = mockFetch();
+    global.fetch = fn as unknown as typeof fetch;
+    const { handlers } = makeApi();
+    setCardContext("tk2", { apiUrl: "https://tk2.test", botToken: "bf", channelId: "g", channelType: ChannelType.Group });
+
+    // agent 循环:thinking → tool → thinking → tool → thinking → tool
+    for (let i = 0; i < 3; i++) {
+      handlers.model_call_started({}, { sessionKey: "tk2" });
+      await vi.advanceTimersByTimeAsync(50);
+      const id = `t${i}`;
+      handlers.before_tool_call({ toolName: "read", params: { path: `/${i}` }, toolCallId: id }, { sessionKey: "tk2" });
+      handlers.after_tool_call({ toolName: id, toolCallId: id, durationMs: 30 }, { sessionKey: "tk2" });
+    }
+    await vi.advanceTimersByTimeAsync(900);
+    // 只验证:发送时的 payload 里出现了 thinking(至少一处)—— 合并/顺序具体断言在 render 层测
+    const send = calls.find((c) => c.url.includes("/sendMessage"));
+    expect(send).toBeTruthy();
+    const s = JSON.stringify((send!.body!.payload as { card: unknown }).card);
+    expect(s).toContain("💭");
+  });
+
+  it("P1-g: finalize 前的 running thinking 被收尾(不留 running 尾巴)", async () => {
+    const { fn, calls } = mockFetch();
+    global.fetch = fn as unknown as typeof fetch;
+    const { handlers } = makeApi();
+    setCardContext("tk3", { apiUrl: "https://tk3.test", botToken: "bf", channelId: "g", channelType: ChannelType.Group });
+
+    // thinking + 一个 tool,然后再一次 thinking(无后续 tool)→ finalize 收尾
+    handlers.model_call_started({}, { sessionKey: "tk3" });
+    handlers.before_tool_call({ toolName: "read", params: { path: "/a" }, toolCallId: "r1" }, { sessionKey: "tk3" });
+    handlers.after_tool_call({ toolName: "read", toolCallId: "r1", durationMs: 30 }, { sessionKey: "tk3" });
+    handlers.model_call_started({}, { sessionKey: "tk3" });
+    await vi.advanceTimersByTimeAsync(900); // 首帧发出
+    calls.length = 0;
+
+    await finalizeCard("tk3", { success: true });
+    const edit = calls.find((c) => c.url.includes("/message/edit"));
+    expect(edit).toBeTruthy();
+    const env = JSON.parse(edit!.body!.content_edit as string);
+    // 终态帧不应残留 running:⏳ 不该出现
+    const cardStr = JSON.stringify(env.card);
+    expect(cardStr).not.toContain("⏳");
+  });
+
+  it("P1-h: octo_send_display_card 不入进度卡 —— 纯 display-card turn 无占位卡、无终态帧", async () => {
+    const { fn, calls } = mockFetch();
+    global.fetch = fn as unknown as typeof fetch;
+    const { handlers } = makeApi();
+    setCardContext("dh1", { apiUrl: "https://dh1.test", botToken: "bf", channelId: "g", channelType: ChannelType.Group });
+    handlers.before_tool_call({ toolName: "octo_send_display_card", toolCallId: "d1" }, { sessionKey: "dh1" });
+    handlers.after_tool_call({ toolName: "octo_send_display_card", toolCallId: "d1", durationMs: 120 }, { sessionKey: "dh1" });
+    await vi.advanceTimersByTimeAsync(900);
+    // 从未 scheduleFlush → 连 gate 探测/发送都没有
+    expect(calls.some((c) => c.url.includes("/sendMessage"))).toBe(false);
+    expect(calls.some((c) => c.url.includes("/card/profile"))).toBe(false);
+    // finalize 因 !messageId 静默,不发终态帧
+    await finalizeCard("dh1", { success: true });
+    expect(calls.some((c) => c.url.includes("/message/edit"))).toBe(false);
+  });
+
+  it("P1-h: 混合 turn:display-card 不计步,真实工具照常显示进度(读取文件在,display-card 不在)", async () => {
+    const { fn, calls } = mockFetch();
+    global.fetch = fn as unknown as typeof fetch;
+    const { handlers } = makeApi();
+    setCardContext("dh2", { apiUrl: "https://dh2.test", botToken: "bf", channelId: "g", channelType: ChannelType.Group });
+    handlers.before_tool_call({ toolName: "octo_send_display_card", toolCallId: "d1" }, { sessionKey: "dh2" }); // 忽略
+    handlers.before_tool_call({ toolName: "read", params: { path: "/a" }, toolCallId: "r1" }, { sessionKey: "dh2" }); // 计入
+    await vi.advanceTimersByTimeAsync(900);
+    const send = calls.find((c) => c.url.includes("/sendMessage"));
+    expect(send).toBeTruthy();
+    const card = (send!.body!.payload as { card: { body: Array<{ text?: string; inlines?: Array<{ text: string }> }> } }).card;
+    const asText = (e: { text?: string; inlines?: Array<{ text: string }> }) =>
+      e.text ?? (e.inlines ?? []).map((i) => i.text).join("");
+    const joined = card.body.map(asText).join(" | ");
+    expect(joined).toContain("读取文件");
+    expect(joined).not.toContain("octo_send_display_card");
+  });
+
+  it("懒发契约:model_call_started 单独不发卡 —— 纯 display-card turn(含思考步)无占位卡、无中断终态", async () => {
+    // 回归:P1-g 的 model_call_started 曾无条件 scheduleFlush,击穿 P1-h 抑制 ——
+    // 纯 display-card turn 仍发占位卡并 finalize 成「⚠️ 已中断」。
+    const { fn, calls } = mockFetch();
+    global.fetch = fn as unknown as typeof fetch;
+    const { handlers } = makeApi();
+    setCardContext("nf1", { apiUrl: "https://nf1.test", botToken: "bf", channelId: "g", channelType: ChannelType.Group });
+    handlers.model_call_started({}, { sessionKey: "nf1" });   // 思考步(真实事件序:先于 tool)
+    handlers.before_tool_call({ toolName: "octo_send_display_card", toolCallId: "d1" }, { sessionKey: "nf1" });
+    handlers.after_tool_call({ toolName: "octo_send_display_card", toolCallId: "d1", durationMs: 120 }, { sessionKey: "nf1" });
+    await vi.advanceTimersByTimeAsync(900);
+    expect(calls.some((c) => c.url.includes("/sendMessage"))).toBe(false);
+    expect(calls.some((c) => c.url.includes("/card/profile"))).toBe(false);
+    await finalizeCard("nf1", { success: false });
+    expect(calls.some((c) => c.url.includes("/message/edit"))).toBe(false); // 无 messageId → 无中断帧
+  });
+
+  it("懒发契约:纯思考(无任何工具)turn 不发进度卡", async () => {
+    const { fn, calls } = mockFetch();
+    global.fetch = fn as unknown as typeof fetch;
+    const { handlers } = makeApi();
+    setCardContext("nf2", { apiUrl: "https://nf2.test", botToken: "bf", channelId: "g", channelType: ChannelType.Group });
+    handlers.model_call_started({}, { sessionKey: "nf2" });
+    await vi.advanceTimersByTimeAsync(900);
+    handlers.model_call_started({}, { sessionKey: "nf2" }); // 连续思考(去重)
+    await vi.advanceTimersByTimeAsync(900);
+    expect(calls.length).toBe(0);
+    await finalizeCard("nf2", { success: true });
+    expect(calls.some((c) => c.url.includes("/message/edit"))).toBe(false);
+  });
+
+  it("懒发契约:真实工具后思考步照常更新已存在的卡", async () => {
+    const { fn, calls } = mockFetch();
+    global.fetch = fn as unknown as typeof fetch;
+    const { handlers } = makeApi();
+    setCardContext("nf3", { apiUrl: "https://nf3.test", botToken: "bf", channelId: "g", channelType: ChannelType.Group });
+    handlers.model_call_started({}, { sessionKey: "nf3" });               // 纯思考:不发
+    handlers.before_tool_call({ toolName: "read", toolCallId: "r1" }, { sessionKey: "nf3" }); // 真实工具:发首帧
+    await vi.advanceTimersByTimeAsync(900);
+    expect(calls.some((c) => c.url.includes("/sendMessage"))).toBe(true);
+    calls.length = 0;
+    handlers.after_tool_call({ toolName: "read", toolCallId: "r1", durationMs: 20 }, { sessionKey: "nf3" });
+    handlers.model_call_started({}, { sessionKey: "nf3" });               // 卡已存在 → 思考步刷新
+    await vi.advanceTimersByTimeAsync(900);
+    expect(calls.some((c) => c.url.includes("/message/edit"))).toBe(true);
+  });
+
+  it("NEW-3: display-card 前的 running thinking 被收尾(思考耗时不吞掉发卡时长)", async () => {
+    const { fn, calls } = mockFetch();
+    global.fetch = fn as unknown as typeof fetch;
+    const { handlers } = makeApi();
+    setCardContext("nf4", { apiUrl: "https://nf4.test", botToken: "bf", channelId: "g", channelType: ChannelType.Group });
+    handlers.before_tool_call({ toolName: "read", toolCallId: "r1" }, { sessionKey: "nf4" }); // 让卡存在
+    handlers.after_tool_call({ toolName: "read", toolCallId: "r1", durationMs: 10 }, { sessionKey: "nf4" });
+    handlers.model_call_started({}, { sessionKey: "nf4" });               // 起一个思考步
+    handlers.before_tool_call({ toolName: "octo_send_display_card", toolCallId: "d1" }, { sessionKey: "nf4" }); // 应收尾思考步
+    handlers.before_tool_call({ toolName: "read", params: { path: "/b" }, toolCallId: "r2" }, { sessionKey: "nf4" });
+    await vi.advanceTimersByTimeAsync(900);
+    const send = calls.find((c) => c.url.includes("/sendMessage")) ?? calls.find((c) => c.url.includes("/message/edit"));
+    // 思考步已 done(有 💭 且带耗时),不再是 running（⏳）
+    expect(send).toBeTruthy();
+  });
+
+  it("§4.1 runId 守卫:超时 run 的迟到 hook 不落到同 sessionKey 的新 run 卡上", async () => {
+    const { fn, calls } = mockFetch();
+    global.fetch = fn as unknown as typeof fetch;
+    const { handlers } = makeApi();
+    const target = { apiUrl: "https://rg.test", botToken: "bf", channelId: "g", channelType: ChannelType.Group };
+
+    // run A 登记并跑一步(runId=A)→ entry 认领给 A;随后超时收尾
+    setCardContext("rg1", target);
+    handlers.before_tool_call({ toolName: "read", params: { path: "/a" }, toolCallId: "a1" }, { sessionKey: "rg1", runId: "A" });
+    await vi.advanceTimersByTimeAsync(900);
+    await finalizeCard("rg1", { success: false });
+
+    // 同 sessionKey 的 run B 登记(fresh entry);B 自己的 hook(runId=B)先到 → 认领 entry
+    setCardContext("rg1", target);
+    handlers.before_tool_call({ toolName: "write", params: { path: "/b" }, toolCallId: "b1" }, { sessionKey: "rg1", runId: "B" });
+    // run A 的迟到 hook(runId=A)—— runId 与属主 B 不符,必须被丢弃
+    handlers.before_tool_call({ toolName: "exec", params: { command: "echo x" }, toolCallId: "a2" }, { sessionKey: "rg1", runId: "A" });
+    handlers.after_tool_call({ toolName: "exec", toolCallId: "a2", durationMs: 9 }, { sessionKey: "rg1", runId: "A" });
+    await vi.advanceTimersByTimeAsync(900);
+
+    // 聚合所有发出去的帧(send payload + edit content_edit)的卡片文本
+    const asText = (e: { text?: string; inlines?: Array<{ text: string }> }) =>
+      e.text ?? (e.inlines ?? []).map((i) => i.text).join("");
+    const allText = calls
+      .filter((c) => c.url.includes("/sendMessage") || c.url.includes("/message/edit"))
+      .map((c) => {
+        const card = c.url.includes("/message/edit")
+          ? JSON.parse(c.body!.content_edit as string).card
+          : (c.body!.payload as { card: { body: unknown[] } }).card;
+        return (card.body as Array<{ text?: string; inlines?: Array<{ text: string }> }>).map(asText).join(" | ");
+      })
+      .join(" || ");
+    expect(allText).toContain("写入文件"); // B 自己的步骤渲染出来了
+    expect(allText).not.toContain("执行命令"); // A 迟到的 exec 步骤从未进入任何帧
   });
 });

--- a/src/card-progress.test.ts
+++ b/src/card-progress.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { ChannelType } from "./types.js";
+import { OCTO_CARD_LAYOUTS } from "./card-render.js";
 import {
   setCardContext,
   finalizeCard,
@@ -29,6 +30,31 @@ function mockFetch(opts: { enabled?: boolean; sendId?: string } = {}) {
     return { ok: true, status: 200, text: async () => "" }; // message/edit
   });
   return { fn, calls };
+}
+
+function elementText(e: Record<string, unknown>): string {
+  if (typeof e.text === "string") return e.text;
+  if (Array.isArray(e.inlines)) return e.inlines.map((i) => (i as { text?: string }).text ?? "").join("");
+  if (Array.isArray(e.items)) return e.items.map((item) => elementText(item as Record<string, unknown>)).join("\n");
+  if (Array.isArray(e.columns)) {
+    return e.columns
+      .flatMap((c) => ((c as { items?: unknown[] }).items ?? []) as Record<string, unknown>[])
+      .map(elementText)
+      .join("\n");
+  }
+  return "";
+}
+
+function progressHeaderText(card: { body: Array<Record<string, unknown>> }): string {
+  return elementText(card.body[0]);
+}
+
+function progressDetailItems(card: { body: Array<Record<string, unknown>> }): Array<Record<string, unknown>> {
+  return ((card.body[1] as { items?: Array<Record<string, unknown>> })?.items ?? []);
+}
+
+function progressCardText(card: { body: Array<Record<string, unknown>> }): string {
+  return card.body.map(elementText).join("\n");
 }
 
 /** 可控 promise:用于把某个请求悬在 in-flight 状态。 */
@@ -115,7 +141,7 @@ describe("card-progress 状态机 + hook + 节流", () => {
     const edit = calls.find((c) => c.url.includes("/message/edit"));
     expect(edit).toBeTruthy();
     const env = JSON.parse(edit!.body!.content_edit as string);
-    expect((env.card.body as Array<{ text: string }>)[0].text).toContain("✅ 已完成");
+    expect(progressHeaderText(env.card)).toContain("✅ 已完成");
     expect(env.transient).toBeUndefined(); // 终态帧进修订历史(不带 transient)
   });
 
@@ -160,7 +186,7 @@ describe("card-progress 状态机 + hook + 节流", () => {
     const edit = calls.find((c) => c.url.includes("/message/edit"));
     expect(edit).toBeTruthy();
     const env = JSON.parse(edit!.body!.content_edit as string);
-    expect((env.card.body as Array<{ text: string }>)[0].text).toContain("✅ 已完成");
+    expect(progressHeaderText(env.card)).toContain("✅ 已完成");
     expect(env.transient).toBeUndefined(); // 终态帧进修订历史
   });
 
@@ -202,7 +228,7 @@ describe("card-progress 状态机 + hook + 节流", () => {
     const edit = calls.find((c) => c.url.includes("/message/edit"));
     expect(edit).toBeTruthy(); // 终态帧未丢
     const env = JSON.parse(edit!.body!.content_edit as string);
-    expect((env.card.body as Array<{ text: string }>)[0].text).toContain("✅ 已完成");
+    expect(progressHeaderText(env.card)).toContain("✅ 已完成");
   });
 
   it("P2-a: gate 5xx 不缓存,下次 flush 重探成功仍能发卡", async () => {
@@ -251,9 +277,9 @@ describe("card-progress 状态机 + hook + 节流", () => {
     const edit = calls.filter((c) => c.url.includes("/message/edit")).pop();
     expect(edit).toBeTruthy();
     const env = JSON.parse(edit!.body!.content_edit as string);
-    const texts = (env.card.body as Array<{ text: string }>).map((b) => b.text);
-    expect(texts[1]).toBe("⌨️ 执行命令：sleep · 50ms"); // A 已完成
-    expect(texts[2]).toBe("⏳ 执行命令：sleep");          // B 仍 running
+    const texts = progressDetailItems(env.card).map(elementText);
+    expect(texts[0]).toBe("⌨️ 执行命令：sleep · 50ms"); // A 已完成
+    expect(texts[1]).toBe("⏳ 执行命令：sleep");          // B 仍 running
   });
 
   it("P2-b(重复投递): toolCallId 命中失败不回退按名匹配,不误标并发步骤", async () => {
@@ -272,9 +298,9 @@ describe("card-progress 状态机 + hook + 节流", () => {
 
     const edit = calls.filter((c) => c.url.includes("/message/edit")).pop();
     const env = JSON.parse(edit!.body!.content_edit as string);
-    const texts = (env.card.body as Array<{ text: string }>).map((b) => b.text);
-    expect(texts[1]).toBe("⌨️ 执行命令：sleep · 50ms"); // A done(只被标一次)
-    expect(texts[2]).toBe("⏳ 执行命令：sleep");          // B 仍 running,未被重复事件误标
+    const texts = progressDetailItems(env.card).map(elementText);
+    expect(texts[0]).toBe("⌨️ 执行命令：sleep · 50ms"); // A done(只被标一次)
+    expect(texts[1]).toBe("⏳ 执行命令：sleep");          // B 仍 running,未被重复事件误标
   });
 
   it("J1: finalize await 期间下一 run setCardContext,不误删新 run 的 entry", async () => {
@@ -453,8 +479,10 @@ describe("card-progress 状态机 + hook + 节流", () => {
     const card = (send!.body!.payload as {
       card: { body: Array<{ type: string; items?: Array<{ type: string }> }> };
     }).card;
-    expect(card.body[1].type).toBe("Container"); // manifest advertise → timeline 分组容器
-    expect(card.body[1].items?.[0]?.type).toBe("RichTextBlock"); // 容器内仍是富文本行
+    expect(card.body[0].type).toBe("ColumnSet");
+    expect(card.body[1].type).toBe("Container"); // timeline_detail
+    expect(card.body[1].items?.[0]?.type).toBe("Container"); // timeline 步骤组
+    expect((card.body[1].items?.[0] as { items?: Array<{ type: string }> }).items?.[0]?.type).toBe("RichTextBlock"); // 组内仍是富文本行
   });
 
   it("波C: manifest advertise Action.ToggleVisibility → 终态 edit 折叠 thinking/tool 明细", async () => {
@@ -468,7 +496,7 @@ describe("card-progress 状态机 + hook + 节流", () => {
           json: async () => ({
             enabled: true,
             profiles: ["octo/v1"],
-            elements: ["TextBlock", "RichTextBlock", "Container", "ActionSet"],
+            elements: ["TextBlock", "RichTextBlock", "Container", "ColumnSet", "ActionSet"],
             actions: ["Action.ToggleVisibility"],
             limits: { max_nodes: 200 },
           }),
@@ -491,19 +519,31 @@ describe("card-progress 状态机 + hook + 节流", () => {
     const edit = calls.filter((c) => c.url.includes("/message/edit")).pop();
     expect(edit).toBeTruthy();
     const env = JSON.parse(edit!.body!.content_edit as string);
+    expect(env.card.metadata).toEqual({ octo_layout: OCTO_CARD_LAYOUTS.agentProgressV1 });
     const body = env.card.body as Array<Record<string, unknown>>;
-    expect(body[1].type).toBe("RichTextBlock");
-    const summaryInlines = body[1].inlines as Array<Record<string, unknown>>;
-    expect(summaryInlines[0]).toMatchObject({ text: "推理与工具调用", weight: "Bolder" });
-    expect(summaryInlines[1]).toMatchObject({ isSubtle: true });
-    expect((body[2] as { type: string }).type).toBe("ActionSet");
-    const action = (body[2] as { actions: Array<Record<string, unknown>> }).actions[0];
-    expect(action).toMatchObject({ type: "Action.ToggleVisibility", title: "展开/收起" });
-    expect(action.title).not.toBe("推理与工具调用");
-    expect((body[3] as { type: string; isVisible: boolean }).type).toBe("Container");
-    expect((body[3] as { isVisible: boolean }).isVisible).toBe(false);
-    expect(action.targetElements).toEqual([(body[3] as { id: string }).id]);
-    expect(JSON.stringify(body[3])).toContain("执行命令");
+    expect(body[0].type).toBe("ColumnSet");
+    const summaryHeader = body[0] as { columns: Array<{ width: string; items: Array<Record<string, unknown>> }> };
+    const headerBlock = summaryHeader.columns[0].items[0] as { type: string; inlines: Array<Record<string, unknown>> };
+    expect(headerBlock.type).toBe("RichTextBlock");
+    expect(headerBlock.inlines[0]).toMatchObject({ text: "✅ 已完成", weight: "Bolder" });
+    const summaryBlock = summaryHeader.columns[0].items[1] as { type: string; inlines: Array<Record<string, unknown>> };
+    expect(summaryBlock.inlines[0]).toMatchObject({ text: "推理与工具调用", weight: "Bolder" });
+    expect(summaryBlock.inlines[1]).toMatchObject({ isSubtle: true });
+    const collapseBtn = summaryHeader.columns[1].items[0] as { id: string; isVisible: boolean; actions: Array<Record<string, unknown>> };
+    const expandBtn = summaryHeader.columns[1].items[1] as { id: string; isVisible: boolean; actions: Array<Record<string, unknown>> };
+    expect(collapseBtn.isVisible).toBe(false);
+    expect(expandBtn.isVisible).toBe(true);
+    expect(collapseBtn.actions[0]).toMatchObject({ type: "Action.ToggleVisibility", title: "收起推理" });
+    expect(expandBtn.actions[0]).toMatchObject({ type: "Action.ToggleVisibility", title: "展开推理" });
+    expect((body[1] as { type: string; id: string; isVisible: boolean }).type).toBe("Container");
+    expect((body[1] as { id: string }).id).toBe("timeline_detail");
+    expect((body[1] as { isVisible: boolean }).isVisible).toBe(false);
+    expect(collapseBtn.actions[0].targetElements).toEqual([
+      { elementId: (body[1] as { id: string }).id, isVisible: false },
+      { elementId: collapseBtn.id, isVisible: false },
+      { elementId: expandBtn.id, isVisible: true },
+    ]);
+    expect(JSON.stringify(body[1])).toContain("执行命令");
   });
 
   it("P1-g: model_call_started 产 running thinking step,before_tool_call 结束它(标 done + durationMs)", async () => {
@@ -522,11 +562,9 @@ describe("card-progress 状态机 + hook + 节流", () => {
 
     const send = calls.find((c) => c.url.includes("/sendMessage"));
     expect(send).toBeTruthy();
-    const body = (send!.body!.payload as { card: { body: Array<{ text?: string; inlines?: Array<{ text: string }> }> } }).card.body;
+    const card = (send!.body!.payload as { card: { body: Array<Record<string, unknown>> } }).card;
     // 首帧应含:header + thinking(done) + read(running/done)
-    const asText = (e: { text?: string; inlines?: Array<{ text: string }> }) =>
-      e.text ?? (e.inlines ?? []).map((i) => i.text).join("");
-    const joined = body.map(asText).join(" | ");
+    const joined = progressCardText(card);
     expect(joined).toContain("💭 思考"); // thinking step 出现
     expect(joined).toContain("读取文件");  // 后续 tool step 也在
   });
@@ -602,10 +640,9 @@ describe("card-progress 状态机 + hook + 节流", () => {
     await vi.advanceTimersByTimeAsync(900);
     const send = calls.find((c) => c.url.includes("/sendMessage"));
     expect(send).toBeTruthy();
-    const card = (send!.body!.payload as { card: { body: Array<{ text?: string; inlines?: Array<{ text: string }> }> } }).card;
-    const asText = (e: { text?: string; inlines?: Array<{ text: string }> }) =>
-      e.text ?? (e.inlines ?? []).map((i) => i.text).join("");
-    const joined = card.body.map(asText).join(" | ");
+    const card = (send!.body!.payload as { card: { metadata?: unknown; body: Array<Record<string, unknown>> } }).card;
+    expect(card.metadata).toEqual({ octo_layout: OCTO_CARD_LAYOUTS.agentProgressV1 });
+    const joined = progressCardText(card);
     expect(joined).toContain("读取文件");
     expect(joined).not.toContain("octo_send_display_card");
   });
@@ -694,15 +731,13 @@ describe("card-progress 状态机 + hook + 节流", () => {
     await vi.advanceTimersByTimeAsync(900);
 
     // 聚合所有发出去的帧(send payload + edit content_edit)的卡片文本
-    const asText = (e: { text?: string; inlines?: Array<{ text: string }> }) =>
-      e.text ?? (e.inlines ?? []).map((i) => i.text).join("");
     const allText = calls
       .filter((c) => c.url.includes("/sendMessage") || c.url.includes("/message/edit"))
       .map((c) => {
         const card = c.url.includes("/message/edit")
           ? JSON.parse(c.body!.content_edit as string).card
-          : (c.body!.payload as { card: { body: unknown[] } }).card;
-        return (card.body as Array<{ text?: string; inlines?: Array<{ text: string }> }>).map(asText).join(" | ");
+          : (c.body!.payload as { card: { body: Array<Record<string, unknown>> } }).card;
+        return progressCardText(card);
       })
       .join(" || ");
     expect(allText).toContain("写入文件"); // B 自己的步骤渲染出来了

--- a/src/card-progress.ts
+++ b/src/card-progress.ts
@@ -182,7 +182,12 @@ async function runFlush(sessionKey: string, entry: CardEntry): Promise<void> {
         entry.skip = true;
         return;
       }
-      if (gate === null) return; // 瞬时探测失败,不 skip、不清 dirty,留待重探
+      if (gate === null) {
+        // 瞬时探测失败:清 dirty 且不自动重排,避免端点故障期每 ~800ms 一次探测风暴。
+        // 累积的 steps 仍在 entry 上,下个工具事件会重新 scheduleFlush 并重探。
+        entry.dirty = false;
+        return;
+      }
     }
 
     entry.dirty = false;

--- a/src/card-progress.ts
+++ b/src/card-progress.ts
@@ -14,8 +14,8 @@
  */
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import { ChannelType, CARD_PROFILE, CARD_VERSION } from "./types.js";
-import { sendCardMessage, editCardMessage, getCardProfile, httpStatusFromApiFetchError } from "./api-fetch.js";
-import { renderProgressCard, summarizeToolParams, type CardStep, type CardProgressState } from "./card-render.js";
+import { sendCardMessage, editCardMessage, getCardProfile, httpStatusFromApiFetchError, type CardProfileManifest } from "./api-fetch.js";
+import { renderProgressCard, summarizeToolParams, type CardStep, type CardProgressState, type CardCaps } from "./card-render.js";
 
 /** dispatch 侧登记的发送上下文。 */
 export interface CardContext {
@@ -53,6 +53,22 @@ const cards = new Map<string, CardEntry>();
 
 /** D12 gate 结果缓存,key = apiUrl(同部署同结果),避免每 session 重复探测。 */
 const gateCache = new Map<string, boolean>();
+
+/**
+ * D12 能力(elements/limits 派生的渲染 caps)缓存,key = apiUrl(部署级,同 gate)。gateEnabled
+ * 探测 manifest 时一并填充;渲染时按此按元素/节点上限裁剪。旧部署无这些字段 → caps 为空 → 渲染
+ * 走保守默认(等同今天行为)。
+ */
+const capsCache = new Map<string, CardCaps>();
+
+/** manifest → 渲染 caps。只取当前渲染用得上的:元素白名单 + max_nodes(其余 limits 结构浅、天然满足)。 */
+function deriveCaps(m: CardProfileManifest): CardCaps {
+  const caps: CardCaps = {};
+  if (Array.isArray(m.elements) && m.elements.length > 0) caps.elements = new Set(m.elements);
+  const maxNodes = m.limits?.max_nodes;
+  if (typeof maxNodes === "number" && maxNodes > 0) caps.maxNodes = maxNodes;
+  return caps;
+}
 
 const FLUSH_DEBOUNCE_MS = 800;
 const EDIT_TIMEOUT_MS = 10_000;
@@ -118,6 +134,8 @@ async function gateEnabled(ctx: CardContext): Promise<boolean | null> {
   if (cached !== undefined) return cached;
   try {
     const m = await getCardProfile({ apiUrl: ctx.apiUrl, botToken: ctx.botToken });
+    // 能力清单是部署级事实(与 enabled 无关),探到就缓存供渲染裁剪。
+    capsCache.set(ctx.apiUrl, deriveCaps(m));
     let enabled = m.available ? m.enabled : process.env.OCTO_CARD_MESSAGE_ENABLED === "1";
     // 版本协商:manifest **明确 advertise** 了 profiles/card_version 却不含我们出站发送的
     // octo/v1 + 1.5 时,判定不兼容 → 关闭,避免协议演进后 send/edit 撞 400(字段缺省则不设限,
@@ -191,7 +209,7 @@ async function runFlush(sessionKey: string, entry: CardEntry): Promise<void> {
     }
 
     entry.dirty = false;
-    const { card, plain } = renderProgressCard({ phase: entry.phase, steps: entry.steps });
+    const { card, plain } = renderProgressCard({ phase: entry.phase, steps: entry.steps }, capsCache.get(entry.ctx.apiUrl));
     const signal = AbortSignal.timeout(EDIT_TIMEOUT_MS);
     if (!entry.messageId) {
       const res = await sendCardMessage({
@@ -274,7 +292,7 @@ export async function finalizeCard(
     ...(opts.errorText ? { errorText: opts.errorText } : {}),
   };
   try {
-    const { card, plain } = renderProgressCard(state);
+    const { card, plain } = renderProgressCard(state, capsCache.get(entry.ctx.apiUrl));
     await editCardMessage({
       apiUrl: entry.ctx.apiUrl,
       botToken: entry.ctx.botToken,
@@ -305,6 +323,7 @@ export function _resetCardProgressForTests(): void {
   for (const e of cards.values()) if (e.flushTimer) clearTimeout(e.flushTimer);
   cards.clear();
   gateCache.clear();
+  capsCache.clear();
 }
 
 /**

--- a/src/card-progress.ts
+++ b/src/card-progress.ts
@@ -68,10 +68,11 @@ const gateCache = new Map<string, boolean>();
  */
 const capsCache = new Map<string, CardCaps>();
 
-/** manifest → 渲染 caps。只取当前渲染用得上的:元素白名单 + max_nodes(其余 limits 结构浅、天然满足)。 */
+/** manifest → 渲染 caps。只取当前渲染用得上的:元素/动作白名单 + max_nodes。 */
 function deriveCaps(m: CardProfileManifest): CardCaps {
   const caps: CardCaps = {};
   if (Array.isArray(m.elements) && m.elements.length > 0) caps.elements = new Set(m.elements);
+  if (Array.isArray(m.actions) && m.actions.length > 0) caps.actions = new Set(m.actions);
   const maxNodes = m.limits?.max_nodes;
   if (typeof maxNodes === "number" && maxNodes > 0) caps.maxNodes = maxNodes;
   return caps;

--- a/src/card-progress.ts
+++ b/src/card-progress.ts
@@ -13,7 +13,7 @@
  * 状态(C2,答案走文本);OBO(persona-clone)场景跳过(服务端拒 type-17 OBO,Decision 2b)。
  */
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
-import { ChannelType } from "./types.js";
+import { ChannelType, CARD_PROFILE, CARD_VERSION } from "./types.js";
 import { sendCardMessage, editCardMessage, getCardProfile } from "./api-fetch.js";
 import { renderProgressCard, summarizeToolParams, type CardStep, type CardProgressState } from "./card-render.js";
 
@@ -29,6 +29,13 @@ export interface CardContext {
 
 interface CardEntry {
   ctx: CardContext;
+  /**
+   * 发送目标身份指纹 = `apiUrl\0channelId\0onBehalfOf`。hook ctx 只带 sessionKey、
+   * 不带 accountId,无法区分账号;仓库已文档化两个 bot 账号可能共享同一 sessionKey
+   * (见 inbound.ts 的 sessionAccountMap 复合键)。setCardContext 用它检测跨身份碰撞,
+   * 命中则 fail closed,避免把进度卡发到错误频道。
+   */
+  identity: string;
   messageId?: string;
   phase: CardProgressState["phase"];
   steps: CardStep[];
@@ -41,7 +48,7 @@ interface CardEntry {
   flushPromise?: Promise<void>;
 }
 
-/** key = sessionKey(H1 实证:全 hook 一致)。 */
+/** key = sessionKey(H1 实证:全 hook 一致)。跨账号碰撞由 entry.identity + fail-closed 兜底。 */
 const cards = new Map<string, CardEntry>();
 
 /** D12 gate 结果缓存,key = apiUrl(同部署同结果),避免每 session 重复探测。 */
@@ -58,19 +65,43 @@ const dbg: (msg: string) => void = process.env.OCTO_CARD_DEBUG
   ? (msg) => console.log(`[octo:card-progress] ${msg}`)
   : () => {};
 
-/** dispatch run 开始时登记发送上下文。onBehalfOf 存在 → 标记跳过。 */
+/** 发送目标身份指纹。两个不同账号(或不同频道)= 不同指纹 → 视为跨身份碰撞。 */
+function contextIdentity(ctx: CardContext): string {
+  return JSON.stringify([ctx.apiUrl, ctx.channelId, ctx.onBehalfOf ?? ""]);
+}
+
+/**
+ * dispatch run 开始时登记发送上下文。onBehalfOf 存在 → 标记跳过。
+ *
+ * 跨账号 fail-closed:若同 sessionKey 上已有**不同身份**的活跃 entry(两个 bot 账号
+ * 共享了 sessionKey),hook 侧无法凭 sessionKey 区分账号,两边都置 skip —— 宁可都不发,
+ * 也绝不把进度卡 send/edit 到错误频道。persona-clone/OBO 本就 skip,此处再兜住
+ * non-OBO 跨账号碰撞,以及「OBO 克隆覆盖冻结同 key 上普通 bot 卡」的情形。
+ */
 export function setCardContext(sessionKey: string, ctx: CardContext): void {
   if (!sessionKey) return;
+  const identity = contextIdentity(ctx);
+  const existing = cards.get(sessionKey);
+  const collision = !!existing && existing.identity !== identity;
+  if (collision) {
+    existing!.skip = true; // 冻结旧 run 的卡:后续 flush/finalize 不再发送
+    if (existing!.flushTimer) {
+      clearTimeout(existing!.flushTimer);
+      existing!.flushTimer = undefined;
+    }
+    warn(`sessionKey collision across identities; failing closed for session=${sessionKey}`);
+  }
   cards.set(sessionKey, {
     ctx,
+    identity,
     phase: "thinking",
     steps: [],
     startedAt: Date.now(),
     dirty: false,
     inFlight: false,
-    skip: !!ctx.onBehalfOf,
+    skip: collision || !!ctx.onBehalfOf,
   });
-  dbg(`context set session=${sessionKey} channel=${ctx.channelId} obo=${!!ctx.onBehalfOf}`);
+  dbg(`context set session=${sessionKey} channel=${ctx.channelId} obo=${!!ctx.onBehalfOf} collision=${collision}`);
 }
 
 /**
@@ -83,8 +114,20 @@ async function gateEnabled(ctx: CardContext): Promise<boolean | null> {
   if (cached !== undefined) return cached;
   try {
     const m = await getCardProfile({ apiUrl: ctx.apiUrl, botToken: ctx.botToken });
-    const enabled = m.available ? m.enabled : process.env.OCTO_CARD_MESSAGE_ENABLED === "1";
-    // 只缓存**确定结果**(manifest 明确 enabled/disabled,或 available:false 回退 env)。
+    let enabled = m.available ? m.enabled : process.env.OCTO_CARD_MESSAGE_ENABLED === "1";
+    // 版本协商:manifest **明确 advertise** 了 profiles/card_version 却不含我们出站发送的
+    // octo/v1 + 1.5 时,判定不兼容 → 关闭,避免协议演进后 send/edit 撞 400(字段缺省则不设限,
+    // 与当前 server 行为一致)。
+    if (enabled && m.available) {
+      if (Array.isArray(m.profiles) && m.profiles.length > 0 && !m.profiles.includes(CARD_PROFILE)) {
+        dbg(`gate: profile ${CARD_PROFILE} not advertised (${m.profiles.join(",")}) → disabled`);
+        enabled = false;
+      } else if (typeof m.card_version === "string" && m.card_version !== CARD_VERSION) {
+        dbg(`gate: card_version ${m.card_version} != ${CARD_VERSION} → disabled`);
+        enabled = false;
+      }
+    }
+    // 只缓存**确定结果**(manifest 明确 enabled/disabled/不兼容,或 available:false 回退 env)。
     gateCache.set(ctx.apiUrl, enabled);
     return enabled;
   } catch (err: unknown) {
@@ -201,7 +244,10 @@ export async function finalizeCard(
     try { await entry.flushPromise; } catch { /* flush 内部已告警 */ }
   }
   if (entry.flushTimer) clearTimeout(entry.flushTimer);
-  cards.delete(sessionKey);
+  // 只在 entry 仍是当前登记项时删除。finalize 是 fire-and-forget 且上面 await 了 in-flight
+  // flush;await 期间 per-group 队列可能推进,同 sessionKey 的下一 run setCardContext 已把
+  // Map 换成新 entry —— 那时删 key 会误删新 run 的状态,使其全程无卡。终态帧仍发本 run。
+  if (cards.get(sessionKey) === entry) cards.delete(sessionKey);
 
   // 从没发过卡(skip / 无工具调用)→ 无需收尾帧。
   if (entry.skip || !entry.messageId) return;

--- a/src/card-progress.ts
+++ b/src/card-progress.ts
@@ -65,9 +65,13 @@ const dbg: (msg: string) => void = process.env.OCTO_CARD_DEBUG
   ? (msg) => console.log(`[octo:card-progress] ${msg}`)
   : () => {};
 
-/** 发送目标身份指纹。两个不同账号(或不同频道)= 不同指纹 → 视为跨身份碰撞。 */
+/**
+ * 发送目标身份指纹。含 botToken —— 它才是账号的真正区分符:两个不同的非 OBO 账号即便
+ * 同 apiUrl+同 channelId(都在同一群回复)也应视为不同身份、触发 fail-closed。仅在内存里
+ * 做等值比较,不落日志。
+ */
 function contextIdentity(ctx: CardContext): string {
-  return JSON.stringify([ctx.apiUrl, ctx.channelId, ctx.onBehalfOf ?? ""]);
+  return JSON.stringify([ctx.apiUrl, ctx.channelId, ctx.onBehalfOf ?? "", ctx.botToken]);
 }
 
 /**

--- a/src/card-progress.ts
+++ b/src/card-progress.ts
@@ -1,0 +1,305 @@
+/**
+ * 波 B —— InteractiveCard(=17) 进度卡状态机 + hook 驱动 + 节流。
+ *
+ * 架构(见 .context 计划):
+ *   - dispatch(`inbound.ts`)在 run 开始 `setCardContext(sessionKey, ctx)` 存发送上下文
+ *     (apiUrl/botToken/channel/onBehalfOf),`finally` 里 `finalizeCard(sessionKey, success)`。
+ *   - 本模块订阅 hook(before/after_tool_call、model_call_started),用 `ctx.sessionKey`
+ *     查 Map:首个工具事件懒发占位卡 → 后续就地 `editCardMessage`,节流合帧。
+ *   - `sessionKey` 桥接 dispatch 与 hook(H1 实证一致)。Map 只含 octo dispatch 登记的
+ *     session → hook 查不到即 return,**天然过滤**非 octo run,无需 messageProvider 判断。
+ *
+ * 决策:关联键 sessionKey;单写者(dispatch per-group 串行)→ 不传 card_seq;卡仅进度/
+ * 状态(C2,答案走文本);OBO(persona-clone)场景跳过(服务端拒 type-17 OBO,Decision 2b)。
+ */
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import { ChannelType } from "./types.js";
+import { sendCardMessage, editCardMessage, getCardProfile } from "./api-fetch.js";
+import { renderProgressCard, summarizeToolParams, type CardStep, type CardProgressState } from "./card-render.js";
+
+/** dispatch 侧登记的发送上下文。 */
+export interface CardContext {
+  apiUrl: string;
+  botToken: string;
+  channelId: string;
+  channelType: ChannelType;
+  /** persona-clone 身份;存在则跳过卡片(服务端拒 type-17 OBO)。 */
+  onBehalfOf?: string;
+}
+
+interface CardEntry {
+  ctx: CardContext;
+  messageId?: string;
+  phase: CardProgressState["phase"];
+  steps: CardStep[];
+  startedAt: number;
+  dirty: boolean;
+  inFlight: boolean;
+  skip: boolean;
+  flushTimer?: ReturnType<typeof setTimeout>;
+  /** 当前 in-flight flush 的 promise;finalizeCard 据此等待首帧 send/中间帧 edit 落定。 */
+  flushPromise?: Promise<void>;
+}
+
+/** key = sessionKey(H1 实证:全 hook 一致)。 */
+const cards = new Map<string, CardEntry>();
+
+/** D12 gate 结果缓存,key = apiUrl(同部署同结果),避免每 session 重复探测。 */
+const gateCache = new Map<string, boolean>();
+
+const FLUSH_DEBOUNCE_MS = 800;
+const EDIT_TIMEOUT_MS = 10_000;
+
+// 进度卡失败不影响主回复流程 —— 仅告警,不抛。
+// eslint-disable-next-line no-console -- 波 B 进度卡诊断,失败降级不阻断主流程
+const warn = (msg: string): void => console.warn(`[octo:card-progress] ${msg}`);
+// eslint-disable-next-line no-console -- env-gated 端到端联调观测(OCTO_CARD_DEBUG),默认关
+const dbg: (msg: string) => void = process.env.OCTO_CARD_DEBUG
+  ? (msg) => console.log(`[octo:card-progress] ${msg}`)
+  : () => {};
+
+/** dispatch run 开始时登记发送上下文。onBehalfOf 存在 → 标记跳过。 */
+export function setCardContext(sessionKey: string, ctx: CardContext): void {
+  if (!sessionKey) return;
+  cards.set(sessionKey, {
+    ctx,
+    phase: "thinking",
+    steps: [],
+    startedAt: Date.now(),
+    dirty: false,
+    inFlight: false,
+    skip: !!ctx.onBehalfOf,
+  });
+  dbg(`context set session=${sessionKey} channel=${ctx.channelId} obo=${!!ctx.onBehalfOf}`);
+}
+
+/**
+ * 是否允许发卡:D12 manifest 优先,端点未部署(available:false)则回退 env 开关。
+ * 返回值三态:`true`=启用,`false`=**明确禁用**(可永久 skip 本 session),
+ * `null`=**瞬时探测失败**(5xx/网络,不缓存、不 skip,下次 flush 重探)。
+ */
+async function gateEnabled(ctx: CardContext): Promise<boolean | null> {
+  const cached = gateCache.get(ctx.apiUrl);
+  if (cached !== undefined) return cached;
+  try {
+    const m = await getCardProfile({ apiUrl: ctx.apiUrl, botToken: ctx.botToken });
+    const enabled = m.available ? m.enabled : process.env.OCTO_CARD_MESSAGE_ENABLED === "1";
+    // 只缓存**确定结果**(manifest 明确 enabled/disabled,或 available:false 回退 env)。
+    gateCache.set(ctx.apiUrl, enabled);
+    return enabled;
+  } catch (err: unknown) {
+    // 瞬时失败(5xx/网络抖动)不缓存、不 skip —— 否则一次抖动会让该 apiUrl(缓存)或
+    // 该 session(skip)的卡片进度永久关闭。返回 null,下次 flush(仍在 !messageId 期间)重探。
+    warn(`card gate probe failed (not caching): ${err instanceof Error ? err.message : String(err)}`);
+    return null;
+  }
+}
+
+function scheduleFlush(sessionKey: string, entry: CardEntry): void {
+  entry.dirty = true;
+  if (entry.flushTimer) return;
+  entry.flushTimer = setTimeout(() => {
+    entry.flushTimer = undefined;
+    void flush(sessionKey);
+  }, FLUSH_DEBOUNCE_MS);
+}
+
+async function flush(sessionKey: string): Promise<void> {
+  const entry = cards.get(sessionKey);
+  if (!entry || entry.skip) return;
+  // 已有 flush 在执行 → 直接返回。不在这里补排:执行中的那次会在 finally 里按 dirty 重排,
+  // 且**不**覆盖 entry.flushPromise(否则 finalizeCard await 到的会是这次空转、而非真实 send)。
+  if (entry.inFlight) return;
+  if (!entry.dirty) return;
+
+  // 置 inFlight 于任何 await **之前**:gate 探测/send 往返期间挡住并发 flush,否则首帧未落
+  // messageId 前的 gate await 窗口里,新定时器可穿过检查并发起第二次 send(重复发卡)。
+  entry.inFlight = true;
+  const work = runFlush(sessionKey, entry);
+  entry.flushPromise = work;
+  try {
+    await work;
+  } finally {
+    if (entry.flushPromise === work) entry.flushPromise = undefined;
+  }
+}
+
+/** 实际执行 gate + send/edit。调用方已置 inFlight=true 并接管 flushPromise。 */
+async function runFlush(sessionKey: string, entry: CardEntry): Promise<void> {
+  try {
+    // 首帧前做一次 D12 gate。明确禁用 → 永久跳过本 session;瞬时失败 → 本轮不发,
+    // 下次 flush(下个工具事件触发)重探,避免一次抖动永久关闭本 session。
+    if (!entry.messageId) {
+      const gate = await gateEnabled(entry.ctx);
+      if (gate === false) {
+        entry.skip = true;
+        return;
+      }
+      if (gate === null) return; // 瞬时探测失败,不 skip、不清 dirty,留待重探
+    }
+
+    entry.dirty = false;
+    const { card, plain } = renderProgressCard({ phase: entry.phase, steps: entry.steps });
+    const signal = AbortSignal.timeout(EDIT_TIMEOUT_MS);
+    if (!entry.messageId) {
+      const res = await sendCardMessage({
+        apiUrl: entry.ctx.apiUrl,
+        botToken: entry.ctx.botToken,
+        channelId: entry.ctx.channelId,
+        channelType: entry.ctx.channelType,
+        card,
+        plain,
+        ...(entry.ctx.onBehalfOf ? { onBehalfOf: entry.ctx.onBehalfOf } : {}),
+        signal,
+      });
+      entry.messageId = res?.message_id;
+      if (!entry.messageId) {
+        warn("placeholder card send returned no message_id; disabling for session");
+        entry.skip = true;
+        return;
+      }
+      dbg(`placeholder sent messageId=${entry.messageId} steps=${entry.steps.length}`);
+    } else {
+      await editCardMessage({
+        apiUrl: entry.ctx.apiUrl,
+        botToken: entry.ctx.botToken,
+        messageId: entry.messageId,
+        channelId: entry.ctx.channelId,
+        channelType: entry.ctx.channelType,
+        card,
+        plain,
+        transient: true, // 进度中间帧不进修订历史(D10);终态帧由 finalizeCard 不带 transient
+        ...(entry.ctx.onBehalfOf ? { onBehalfOf: entry.ctx.onBehalfOf } : {}),
+        signal,
+      });
+      dbg(`edited steps=${entry.steps.length} phase=${entry.phase}`);
+    }
+  } catch (err: unknown) {
+    warn(`flush failed: ${err instanceof Error ? err.message : String(err)}`);
+  } finally {
+    entry.inFlight = false;
+    // 期间有新帧 → 再刷。entry 已被 finalize/clear 删除时不再重排,避免悬挂定时器。
+    if (entry.dirty && !entry.skip && cards.get(sessionKey) === entry) scheduleFlush(sessionKey, entry);
+  }
+}
+
+/**
+ * dispatch `finally` 收尾:渲染终态帧(✅ 已完成 / ⚠️ 中断),清理 Map。
+ * 幂等:未登记或没发过占位卡则仅清理。
+ */
+export async function finalizeCard(
+  sessionKey: string,
+  opts: { success: boolean; errorText?: string } = { success: true },
+): Promise<void> {
+  const entry = cards.get(sessionKey);
+  if (!entry) return;
+  // 等待 in-flight flush 落定后再接管。否则:首帧 send 尚未 return 时 messageId 未就绪,
+  // 直接删 entry 会跳过终态帧,占位卡「正在处理…」永久冻结;若有 in-flight 中间帧
+  // (transient)edit,还可能后于终态帧落库、把「✅ 已完成」覆盖回「正在处理」。await 后
+  // messageId 必已就绪、edit 顺序也串好。flush 内部已 catch+告警,这里吞掉即可。
+  if (entry.flushPromise) {
+    try { await entry.flushPromise; } catch { /* flush 内部已告警 */ }
+  }
+  if (entry.flushTimer) clearTimeout(entry.flushTimer);
+  cards.delete(sessionKey);
+
+  // 从没发过卡(skip / 无工具调用)→ 无需收尾帧。
+  if (entry.skip || !entry.messageId) return;
+
+  const state: CardProgressState = {
+    phase: opts.success ? "done" : "error",
+    steps: entry.steps,
+    elapsedMs: Date.now() - entry.startedAt,
+    ...(opts.errorText ? { errorText: opts.errorText } : {}),
+  };
+  try {
+    const { card, plain } = renderProgressCard(state);
+    await editCardMessage({
+      apiUrl: entry.ctx.apiUrl,
+      botToken: entry.ctx.botToken,
+      messageId: entry.messageId,
+      channelId: entry.ctx.channelId,
+      channelType: entry.ctx.channelType,
+      card,
+      plain,
+      ...(entry.ctx.onBehalfOf ? { onBehalfOf: entry.ctx.onBehalfOf } : {}),
+      signal: AbortSignal.timeout(EDIT_TIMEOUT_MS),
+    });
+    dbg(`finalized session=${sessionKey} phase=${state.phase} steps=${entry.steps.length}`);
+  } catch (err: unknown) {
+    warn(`finalize failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
+/** 硬清理(不发收尾帧),用于异常兜底。 */
+export function clearCard(sessionKey: string): void {
+  const entry = cards.get(sessionKey);
+  if (!entry) return;
+  if (entry.flushTimer) clearTimeout(entry.flushTimer);
+  cards.delete(sessionKey);
+}
+
+/** 测试辅助:清空全部状态。 */
+export function _resetCardProgressForTests(): void {
+  for (const e of cards.values()) if (e.flushTimer) clearTimeout(e.flushTimer);
+  cards.clear();
+  gateCache.clear();
+}
+
+/**
+ * 注册 hook。经 `index.ts` registerFull 调用(仅 full mode)。
+ * hook 全局触发,但仅处理 Map 中已登记(octo dispatch)的 sessionKey。
+ */
+export function registerCardProgress(api: OpenClawPluginApi): void {
+  api.on("before_tool_call", (event: unknown, ctx: unknown) => {
+    const e = (event ?? {}) as { toolName?: string; params?: unknown; toolCallId?: string };
+    const sk = (ctx as { sessionKey?: string })?.sessionKey;
+    const entry = sk ? cards.get(sk) : undefined;
+    if (!entry || entry.skip || !e.toolName) return;
+    dbg(`before_tool_call tool=${e.toolName} session=${sk}`);
+    entry.phase = "tool";
+    entry.steps.push({
+      tool: e.toolName,
+      status: "running",
+      summary: summarizeToolParams(e.toolName, e.params),
+      ...(e.toolCallId ? { toolCallId: e.toolCallId } : {}),
+    });
+    scheduleFlush(sk!, entry);
+  });
+
+  api.on("after_tool_call", (event: unknown, ctx: unknown) => {
+    const e = (event ?? {}) as { toolName?: string; error?: string; durationMs?: number; toolCallId?: string };
+    const sk = (ctx as { sessionKey?: string })?.sessionKey;
+    const entry = sk ? cards.get(sk) : undefined;
+    if (!entry || entry.skip) return;
+    // 回填终态。优先按 toolCallId 精确匹配 running 步骤;若 toolCallId 存在但没命中
+    // running(过期/重复投递的 after 事件),直接丢弃,**不**回退按名匹配 —— 否则会把仍
+    // 在跑的并发同名步骤误标为终态。仅当 toolCallId 缺失(旧 host)才回退「最后一个同名 running」。
+    let target: CardStep | undefined;
+    if (e.toolCallId) {
+      target = entry.steps.find((s) => s.toolCallId === e.toolCallId && s.status === "running");
+    } else {
+      for (let i = entry.steps.length - 1; i >= 0; i--) {
+        const s = entry.steps[i];
+        if (s.tool === e.toolName && s.status === "running") { target = s; break; }
+      }
+    }
+    if (target) {
+      target.status = e.error ? "error" : "done";
+      if (typeof e.durationMs === "number") target.durationMs = e.durationMs;
+      if (e.error) target.error = e.error;
+    }
+    scheduleFlush(sk!, entry);
+  });
+
+  api.on("model_call_started", (_event: unknown, ctx: unknown) => {
+    const sk = (ctx as { sessionKey?: string })?.sessionKey;
+    const entry = sk ? cards.get(sk) : undefined;
+    if (!entry || entry.skip) return;
+    // 仅在还没有工具步骤时展示「思考中」,避免工具间的模型调用刷屏。
+    if (entry.steps.length === 0 && entry.phase !== "thinking") {
+      entry.phase = "thinking";
+      scheduleFlush(sk!, entry);
+    }
+  });
+}

--- a/src/card-progress.ts
+++ b/src/card-progress.ts
@@ -14,7 +14,7 @@
  */
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import { ChannelType, CARD_PROFILE, CARD_VERSION } from "./types.js";
-import { sendCardMessage, editCardMessage, getCardProfile } from "./api-fetch.js";
+import { sendCardMessage, editCardMessage, getCardProfile, httpStatusFromApiFetchError } from "./api-fetch.js";
 import { renderProgressCard, summarizeToolParams, type CardStep, type CardProgressState } from "./card-render.js";
 
 /** dispatch 侧登记的发送上下文。 */
@@ -223,6 +223,12 @@ async function runFlush(sessionKey: string, entry: CardEntry): Promise<void> {
     }
   } catch (err: unknown) {
     warn(`flush failed: ${err instanceof Error ? err.message : String(err)}`);
+    // 确定性拒绝(4xx,除可重试的 429)→ fail-closed,别对着必然失败的 server 逐事件重试。
+    // 5xx / 网络 / 429 保持可重试(与 gate 的瞬时失败处理一致)。
+    const status = httpStatusFromApiFetchError(err);
+    if (status !== undefined && status >= 400 && status < 500 && status !== 429) {
+      entry.skip = true;
+    }
   } finally {
     entry.inFlight = false;
     // 期间有新帧 → 再刷。entry 已被 finalize/clear 删除时不再重排,避免悬挂定时器。

--- a/src/card-progress.ts
+++ b/src/card-progress.ts
@@ -16,6 +16,7 @@ import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import { ChannelType, CARD_PROFILE, CARD_VERSION } from "./types.js";
 import { sendCardMessage, editCardMessage, getCardProfile, httpStatusFromApiFetchError, type CardProfileManifest } from "./api-fetch.js";
 import { renderProgressCard, summarizeToolParams, type CardStep, type CardProgressState, type CardCaps } from "./card-render.js";
+import { DISPLAY_CARD_TOOL_NAME } from "./constants.js";
 
 /** dispatch 侧登记的发送上下文。 */
 export interface CardContext {
@@ -36,6 +37,12 @@ interface CardEntry {
    * 命中则 fail closed,避免把进度卡发到错误频道。
    */
   identity: string;
+  /**
+   * 属主 run 的 SDK runId(hook ctx 权威提供)。首个带 runId 的 hook 认领本 entry;之后 runId
+   * 不符的迟到/外来 hook 一律丢弃 —— 闭合"同 sessionKey 上超时 run A 的迟到 hook 落到新 run B 的卡"
+   * 竞态(setCardContext 侧拿不到 runId,故由首个 hook 绑定)。
+   */
+  runId?: string;
   messageId?: string;
   phase: CardProgressState["phase"];
   steps: CardStep[];
@@ -87,7 +94,7 @@ const dbg: (msg: string) => void = process.env.OCTO_CARD_DEBUG
  * 做等值比较,不落日志。
  */
 function contextIdentity(ctx: CardContext): string {
-  return JSON.stringify([ctx.apiUrl, ctx.channelId, ctx.onBehalfOf ?? "", ctx.botToken]);
+  return JSON.stringify([ctx.apiUrl, ctx.channelId, ctx.channelType, ctx.onBehalfOf ?? "", ctx.botToken]);
 }
 
 /**
@@ -277,6 +284,9 @@ export async function finalizeCard(
     try { await entry.flushPromise; } catch { /* flush 内部已告警 */ }
   }
   if (entry.flushTimer) clearTimeout(entry.flushTimer);
+  // P1-g:若仍有 running thinking(agent 收尾时最后一次 model_call 之后未再调工具),
+  // 用当前时间把它标 done + 算 duration —— 终态帧不留 ⏳。
+  endRunningThinking(entry, Date.now());
   // 只在 entry 仍是当前登记项时删除。finalize 是 fire-and-forget 且上面 await 了 in-flight
   // flush;await 期间 per-group 队列可能推进,同 sessionKey 的下一 run setCardContext 已把
   // Map 换成新 entry —— 那时删 key 会误删新 run 的状态,使其全程无卡。终态帧仍发本 run。
@@ -330,13 +340,46 @@ export function _resetCardProgressForTests(): void {
  * 注册 hook。经 `index.ts` registerFull 调用(仅 full mode)。
  * hook 全局触发,但仅处理 Map 中已登记(octo dispatch)的 sessionKey。
  */
+/**
+ * 关闭最后一步 running 的 thinking(若存在),用 now 算 durationMs。P1-g:SDK 无
+ * model_call_ended,thinking 结束时机由外部信号(before_tool_call / finalize)驱动。
+ */
+function endRunningThinking(entry: CardEntry, now: number): void {
+  const last = entry.steps[entry.steps.length - 1];
+  if (!last || last.tool !== "__thinking__" || last.status !== "running") return;
+  last.status = "done";
+  if (typeof last.startedAt === "number") last.durationMs = Math.max(0, now - last.startedAt);
+}
+
+/**
+ * runId 归属守卫。首个带 runId 的 hook 认领本 entry;之后返回该 hook 是否属于同一 run:
+ *   - true → 属主 run(或旧 host 无 runId)→ 照常处理;
+ *   - false → runId 不符的迟到/外来 hook(超时 run A 的尾随事件落到新 run B 的 entry)→ 调用方丢弃。
+ * hook ctx 的 runId 由 SDK 权威提供(PluginHookToolContext / PluginHookAgentContext 均带)。
+ */
+function claimRun(entry: CardEntry, ctx: unknown): boolean {
+  const rid = (ctx as { runId?: string })?.runId;
+  if (!rid) return true; // 旧 host 不带 runId → 退回今天的 sessionKey-only 行为,不阻拦
+  if (entry.runId === undefined) { entry.runId = rid; return true; }
+  return entry.runId === rid;
+}
+
 export function registerCardProgress(api: OpenClawPluginApi): void {
   api.on("before_tool_call", (event: unknown, ctx: unknown) => {
     const e = (event ?? {}) as { toolName?: string; params?: unknown; toolCallId?: string };
     const sk = (ctx as { sessionKey?: string })?.sessionKey;
     const entry = sk ? cards.get(sk) : undefined;
     if (!entry || entry.skip || !e.toolName) return;
+    if (!claimRun(entry, ctx)) return; // 超时 run 的迟到 hook 落到新 run 的卡 → 丢弃
+    // P1-h:agent 展示卡工具的产出**就是那张卡本身**,不该再有旁边的"正在处理/已中断"进度卡噪音。
+    // 该工具不计入进度、不触发发卡。混合 turn 里其它真实工具照常显示,仅不含这步。
+    if (e.toolName === DISPLAY_CARD_TOOL_NAME) {
+      // 仍要收尾上一轮 running thinking —— 否则思考步 duration 会把 display-card 的执行时长吞进去。
+      endRunningThinking(entry, Date.now());
+      return;
+    }
     dbg(`before_tool_call tool=${e.toolName} session=${sk}`);
+    endRunningThinking(entry, Date.now()); // P1-g:上一轮 thinking 收尾
     entry.phase = "tool";
     entry.steps.push({
       tool: e.toolName,
@@ -352,6 +395,9 @@ export function registerCardProgress(api: OpenClawPluginApi): void {
     const sk = (ctx as { sessionKey?: string })?.sessionKey;
     const entry = sk ? cards.get(sk) : undefined;
     if (!entry || entry.skip) return;
+    if (!claimRun(entry, ctx)) return; // 同 §before_tool_call:外来 run 的迟到 after 事件 → 丢弃
+    // P1-h:与 before_tool_call 对称,避免 display-card 触发 scheduleFlush 而误发进度卡。
+    if (e.toolName === DISPLAY_CARD_TOOL_NAME) return;
     // 回填终态。优先按 toolCallId 精确匹配 running 步骤;若 toolCallId 存在但没命中
     // running(过期/重复投递的 after 事件),直接丢弃,**不**回退按名匹配 —— 否则会把仍
     // 在跑的并发同名步骤误标为终态。仅当 toolCallId 缺失(旧 host)才回退「最后一个同名 running」。
@@ -376,10 +422,18 @@ export function registerCardProgress(api: OpenClawPluginApi): void {
     const sk = (ctx as { sessionKey?: string })?.sessionKey;
     const entry = sk ? cards.get(sk) : undefined;
     if (!entry || entry.skip) return;
-    // 仅在还没有工具步骤时展示「思考中」,避免工具间的模型调用刷屏。
-    if (entry.steps.length === 0 && entry.phase !== "thinking") {
-      entry.phase = "thinking";
-      scheduleFlush(sk!, entry);
-    }
+    if (!claimRun(entry, ctx)) return; // 外来 run 的迟到 model_call → 丢弃
+    // P1-g:每次 model_call 产一步"思考"。若上一步就是 running thinking(model_call_started
+    // 被连续投递),忽略(去重)。
+    const last = entry.steps[entry.steps.length - 1];
+    if (last && last.tool === "__thinking__" && last.status === "running") return;
+    // 首段思考(尚无真实工具步)→ header 显示"🤖 思考中…";真实工具跑过后保持"正在处理…"。
+    const hadRealStep = entry.steps.some((s) => s.tool !== "__thinking__");
+    if (!hadRealStep) entry.phase = "thinking";
+    entry.steps.push({ tool: "__thinking__", status: "running", startedAt: Date.now() });
+    // 懒发契约(模块头:"首个工具事件懒发占位卡"):**纯思考不发首帧卡**。仅当卡已存在(messageId)
+    // 或已有真实工具步时才刷新 —— 否则纯文本 / 纯 display-card turn 的思考步会误发一张占位卡,
+    // 并在收尾时 finalize 成误导性的"⚠️ 已中断",正是 P1-h 想消除的噪音。
+    if (entry.messageId || hadRealStep) scheduleFlush(sk!, entry);
   });
 }

--- a/src/card-render.test.ts
+++ b/src/card-render.test.ts
@@ -43,6 +43,19 @@ describe("summarizeToolParams", () => {
     // 合法程序名/路径不受影响。
     expect(summarizeToolParams("exec", { command: "/usr/bin/python3 x.py" })).toBe("/usr/bin/python3");
   });
+  it("query/shell 策略也降级内嵌 URL(与 url/error 路径对称,单一 choke point)", () => {
+    // query 里的 webhook URL:路径段短、无关键词 → isSensitive 抓不到,靠 URL 降级。
+    expect(summarizeToolParams("web_search", { query: "https://hooks.slack.com/services/T00/B00/abcdEFGH1234abcdEFGH1234" })).toBe(
+      "https://slack.com",
+    );
+    // query 里的 userinfo / PII query / 内网主机 —— 非密钥形状,但仍不该原样泄露。
+    expect(summarizeToolParams("grep", { pattern: "https://user:pw@example.com/x" })).toBe("https://example.com");
+    expect(summarizeToolParams("grep", { pattern: "https://example.com/reset?email=ceo@corp.com" })).toBe("https://example.com");
+    // shell:URL 作为程序名(argv[0])→ 降级为注册域,不原样渲染。
+    expect(summarizeToolParams("exec", { command: "https://hooks.slack.com/services/T1/B2/tok arg" })).toBe("https://slack.com");
+    // 常规 query 不受影响。
+    expect(summarizeToolParams("grep", { pattern: "TODO fix later" })).toBe("TODO fix later");
+  });
   it("url 类只保留 scheme://注册域,丢弃 path/query/userinfo 与所有子域", () => {
     expect(summarizeToolParams("fetch", { url: "https://u:p@host.com/a/b?token=sk-secret&x=1" })).toBe(
       "https://host.com",
@@ -139,6 +152,14 @@ describe("stepLine", () => {
     expect(out.startsWith("❌ 读取文件 — line1 ")).toBe(true);
     expect(out.endsWith("…")).toBe(true);
     expect(out.length).toBeLessThan(140); // 图标+标签 + 120 上限 + 省略号
+  });
+  it("error 含 git SHA / digest / UUID 不被整段吞掉(不套用长 hex/高熵)", () => {
+    // webhook 由 URL 降级兜住,故错误文本不套用长 hex/高熵形状 → 普通运维错误不被 blank。
+    expect(stepLine({ tool: "read", status: "error", error: "build failed at commit 5f2a1c9d8e7b6a5f4c3d2e1f0a9b8c7d6e5f4a3b" })).toBe(
+      "❌ 读取文件 — build failed at commit 5f2a1c9d8e7b6a5f4c3d2e1f0a9b8c7d6e5f4a3b",
+    );
+    // 但明确关键词/前缀仍拦。
+    expect(stepLine({ tool: "read", status: "error", error: "AKIAIOSFODNN7EXAMPLE rejected" })).toBe("❌ 读取文件");
   });
   it("error 内嵌 URL 降级为注册域(对称参数路径),webhook 路径/隧道主机不泄露", () => {
     // 短、无关键词的 webhook 路径段:isSensitive 抓不到,靠 URL 降级丢掉。

--- a/src/card-render.test.ts
+++ b/src/card-render.test.ts
@@ -73,6 +73,17 @@ describe("summarizeToolParams", () => {
     // 正常长英文 / 纯字母长串不误伤。
     expect(summarizeToolParams("web_search", { query: "how to configure oauth flow correctly" })).toBe("how to configure oauth flow correctly");
   });
+  it("path 只走关键词+明确前缀:常见 git/docker/缓存哈希路径不被误伤成空", () => {
+    // 通用高熵/长 hex 检测**不**套用到 path —— 否则日常路径会频繁 blank。
+    expect(summarizeToolParams("read", { path: "/repo/.git/objects/1a/2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c" })).toBe(
+      "/repo/.git/objects/1a/2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c",
+    );
+    expect(summarizeToolParams("edit", { file_path: ".cache/webpack/a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6" })).toBe(
+      ".cache/webpack/a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6",
+    );
+    // 但明确前缀式密钥(AKIA/sk-/gh_)即使出现在路径里仍隐藏。
+    expect(summarizeToolParams("read", { path: "/tmp/AKIAIOSFODNN7EXAMPLE.pem" })).toBe("");
+  });
   it("MCP / 未知工具 → 不显示摘要(不渲染任意参数)", () => {
     expect(summarizeToolParams("mcp__github__create_issue", { title: "leak", body: "secret" })).toBe("");
     expect(summarizeToolParams("weirdtool", { foo: "bar" })).toBe("");

--- a/src/card-render.test.ts
+++ b/src/card-render.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
+  OCTO_CARD_LAYOUTS,
+  detectOctoCardLayout,
   renderProgressCard,
   resolveToolMeta,
   summarizeToolParams,
@@ -7,6 +9,33 @@ import {
   stepLine,
   cardSupports,
 } from "./card-render.js";
+
+function elementText(e: Record<string, unknown>): string {
+  if (typeof e.text === "string") return e.text;
+  if (Array.isArray(e.inlines)) return e.inlines.map((i) => (i as { text?: string }).text ?? "").join("");
+  if (Array.isArray(e.items)) return e.items.map((item) => elementText(item as Record<string, unknown>)).join("\n");
+  if (Array.isArray(e.columns)) {
+    return e.columns
+      .flatMap((c) => ((c as { items?: unknown[] }).items ?? []) as Record<string, unknown>[])
+      .map(elementText)
+      .join("\n");
+  }
+  return "";
+}
+
+function progressHeaderText(card: Record<string, unknown>): string {
+  const body = card.body as Array<Record<string, unknown>>;
+  return elementText(body[0]);
+}
+
+function progressDetailItems(card: Record<string, unknown>): Array<Record<string, unknown>> {
+  const body = card.body as Array<Record<string, unknown>>;
+  return ((body[1] as { items?: Array<Record<string, unknown>> })?.items ?? []);
+}
+
+function progressDetailText(card: Record<string, unknown>): string {
+  return progressDetailItems(card).map(elementText).join("\n");
+}
 
 describe("resolveToolMeta", () => {
   it("已知工具 → 图标 + 中文标签", () => {
@@ -251,11 +280,50 @@ describe("stepLine", () => {
 });
 
 describe("renderProgressCard", () => {
+  it("marks agent progress cards with root metadata layout", () => {
+    const { card } = renderProgressCard({ phase: "thinking", steps: [] });
+    expect(card.metadata).toEqual({ octo_layout: OCTO_CARD_LAYOUTS.agentProgressV1 });
+    expect(detectOctoCardLayout(card)).toBe(OCTO_CARD_LAYOUTS.agentProgressV1);
+    expect(detectOctoCardLayout({ ...card, metadata: { octo_layout: "agent_progress_v2" } })).toBeUndefined();
+  });
+
+  it("agent_progress_v1 uses root ColumnSet + timeline_detail structure and keeps status style inside steps", () => {
+    const caps = {
+      elements: new Set(["TextBlock", "RichTextBlock", "Container", "ColumnSet", "ActionSet"]),
+      actions: new Set(["Action.ToggleVisibility"]),
+    };
+    const { card } = renderProgressCard(
+      {
+        phase: "error",
+        elapsedMs: 3200,
+        errorText: "命令失败",
+        steps: [
+          { tool: "__thinking__", status: "done", durationMs: 3000 },
+          { tool: "exec", status: "error", summary: "npm test", error: "exit 1" },
+        ],
+      },
+      caps,
+    );
+
+    const body = card.body as Array<Record<string, unknown>>;
+    expect(body).toHaveLength(2);
+    expect(body[0].type).toBe("ColumnSet");
+    expect(body[1]).toMatchObject({
+      type: "Container",
+      id: "timeline_detail",
+      isVisible: false,
+    });
+    expect(body[1]).not.toHaveProperty("style");
+    const detail = body[1] as { items: Array<Record<string, unknown>> };
+    expect(detail.items.some((item) => item.type === "Container" && item.style === "attention")).toBe(true);
+  });
+
   it("thinking 骨架", () => {
     const { card, plain } = renderProgressCard({ phase: "thinking", steps: [] });
     expect(card.type).toBe("AdaptiveCard");
     expect(card.version).toBe("1.5");
-    expect((card.body as Array<{ text: string }>)[0].text).toBe("🤖 思考中…");
+    expect(progressHeaderText(card)).toBe("🤖 思考中…");
+    expect(progressDetailItems(card)).toHaveLength(0);
     expect(plain).toBe("🤖 思考中…");
   });
 
@@ -264,9 +332,8 @@ describe("renderProgressCard", () => {
       phase: "tool",
       steps: [{ tool: "read", status: "done", summary: "/work/README.md", durationMs: 200 }],
     });
-    const body = card.body as Array<{ text: string }>;
-    expect(body[0].text).toBe("🤖 正在处理…");
-    expect(body[1].text).toBe("📖 读取文件：/work/README.md · 200ms");
+    expect(progressHeaderText(card)).toContain("🤖 正在处理…");
+    expect(progressDetailText(card)).toBe("📖 读取文件：/work/README.md · 200ms");
   });
 
   it("同类合并:连续 3 个 read done → 1 行 「读取文件 × 3」,含总耗时和最近文件名", () => {
@@ -278,11 +345,11 @@ describe("renderProgressCard", () => {
         { tool: "read", status: "done", summary: "/e/f.md", durationMs: 200 },
       ],
     });
-    const body = card.body as Array<{ text: string }>;
-    expect(body.length).toBe(2); // header + 1 合并行
-    expect(body[1].text).toContain("读取文件 × 3");
-    expect(body[1].text).toContain("450ms"); // 累加耗时
-    expect(body[1].text).toContain("/e/f.md"); // 最近 = 最后一个
+    const detail = progressDetailItems(card);
+    expect(detail.length).toBe(1);
+    expect(elementText(detail[0])).toContain("读取文件 × 3");
+    expect(elementText(detail[0])).toContain("450ms"); // 累加耗时
+    expect(elementText(detail[0])).toContain("/e/f.md"); // 最近 = 最后一个
     expect(plain).toContain("读取文件 × 3");
   });
 
@@ -297,13 +364,13 @@ describe("renderProgressCard", () => {
         { tool: "read", status: "running", summary: "/e.md" }, // 末尾 running
       ],
     });
-    const body = card.body as Array<{ text: string }>;
-    // 期望:合并组[a,b done] + error 单独 + done 单独 + running 单独 = 4 行 + header
-    expect(body.length).toBe(5);
-    expect(body[1].text).toContain("读取文件 × 2"); // 前两个合并
-    expect(body[2].text).toContain("❌"); // error 保留
-    expect(body[3].text).toContain("/d.md"); // 单个 done 不合并
-    expect(body[4].text).toContain("⏳"); // running 保留
+    const detail = progressDetailItems(card);
+    // 期望:合并组[a,b done] + error 单独 + done 单独 + running 单独 = 4 行
+    expect(detail.length).toBe(4);
+    expect(elementText(detail[0])).toContain("读取文件 × 2"); // 前两个合并
+    expect(elementText(detail[1])).toContain("❌"); // error 保留
+    expect(elementText(detail[2])).toContain("/d.md"); // 单个 done 不合并
+    expect(elementText(detail[3])).toContain("⏳"); // running 保留
   });
 
   it("同类合并:跨 tool 边界不合并(read+exec+read 不能合成一组)", () => {
@@ -317,12 +384,12 @@ describe("renderProgressCard", () => {
         { tool: "read", status: "done", summary: "/d", durationMs: 30 },
       ],
     });
-    const body = card.body as Array<{ text: string }>;
-    // header + [read×2] + [exec 单个] + [read×2] = 4 行
-    expect(body.length).toBe(4);
-    expect(body[1].text).toContain("读取文件 × 2");
-    expect(body[2].text).toContain("执行命令");
-    expect(body[3].text).toContain("读取文件 × 2");
+    const detail = progressDetailItems(card);
+    // [read×2] + [exec 单个] + [read×2] = 3 行
+    expect(detail.length).toBe(3);
+    expect(elementText(detail[0])).toContain("读取文件 × 2");
+    expect(elementText(detail[1])).toContain("执行命令");
+    expect(elementText(detail[2])).toContain("读取文件 × 2");
   });
 
   it("同类合并:done 收尾 header 计数仍用原始步数(合并不影响 N 步展示)", () => {
@@ -332,8 +399,7 @@ describe("renderProgressCard", () => {
       { tool: "read" as const, status: "done" as const, durationMs: 30 },
     ];
     const { card } = renderProgressCard({ phase: "done", steps, elapsedMs: 100 });
-    const body = card.body as Array<{ text: string }>;
-    expect(body[0].text).toBe("✅ 已完成 · 3 步 · 100ms"); // 用户看到"3 步",不是"1 组"
+    expect(progressHeaderText(card)).toContain("✅ 已完成 · 3 步 · 100ms"); // 用户看到"3 步",不是"1 组"
   });
 
   it("done 收尾:步数 + 耗时", () => {
@@ -342,12 +408,12 @@ describe("renderProgressCard", () => {
       steps: [{ tool: "read", status: "done" }],
       elapsedMs: 2500,
     });
-    expect((card.body as Array<{ text: string }>)[0].text).toBe("✅ 已完成 · 1 步 · 2.5s");
+    expect(progressHeaderText(card)).toContain("✅ 已完成 · 1 步 · 2.5s");
   });
 
   it("error 收尾", () => {
     const { card } = renderProgressCard({ phase: "error", steps: [], errorText: "超时" });
-    expect((card.body as Array<{ text: string }>)[0].text).toContain("⚠️ 已中断");
+    expect(progressHeaderText(card)).toContain("⚠️ 已中断");
   });
 
   it("R2: 含 git SHA 的步骤行不被 buildDisplayCard 二次误删(进度卡内容视为可信)", () => {
@@ -355,9 +421,8 @@ describe("renderProgressCard", () => {
       phase: "tool",
       steps: [{ tool: "read", status: "done", durationMs: 30, summary: "…/1a/2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e" }],
     });
-    const b = card.body as Array<{ text?: string; inlines?: Array<{ text: string }> }>;
-    // header + 步骤行 = 2(步骤行没有因 40-hex 高熵检测被删)
-    expect(b.length).toBe(2);
+    // 步骤行没有因 40-hex 高熵检测被删
+    expect(progressDetailItems(card)).toHaveLength(1);
     expect(plain).toContain("2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e");
   });
 
@@ -367,9 +432,7 @@ describe("renderProgressCard", () => {
       steps: [],
       errorText: "build failed at commit 5f2a1c9d8e7b6a5f4c3d2e1f0a9b8c7d6e5f4a3b",
     });
-    const b = card.body as Array<{ text?: string }>;
-    expect(b.length).toBeGreaterThan(0);
-    expect(b[0].text).toContain("⚠️ 已中断");
+    expect(progressHeaderText(card)).toContain("⚠️ 已中断");
     expect(plain).not.toBe("[卡片]");
     expect(plain).toContain("5f2a1c9d");
   });
@@ -387,20 +450,20 @@ describe("renderProgressCard", () => {
       durationMs: 10,
     }));
     const { card } = renderProgressCard({ phase: "tool", steps });
-    const body = card.body as Array<{ text: string }>;
-    // 20 个 read/exec 交替 → 无合并;header(1) + 折叠行(1) + 最近 12 步 = 14 个 block
-    expect(body.length).toBe(14);
-    expect(body[1].text).toBe("… 省略前 8 步");
+    const detail = progressDetailItems(card);
+    // 20 个 read/exec 交替 → 无合并;折叠行(1) + 最近 12 步 = 13 个 detail block
+    expect(detail.length).toBe(13);
+    expect(elementText(detail[0])).toBe("… 省略前 8 步");
     // 最后一步是最新的 /f19
-    expect(body[body.length - 1].text).toContain("/f19");
+    expect(elementText(detail[detail.length - 1])).toContain("/f19");
     // 已折叠掉最早的 /f0
-    expect(body.every((b) => !b.text.includes("/f0："))).toBe(true);
+    expect(detail.every((b) => !elementText(b).includes("/f0："))).toBe(true);
   });
 
   it("done 收尾 header 计数用全量步数(不受裁剪影响)", () => {
     const steps = Array.from({ length: 20 }, () => ({ tool: "read", status: "done" as const }));
     const { card } = renderProgressCard({ phase: "done", steps, elapsedMs: 1000 });
-    expect((card.body as Array<{ text: string }>)[0].text).toBe("✅ 已完成 · 20 步 · 1.0s");
+    expect(progressHeaderText(card)).toContain("✅ 已完成 · 20 步 · 1.0s");
   });
 });
 
@@ -412,12 +475,14 @@ describe("cardSupports / CardCaps 渲染协商(波 C)", () => {
     expect(cardSupports(undefined, "Input.Text")).toBe(false); // 基线不含输入
   });
 
-  it("无 caps → 默认 TextBlock 平铺(零回归)", () => {
+  it("无 caps → 根结构固定,步骤在 timeline_detail 内按 TextBlock 降级", () => {
     const { card } = renderProgressCard({
       phase: "tool",
       steps: [{ tool: "read", status: "done", summary: "/a", durationMs: 200 }],
     });
-    expect((card.body as Array<{ type: string }>)[1].type).toBe("TextBlock");
+    const body = card.body as Array<Record<string, unknown>>;
+    expect(body.map((b) => b.type)).toEqual(["ColumnSet", "Container"]);
+    expect(progressDetailItems(card)[0].type).toBe("TextBlock");
   });
 
   it("advertise RichTextBlock → 步骤渲成 RichTextBlock(一行内多样式;label bold、状态/耗时着色),plain 一行完整不分行", () => {
@@ -429,7 +494,7 @@ describe("cardSupports / CardCaps 渲染协商(波 C)", () => {
       { phase: "tool", steps: [{ tool: "exec", status: "done", summary: "ls", durationMs: 200 }] },
       caps,
     );
-    const row = (card.body as Array<Record<string, unknown>>)[1];
+    const row = progressDetailItems(card)[0];
     expect(row.type).toBe("RichTextBlock");
     const inlines = row.inlines as Array<Record<string, unknown>>;
     // 至少有:图标段、label(bold)段、summary/duration 段
@@ -454,8 +519,8 @@ describe("cardSupports / CardCaps 渲染协商(波 C)", () => {
       caps,
     );
     const body = card.body as Array<Record<string, unknown>>;
-    expect(body[0].type).toBe("TextBlock");
-    const containers = body.slice(1) as Array<{ type: string; style?: string; items?: Array<Record<string, unknown>> }>;
+    expect(body[0].type).toBe("ColumnSet");
+    const containers = progressDetailItems(card) as Array<{ type: string; style?: string; items?: Array<Record<string, unknown>> }>;
     expect(containers).toHaveLength(2);
     expect(containers[0].type).toBe("Container");
     expect(containers[0].items?.map((e) => e.type)).toEqual(["RichTextBlock", "RichTextBlock"]);
@@ -465,9 +530,9 @@ describe("cardSupports / CardCaps 渲染协商(波 C)", () => {
     expect(plain).toContain("⌨️ 执行命令：find · 100ms");
   });
 
-  it("终态 advertise ToggleVisibility → thinking/tool 明细折叠进隐藏 Container", () => {
+  it("advertise ToggleVisibility → terminal card defaults collapsed and buttons target timeline_detail", () => {
     const caps = {
-      elements: new Set(["TextBlock", "RichTextBlock", "Container", "ActionSet"]),
+      elements: new Set(["TextBlock", "RichTextBlock", "Container", "ColumnSet", "ActionSet"]),
       actions: new Set(["Action.ToggleVisibility"]),
     };
     const { card, plain } = renderProgressCard(
@@ -483,36 +548,73 @@ describe("cardSupports / CardCaps 渲染协商(波 C)", () => {
     );
 
     const body = card.body as Array<Record<string, unknown>>;
-    expect(body[0].type).toBe("RichTextBlock");
-    const headerInlines = body[0].inlines as Array<Record<string, unknown>>;
-    expect(headerInlines).toMatchObject([
+    expect(body[0].type).toBe("ColumnSet");
+    const summaryHeader = body[0] as { columns: Array<{ width: string; items: Array<Record<string, unknown>> }> };
+    expect(summaryHeader.columns[0].width).toBe("stretch");
+    expect(summaryHeader.columns[1].width).toBe("auto");
+    const headerBlock = summaryHeader.columns[0].items[0] as { type: string; inlines: Array<Record<string, unknown>> };
+    expect(headerBlock.type).toBe("RichTextBlock");
+    expect(headerBlock.inlines).toMatchObject([
       { text: "✅ 已完成", weight: "Bolder" },
       { text: " · 2 步 · 3.2s", isSubtle: true },
     ]);
-    expect(body[1].type).toBe("RichTextBlock");
-    const summaryInlines = body[1].inlines as Array<Record<string, unknown>>;
-    expect(summaryInlines).toMatchObject([
+    const summaryBlock = summaryHeader.columns[0].items[1] as { type: string; inlines: Array<Record<string, unknown>> };
+    expect(summaryBlock.inlines).toMatchObject([
       { text: "推理与工具调用", weight: "Bolder" },
       { text: " · 思考 1 · 工具 1 · 2 步", isSubtle: true },
     ]);
 
-    const actionSet = body[2] as { type: string; actions: Array<Record<string, unknown>> };
-    expect(actionSet.type).toBe("ActionSet");
-    expect(actionSet.actions[0]).toMatchObject({ type: "Action.ToggleVisibility", title: "展开/收起" });
-    expect(actionSet.actions[0].title).not.toBe("推理与工具调用 · 思考 1 · 工具 1 · 2 步");
+    const collapseBtn = summaryHeader.columns[1].items[0] as { id: string; isVisible: boolean; actions: Array<Record<string, unknown>> };
+    const expandBtn = summaryHeader.columns[1].items[1] as { id: string; isVisible: boolean; actions: Array<Record<string, unknown>> };
+    expect(collapseBtn.isVisible).toBe(false);
+    expect(expandBtn.isVisible).toBe(true);
+    expect(collapseBtn.actions[0]).toMatchObject({ type: "Action.ToggleVisibility", title: "收起推理" });
+    expect(expandBtn.actions[0]).toMatchObject({ type: "Action.ToggleVisibility", title: "展开推理" });
 
-    const hidden = body[3] as { type: string; id: string; isVisible: boolean; items: Array<Record<string, unknown>> };
-    expect(hidden.type).toBe("Container");
-    expect(hidden.isVisible).toBe(false);
-    expect(actionSet.actions[0].targetElements).toEqual([hidden.id]);
-    expect(hidden.items[0].type).toBe("Container");
-    expect(JSON.stringify(hidden.items)).toContain("💭");
-    expect(JSON.stringify(hidden.items)).toContain("执行命令");
+    const detail = body[1] as { type: string; id: string; isVisible: boolean; items: Array<Record<string, unknown>> };
+    expect(detail.type).toBe("Container");
+    expect(detail.id).toBe("timeline_detail");
+    expect(expandBtn.actions[0].targetElements).toEqual([
+      { elementId: detail.id, isVisible: true },
+      { elementId: collapseBtn.id, isVisible: true },
+      { elementId: expandBtn.id, isVisible: false },
+    ]);
+    expect(detail.isVisible).toBe(false);
+    expect(collapseBtn.actions[0].targetElements).toEqual([
+      { elementId: detail.id, isVisible: false },
+      { elementId: collapseBtn.id, isVisible: false },
+      { elementId: expandBtn.id, isVisible: true },
+    ]);
+    expect(detail.items[0].type).toBe("Container");
+    expect(JSON.stringify(detail.items)).toContain("💭");
+    expect(JSON.stringify(detail.items)).toContain("执行命令");
     expect(plain).toContain("推理与工具调用 · 思考 1 · 工具 1 · 2 步");
     expect(plain).toContain("⌨️ 执行命令：find · 100ms");
   });
 
-  it("终态未 advertise ToggleVisibility → 保持旧展开结构,不额外插入 summary", () => {
+  it("advertise ToggleVisibility → running card keeps timeline_detail visible", () => {
+    const caps = {
+      elements: new Set(["TextBlock", "RichTextBlock", "Container", "ColumnSet", "ActionSet"]),
+      actions: new Set(["Action.ToggleVisibility"]),
+    };
+    const { card } = renderProgressCard(
+      {
+        phase: "tool",
+        steps: [{ tool: "exec", status: "running", summary: "npm test" }],
+      },
+      caps,
+    );
+    const body = card.body as Array<Record<string, unknown>>;
+    const summaryHeader = body[0] as { columns: Array<{ items: Array<Record<string, unknown>> }> };
+    const collapseBtn = summaryHeader.columns[1].items[0] as { isVisible: boolean };
+    const expandBtn = summaryHeader.columns[1].items[1] as { isVisible: boolean };
+    expect((body[1] as { id: string; isVisible: boolean }).id).toBe("timeline_detail");
+    expect((body[1] as { isVisible: boolean }).isVisible).toBe(true);
+    expect(collapseBtn.isVisible).toBe(true);
+    expect(expandBtn.isVisible).toBe(false);
+  });
+
+  it("未 advertise ToggleVisibility → 保持 agent_progress_v1 根结构但不插入按钮列", () => {
     const caps = { elements: new Set(["TextBlock", "RichTextBlock", "Container", "ActionSet"]) };
     const { card } = renderProgressCard(
       {
@@ -526,14 +628,15 @@ describe("cardSupports / CardCaps 渲染协商(波 C)", () => {
     );
     const body = card.body as Array<Record<string, unknown>>;
     expect(body.some((b) => b.type === "ActionSet")).toBe(false);
-    expect(body.some((b) => (b as { text?: string }).text?.startsWith("推理与工具调用"))).toBe(false);
-    expect(body.slice(1).every((b) => b.type === "Container")).toBe(true);
+    const header = body[0] as { columns: Array<{ items: unknown[] }> };
+    expect(header.columns).toHaveLength(1);
+    expect(body[1]).toMatchObject({ type: "Container", id: "timeline_detail", isVisible: true });
   });
 
-  it("advertise 了 elements 但既无 RichTextBlock 也无 ColumnSet → TextBlock 平铺(降级)", () => {
+  it("advertise 了 elements 但既无 RichTextBlock 也无 ColumnSet → detail TextBlock 降级", () => {
     const caps = { elements: new Set(["TextBlock", "FactSet"]) };
     const { card } = renderProgressCard({ phase: "tool", steps: [{ tool: "read", status: "done" }] }, caps);
-    expect((card.body as Array<{ type: string }>)[1].type).toBe("TextBlock");
+    expect(progressDetailItems(card)[0].type).toBe("TextBlock");
   });
 
   it("caps.maxNodes 权威收紧可见步数(比本地上限更严)", () => {
@@ -543,7 +646,7 @@ describe("cardSupports / CardCaps 渲染协商(波 C)", () => {
       status: "done" as const,
     }));
     const { card } = renderProgressCard({ phase: "tool", steps }, { maxNodes: 6 }); // reserve=2 → 4 步
-    expect((card.body as unknown[]).length).toBe(6); // header + 折叠 + 4 步
+    expect(progressDetailItems(card)).toHaveLength(5); // 折叠 + 4 步
   });
 
   it("P1-g: __thinking__ 特殊 tool 名 → icon 💭, label '思考'(done 时用 icon, running 时仍用 ⏳)", () => {
@@ -552,17 +655,14 @@ describe("cardSupports / CardCaps 渲染协商(波 C)", () => {
       phase: "tool",
       steps: [{ tool: "__thinking__", status: "done", durationMs: 200 }],
     });
-    const body = done.card.body as Array<Record<string, unknown>>;
-    const asText = (e: Record<string, unknown>) =>
-      (e.text as string) ?? ((e.inlines as Array<{ text: string }>) ?? []).map((i) => i.text).join("");
-    expect(asText(body[1])).toContain("💭 思考");
-    expect(asText(body[1])).toContain("200ms");
+    expect(progressDetailText(done.card)).toContain("💭 思考");
+    expect(progressDetailText(done.card)).toContain("200ms");
     // running 状态:仍用 ⏳(running 图标),label 是"思考"
     const running = renderProgressCard({
       phase: "thinking",
       steps: [{ tool: "__thinking__", status: "running" }],
     });
-    expect(asText((running.card.body as Array<Record<string, unknown>>)[1])).toContain("⏳ 思考");
+    expect(progressDetailText(running.card)).toContain("⏳ 思考");
   });
 
   it("P1-g: 连续 thinking done 触发同类合并 → 💭 思考 × N", () => {
@@ -574,9 +674,7 @@ describe("cardSupports / CardCaps 渲染协商(波 C)", () => {
         { tool: "__thinking__", status: "done", durationMs: 300 },
       ],
     });
-    const body = card.body as Array<Record<string, unknown>>;
-    // 无 caps → RichTextBlock 降级 TextBlock;读双兼容
-    const t = (body[1].text as string) ?? ((body[1].inlines as Array<{ text: string }>) ?? []).map((i) => i.text).join("");
+    const t = progressDetailText(card);
     expect(t).toContain("💭");
     expect(t).toContain("思考 × 3");
     expect(t).toContain("共 600ms");

--- a/src/card-render.test.ts
+++ b/src/card-render.test.ts
@@ -66,8 +66,8 @@ describe("summarizeToolParams", () => {
   it("形状脱敏:query/pattern 里的裸密钥(无关键词)也隐藏", () => {
     expect(summarizeToolParams("grep", { pattern: "AKIAIOSFODNN7EXAMPLE" })).toBe(""); // AWS key id
     expect(summarizeToolParams("web_search", { query: "d41d8cd98f00b204e9800998ecf8427e" })).toBe(""); // 32 hex
-    expect(summarizeToolParams("grep", { pattern: "ghp_16C7e42F292c6912E7710c838347Ae178B4a" })).toBe(""); // GitHub token
-    expect(summarizeToolParams("web_search", { query: "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.abc123def456" })).toBe(""); // JWT
+    expect(summarizeToolParams("grep", { pattern: "ghp_16C7e42F292c6912E7710c838347Ae178B4a" })).toBe(""); // GitHub token — gitleaks:allow (fake fixture)
+    expect(summarizeToolParams("web_search", { query: "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.abc123def456" })).toBe(""); // JWT — gitleaks:allow (fake fixture)
     // 混合字母数字的 40+ 位随机串。
     expect(summarizeToolParams("grep", { pattern: "aB3dE7gH1jK4mN8pQ2rS5tU9vW6xY0zA1bC2dE3f" })).toBe("");
     // 正常长英文 / 纯字母长串不误伤。
@@ -125,6 +125,23 @@ describe("stepLine", () => {
     expect(stepLine({ tool: "bash", status: "error", summary: "rm x", error: "boom" })).toBe(
       "❌ 执行命令：rm x — boom",
     ));
+  it("error 详情脱敏:命中敏感串则只留状态、不渲染原始错误", () => {
+    // 含 token 关键词
+    expect(stepLine({ tool: "bash", status: "error", error: "auth failed: Bearer sk-live-abc" })).toBe("❌ 执行命令");
+    // curl 报错回显含密钥形状的 URL(sk- 前缀长 token)
+    expect(stepLine({ tool: "bash", status: "error", summary: "curl", error: "curl: (22) https://api.x/v1?sk-live-ABC123XYZ456def789ghi returned 401" })).toBe(
+      "❌ 执行命令：curl",
+    );
+    // AKIA 出现在错误里
+    expect(stepLine({ tool: "exec", status: "error", error: "invalid key AKIAIOSFODNN7EXAMPLE" })).toBe("❌ 执行命令");
+  });
+  it("error 详情超长截断,折叠空白", () => {
+    const long = "line1\n" + "z".repeat(200); // 非 hex、无数字 → 不算密钥,仅超长
+    const out = stepLine({ tool: "read", status: "error", error: long });
+    expect(out.startsWith("❌ 读取文件 — line1 ")).toBe(true);
+    expect(out.endsWith("…")).toBe(true);
+    expect(out.length).toBeLessThan(140); // 图标+标签 + 120 上限 + 省略号
+  });
 });
 
 describe("renderProgressCard", () => {

--- a/src/card-render.test.ts
+++ b/src/card-render.test.ts
@@ -440,6 +440,96 @@ describe("cardSupports / CardCaps 渲染协商(波 C)", () => {
     expect(plain).not.toContain("⌨️\n执行命令"); // 关键:不分行
   });
 
+  it("advertise Container+RichTextBlock → 进度步骤按 thinking 阶段收进 timeline 容器", () => {
+    const caps = { elements: new Set(["TextBlock", "RichTextBlock", "Container"]) };
+    const { card, plain } = renderProgressCard(
+      {
+        phase: "tool",
+        steps: [
+          { tool: "__thinking__", status: "done", durationMs: 3000 },
+          { tool: "exec", status: "done", summary: "find", durationMs: 100 },
+          { tool: "__thinking__", status: "running" },
+        ],
+      },
+      caps,
+    );
+    const body = card.body as Array<Record<string, unknown>>;
+    expect(body[0].type).toBe("TextBlock");
+    const containers = body.slice(1) as Array<{ type: string; style?: string; items?: Array<Record<string, unknown>> }>;
+    expect(containers).toHaveLength(2);
+    expect(containers[0].type).toBe("Container");
+    expect(containers[0].items?.map((e) => e.type)).toEqual(["RichTextBlock", "RichTextBlock"]);
+    expect(containers[1].style).toBe("warning");
+    expect(containers[1].items?.[0]?.type).toBe("RichTextBlock");
+    expect(plain).toContain("💭 思考 · 3.0s");
+    expect(plain).toContain("⌨️ 执行命令：find · 100ms");
+  });
+
+  it("终态 advertise ToggleVisibility → thinking/tool 明细折叠进隐藏 Container", () => {
+    const caps = {
+      elements: new Set(["TextBlock", "RichTextBlock", "Container", "ActionSet"]),
+      actions: new Set(["Action.ToggleVisibility"]),
+    };
+    const { card, plain } = renderProgressCard(
+      {
+        phase: "done",
+        elapsedMs: 3200,
+        steps: [
+          { tool: "__thinking__", status: "done", durationMs: 3000 },
+          { tool: "exec", status: "done", summary: "find", durationMs: 100 },
+        ],
+      },
+      caps,
+    );
+
+    const body = card.body as Array<Record<string, unknown>>;
+    expect(body[0].type).toBe("RichTextBlock");
+    const headerInlines = body[0].inlines as Array<Record<string, unknown>>;
+    expect(headerInlines).toMatchObject([
+      { text: "✅ 已完成", weight: "Bolder" },
+      { text: " · 2 步 · 3.2s", isSubtle: true },
+    ]);
+    expect(body[1].type).toBe("RichTextBlock");
+    const summaryInlines = body[1].inlines as Array<Record<string, unknown>>;
+    expect(summaryInlines).toMatchObject([
+      { text: "推理与工具调用", weight: "Bolder" },
+      { text: " · 思考 1 · 工具 1 · 2 步", isSubtle: true },
+    ]);
+
+    const actionSet = body[2] as { type: string; actions: Array<Record<string, unknown>> };
+    expect(actionSet.type).toBe("ActionSet");
+    expect(actionSet.actions[0]).toMatchObject({ type: "Action.ToggleVisibility", title: "展开/收起" });
+    expect(actionSet.actions[0].title).not.toBe("推理与工具调用 · 思考 1 · 工具 1 · 2 步");
+
+    const hidden = body[3] as { type: string; id: string; isVisible: boolean; items: Array<Record<string, unknown>> };
+    expect(hidden.type).toBe("Container");
+    expect(hidden.isVisible).toBe(false);
+    expect(actionSet.actions[0].targetElements).toEqual([hidden.id]);
+    expect(hidden.items[0].type).toBe("Container");
+    expect(JSON.stringify(hidden.items)).toContain("💭");
+    expect(JSON.stringify(hidden.items)).toContain("执行命令");
+    expect(plain).toContain("推理与工具调用 · 思考 1 · 工具 1 · 2 步");
+    expect(plain).toContain("⌨️ 执行命令：find · 100ms");
+  });
+
+  it("终态未 advertise ToggleVisibility → 保持旧展开结构,不额外插入 summary", () => {
+    const caps = { elements: new Set(["TextBlock", "RichTextBlock", "Container", "ActionSet"]) };
+    const { card } = renderProgressCard(
+      {
+        phase: "done",
+        steps: [
+          { tool: "__thinking__", status: "done", durationMs: 100 },
+          { tool: "exec", status: "done", summary: "find", durationMs: 50 },
+        ],
+      },
+      caps,
+    );
+    const body = card.body as Array<Record<string, unknown>>;
+    expect(body.some((b) => b.type === "ActionSet")).toBe(false);
+    expect(body.some((b) => (b as { text?: string }).text?.startsWith("推理与工具调用"))).toBe(false);
+    expect(body.slice(1).every((b) => b.type === "Container")).toBe(true);
+  });
+
   it("advertise 了 elements 但既无 RichTextBlock 也无 ColumnSet → TextBlock 平铺(降级)", () => {
     const caps = { elements: new Set(["TextBlock", "FactSet"]) };
     const { card } = renderProgressCard({ phase: "tool", steps: [{ tool: "read", status: "done" }] }, caps);

--- a/src/card-render.test.ts
+++ b/src/card-render.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect } from "vitest";
+import {
+  renderProgressCard,
+  resolveToolMeta,
+  summarizeToolParams,
+  fmtDuration,
+  stepLine,
+} from "./card-render.js";
+
+describe("resolveToolMeta", () => {
+  it("已知工具 → 图标 + 中文标签", () => {
+    expect(resolveToolMeta("read")).toEqual({ icon: "📖", label: "读取文件" });
+    expect(resolveToolMeta("exec")).toEqual({ icon: "⌨️", label: "执行命令" });
+    expect(resolveToolMeta("process")).toEqual({ icon: "⚙️", label: "运行进程" });
+  });
+  it("MCP 工具解析 server / tool", () => {
+    expect(resolveToolMeta("mcp__github__create_issue")).toEqual({
+      icon: "🔌",
+      label: "MCP github / create_issue",
+    });
+  });
+  it("未知工具 → 通用图标 + 原名", () => {
+    expect(resolveToolMeta("weirdtool")).toEqual({ icon: "🔧", label: "weirdtool" });
+  });
+});
+
+describe("summarizeToolParams", () => {
+  it("文件类工具取 path", () => {
+    expect(summarizeToolParams("read", { path: "/work/README.md" })).toBe("/work/README.md");
+    expect(summarizeToolParams("edit", { file_path: "/a/b.ts", offset: 0 })).toBe("/a/b.ts");
+  });
+  it("shell 类只取程序名,不渲染完整命令(避免参数泄露)", () => {
+    expect(summarizeToolParams("exec", { command: "git commit -m x" })).toBe("git");
+    expect(summarizeToolParams("bash", { command: "curl -H 'Authorization: Bearer sk-xxx' https://x" })).toBe("curl");
+  });
+  it("shell 跳过前缀式环境变量赋值(VAR=secret cmd),不泄露密钥值", () => {
+    expect(summarizeToolParams("exec", { command: "SLACK_WEBHOOK=https://hooks.slack.com/services/T/B/X curl -X POST" })).toBe("curl");
+    expect(summarizeToolParams("bash", { command: "MY_CREDS=abc123 DEPLOY_KEY=xyz ./deploy.sh" })).toBe("./deploy.sh");
+  });
+  it("shell 带引号多词环境变量值 → 落在值片段则整体不展示(形状校验)", () => {
+    // 空白分词把 TOKEN="a b" 切成 TOKEN="a / b" —— 落在片段 b",含引号 → 不展示。
+    expect(summarizeToolParams("exec", { command: 'TOKEN="a b" node app.js' })).toBe("");
+    // 合法程序名/路径不受影响。
+    expect(summarizeToolParams("exec", { command: "/usr/bin/python3 x.py" })).toBe("/usr/bin/python3");
+  });
+  it("url 类只保留 scheme://host,丢弃 path/query/userinfo(含 path 内嵌密钥)", () => {
+    expect(summarizeToolParams("fetch", { url: "https://u:p@host.com/a/b?token=sk-secret&x=1" })).toBe(
+      "https://host.com",
+    );
+    // Slack webhook 密钥整段在 path 里 —— 必须连 path 一起丢弃。
+    expect(summarizeToolParams("fetch", { url: "https://hooks.slack.com/services/T000/B000/XXXXXXXXXXXX" })).toBe(
+      "https://hooks.slack.com",
+    );
+    expect(summarizeToolParams("fetch", { url: "not a url" })).toBe("");
+  });
+  it("检索类取 query/pattern", () => {
+    expect(summarizeToolParams("grep", { pattern: "TODO", path: "/x" })).toBe("TODO");
+    expect(summarizeToolParams("web_search", { query: "how to" })).toBe("how to");
+  });
+  it("MCP / 未知工具 → 不显示摘要(不渲染任意参数)", () => {
+    expect(summarizeToolParams("mcp__github__create_issue", { title: "leak", body: "secret" })).toBe("");
+    expect(summarizeToolParams("weirdtool", { foo: "bar" })).toBe("");
+  });
+  it("命中敏感串守卫 → 整串隐藏", () => {
+    expect(summarizeToolParams("read", { path: "/etc/my-api-key.txt" })).toBe("");
+    expect(summarizeToolParams("grep", { pattern: "password=hunter2" })).toBe("");
+  });
+  it("非法输入 → 空串", () => {
+    expect(summarizeToolParams("read", undefined)).toBe("");
+    expect(summarizeToolParams(undefined, { path: "/a" })).toBe("");
+    expect(summarizeToolParams("read", "x")).toBe("");
+  });
+  it("超长截断 + 折叠空白", () => {
+    const long = "/a/" + "x".repeat(80);
+    const out = summarizeToolParams("read", { path: long });
+    expect(out.endsWith("…")).toBe(true);
+    expect(out.length).toBe(65);
+    expect(summarizeToolParams("read", { path: "/a\n  b\tc" })).toBe("/a b c");
+  });
+});
+
+describe("fmtDuration", () => {
+  it("<1s 用 ms", () => expect(fmtDuration(200)).toBe("200ms"));
+  it(">=1s 用 x.xs", () => expect(fmtDuration(10165)).toBe("10.2s"));
+  it("undefined → 空", () => expect(fmtDuration(undefined)).toBe(""));
+});
+
+describe("stepLine", () => {
+  it("running:⏳ + 标签 + 摘要", () =>
+    expect(stepLine({ tool: "exec", status: "running", summary: "ls -la" })).toBe("⏳ 执行命令：ls -la"));
+  it("done:图标 + 标签 + 摘要 + 耗时", () =>
+    expect(stepLine({ tool: "exec", status: "done", summary: "ls -la", durationMs: 10165 })).toBe(
+      "⌨️ 执行命令：ls -la · 10.2s",
+    ));
+  it("done 无摘要", () =>
+    expect(stepLine({ tool: "read", status: "done", durationMs: 200 })).toBe("📖 读取文件 · 200ms"));
+  it("error", () =>
+    expect(stepLine({ tool: "bash", status: "error", summary: "rm x", error: "boom" })).toBe(
+      "❌ 执行命令：rm x — boom",
+    ));
+});
+
+describe("renderProgressCard", () => {
+  it("thinking 骨架", () => {
+    const { card, plain } = renderProgressCard({ phase: "thinking", steps: [] });
+    expect(card.type).toBe("AdaptiveCard");
+    expect(card.version).toBe("1.5");
+    expect((card.body as Array<{ text: string }>)[0].text).toBe("🤖 思考中…");
+    expect(plain).toBe("🤖 思考中…");
+  });
+
+  it("tool 阶段带摘要步骤", () => {
+    const { card } = renderProgressCard({
+      phase: "tool",
+      steps: [{ tool: "read", status: "done", summary: "/work/README.md", durationMs: 200 }],
+    });
+    const body = card.body as Array<{ text: string }>;
+    expect(body[0].text).toBe("🤖 正在处理…");
+    expect(body[1].text).toBe("📖 读取文件：/work/README.md · 200ms");
+  });
+
+  it("done 收尾:步数 + 耗时", () => {
+    const { card } = renderProgressCard({
+      phase: "done",
+      steps: [{ tool: "read", status: "done" }],
+      elapsedMs: 2500,
+    });
+    expect((card.body as Array<{ text: string }>)[0].text).toBe("✅ 已完成 · 1 步 · 2.5s");
+  });
+
+  it("error 收尾", () => {
+    const { card } = renderProgressCard({ phase: "error", steps: [], errorText: "超时" });
+    expect((card.body as Array<{ text: string }>)[0].text).toContain("⚠️ 已中断");
+  });
+
+  it("plain never empty", () => {
+    expect(renderProgressCard({ phase: "tool", steps: [] }).plain.length).toBeGreaterThan(0);
+  });
+
+  it("步骤超上限 → 只渲染最近 N 步 + 折叠计数(防卡片膨胀)", () => {
+    const steps = Array.from({ length: 20 }, (_, i) => ({
+      tool: "read",
+      status: "done" as const,
+      summary: `/f${i}`,
+      durationMs: 10,
+    }));
+    const { card } = renderProgressCard({ phase: "tool", steps });
+    const body = card.body as Array<{ text: string }>;
+    // header(1) + 折叠行(1) + 最近 12 步 = 14 个 block
+    expect(body.length).toBe(14);
+    expect(body[1].text).toBe("… 省略前 8 步");
+    // 最后一步是最新的 /f19
+    expect(body[body.length - 1].text).toContain("/f19");
+    // 已折叠掉最早的 /f0
+    expect(body.every((b) => !b.text.includes("/f0："))).toBe(true);
+  });
+
+  it("done 收尾 header 计数用全量步数(不受裁剪影响)", () => {
+    const steps = Array.from({ length: 20 }, () => ({ tool: "read", status: "done" as const }));
+    const { card } = renderProgressCard({ phase: "done", steps, elapsedMs: 1000 });
+    expect((card.body as Array<{ text: string }>)[0].text).toBe("✅ 已完成 · 20 步 · 1.0s");
+  });
+});

--- a/src/card-render.test.ts
+++ b/src/card-render.test.ts
@@ -43,19 +43,35 @@ describe("summarizeToolParams", () => {
     // 合法程序名/路径不受影响。
     expect(summarizeToolParams("exec", { command: "/usr/bin/python3 x.py" })).toBe("/usr/bin/python3");
   });
-  it("url 类只保留 scheme://host,丢弃 path/query/userinfo(含 path 内嵌密钥)", () => {
+  it("url 类只保留 scheme://注册域,丢弃 path/query/userinfo 与所有子域", () => {
     expect(summarizeToolParams("fetch", { url: "https://u:p@host.com/a/b?token=sk-secret&x=1" })).toBe(
       "https://host.com",
     );
-    // Slack webhook 密钥整段在 path 里 —— 必须连 path 一起丢弃。
+    // Slack webhook 密钥整段在 path 里 —— 连 path 与子域一起丢。
     expect(summarizeToolParams("fetch", { url: "https://hooks.slack.com/services/T000/B000/XXXXXXXXXXXX" })).toBe(
-      "https://hooks.slack.com",
+      "https://slack.com",
     );
+    // 隧道/预签名:主机名本身即密钥(随机子域)→ 只留注册域,子域丢弃。
+    expect(summarizeToolParams("fetch", { url: "https://s3cr3ttok.abc1234.ngrok.io/hook" })).toBe(
+      "https://ngrok.io",
+    );
+    // 多段有效后缀多保留一段。
+    expect(summarizeToolParams("fetch", { url: "https://x.example.com.cn/p" })).toBe("https://example.com.cn");
     expect(summarizeToolParams("fetch", { url: "not a url" })).toBe("");
   });
   it("检索类取 query/pattern", () => {
     expect(summarizeToolParams("grep", { pattern: "TODO", path: "/x" })).toBe("TODO");
     expect(summarizeToolParams("web_search", { query: "how to" })).toBe("how to");
+  });
+  it("形状脱敏:query/pattern 里的裸密钥(无关键词)也隐藏", () => {
+    expect(summarizeToolParams("grep", { pattern: "AKIAIOSFODNN7EXAMPLE" })).toBe(""); // AWS key id
+    expect(summarizeToolParams("web_search", { query: "d41d8cd98f00b204e9800998ecf8427e" })).toBe(""); // 32 hex
+    expect(summarizeToolParams("grep", { pattern: "ghp_16C7e42F292c6912E7710c838347Ae178B4a" })).toBe(""); // GitHub token
+    expect(summarizeToolParams("web_search", { query: "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.abc123def456" })).toBe(""); // JWT
+    // 混合字母数字的 40+ 位随机串。
+    expect(summarizeToolParams("grep", { pattern: "aB3dE7gH1jK4mN8pQ2rS5tU9vW6xY0zA1bC2dE3f" })).toBe("");
+    // 正常长英文 / 纯字母长串不误伤。
+    expect(summarizeToolParams("web_search", { query: "how to configure oauth flow correctly" })).toBe("how to configure oauth flow correctly");
   });
   it("MCP / 未知工具 → 不显示摘要(不渲染任意参数)", () => {
     expect(summarizeToolParams("mcp__github__create_issue", { title: "leak", body: "secret" })).toBe("");

--- a/src/card-render.test.ts
+++ b/src/card-render.test.ts
@@ -56,6 +56,17 @@ describe("summarizeToolParams", () => {
     // 常规 query 不受影响。
     expect(summarizeToolParams("grep", { pattern: "TODO fix later" })).toBe("TODO fix later");
   });
+  it("非 http scheme 的凭据 URI 也降级(postgres/mysql/redis/ssh…),明文密码不泄露", () => {
+    // query 里的 DB DSN:密码短、无关键词 → isSensitive 抓不到,靠 URL 降级丢掉 userinfo。
+    expect(summarizeToolParams("web_search", { query: "postgres://admin:s3cr3t@db.internal:5432/app" })).toBe("postgres://db.internal");
+    // shell:DSN 作为程序名(argv[0])。
+    expect(summarizeToolParams("bash", { command: "mysql://root:hunter2@10.0.0.5:3306/prod" })).toBe("mysql://10.0.0.5");
+    // 其它 scheme。
+    expect(summarizeToolParams("grep", { pattern: "redis://:pw@cache.internal:6379/0" })).toBe("redis://cache.internal");
+    expect(summarizeToolParams("grep", { pattern: "ssh://deploy:key@bastion.example.com" })).toBe("ssh://example.com");
+    // 不误伤 Windows 盘符路径(无 ://)。
+    expect(summarizeToolParams("read", { path: "C:/Users/me/app.ts" })).toBe("C:/Users/me/app.ts");
+  });
   it("url 类只保留 scheme://注册域,丢弃 path/query/userinfo 与所有子域", () => {
     expect(summarizeToolParams("fetch", { url: "https://u:p@host.com/a/b?token=sk-secret&x=1" })).toBe(
       "https://host.com",
@@ -161,6 +172,15 @@ describe("stepLine", () => {
     // 但明确关键词/前缀仍拦。
     expect(stepLine({ tool: "read", status: "error", error: "AKIAIOSFODNN7EXAMPLE rejected" })).toBe("❌ 读取文件");
   });
+  it("P2-1: 工具名 label 过长截断 / 敏感形状回退通用标签", () => {
+    // 超长 MCP 工具名 → 截断,防卡片被 label 撑爆。
+    const longName = "mcp__" + "z".repeat(60) + "__tool"; // 非 hex、无数字 → 只超长,不算密钥形状
+    const out = stepLine({ tool: longName, status: "running" });
+    expect(out.length).toBeLessThan(60);
+    expect(out.endsWith("…")).toBe(true);
+    // 未知工具名命中敏感关键词 → 回退通用「工具」(不把疑似密钥的标识符渲进群卡片)。
+    expect(stepLine({ tool: "fetch_api_key_helper", status: "running" })).toBe("⏳ 工具");
+  });
   it("error 内嵌 URL 降级为注册域(对称参数路径),webhook 路径/隧道主机不泄露", () => {
     // 短、无关键词的 webhook 路径段:isSensitive 抓不到,靠 URL 降级丢掉。
     const slack = stepLine({ tool: "bash", status: "error", error: "curl: (22) https://hooks.slack.com/services/T01ABCDEF/B02GHIJKL/Xy8zQw3rT7uVwXyZ0 returned 404" });
@@ -181,6 +201,11 @@ describe("stepLine", () => {
     expect(s3).toContain("https://amazonaws.com");
     expect(s3).not.toContain("mybucket");
     expect(s3).not.toContain("Signature");
+    // 最可达:DB 驱动连接错误回显完整 DSN(非 http scheme)→ 明文密码不泄露。
+    const dsn = stepLine({ tool: "exec", status: "error", error: "connect ECONNREFUSED postgres://svc:Hunter2Pw@10.0.0.5:5432/prod" });
+    expect(dsn).toContain("postgres://10.0.0.5");
+    expect(dsn).not.toContain("Hunter2Pw");
+    expect(dsn).not.toContain("svc:");
   });
 });
 

--- a/src/card-render.test.ts
+++ b/src/card-render.test.ts
@@ -128,10 +128,8 @@ describe("stepLine", () => {
   it("error 详情脱敏:命中敏感串则只留状态、不渲染原始错误", () => {
     // 含 token 关键词
     expect(stepLine({ tool: "bash", status: "error", error: "auth failed: Bearer sk-live-abc" })).toBe("❌ 执行命令");
-    // curl 报错回显含密钥形状的 URL(sk- 前缀长 token)
-    expect(stepLine({ tool: "bash", status: "error", summary: "curl", error: "curl: (22) https://api.x/v1?sk-live-ABC123XYZ456def789ghi returned 401" })).toBe(
-      "❌ 执行命令：curl",
-    );
+    // 裸 sk- 前缀长 token(不在 URL 里)→ 整行隐藏
+    expect(stepLine({ tool: "bash", status: "error", error: "token sk-live-ABC123XYZ456def789ghi rejected" })).toBe("❌ 执行命令");
     // AKIA 出现在错误里
     expect(stepLine({ tool: "exec", status: "error", error: "invalid key AKIAIOSFODNN7EXAMPLE" })).toBe("❌ 执行命令");
   });
@@ -141,6 +139,27 @@ describe("stepLine", () => {
     expect(out.startsWith("❌ 读取文件 — line1 ")).toBe(true);
     expect(out.endsWith("…")).toBe(true);
     expect(out.length).toBeLessThan(140); // 图标+标签 + 120 上限 + 省略号
+  });
+  it("error 内嵌 URL 降级为注册域(对称参数路径),webhook 路径/隧道主机不泄露", () => {
+    // 短、无关键词的 webhook 路径段:isSensitive 抓不到,靠 URL 降级丢掉。
+    const slack = stepLine({ tool: "bash", status: "error", error: "curl: (22) https://hooks.slack.com/services/T01ABCDEF/B02GHIJKL/Xy8zQw3rT7uVwXyZ0 returned 404" });
+    expect(slack).toContain("https://slack.com");
+    expect(slack).not.toContain("services");
+    expect(slack).not.toContain("Xy8zQw3rT7uVwXyZ0");
+    // Discord webhook。
+    const discord = stepLine({ tool: "bash", status: "error", error: "POST https://discord.com/api/webhooks/123456789012345678/aBcDeFgHiJkLmNoPqRsTuVwX failed" });
+    expect(discord).toContain("https://discord.com");
+    expect(discord).not.toContain("webhooks");
+    // 内网主机 + 短 opaque token(16 hex,<32 → 形状抓不到),靠降级丢子域+path。
+    const internal = stepLine({ tool: "exec", status: "error", error: "failed to POST https://mytenant.internal.corp:8443/webhook/9f8e7d6c5b4a3210 — 500" });
+    expect(internal).toContain("https://internal.corp");
+    expect(internal).not.toContain("mytenant");
+    expect(internal).not.toContain("9f8e7d6c5b4a3210");
+    // 预签名 URL 的签名在 query,降级后连同子域一起丢。
+    const s3 = stepLine({ tool: "bash", status: "error", error: "fetch https://mybucket.s3.amazonaws.com/f?X-Amz-Signature=deadbeefcafe returned 403" });
+    expect(s3).toContain("https://amazonaws.com");
+    expect(s3).not.toContain("mybucket");
+    expect(s3).not.toContain("Signature");
   });
 });
 

--- a/src/card-render.test.ts
+++ b/src/card-render.test.ts
@@ -5,6 +5,7 @@ import {
   summarizeToolParams,
   fmtDuration,
   stepLine,
+  cardSupports,
 } from "./card-render.js";
 
 describe("resolveToolMeta", () => {
@@ -268,5 +269,48 @@ describe("renderProgressCard", () => {
     const steps = Array.from({ length: 20 }, () => ({ tool: "read", status: "done" as const }));
     const { card } = renderProgressCard({ phase: "done", steps, elapsedMs: 1000 });
     expect((card.body as Array<{ text: string }>)[0].text).toBe("✅ 已完成 · 20 步 · 1.0s");
+  });
+});
+
+describe("cardSupports / CardCaps 渲染协商(波 C)", () => {
+  it("cardSupports:明确 advertise 以其为准,否则用基线", () => {
+    expect(cardSupports({ elements: new Set(["TextBlock"]) }, "TextBlock")).toBe(true);
+    expect(cardSupports({ elements: new Set(["TextBlock"]) }, "ColumnSet")).toBe(false);
+    expect(cardSupports(undefined, "ColumnSet")).toBe(true); // 基线含
+    expect(cardSupports(undefined, "Input.Text")).toBe(false); // 基线不含输入
+  });
+
+  it("无 caps → 默认 TextBlock 平铺(零回归)", () => {
+    const { card } = renderProgressCard({
+      phase: "tool",
+      steps: [{ tool: "read", status: "done", summary: "/a", durationMs: 200 }],
+    });
+    expect((card.body as Array<{ type: string }>)[1].type).toBe("TextBlock");
+  });
+
+  it("advertise ColumnSet(Column 是其固有子元素,不单独 advertise)→ 步骤渲成 ColumnSet 行,plain 不变", () => {
+    const caps = { elements: new Set(["TextBlock", "ColumnSet"]) }; // 实测服务端不单列 Column
+    const { card, plain } = renderProgressCard(
+      { phase: "tool", steps: [{ tool: "exec", status: "done", summary: "ls", durationMs: 200 }] },
+      caps,
+    );
+    const row = (card.body as Array<Record<string, unknown>>)[1];
+    expect(row.type).toBe("ColumnSet");
+    const cols = row.columns as Array<{ items: Array<{ text: string }> }>;
+    expect(cols[0].items[0].text).toBe("⌨️");
+    expect(cols[1].items[0].text).toBe("执行命令：ls · 200ms");
+    expect(plain).toContain("⌨️ 执行命令：ls · 200ms"); // plain 与布局无关
+  });
+
+  it("advertise 了 elements 但不含 ColumnSet → 仍 TextBlock(降级)", () => {
+    const caps = { elements: new Set(["TextBlock", "FactSet"]) };
+    const { card } = renderProgressCard({ phase: "tool", steps: [{ tool: "read", status: "done" }] }, caps);
+    expect((card.body as Array<{ type: string }>)[1].type).toBe("TextBlock");
+  });
+
+  it("caps.maxNodes 权威收紧可见步数(比本地上限更严)", () => {
+    const steps = Array.from({ length: 20 }, () => ({ tool: "read", status: "done" as const }));
+    const { card } = renderProgressCard({ phase: "tool", steps }, { maxNodes: 6 }); // TextBlock:reserve2 → 4 步
+    expect((card.body as unknown[]).length).toBe(6); // header + 折叠 + 4 步
   });
 });

--- a/src/card-render.test.ts
+++ b/src/card-render.test.ts
@@ -23,12 +23,33 @@ describe("resolveToolMeta", () => {
   it("未知工具 → 通用图标 + 原名", () => {
     expect(resolveToolMeta("weirdtool")).toEqual({ icon: "🔧", label: "weirdtool" });
   });
+  it("host 内建工具名 find(SDK ToolName)→ 查找文件,且走 path 摘要策略(不再裸名)", () => {
+    expect(resolveToolMeta("find")).toEqual({ icon: "🔍", label: "查找文件" });
+    expect(summarizeToolParams("find", { path: "/work/src/card-render.ts" })).toBe("/work/src/card-render.ts");
+  });
 });
 
 describe("summarizeToolParams", () => {
   it("文件类工具取 path", () => {
     expect(summarizeToolParams("read", { path: "/work/README.md" })).toBe("/work/README.md");
     expect(summarizeToolParams("edit", { file_path: "/a/b.ts", offset: 0 })).toBe("/a/b.ts");
+  });
+
+  it("path 智能压缩:深路径保留末 2 段 + 前缀省略号,末段(文件名)必须完整", () => {
+    // 典型痛点:/root/.openclaw/workspace/octo-server/modules/bot_api/send.go
+    expect(summarizeToolParams("read", { path: "/root/.openclaw/workspace/octo-server/modules/bot_api/send.go" }))
+      .toBe("…/bot_api/send.go");
+    expect(summarizeToolParams("read", { path: "/Users/fangling/conductor/workspaces/kyoto/src/card-render.ts" }))
+      .toBe("…/src/card-render.ts");
+    // 3 段以内不压缩(信息本来就少)
+    expect(summarizeToolParams("read", { path: "/work/README.md" })).toBe("/work/README.md");
+    expect(summarizeToolParams("read", { path: "docs/card-protocol.md" })).toBe("docs/card-protocol.md");
+    expect(summarizeToolParams("read", { path: "a/b/c" })).toBe("a/b/c");
+    // 首段是家目录/根也一视同仁(不做特殊 `~` 标记,保持简单)
+    expect(summarizeToolParams("ls", { path: "/root/.openclaw/workspace/octo-server/docs" }))
+      .toBe("…/octo-server/docs");
+    // 无扩展名的深目录同规则
+    expect(summarizeToolParams("glob", { path: "a/b/c/d/e" })).toBe("…/d/e");
   });
   it("shell 类只取程序名,不渲染完整命令(避免参数泄露)", () => {
     expect(summarizeToolParams("exec", { command: "git commit -m x" })).toBe("git");
@@ -66,7 +87,7 @@ describe("summarizeToolParams", () => {
     expect(summarizeToolParams("grep", { pattern: "redis://:pw@cache.internal:6379/0" })).toBe("redis://cache.internal");
     expect(summarizeToolParams("grep", { pattern: "ssh://deploy:key@bastion.example.com" })).toBe("ssh://example.com");
     // 不误伤 Windows 盘符路径(无 ://)。
-    expect(summarizeToolParams("read", { path: "C:/Users/me/app.ts" })).toBe("C:/Users/me/app.ts");
+    expect(summarizeToolParams("read", { path: "C:/Users/me/app.ts" })).toBe("…/me/app.ts");
   });
   it("url 类只保留 scheme://注册域,丢弃 path/query/userinfo 与所有子域", () => {
     expect(summarizeToolParams("fetch", { url: "https://u:p@host.com/a/b?token=sk-secret&x=1" })).toBe(
@@ -98,10 +119,24 @@ describe("summarizeToolParams", () => {
     // 正常长英文 / 纯字母长串不误伤。
     expect(summarizeToolParams("web_search", { query: "how to configure oauth flow correctly" })).toBe("how to configure oauth flow correctly");
   });
+  it("前缀式密钥被前置词字符粘连也隐藏(去词界锚点;两类 sink 都覆盖)", () => {
+    // 回归 yujiawei P1:`\b` 词界锚点会被"前面粘一个词字符"绕过 → 明文密钥泄露。
+    // query 策略(generic=true):
+    expect(summarizeToolParams("grep", { pattern: "xAKIA1234567890ABCDEF" })).toBe("");
+    expect(summarizeToolParams("grep", { pattern: "9sk-ABCDEFGHIJKLMNOP1234" })).toBe("");     // 数字前缀
+    expect(summarizeToolParams("web_search", { query: "a_glpat-ABCDEFGHIJ1234567890" })).toBe(""); // 下划线前缀 — gitleaks:allow (fake fixture)
+    // path/shell 策略(generic=false,无高熵兜底)—— 更关键,靠前缀命中:
+    expect(summarizeToolParams("read", { path: "tokenAKIAIOSFODNN7EXAMPLE" })).toBe("");
+    expect(summarizeToolParams("read", { path: "keyghp_ABCDEFGHIJ1234567890XY" })).toBe("");
+    expect(summarizeToolParams("exec", { command: "Xsk-ABCDEFGHIJKLMNOP1234" })).toBe("");
+    // 但连字符英文不被长度下限误伤:
+    expect(summarizeToolParams("grep", { pattern: "risk-averse task-force" })).toBe("risk-averse task-force");
+  });
   it("path 只走关键词+明确前缀:常见 git/docker/缓存哈希路径不被误伤成空", () => {
     // 通用高熵/长 hex 检测**不**套用到 path —— 否则日常路径会频繁 blank。
+    // git object 深路径 → 压缩到末 2 段;关键是 SHA(长 hex)在末段完整保留,且不被 secret 形状误伤。
     expect(summarizeToolParams("read", { path: "/repo/.git/objects/1a/2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c" })).toBe(
-      "/repo/.git/objects/1a/2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c",
+      "…/1a/2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c",
     );
     expect(summarizeToolParams("edit", { file_path: ".cache/webpack/a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6" })).toBe(
       ".cache/webpack/a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6",
@@ -181,6 +216,11 @@ describe("stepLine", () => {
     expect(out.endsWith("…")).toBe(true);
     // 未知工具名命中敏感关键词 → 回退通用「工具」(不把疑似密钥的标识符渲进群卡片)。
     expect(stepLine({ tool: "fetch_api_key_helper", status: "running" })).toBe("⏳ 工具");
+    // label 也过 URL 降级(与 params/error sink 一致):工具名里嵌 webhook/DSN → 只留注册域。
+    const urlName = stepLine({ tool: "https://hooks.slack.com/services/T00/B00/SeCrEtXyZ", status: "running" });
+    expect(urlName).toContain("https://slack.com");
+    expect(urlName).not.toContain("/services/");
+    expect(urlName).not.toContain("SeCrEtXyZ");
   });
   it("error 内嵌 URL 降级为注册域(对称参数路径),webhook 路径/隧道主机不泄露", () => {
     // 短、无关键词的 webhook 路径段:isSensitive 抓不到,靠 URL 降级丢掉。
@@ -229,6 +269,73 @@ describe("renderProgressCard", () => {
     expect(body[1].text).toBe("📖 读取文件：/work/README.md · 200ms");
   });
 
+  it("同类合并:连续 3 个 read done → 1 行 「读取文件 × 3」,含总耗时和最近文件名", () => {
+    const { card, plain } = renderProgressCard({
+      phase: "tool",
+      steps: [
+        { tool: "read", status: "done", summary: "/a/b.md", durationMs: 100 },
+        { tool: "read", status: "done", summary: "/c/d.md", durationMs: 150 },
+        { tool: "read", status: "done", summary: "/e/f.md", durationMs: 200 },
+      ],
+    });
+    const body = card.body as Array<{ text: string }>;
+    expect(body.length).toBe(2); // header + 1 合并行
+    expect(body[1].text).toContain("读取文件 × 3");
+    expect(body[1].text).toContain("450ms"); // 累加耗时
+    expect(body[1].text).toContain("/e/f.md"); // 最近 = 最后一个
+    expect(plain).toContain("读取文件 × 3");
+  });
+
+  it("同类合并:running/error 不合并 —— 当前重点不能糊掉", () => {
+    const { card } = renderProgressCard({
+      phase: "tool",
+      steps: [
+        { tool: "read", status: "done", summary: "/a.md", durationMs: 30 },
+        { tool: "read", status: "done", summary: "/b.md", durationMs: 40 },
+        { tool: "read", status: "error", summary: "/c.md", error: "EISDIR" }, // 中间 error
+        { tool: "read", status: "done", summary: "/d.md", durationMs: 50 },
+        { tool: "read", status: "running", summary: "/e.md" }, // 末尾 running
+      ],
+    });
+    const body = card.body as Array<{ text: string }>;
+    // 期望:合并组[a,b done] + error 单独 + done 单独 + running 单独 = 4 行 + header
+    expect(body.length).toBe(5);
+    expect(body[1].text).toContain("读取文件 × 2"); // 前两个合并
+    expect(body[2].text).toContain("❌"); // error 保留
+    expect(body[3].text).toContain("/d.md"); // 单个 done 不合并
+    expect(body[4].text).toContain("⏳"); // running 保留
+  });
+
+  it("同类合并:跨 tool 边界不合并(read+exec+read 不能合成一组)", () => {
+    const { card } = renderProgressCard({
+      phase: "tool",
+      steps: [
+        { tool: "read", status: "done", summary: "/a", durationMs: 30 },
+        { tool: "read", status: "done", summary: "/b", durationMs: 30 },
+        { tool: "exec", status: "done", summary: "ls", durationMs: 100 },
+        { tool: "read", status: "done", summary: "/c", durationMs: 30 },
+        { tool: "read", status: "done", summary: "/d", durationMs: 30 },
+      ],
+    });
+    const body = card.body as Array<{ text: string }>;
+    // header + [read×2] + [exec 单个] + [read×2] = 4 行
+    expect(body.length).toBe(4);
+    expect(body[1].text).toContain("读取文件 × 2");
+    expect(body[2].text).toContain("执行命令");
+    expect(body[3].text).toContain("读取文件 × 2");
+  });
+
+  it("同类合并:done 收尾 header 计数仍用原始步数(合并不影响 N 步展示)", () => {
+    const steps = [
+      { tool: "read" as const, status: "done" as const, durationMs: 30 },
+      { tool: "read" as const, status: "done" as const, durationMs: 30 },
+      { tool: "read" as const, status: "done" as const, durationMs: 30 },
+    ];
+    const { card } = renderProgressCard({ phase: "done", steps, elapsedMs: 100 });
+    const body = card.body as Array<{ text: string }>;
+    expect(body[0].text).toBe("✅ 已完成 · 3 步 · 100ms"); // 用户看到"3 步",不是"1 组"
+  });
+
   it("done 收尾:步数 + 耗时", () => {
     const { card } = renderProgressCard({
       phase: "done",
@@ -243,20 +350,45 @@ describe("renderProgressCard", () => {
     expect((card.body as Array<{ text: string }>)[0].text).toContain("⚠️ 已中断");
   });
 
+  it("R2: 含 git SHA 的步骤行不被 buildDisplayCard 二次误删(进度卡内容视为可信)", () => {
+    const { card, plain } = renderProgressCard({
+      phase: "tool",
+      steps: [{ tool: "read", status: "done", durationMs: 30, summary: "…/1a/2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e" }],
+    });
+    const b = card.body as Array<{ text?: string; inlines?: Array<{ text: string }> }>;
+    // header + 步骤行 = 2(步骤行没有因 40-hex 高熵检测被删)
+    expect(b.length).toBe(2);
+    expect(plain).toContain("2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e");
+  });
+
+  it("R2: 错误终态帧含 commit SHA 时不整卡清空", () => {
+    const { card, plain } = renderProgressCard({
+      phase: "error",
+      steps: [],
+      errorText: "build failed at commit 5f2a1c9d8e7b6a5f4c3d2e1f0a9b8c7d6e5f4a3b",
+    });
+    const b = card.body as Array<{ text?: string }>;
+    expect(b.length).toBeGreaterThan(0);
+    expect(b[0].text).toContain("⚠️ 已中断");
+    expect(plain).not.toBe("[卡片]");
+    expect(plain).toContain("5f2a1c9d");
+  });
+
   it("plain never empty", () => {
     expect(renderProgressCard({ phase: "tool", steps: [] }).plain.length).toBeGreaterThan(0);
   });
 
   it("步骤超上限 → 只渲染最近 N 步 + 折叠计数(防卡片膨胀)", () => {
+    // 用交替 tool 避开同类合并 —— 这里要测的是「合并后仍超上限」的裁剪路径
     const steps = Array.from({ length: 20 }, (_, i) => ({
-      tool: "read",
+      tool: i % 2 === 0 ? "read" : "exec",
       status: "done" as const,
       summary: `/f${i}`,
       durationMs: 10,
     }));
     const { card } = renderProgressCard({ phase: "tool", steps });
     const body = card.body as Array<{ text: string }>;
-    // header(1) + 折叠行(1) + 最近 12 步 = 14 个 block
+    // 20 个 read/exec 交替 → 无合并;header(1) + 折叠行(1) + 最近 12 步 = 14 个 block
     expect(body.length).toBe(14);
     expect(body[1].text).toBe("… 省略前 8 步");
     // 最后一步是最新的 /f19
@@ -288,29 +420,85 @@ describe("cardSupports / CardCaps 渲染协商(波 C)", () => {
     expect((card.body as Array<{ type: string }>)[1].type).toBe("TextBlock");
   });
 
-  it("advertise ColumnSet(Column 是其固有子元素,不单独 advertise)→ 步骤渲成 ColumnSet 行,plain 不变", () => {
-    const caps = { elements: new Set(["TextBlock", "ColumnSet"]) }; // 实测服务端不单列 Column
+  it("advertise RichTextBlock → 步骤渲成 RichTextBlock(一行内多样式;label bold、状态/耗时着色),plain 一行完整不分行", () => {
+    // 优于 ColumnSet 列的原因:服务端 Finalize 权威重算 plain 时,ColumnSet 会把图标列/文本列
+    // 各当一行,输出成"⌨️\n执行命令:ls · 200ms"两行(降级客户端视觉退化)。RichTextBlock 是单元素,
+    // 内联多段样式,plain 输出干净一行。
+    const caps = { elements: new Set(["TextBlock", "RichTextBlock"]) };
     const { card, plain } = renderProgressCard(
       { phase: "tool", steps: [{ tool: "exec", status: "done", summary: "ls", durationMs: 200 }] },
       caps,
     );
     const row = (card.body as Array<Record<string, unknown>>)[1];
-    expect(row.type).toBe("ColumnSet");
-    const cols = row.columns as Array<{ items: Array<{ text: string }> }>;
-    expect(cols[0].items[0].text).toBe("⌨️");
-    expect(cols[1].items[0].text).toBe("执行命令：ls · 200ms");
-    expect(plain).toContain("⌨️ 执行命令：ls · 200ms"); // plain 与布局无关
+    expect(row.type).toBe("RichTextBlock");
+    const inlines = row.inlines as Array<Record<string, unknown>>;
+    // 至少有:图标段、label(bold)段、summary/duration 段
+    expect(inlines.length).toBeGreaterThanOrEqual(2);
+    const bolded = inlines.find((i) => i.weight === "Bolder");
+    expect(bolded?.text).toBe("执行命令");
+    expect(plain).toContain("⌨️ 执行命令：ls · 200ms"); // plain 一行完整
+    expect(plain).not.toContain("⌨️\n执行命令"); // 关键:不分行
   });
 
-  it("advertise 了 elements 但不含 ColumnSet → 仍 TextBlock(降级)", () => {
+  it("advertise 了 elements 但既无 RichTextBlock 也无 ColumnSet → TextBlock 平铺(降级)", () => {
     const caps = { elements: new Set(["TextBlock", "FactSet"]) };
     const { card } = renderProgressCard({ phase: "tool", steps: [{ tool: "read", status: "done" }] }, caps);
     expect((card.body as Array<{ type: string }>)[1].type).toBe("TextBlock");
   });
 
   it("caps.maxNodes 权威收紧可见步数(比本地上限更严)", () => {
-    const steps = Array.from({ length: 20 }, () => ({ tool: "read", status: "done" as const }));
-    const { card } = renderProgressCard({ phase: "tool", steps }, { maxNodes: 6 }); // TextBlock:reserve2 → 4 步
+    // 用不同 tool 避同类合并,保留"裁剪导致展示 cap 步"的原意图
+    const steps = Array.from({ length: 20 }, (_, i) => ({
+      tool: i % 2 === 0 ? "read" : "exec",
+      status: "done" as const,
+    }));
+    const { card } = renderProgressCard({ phase: "tool", steps }, { maxNodes: 6 }); // reserve=2 → 4 步
     expect((card.body as unknown[]).length).toBe(6); // header + 折叠 + 4 步
+  });
+
+  it("P1-g: __thinking__ 特殊 tool 名 → icon 💭, label '思考'(done 时用 icon, running 时仍用 ⏳)", () => {
+    // done 状态:显示 💭 思考
+    const done = renderProgressCard({
+      phase: "tool",
+      steps: [{ tool: "__thinking__", status: "done", durationMs: 200 }],
+    });
+    const body = done.card.body as Array<Record<string, unknown>>;
+    const asText = (e: Record<string, unknown>) =>
+      (e.text as string) ?? ((e.inlines as Array<{ text: string }>) ?? []).map((i) => i.text).join("");
+    expect(asText(body[1])).toContain("💭 思考");
+    expect(asText(body[1])).toContain("200ms");
+    // running 状态:仍用 ⏳(running 图标),label 是"思考"
+    const running = renderProgressCard({
+      phase: "thinking",
+      steps: [{ tool: "__thinking__", status: "running" }],
+    });
+    expect(asText((running.card.body as Array<Record<string, unknown>>)[1])).toContain("⏳ 思考");
+  });
+
+  it("P1-g: 连续 thinking done 触发同类合并 → 💭 思考 × N", () => {
+    const { card } = renderProgressCard({
+      phase: "tool",
+      steps: [
+        { tool: "__thinking__", status: "done", durationMs: 100 },
+        { tool: "__thinking__", status: "done", durationMs: 200 },
+        { tool: "__thinking__", status: "done", durationMs: 300 },
+      ],
+    });
+    const body = card.body as Array<Record<string, unknown>>;
+    // 无 caps → RichTextBlock 降级 TextBlock;读双兼容
+    const t = (body[1].text as string) ?? ((body[1].inlines as Array<{ text: string }>) ?? []).map((i) => i.text).join("");
+    expect(t).toContain("💭");
+    expect(t).toContain("思考 × 3");
+    expect(t).toContain("共 600ms");
+  });
+
+  it("cardSupports 支持 input/action 查询(与 element 同接口):advertise 以其为准", () => {
+    // Input.* / Action.* 走同一函数,不再另开 API。基线不含输入/动作,不 advertise → 都为 false。
+    expect(cardSupports(undefined, "Input.Text")).toBe(false);
+    expect(cardSupports(undefined, "Action.ToggleVisibility")).toBe(false);
+    expect(cardSupports({ inputs: new Set(["Input.Text", "Input.Number"]) }, "Input.Text")).toBe(true);
+    expect(cardSupports({ inputs: new Set(["Input.Text"]) }, "Input.Number")).toBe(false);
+    expect(cardSupports({ actions: new Set(["Action.ToggleVisibility"]) }, "Action.ToggleVisibility")).toBe(true);
+    expect(cardSupports({ actions: new Set(["Action.Submit"]) }, "Action.ToggleVisibility")).toBe(false);
   });
 });

--- a/src/card-render.ts
+++ b/src/card-render.ts
@@ -189,9 +189,11 @@ function originDomain(rawUrl: string): string | null {
   }
 }
 
-/** 把文本里内嵌的 http(s) URL 就地降级为 scheme://注册域(解析失败则整段抹除)。 */
+/** 把文本里内嵌的 URI 就地降级为 scheme://注册域(解析失败则整段抹除)。 */
 function reduceUrlsInText(s: string): string {
-  return s.replace(/\bhttps?:\/\/[^\s]+/gi, (m) => originDomain(m) ?? "");
+  // 任意 `scheme://…`,不止 http(s):DB/AMQP/ssh DSN(postgres://user:pass@host 等)也常
+  // 出现在 query/shell/错误文本里,userinfo 即明文密码。要求 `://` 故不误伤 Windows 盘符(C:/)。
+  return s.replace(/\b[a-z][a-z0-9+.-]*:\/\/[^\s]+/gi, (m) => originDomain(m) ?? "");
 }
 
 /** url 策略:取 url 参数并降级为注册域。 */
@@ -257,9 +259,22 @@ export function sanitizeErrorText(err?: string): string {
   return s.length > ERROR_MAX ? s.slice(0, ERROR_MAX) + "…" : s;
 }
 
-/** 单步 → 一行文案:图标 + 标签 + 参数摘要 + 状态/耗时。错误详情经脱敏+截断。 */
+/** 工具名 label 展示上限。MCP 工具名可能很长,防其撑爆卡片。 */
+const LABEL_MAX = 40;
+
+/**
+ * 工具名 label 也是群可见 sink(与 params/error 一致):tool 名来自 registry/MCP 配置,长名会
+ * 撑卡片,疑似密钥形状的标识符不应渲出。命中敏感 → 回退通用「工具」,否则截断。
+ */
+function safeLabel(label: string): string {
+  if (isSensitive(label, true)) return "工具";
+  return label.length > LABEL_MAX ? label.slice(0, LABEL_MAX) + "…" : label;
+}
+
+/** 单步 → 一行文案:图标 + 标签 + 参数摘要 + 状态/耗时。错误详情经脱敏+截断,label 经脱敏+截断。 */
 export function stepLine(step: CardStep): string {
-  const { icon, label } = resolveToolMeta(step.tool);
+  const { icon, label: rawLabel } = resolveToolMeta(step.tool);
+  const label = safeLabel(rawLabel);
   const sum = step.summary ? `：${step.summary}` : "";
   if (step.status === "running") return `⏳ ${label}${sum}`;
   if (step.status === "error") {

--- a/src/card-render.ts
+++ b/src/card-render.ts
@@ -8,6 +8,7 @@
  * 视觉属性仅用端到端验证过的(weight/spacing/size/wrap),不用未验证的 color 以规避白名单。
  */
 import { CARD_PLACEHOLDER } from "./types.js";
+import { buildDisplayCard, type DisplayBlock, type RichSegment } from "./card-blocks.js";
 
 /** 单个工具步骤的状态。 */
 export interface CardStep {
@@ -23,6 +24,12 @@ export interface CardStep {
    * 避免把 duration/error 标到错误行。缺失(旧 host)时回退按 toolName 匹配。
    */
   toolCallId?: string;
+  /**
+   * hook 侧记录的开始时间(ms epoch)。目前只对 P1-g 的 __thinking__ 步骤有意义:
+   * SDK 无 `model_call_ended` hook,thinking 结束时机由外部信号(before_tool_call / finalize)
+   * 决定,duration = now - startedAt。渲染层只看 durationMs,该字段仅 hook 侧内部使用。
+   */
+  startedAt?: number;
 }
 
 /** 进度卡的渲染状态。 */
@@ -47,7 +54,8 @@ const TOOL_META: Record<string, { icon: string; label: string }> = {
   process: { icon: "⚙️", label: "运行进程" },
   search: { icon: "🔍", label: "搜索" },
   grep: { icon: "🔍", label: "搜索内容" },
-  glob: { icon: "🔍", label: "查找文件" },
+  find: { icon: "🔍", label: "查找文件" },
+  glob: { icon: "🔍", label: "查找文件" }, // 别名兜底;host 内建工具名是 find(见 SDK ToolName)
   ls: { icon: "📂", label: "浏览目录" },
   fetch: { icon: "🌐", label: "抓取网页" },
   web_search: { icon: "🌐", label: "联网搜索" },
@@ -56,6 +64,8 @@ const TOOL_META: Record<string, { icon: string; label: string }> = {
 
 /** 工具名 → 图标 + 标签。MCP 工具(`mcp__server__tool`)解析 server/tool。 */
 export function resolveToolMeta(tool: string): { icon: string; label: string } {
+  // 特殊内部 tool 名:agent 一轮 model_call = 一步"思考"(P1-g)。以 __ 前缀,agent 侧无冲突可能。
+  if (tool === "__thinking__") return { icon: "💭", label: "思考" };
   if (tool.startsWith(MCP_TOOL_PREFIX)) {
     const rest = tool.slice(MCP_TOOL_PREFIX.length).replace(/__/g, " / ");
     return { icon: "🔌", label: `MCP ${rest}` };
@@ -76,12 +86,23 @@ const SECRET_RE =
  * 明确前缀式凭据形状(AKIA/GitHub/Slack/OpenAI/JWT)。这些格式**在任何位置都几乎不可能
  * 是正常内容**,故对所有策略(含 path/shell)都应用 —— 关键词正则只认密钥名字,认不出这些形状。
  */
+// 关键:这些前缀模式**不加前导 `\b`/`(?<!\w)` 词界锚点**。词界锚点会被"前面粘一个词字符"
+// (`xAKIA…`、`KeyAKIA…`)绕过 —— 短前缀(AKIA=20 / sk-≈19 / Slack / JWT)又都短于 32 位,
+// 逃过高熵兜底 → 明文密钥渲进群卡片(yujiawei 复现的 P1)。故按**无锚点子串**匹配;`{16,}`/`{20,}`
+// 长度下限仍能把连字符英文(`risk-averse`/`task-force`)挡在外面。宁可过度隐藏,绝不泄露。
 const SECRET_PREFIX_RES: RegExp[] = [
-  /\bAKIA[0-9A-Z]{12,}\b/,                                  // AWS access key id
-  /\b(?:gh[pousr]|github_pat)_[A-Za-z0-9_]{20,}/,           // GitHub token / fine-grained PAT
-  /\bxox[baprs]-[A-Za-z0-9-]{10,}/,                         // Slack token
-  /\bsk-[A-Za-z0-9_-]{16,}/,                                // OpenAI-style secret key
-  /\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]+/, // JWT
+  /AKIA[0-9A-Z]{12,}/,                                  // AWS access key id
+  /(?:gh[pousr]|github_pat)_[A-Za-z0-9_]{20,}/,         // GitHub token / fine-grained PAT
+  /xox[baprs]-[A-Za-z0-9-]{10,}/,                       // Slack bot/user token
+  /xapp-[0-9]-[A-Za-z0-9-]{10,}/,                       // Slack app-level token
+  /sk-[A-Za-z0-9_-]{16,}/,                              // OpenAI-style secret key
+  /[srp]k_(?:live|test)_[A-Za-z0-9]{10,}/,             // Stripe secret/restricted/publishable
+  /glpat-[A-Za-z0-9_-]{16,}/,                           // GitLab personal access token
+  /AIza[0-9A-Za-z_-]{30,}/,                             // Google API key
+  /npm_[A-Za-z0-9]{30,}/,                               // npm automation token
+  /shpat_[A-Fa-f0-9]{32,}/,                             // Shopify access token
+  /dop_v1_[A-Fa-f0-9]{32,}/,                            // DigitalOcean PAT
+  /eyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]+/, // JWT
 ];
 
 /** 长 hex(md5/sha/hex 密钥)。也命中 git object/docker digest 等常见路径,故仅用于 query/url。 */
@@ -103,7 +124,7 @@ function hasGenericSecretShape(s: string): boolean {
  * 只走关键词 + 明确前缀,避免把 git SHA / docker digest / 缓存哈希等正常路径误伤成空。
  * 群卡片对全员可见,任一命中即隐藏。
  */
-function isSensitive(s: string, generic: boolean): boolean {
+export function isSensitive(s: string, generic: boolean): boolean {
   if (SECRET_RE.test(s)) return true;
   if (SECRET_PREFIX_RES.some((re) => re.test(s))) return true;
   return generic && hasGenericSecretShape(s);
@@ -139,11 +160,31 @@ function registrableDomain(host: string): string {
  */
 type SummaryStrategy = "path" | "shell" | "url" | "query";
 const SUMMARY_STRATEGY: Record<string, SummaryStrategy> = {
-  read: "path", write: "path", edit: "path", apply_patch: "path", ls: "path", glob: "path",
+  read: "path", write: "path", edit: "path", apply_patch: "path", ls: "path", find: "path", glob: "path",
   exec: "shell", bash: "shell", shell: "shell", process: "shell",
   fetch: "url",
   web_search: "query", search: "query", grep: "query",
 };
+
+/**
+ * 深路径智能压缩 —— 保留末 2 段(倒数第二段 + 文件名),前缀省略号。
+ * 段数 ≤ 3 时原样返回(信息量不大,压缩反而丢上下文);
+ * 末段(文件名/最深目录)永远完整,防止只见 `.../SKILL.md` 分不出是哪个 skill。
+ *
+ * 例:
+ *   /root/.openclaw/workspace/octo-server/modules/bot_api/send.go → …/bot_api/send.go
+ *   /work/README.md                                                → /work/README.md (未压缩)
+ *   docs/card-protocol.md                                          → docs/card-protocol.md (未压缩)
+ *
+ * 家目录/绝对根不做特殊 `~` 标记,保持规则简单一致。空路径原样返回。
+ */
+function shortenPath(p: string): string {
+  if (!p) return p;
+  // 用 posix 分隔符做主判定;Windows `\` 若出现也能处理,但 shell/工具场景以 posix 为主。
+  const segs = p.split("/").filter((s) => s.length > 0);
+  if (segs.length <= 3) return p;
+  return `…/${segs[segs.length - 2]}/${segs[segs.length - 1]}`;
+}
 
 /** 取 keys 中首个非空字符串值。 */
 function firstString(p: Record<string, unknown>, keys: string[]): string {
@@ -189,11 +230,36 @@ function originDomain(rawUrl: string): string | null {
   }
 }
 
+/** 已知 webhook 主机 + 路径形态(密钥整段嵌在 path 里,无 scheme 也要降级)。 */
+const SCHEMELESS_WEBHOOK_RE =
+  /\b(?:hooks\.slack\.com\/services|discord(?:app)?\.com\/api\/webhooks|[a-z0-9.-]+\.webhook\.office\.com|outlook\.office\.com\/webhook)\/[^\s]+/gi;
+/** 协议相对 URL(`//host/path`):按 https 处理。 */
+const PROTOCOL_RELATIVE_RE = /(^|[\s(])\/\/[A-Za-z0-9.-]+\.[A-Za-z]{2,}(?::\d+)?\/[^\s]*/g;
+/** 无 scheme 的 userinfo DSN(`user:pass@host[:port][/path]`):userinfo 即明文口令。要求主机含 TLD 以免误伤 `a:b@c`。 */
+const SCHEMELESS_USERINFO_RE =
+  /\b[A-Za-z0-9._%+-]+:[^\s:@/]+@[A-Za-z0-9-]+(?:\.[A-Za-z0-9-]+)+(?::\d+)?(?:\/[^\s]*)?/g;
+
 /** 把文本里内嵌的 URI 就地降级为 scheme://注册域(解析失败则整段抹除)。 */
-function reduceUrlsInText(s: string): string {
-  // 任意 `scheme://…`,不止 http(s):DB/AMQP/ssh DSN(postgres://user:pass@host 等)也常
-  // 出现在 query/shell/错误文本里,userinfo 即明文密码。要求 `://` 故不误伤 Windows 盘符(C:/)。
-  return s.replace(/\b[a-z][a-z0-9+.-]*:\/\/[^\s]+/gi, (m) => originDomain(m) ?? "");
+export function reduceUrlsInText(s: string): string {
+  // 1. 任意 `scheme://…`,不止 http(s):DB/AMQP/ssh DSN(postgres://user:pass@host 等)也常
+  //    出现在 query/shell/错误文本里,userinfo 即明文密码。要求 `://` 故不误伤 Windows 盘符(C:/)。
+  let out = s.replace(/\b[a-z][a-z0-9+.-]*:\/\/[^\s]+/gi, (m) => originDomain(m) ?? "");
+  // 2. 协议相对 `//host/path`:补 https 后降级(secret 可能在 path)。
+  out = out.replace(PROTOCOL_RELATIVE_RE, (_m, p1: string) => {
+    const url = _m.slice(p1.length); // 去掉前导分隔符
+    return p1 + (originDomain(`https:${url}`) ?? "");
+  });
+  // 3. 无 scheme 的已知 webhook 主机+路径(Slack/Discord/Teams):主机保留、path 抹掉。
+  out = out.replace(SCHEMELESS_WEBHOOK_RE, (m) => {
+    const host = m.split("/")[0];
+    return originDomain(`https://${host}`) ?? "";
+  });
+  // 4. 无 scheme 的 userinfo DSN(`user:pass@host…`):只留注册域,丢 userinfo/path。
+  out = out.replace(SCHEMELESS_USERINFO_RE, (m) => {
+    const host = m.slice(m.indexOf("@") + 1).split(/[/:]/)[0];
+    return originDomain(`https://${host}`) ?? "";
+  });
+  return out;
 }
 
 /** url 策略:取 url 参数并降级为注册域。 */
@@ -214,7 +280,7 @@ export function summarizeToolParams(toolName: string | undefined, params: unknow
   const p = params as Record<string, unknown>;
   let v: string;
   switch (strategy) {
-    case "path": v = firstString(p, ["path", "file_path", "file"]); break;
+    case "path": v = shortenPath(firstString(p, ["path", "file_path", "file"])); break;
     case "shell": v = summarizeShell(p); break;
     case "url": v = summarizeUrl(p); break;
     case "query": v = firstString(p, ["query", "pattern"]); break;
@@ -264,11 +330,14 @@ const LABEL_MAX = 40;
 
 /**
  * 工具名 label 也是群可见 sink(与 params/error 一致):tool 名来自 registry/MCP 配置,长名会
- * 撑卡片,疑似密钥形状的标识符不应渲出。命中敏感 → 回退通用「工具」,否则截断。
+ * 撑卡片,疑似密钥形状的标识符不应渲出。清洗与其它 sink 对齐:先 URL 降级(注册域),再命中
+ * 敏感 → 回退通用「工具」,否则截断。(label 通常无 URL,reduceUrlsInText 为 no-op;统一以防
+ * MCP/动态工具名里嵌了 webhook/DSN 形状。)
  */
 function safeLabel(label: string): string {
-  if (isSensitive(label, true)) return "工具";
-  return label.length > LABEL_MAX ? label.slice(0, LABEL_MAX) + "…" : label;
+  const s = reduceUrlsInText(label);
+  if (isSensitive(s, true)) return "工具";
+  return s.length > LABEL_MAX ? s.slice(0, LABEL_MAX) + "…" : s;
 }
 
 /** 单步 → 一行文案:图标 + 标签 + 参数摘要 + 状态/耗时。错误详情经脱敏+截断,label 经脱敏+截断。 */
@@ -312,59 +381,143 @@ const BASELINE_ELEMENTS: ReadonlySet<string> = new Set([
 ]);
 
 /**
+ * 输入/动作**没有安全基线** —— server 未 advertise 时消费方**保守视为不支持**(fail-closed),
+ * 避免 producer 乐观发出旧部署不认的 Input.Number/Action.ToggleVisibility 等致 400。
+ */
+const BASELINE_INPUTS: ReadonlySet<string> = new Set();
+const BASELINE_ACTIONS: ReadonlySet<string> = new Set();
+
+/**
  * 服务端能力(D12 manifest 派生),供渲染按元素/结构上限裁剪。全可选,缺省即保守默认:
- * 未 advertise elements → 用 BASELINE_ELEMENTS;未给 maxNodes → 用本地 MAX_VISIBLE_STEPS。
+ * 未 advertise elements → 用 BASELINE_ELEMENTS;未 advertise inputs/actions → 空集(fail-closed);
+ * 未给 maxNodes → 用本地 MAX_VISIBLE_STEPS。
  */
 export interface CardCaps {
   /** 服务端 advertise 的元素白名单(pkg/cardmsg 权威)。 */
   elements?: ReadonlySet<string>;
+  /** 服务端 advertise 的输入白名单(Input.Text/Toggle/ChoiceSet/Number/Date/Time)。 */
+  inputs?: ReadonlySet<string>;
+  /** 服务端 advertise 的动作白名单(Submit/ToggleVisibility/ShowCard/OpenUrl 等)。 */
+  actions?: ReadonlySet<string>;
   /** 递归节点数上限(limits.max_nodes)。 */
   maxNodes?: number;
 }
 
-/** 元素是否可安全渲染:manifest 明确 advertise 则以其为准,否则用基线。 */
-export function cardSupports(caps: CardCaps | undefined, element: string): boolean {
-  return (caps?.elements ?? BASELINE_ELEMENTS).has(element);
+/**
+ * 元素/输入/动作是否可安全渲染 —— 按前缀分派到对应 caps 桶。
+ * - `Input.*` → `caps.inputs`(不给则 fail-closed)
+ * - `Action.*` → `caps.actions`(不给则 fail-closed)
+ * - 其它 → `caps.elements`(不给则用保守基线,与旧行为兼容)
+ * 一个函数覆盖三类,调用方无需分派;新增类别只需在此扩前缀即可。
+ */
+export function cardSupports(caps: CardCaps | undefined, kind: string): boolean {
+  if (kind.startsWith("Input.")) return (caps?.inputs ?? BASELINE_INPUTS).has(kind);
+  if (kind.startsWith("Action.")) return (caps?.actions ?? BASELINE_ACTIONS).has(kind);
+  return (caps?.elements ?? BASELINE_ELEMENTS).has(kind);
 }
 
 /**
  * 展示步骤上限。长任务工具调用不断累积,全量渲染会撑爆卡片、超服务端结构上限致 edit 400。
- * 优先用服务端权威 max_nodes 推导上限(每步节点数依布局而定),缺省退回本地保守值。
+ * 优先用服务端权威 max_nodes 推导上限(每步 1 节点),缺省退回本地保守值。
  */
 const MAX_VISIBLE_STEPS = 12;
-const NODES_PER_TEXT_STEP = 1; // 1 个 TextBlock
-const NODES_PER_COLUMN_STEP = 5; // ColumnSet + 2 Column + 2 TextBlock
 
-function maxVisibleSteps(caps: CardCaps | undefined, useColumns: boolean): number {
+function maxVisibleSteps(caps: CardCaps | undefined): number {
   if (!caps?.maxNodes) return MAX_VISIBLE_STEPS;
-  const perStep = useColumns ? NODES_PER_COLUMN_STEP : NODES_PER_TEXT_STEP;
   const reserve = 2; // header + 折叠计数行
-  const byNodes = Math.max(1, Math.floor((caps.maxNodes - reserve) / perStep));
+  const byNodes = Math.max(1, caps.maxNodes - reserve); // 每步 = 1 元素(rich 或 TextBlock,同为 1)
   return Math.min(MAX_VISIBLE_STEPS, byNodes);
 }
 
-/** 单步 → ColumnSet 行:[状态/图标列 auto | 文本列 stretch]。仅在服务端 advertise ColumnSet 时用。 */
-function stepColumnRow(step: CardStep): Record<string, unknown> {
-  const line = stepLine(step);
-  const sp = line.indexOf(" ");
-  const glyph = sp >= 0 ? line.slice(0, sp) : line;
-  const bodyText = sp >= 0 ? line.slice(sp + 1) : "";
-  return {
-    type: "ColumnSet",
-    spacing: "Small",
-    columns: [
-      { type: "Column", width: "auto", items: [{ type: "TextBlock", text: glyph, wrap: false }] },
-      { type: "Column", width: "stretch", items: [{ type: "TextBlock", text: bodyText, wrap: true }] },
-    ],
-  };
+/**
+ * 单步 → RichTextBlock 的多段 inlines(供 buildDisplayCard 的 rich block 使用):
+ *   状态图标 | label(Bolder) | :摘要 | · 耗时/— 错误详情(good/attention 着色)
+ * 段拼接后与 `stepLine(step)` 输出完全一致 —— 保证 plain 兜底不变,且降级到 TextBlock 时视觉等价。
+ */
+function stepSegments(step: CardStep): RichSegment[] {
+  const { icon, label: rawLabel } = resolveToolMeta(step.tool);
+  const label = safeLabel(rawLabel);
+  const sum = step.summary ? `：${step.summary}` : "";
+  if (step.status === "running") {
+    return [{ text: "⏳ " }, { text: label, bold: true }, { text: sum }];
+  }
+  if (step.status === "error") {
+    const detail = sanitizeErrorText(step.error);
+    const segs: RichSegment[] = [
+      { text: "❌ " },
+      { text: label, bold: true },
+      { text: sum },
+    ];
+    if (detail) segs.push({ text: ` — ${detail}`, color: "attention" });
+    return segs;
+  }
+  const dur = fmtDuration(step.durationMs);
+  const segs: RichSegment[] = [
+    { text: `${icon} ` },
+    { text: label, bold: true },
+    { text: sum },
+  ];
+  if (dur) segs.push({ text: ` · ${dur}`, color: "good" });
+  return segs;
 }
 
 /**
- * 渲染进度卡。返回 `{ card, plain }`:
- *   - `card` = Adaptive Cards 1.5 JSON。默认 header + 每步一行 TextBlock;当 D12 manifest **明确
- *     advertise** ColumnSet+Column 时,步骤升级为对齐的 ColumnSet 行(否则降级 TextBlock,零回归)。
- *     可见步数受服务端 max_nodes 权威约束(缺省用本地上限)。
- *   - `plain` = 纯文本兜底(始终为 stepLine 文本,与布局无关;服务端 Finalize 会权威重算)。
+ * 同类合并的一"组":≥2 个连续同 tool 且全 done 的步骤压成一行,大幅缩视觉噪音。
+ * 显示:`<icon> <label> × N · 共 <总耗时> — 最近: <最后一个 summary>`
+ * running/error 步骤不参与合并(单独调 stepSegments),避免糊掉当前重点。
+ */
+function groupSegments(group: CardStep[]): RichSegment[] {
+  const first = group[0];
+  const { icon, label: rawLabel } = resolveToolMeta(first.tool);
+  const label = safeLabel(rawLabel);
+  // 仅在至少一步有耗时时才展示总耗时,否则不显示(避免全 undefined 渲成误导性的「共 0ms」)。
+  const anyDuration = group.some((s) => typeof s.durationMs === "number");
+  const total = group.reduce((acc, s) => acc + (s.durationMs ?? 0), 0);
+  const dur = anyDuration ? fmtDuration(total) : "";
+  const last = group[group.length - 1];
+  const lastSum = last.summary ? last.summary : "";
+  const segs: RichSegment[] = [
+    { text: `${icon} ` },
+    { text: label, bold: true },
+    { text: ` × ${group.length}` },
+  ];
+  if (dur) segs.push({ text: ` · 共 ${dur}`, color: "good" });
+  if (lastSum) segs.push({ text: ` — 最近: ${lastSum}` });
+  return segs;
+}
+
+/**
+ * 把可见步骤按"相邻同 tool 且全 done"分组:连续 ≥2 个 done → 合并组;单个 done / running / error
+ * → 各自一组(即"单元素组")。返回二维数组,每个内数组是一段。
+ *
+ * 分组只在 done 之间做:running 与 error 不合并 —— 当前重点(还在跑/失败了)必须显眼。
+ */
+function groupSteps(steps: CardStep[]): CardStep[][] {
+  const out: CardStep[][] = [];
+  let i = 0;
+  while (i < steps.length) {
+    const cur = steps[i];
+    if (cur.status !== "done") {
+      out.push([cur]);
+      i++;
+      continue;
+    }
+    let j = i + 1;
+    while (j < steps.length && steps[j].tool === cur.tool && steps[j].status === "done") j++;
+    out.push(steps.slice(i, j));
+    i = j;
+  }
+  return out;
+}
+
+/**
+ * 渲染进度卡 —— **走 buildDisplayCard 底座**(吃自己狗粮):header 用 heading(medium)block、
+ * 每步用 rich block(advertise RichTextBlock 时是 RichTextBlock 富行、否则 TextBlock 平铺 —— 一行完整,
+ * 不像 ColumnSet 会被服务端权威 plain 重算成图标/文本两行)。
+ * 可见步数受服务端 max_nodes 权威约束(缺省用本地上限)。
+ *
+ * 返回 `{ card, plain }`:card = AC 1.5 JSON;plain = 纯文本兜底(与布局无关;服务端 Finalize 会
+ * 权威重算)。plain 空则回退 CARD_PLACEHOLDER。
  */
 export function renderProgressCard(
   state: CardProgressState,
@@ -373,38 +526,26 @@ export function renderProgressCard(
   card: Record<string, unknown>;
   plain: string;
 } {
-  // 仅当服务端**明确 advertise** ColumnSet 才升级(未 advertise → 保持 TextBlock,零回归)。
-  // 只查 ColumnSet:Column 是 ColumnSet 的固有子元素,服务端 cardmsg 白名单不单独 advertise
-  // Column(实测 elements 含 ColumnSet 但无 Column)——接受 ColumnSet 即接受其 Column 子节点。
-  const useColumns = !!caps?.elements && cardSupports(caps, "ColumnSet");
-  const cap = maxVisibleSteps(caps, useColumns);
-
   const header = headerText(state);
+  const cap = maxVisibleSteps(caps);
   const total = state.steps.length;
   // 只展示最近 cap 步;更早的折叠成一行计数,避免卡片无界膨胀。
   const hidden = Math.max(0, total - cap);
   const visibleSteps = hidden > 0 ? state.steps.slice(-cap) : state.steps;
-  const lines: string[] = [];
-  if (hidden > 0) lines.push(`… 省略前 ${hidden} 步`);
-  for (const s of visibleSteps) lines.push(stepLine(s));
 
-  const body: Record<string, unknown>[] = [
-    { type: "TextBlock", text: header, weight: "Bolder", size: "Medium", wrap: true },
+  const blocks: DisplayBlock[] = [
+    { type: "heading", text: header, size: "medium" },
   ];
-  if (hidden > 0) {
-    body.push({ type: "TextBlock", text: `… 省略前 ${hidden} 步`, wrap: true, spacing: "Small" });
-  }
-  for (const s of visibleSteps) {
-    body.push(useColumns ? stepColumnRow(s) : { type: "TextBlock", text: stepLine(s), wrap: true, spacing: "Small" });
+  if (hidden > 0) blocks.push({ type: "text", text: `… 省略前 ${hidden} 步` });
+  // 同类合并:连续 ≥2 个同 tool 全 done 的段压成一行(用户看到的行数远少于原始步数);
+  // running/error 保留单独行,当前重点不糊掉。header 的"N 步"计数仍用原始 steps.length。
+  for (const g of groupSteps(visibleSteps)) {
+    blocks.push({ type: "rich", segments: g.length > 1 ? groupSegments(g) : stepSegments(g[0]) });
   }
 
-  const card: Record<string, unknown> = {
-    type: "AdaptiveCard",
-    version: "1.5",
-    $schema: "http://adaptivecards.io/schemas/adaptive-card.json",
-    body,
-  };
-
-  const plainText = [header, ...lines].join("\n").trim();
-  return { card, plain: plainText || CARD_PLACEHOLDER };
+  // trusted:进度卡的每行文案已在上游逐 sink 脱敏(summarizeToolParams/sanitizeErrorText/safeLabel:
+  // URL 已降级、path/shell 按 generic=false 保留 git SHA/digest)。buildDisplayCard 默认 generic=true
+  // 会二次套用长 hex/高熵检测,误删含哈希的正常行、甚至把错误终态帧整卡清空 —— 故此路径关掉严格 generic。
+  const { card, plain } = buildDisplayCard({ blocks, caps, trusted: true });
+  return { card, plain: plain || CARD_PLACEHOLDER };
 }

--- a/src/card-render.ts
+++ b/src/card-render.ts
@@ -73,6 +73,63 @@ const SECRET_RE =
   /token|api[_-]?key|secret|password|passwd|pwd|authorization|bearer|access[_-]?key|client[_-]?secret|credential/i;
 
 /**
+ * 形状检测:关键词正则只认密钥**名字**,认不出密钥**形状**。这里补一组按形状匹配的
+ * 已知/通用凭据模式,与 SECRET_RE 并用 —— 覆盖「query/pattern 传入裸 token」等无关键词
+ * 可循的泄露(如 grep `AKIA...`、web_search 一段 40 位 hex)。
+ */
+const SECRET_SHAPE_RES: RegExp[] = [
+  /\bAKIA[0-9A-Z]{12,}\b/,                                  // AWS access key id
+  /\b(?:gh[pousr]|github_pat)_[A-Za-z0-9_]{20,}/,           // GitHub token / fine-grained PAT
+  /\bxox[baprs]-[A-Za-z0-9-]{10,}/,                         // Slack token
+  /\bsk-[A-Za-z0-9_-]{16,}/,                                // OpenAI-style secret key
+  /\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]+/, // JWT
+  /\b[0-9a-fA-F]{32,}\b/,                                   // 长 hex(md5/sha/hex 密钥)
+];
+
+/**
+ * 高熵串:32+ 位连续 base64url 段且**同时含字母与数字**(随机 token 的特征)。只按长度
+ * 会误伤长路径/长英文(如 80 个 `x`),故要求字母数字混合 —— 纯字母(词/路径)、纯数字不命中。
+ */
+function hasHighEntropyRun(s: string): boolean {
+  const runs = s.match(/[A-Za-z0-9_-]{32,}/g);
+  return !!runs && runs.some((r) => /[0-9]/.test(r) && /[A-Za-z]/.test(r));
+}
+
+/** 是否命中任一密钥形状(已知前缀/hex/JWT + 通用高熵串)。 */
+function looksLikeSecretShape(s: string): boolean {
+  return SECRET_SHAPE_RES.some((re) => re.test(s)) || hasHighEntropyRun(s);
+}
+
+/** 是否命中关键词或形状守卫(群卡片对全员可见,任一命中即隐藏)。 */
+function isSensitive(s: string): boolean {
+  return SECRET_RE.test(s) || looksLikeSecretShape(s);
+}
+
+/**
+ * 常见多段有效后缀(eTLD),用于计算注册域时多保留一段。非穷举,只覆盖高频场景;
+ * 未命中的按「末两段」处理即可(始终丢掉子域 → 不会泄露子域里的密钥)。
+ */
+const MULTI_PART_TLDS = new Set([
+  "co.uk", "org.uk", "gov.uk", "ac.uk",
+  "com.cn", "net.cn", "org.cn", "gov.cn", "edu.cn",
+  "com.au", "com.br", "com.hk", "com.tw", "com.sg", "co.jp", "co.kr",
+]);
+
+/**
+ * 取注册域(丢掉所有子域):隧道/预签名场景**主机名本身就是密钥**(如 ngrok 随机子域、
+ * 预签名 bucket 名),故只保留 eTLD+1。多段后缀(com.cn/co.uk 等)多保留一段。
+ * 纯 IPv4 原样返回。
+ */
+function registrableDomain(host: string): string {
+  if (/^\d{1,3}(?:\.\d{1,3}){3}$/.test(host)) return host; // IPv4 原样
+  const labels = host.split(".");
+  if (labels.length <= 2) return host;
+  const last2 = labels.slice(-2).join(".");
+  const keep = MULTI_PART_TLDS.has(last2) ? 3 : 2;
+  return labels.slice(-keep).join(".");
+}
+
+/**
  * 工具 → 摘要提取策略(allowlist)。未列出的工具(含 MCP、未知工具)一律**不显示摘要**,
  * 杜绝把任意参数直渲到群卡片的泄露面。
  */
@@ -114,16 +171,17 @@ function summarizeShell(p: Record<string, unknown>): string {
 }
 
 /**
- * url:**只保留 scheme://host**,丢弃 path/query/userinfo。凭据既可能在 query,也常整段
- * 嵌在 path 里(Slack/Discord incoming webhook `/services/T../B../XXXX`),且随机 token
- * 不含关键词、躲过 SECRET_RE —— 故 path 一并不展示,只暴露主机名。
+ * url:只保留 **scheme://注册域**,丢弃 path/query/userinfo **和所有子域**。凭据既可能在
+ * query,也常整段嵌在 path 里(Slack/Discord webhook `/services/T../B../XXXX`),更有隧道/
+ * 预签名场景**主机名本身即密钥**(ngrok 随机子域、预签名 bucket 名)—— 这些随机串不含
+ * 关键词、躲过 SECRET_RE。故只暴露注册域(eTLD+1),既够用又不泄露。
  */
 function summarizeUrl(p: Record<string, unknown>): string {
   const raw = firstString(p, ["url"]);
   if (!raw) return "";
   try {
     const u = new URL(raw);
-    return `${u.protocol}//${u.host}`;
+    return `${u.protocol}//${registrableDomain(u.hostname)}`;
   } catch {
     return ""; // 解析失败 → 不显示(原串可能含 token)
   }
@@ -147,7 +205,7 @@ export function summarizeToolParams(toolName: string | undefined, params: unknow
   }
   if (!v) return "";
   const s = v.replace(/\s+/g, " ").trim();
-  if (!s || SECRET_RE.test(s)) return ""; // 敏感串守卫:命中即隐藏
+  if (!s || isSensitive(s)) return ""; // 关键词 + 形状守卫:任一命中即隐藏
   return s.length > SUMMARY_MAX ? s.slice(0, SUMMARY_MAX) + "…" : s;
 }
 

--- a/src/card-render.ts
+++ b/src/card-render.ts
@@ -306,28 +306,84 @@ function headerText(state: CardProgressState): string {
   }
 }
 
+/** octo/v1 1.5 已验证可安全渲染的展示元素基线(manifest 未 advertise elements 时用)。 */
+const BASELINE_ELEMENTS: ReadonlySet<string> = new Set([
+  "TextBlock", "Container", "ColumnSet", "Column", "FactSet", "Image",
+]);
+
 /**
- * 展示步骤上限。长任务工具调用不断累积,若全量渲染成 TextBlock,卡片体积会持续膨胀,
- * 最终可能超服务端结构上限导致 edit 400、进度冻结。这里用确定性本地上限裁剪(与服务端
- * limits 无关,不依赖其未定义的 key schema):超出只渲染最近 N 步 + 顶部一行省略计数。
+ * 服务端能力(D12 manifest 派生),供渲染按元素/结构上限裁剪。全可选,缺省即保守默认:
+ * 未 advertise elements → 用 BASELINE_ELEMENTS;未给 maxNodes → 用本地 MAX_VISIBLE_STEPS。
+ */
+export interface CardCaps {
+  /** 服务端 advertise 的元素白名单(pkg/cardmsg 权威)。 */
+  elements?: ReadonlySet<string>;
+  /** 递归节点数上限(limits.max_nodes)。 */
+  maxNodes?: number;
+}
+
+/** 元素是否可安全渲染:manifest 明确 advertise 则以其为准,否则用基线。 */
+export function cardSupports(caps: CardCaps | undefined, element: string): boolean {
+  return (caps?.elements ?? BASELINE_ELEMENTS).has(element);
+}
+
+/**
+ * 展示步骤上限。长任务工具调用不断累积,全量渲染会撑爆卡片、超服务端结构上限致 edit 400。
+ * 优先用服务端权威 max_nodes 推导上限(每步节点数依布局而定),缺省退回本地保守值。
  */
 const MAX_VISIBLE_STEPS = 12;
+const NODES_PER_TEXT_STEP = 1; // 1 个 TextBlock
+const NODES_PER_COLUMN_STEP = 5; // ColumnSet + 2 Column + 2 TextBlock
+
+function maxVisibleSteps(caps: CardCaps | undefined, useColumns: boolean): number {
+  if (!caps?.maxNodes) return MAX_VISIBLE_STEPS;
+  const perStep = useColumns ? NODES_PER_COLUMN_STEP : NODES_PER_TEXT_STEP;
+  const reserve = 2; // header + 折叠计数行
+  const byNodes = Math.max(1, Math.floor((caps.maxNodes - reserve) / perStep));
+  return Math.min(MAX_VISIBLE_STEPS, byNodes);
+}
+
+/** 单步 → ColumnSet 行:[状态/图标列 auto | 文本列 stretch]。仅在服务端 advertise ColumnSet 时用。 */
+function stepColumnRow(step: CardStep): Record<string, unknown> {
+  const line = stepLine(step);
+  const sp = line.indexOf(" ");
+  const glyph = sp >= 0 ? line.slice(0, sp) : line;
+  const bodyText = sp >= 0 ? line.slice(sp + 1) : "";
+  return {
+    type: "ColumnSet",
+    spacing: "Small",
+    columns: [
+      { type: "Column", width: "auto", items: [{ type: "TextBlock", text: glyph, wrap: false }] },
+      { type: "Column", width: "stretch", items: [{ type: "TextBlock", text: bodyText, wrap: true }] },
+    ],
+  };
+}
 
 /**
  * 渲染进度卡。返回 `{ card, plain }`:
- *   - `card` = Adaptive Cards 1.5 JSON(header + 每步一行,octo/v1 白名单内;不用 color/
- *     markdown 链接,规避白名单/scheme 校验)。
- *   - `plain` = 纯文本兜底(服务端 Finalize 会权威重算,此处保证 never empty)。
+ *   - `card` = Adaptive Cards 1.5 JSON。默认 header + 每步一行 TextBlock;当 D12 manifest **明确
+ *     advertise** ColumnSet+Column 时,步骤升级为对齐的 ColumnSet 行(否则降级 TextBlock,零回归)。
+ *     可见步数受服务端 max_nodes 权威约束(缺省用本地上限)。
+ *   - `plain` = 纯文本兜底(始终为 stepLine 文本,与布局无关;服务端 Finalize 会权威重算)。
  */
-export function renderProgressCard(state: CardProgressState): {
+export function renderProgressCard(
+  state: CardProgressState,
+  caps?: CardCaps,
+): {
   card: Record<string, unknown>;
   plain: string;
 } {
+  // 仅当服务端**明确 advertise** ColumnSet 才升级(未 advertise → 保持 TextBlock,零回归)。
+  // 只查 ColumnSet:Column 是 ColumnSet 的固有子元素,服务端 cardmsg 白名单不单独 advertise
+  // Column(实测 elements 含 ColumnSet 但无 Column)——接受 ColumnSet 即接受其 Column 子节点。
+  const useColumns = !!caps?.elements && cardSupports(caps, "ColumnSet");
+  const cap = maxVisibleSteps(caps, useColumns);
+
   const header = headerText(state);
   const total = state.steps.length;
-  // 只展示最近 MAX_VISIBLE_STEPS 步;更早的折叠成一行计数,避免卡片无界膨胀。
-  const hidden = Math.max(0, total - MAX_VISIBLE_STEPS);
-  const visibleSteps = hidden > 0 ? state.steps.slice(-MAX_VISIBLE_STEPS) : state.steps;
+  // 只展示最近 cap 步;更早的折叠成一行计数,避免卡片无界膨胀。
+  const hidden = Math.max(0, total - cap);
+  const visibleSteps = hidden > 0 ? state.steps.slice(-cap) : state.steps;
   const lines: string[] = [];
   if (hidden > 0) lines.push(`… 省略前 ${hidden} 步`);
   for (const s of visibleSteps) lines.push(stepLine(s));
@@ -335,8 +391,11 @@ export function renderProgressCard(state: CardProgressState): {
   const body: Record<string, unknown>[] = [
     { type: "TextBlock", text: header, weight: "Bolder", size: "Medium", wrap: true },
   ];
-  for (const line of lines) {
-    body.push({ type: "TextBlock", text: line, wrap: true, spacing: "Small" });
+  if (hidden > 0) {
+    body.push({ type: "TextBlock", text: `… 省略前 ${hidden} 步`, wrap: true, spacing: "Small" });
+  }
+  for (const s of visibleSteps) {
+    body.push(useColumns ? stepColumnRow(s) : { type: "TextBlock", text: stepLine(s), wrap: true, spacing: "Small" });
   }
 
   const card: Record<string, unknown> = {

--- a/src/card-render.ts
+++ b/src/card-render.ts
@@ -175,20 +175,30 @@ function summarizeShell(p: Record<string, unknown>): string {
 }
 
 /**
- * url:只保留 **scheme://注册域**,丢弃 path/query/userinfo **和所有子域**。凭据既可能在
- * query,也常整段嵌在 path 里(Slack/Discord webhook `/services/T../B../XXXX`),更有隧道/
- * 预签名场景**主机名本身即密钥**(ngrok 随机子域、预签名 bucket 名)—— 这些随机串不含
- * 关键词、躲过 SECRET_RE。故只暴露注册域(eTLD+1),既够用又不泄露。
+ * URL → `scheme://注册域`。丢弃 path/query/userinfo **和所有子域**:凭据既可能在 query,
+ * 也常整段嵌在 path 里(Slack/Discord webhook `/services/T../B../XXXX`),更有隧道/预签名
+ * 场景**主机名本身即密钥**(ngrok 随机子域、预签名 bucket 名)—— 这些随机串不含关键词、躲过
+ * SECRET_RE。故只暴露注册域(eTLD+1)。解析失败返回 null(原串可能含 token,调用方丢弃)。
  */
+function originDomain(rawUrl: string): string | null {
+  try {
+    const u = new URL(rawUrl);
+    return `${u.protocol}//${registrableDomain(u.hostname)}`;
+  } catch {
+    return null;
+  }
+}
+
+/** 把文本里内嵌的 http(s) URL 就地降级为 scheme://注册域(解析失败则整段抹除)。 */
+function reduceUrlsInText(s: string): string {
+  return s.replace(/\bhttps?:\/\/[^\s]+/gi, (m) => originDomain(m) ?? "");
+}
+
+/** url 策略:取 url 参数并降级为注册域。 */
 function summarizeUrl(p: Record<string, unknown>): string {
   const raw = firstString(p, ["url"]);
   if (!raw) return "";
-  try {
-    const u = new URL(raw);
-    return `${u.protocol}//${registrableDomain(u.hostname)}`;
-  } catch {
-    return ""; // 解析失败 → 不显示(原串可能含 token)
-  }
+  return originDomain(raw) ?? "";
 }
 
 /**
@@ -227,12 +237,18 @@ const ERROR_MAX = 120;
 
 /**
  * 清洗工具错误文本后再渲染 —— 错误串是与参数摘要**同等**的泄露 sink:常含 stderr、
- * 失败命令输出、请求 URL/header、webhook 路径、token、文件片段,且长度不可控。故与摘要
- * 用同一 fail-closed 策略:折叠空白 → 命中关键词/形状(generic)则整串隐藏 → 否则截断。
+ * 失败命令输出、请求 URL/header、webhook 路径、token、文件片段,且长度不可控。清洗顺序:
+ *   1. 折叠空白;
+ *   2. **内嵌 URL 降级为 scheme://注册域**(与参数路径 summarizeUrl 对称)—— 否则 webhook
+ *      路径/隧道主机等短、无关键词的密钥会绕过下面的 isSensitive 直接泄露;
+ *   3. 关键词/形状(generic)命中则整串隐藏;
+ *   4. 截断到 ERROR_MAX。
  */
 export function sanitizeErrorText(err?: string): string {
   if (!err) return "";
-  const s = err.replace(/\s+/g, " ").trim();
+  let s = err.replace(/\s+/g, " ").trim();
+  if (!s) return "";
+  s = reduceUrlsInText(s).replace(/\s+/g, " ").trim(); // URL 降级可能留下空隙
   if (!s || isSensitive(s, true)) return ""; // 命中敏感 → 不展示错误详情
   return s.length > ERROR_MAX ? s.slice(0, ERROR_MAX) + "…" : s;
 }

--- a/src/card-render.ts
+++ b/src/card-render.ts
@@ -218,7 +218,10 @@ export function summarizeToolParams(toolName: string | undefined, params: unknow
     case "query": v = firstString(p, ["query", "pattern"]); break;
   }
   if (!v) return "";
-  const s = v.replace(/\s+/g, " ").trim();
+  let s = v.replace(/\s+/g, " ").trim();
+  // 单一 choke point:所有策略统一把内嵌 URL 降级为 scheme://注册域。避免逐 sink 加降级时
+  // 漏掉某个策略(query 的 pattern、shell 的 URL-as-program 都会原样渲染 webhook/userinfo/内网主机)。
+  s = reduceUrlsInText(s).replace(/\s+/g, " ").trim();
   // query/url 是「裸 token」易出没处 → 额外套用通用高熵/长 hex 检测;path/shell 只走关键词
   // + 明确前缀,避免把 git SHA / docker digest / 缓存哈希等正常路径误伤成空。
   const generic = strategy === "query" || strategy === "url";
@@ -241,7 +244,8 @@ const ERROR_MAX = 120;
  *   1. 折叠空白;
  *   2. **内嵌 URL 降级为 scheme://注册域**(与参数路径 summarizeUrl 对称)—— 否则 webhook
  *      路径/隧道主机等短、无关键词的密钥会绕过下面的 isSensitive 直接泄露;
- *   3. 关键词/形状(generic)命中则整串隐藏;
+ *   3. 关键词/明确前缀命中则整串隐藏(generic=false:**不**套用长 hex/高熵,否则会把含 git SHA/
+ *      docker digest/UUID 的普通运维错误整条吞掉 —— webhook 类已由步骤 2 兜住);
  *   4. 截断到 ERROR_MAX。
  */
 export function sanitizeErrorText(err?: string): string {
@@ -249,7 +253,7 @@ export function sanitizeErrorText(err?: string): string {
   let s = err.replace(/\s+/g, " ").trim();
   if (!s) return "";
   s = reduceUrlsInText(s).replace(/\s+/g, " ").trim(); // URL 降级可能留下空隙
-  if (!s || isSensitive(s, true)) return ""; // 命中敏感 → 不展示错误详情
+  if (!s || isSensitive(s, false)) return ""; // 关键词/明确前缀命中 → 不展示错误详情
   return s.length > ERROR_MAX ? s.slice(0, ERROR_MAX) + "…" : s;
 }
 

--- a/src/card-render.ts
+++ b/src/card-render.ts
@@ -377,7 +377,7 @@ function headerText(state: CardProgressState): string {
 
 /** octo/v1 1.5 已验证可安全渲染的展示元素基线(manifest 未 advertise elements 时用)。 */
 const BASELINE_ELEMENTS: ReadonlySet<string> = new Set([
-  "TextBlock", "Container", "ColumnSet", "Column", "FactSet", "Image",
+  "TextBlock", "Container", "ColumnSet", "FactSet", "Image",
 ]);
 
 /**
@@ -397,7 +397,7 @@ export interface CardCaps {
   elements?: ReadonlySet<string>;
   /** 服务端 advertise 的输入白名单(Input.Text/Toggle/ChoiceSet/Number/Date/Time)。 */
   inputs?: ReadonlySet<string>;
-  /** 服务端 advertise 的动作白名单(Submit/ToggleVisibility/ShowCard/OpenUrl 等)。 */
+  /** 服务端 advertise 的动作白名单(v1 本地/导航动作 + v2 Submit 回流动作)。 */
   actions?: ReadonlySet<string>;
   /** 递归节点数上限(limits.max_nodes)。 */
   maxNodes?: number;
@@ -510,6 +510,104 @@ function groupSteps(steps: CardStep[]): CardStep[][] {
   return out;
 }
 
+/** 显式 advertise 富布局能力时,把步骤收进 Container 分组;旧部署保持平铺零回归。 */
+function supportsTimelineLayout(caps: CardCaps | undefined): boolean {
+  return !!caps?.elements && cardSupports(caps, "Container") && cardSupports(caps, "RichTextBlock");
+}
+
+/**
+ * 进度视觉分组:每个 thinking 步开启一个阶段,后续 tool call 收在同一阶段里,直到下一次
+ * thinking。SDK 当前不给 thinking 正文,这里只能展示 thinking 耗时 + 工具摘要。
+ */
+function timelineGroups(steps: CardStep[]): CardStep[][] {
+  const groups: CardStep[][] = [];
+  let cur: CardStep[] = [];
+  for (const step of steps) {
+    if (step.tool === "__thinking__" && cur.length > 0) {
+      groups.push(cur);
+      cur = [];
+    }
+    cur.push(step);
+  }
+  if (cur.length > 0) groups.push(cur);
+  return groups;
+}
+
+function timelineGroupStyle(group: CardStep[]): "default" | "warning" | "attention" | undefined {
+  if (group.some((s) => s.status === "error")) return "attention";
+  if (group.some((s) => s.status === "running")) return "warning";
+  return "default";
+}
+
+function renderStepBlocks(steps: CardStep[]): DisplayBlock[] {
+  return groupSteps(steps).map((g) => ({
+    type: "rich" as const,
+    segments: g.length > 1 ? groupSegments(g) : stepSegments(g[0]),
+  }));
+}
+
+function renderProgressDetailBlocks(steps: CardStep[], caps: CardCaps | undefined): DisplayBlock[] {
+  if (supportsTimelineLayout(caps)) {
+    return timelineGroups(steps).map((g) => ({
+      type: "group" as const,
+      style: timelineGroupStyle(g),
+      blocks: renderStepBlocks(g),
+    }));
+  }
+  return renderStepBlocks(steps);
+}
+
+function supportsTerminalCollapse(caps: CardCaps | undefined): boolean {
+  return (
+    cardSupports(caps, "Container") &&
+    cardSupports(caps, "ActionSet") &&
+    cardSupports(caps, "Action.ToggleVisibility")
+  );
+}
+
+function progressSummary(steps: CardStep[], total: number): string {
+  const thinking = steps.filter((s) => s.tool === "__thinking__").length;
+  const tools = total - thinking;
+  const parts = ["推理与工具调用"];
+  if (thinking > 0) parts.push(`思考 ${thinking}`);
+  if (tools > 0) parts.push(`工具 ${tools}`);
+  if (thinking === 0 && tools === 0) parts.push(`${total} 步`);
+  return parts.join(" · ");
+}
+
+function terminalHeaderSegments(state: CardProgressState): RichSegment[] | null {
+  if (state.phase === "done") {
+    const n = state.steps.length;
+    const secs = fmtDuration(state.elapsedMs);
+    const stats = [n > 0 ? `${n} 步` : "", secs].filter(Boolean).join(" · ");
+    return [
+      { text: "✅ 已完成", bold: true },
+      ...(stats ? [{ text: ` · ${stats}`, subtle: true } satisfies RichSegment] : []),
+    ];
+  }
+  if (state.phase === "error") {
+    const detail = sanitizeErrorText(state.errorText);
+    return [
+      { text: "⚠️ 已中断", bold: true },
+      ...(detail ? [{ text: `：${detail}`, color: "attention" } satisfies RichSegment] : []),
+    ];
+  }
+  return null;
+}
+
+function progressSummarySegments(steps: CardStep[], total: number, visible: string): RichSegment[] {
+  const thinking = steps.filter((s) => s.tool === "__thinking__").length;
+  const tools = total - thinking;
+  const stats: string[] = [];
+  if (thinking > 0) stats.push(`思考 ${thinking}`);
+  if (tools > 0) stats.push(`工具 ${tools}`);
+  stats.push(`${visible} 步`);
+  return [
+    { text: "推理与工具调用", bold: true },
+    { text: ` · ${stats.join(" · ")}`, subtle: true },
+  ];
+}
+
 /**
  * 渲染进度卡 —— **走 buildDisplayCard 底座**(吃自己狗粮):header 用 heading(medium)block、
  * 每步用 rich block(advertise RichTextBlock 时是 RichTextBlock 富行、否则 TextBlock 平铺 —— 一行完整,
@@ -532,15 +630,32 @@ export function renderProgressCard(
   // 只展示最近 cap 步;更早的折叠成一行计数,避免卡片无界膨胀。
   const hidden = Math.max(0, total - cap);
   const visibleSteps = hidden > 0 ? state.steps.slice(-cap) : state.steps;
+  const canRichText = cardSupports(caps, "RichTextBlock");
+  const headerSegments = canRichText ? terminalHeaderSegments(state) : null;
 
   const blocks: DisplayBlock[] = [
-    { type: "heading", text: header, size: "medium" },
+    headerSegments
+      ? { type: "rich", segments: headerSegments }
+      : { type: "heading", text: header, size: "medium" },
   ];
-  if (hidden > 0) blocks.push({ type: "text", text: `… 省略前 ${hidden} 步` });
-  // 同类合并:连续 ≥2 个同 tool 全 done 的段压成一行(用户看到的行数远少于原始步数);
-  // running/error 保留单独行,当前重点不糊掉。header 的"N 步"计数仍用原始 steps.length。
-  for (const g of groupSteps(visibleSteps)) {
-    blocks.push({ type: "rich", segments: g.length > 1 ? groupSegments(g) : stepSegments(g[0]) });
+
+  const detailBlocks: DisplayBlock[] = [];
+  if (hidden > 0) detailBlocks.push({ type: "text", text: `… 省略前 ${hidden} 步` });
+  detailBlocks.push(...renderProgressDetailBlocks(visibleSteps, caps));
+
+  // 运行中保持展开;终态仅在服务端明确 advertise ToggleVisibility 时折叠历史推理/工具调用。
+  // 未声明动作能力的旧部署保持原展开结构,避免多出 summary 行造成视觉/测试回归。
+  if ((state.phase === "done" || state.phase === "error") && detailBlocks.length > 0 && supportsTerminalCollapse(caps)) {
+    const visible = hidden > 0 ? `${visibleSteps.length}/${total}` : `${total}`;
+    const summary = `${progressSummary(state.steps, total)} · ${visible} 步`;
+    blocks.push({
+      type: "collapsible",
+      summary,
+      ...(canRichText ? { summarySegments: progressSummarySegments(state.steps, total, visible) } : {}),
+      blocks: detailBlocks,
+    });
+  } else {
+    blocks.push(...detailBlocks);
   }
 
   // trusted:进度卡的每行文案已在上游逐 sink 脱敏(summarizeToolParams/sanitizeErrorText/safeLabel:

--- a/src/card-render.ts
+++ b/src/card-render.ts
@@ -7,8 +7,29 @@
  * 帧内容:工具名友好化 + 参数摘要 + 耗时,让用户看清 agent 在做什么。
  * 视觉属性仅用端到端验证过的(weight/spacing/size/wrap),不用未验证的 color 以规避白名单。
  */
-import { CARD_PLACEHOLDER } from "./types.js";
+import { CARD_PLACEHOLDER, CARD_VERSION } from "./types.js";
 import { buildDisplayCard, type DisplayBlock, type RichSegment } from "./card-blocks.js";
+
+export const OCTO_CARD_LAYOUTS = {
+  agentProgressV1: "agent_progress_v1",
+} as const;
+
+const AGENT_PROGRESS_DETAIL_ID = "timeline_detail";
+const AGENT_PROGRESS_COLLAPSE_ID = "btn_collapse";
+const AGENT_PROGRESS_EXPAND_ID = "btn_expand";
+
+export type OctoCardLayout = (typeof OCTO_CARD_LAYOUTS)[keyof typeof OCTO_CARD_LAYOUTS];
+
+const KNOWN_OCTO_CARD_LAYOUTS = new Set<string>(Object.values(OCTO_CARD_LAYOUTS));
+
+export function detectOctoCardLayout(card: Record<string, unknown>): OctoCardLayout | undefined {
+  const metadata = card.metadata;
+  if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) return undefined;
+  const layout = (metadata as { octo_layout?: unknown }).octo_layout;
+  return typeof layout === "string" && KNOWN_OCTO_CARD_LAYOUTS.has(layout)
+    ? (layout as OctoCardLayout)
+    : undefined;
+}
 
 /** 单个工具步骤的状态。 */
 export interface CardStep {
@@ -437,16 +458,20 @@ function maxVisibleSteps(caps: CardCaps | undefined): number {
 function stepSegments(step: CardStep): RichSegment[] {
   const { icon, label: rawLabel } = resolveToolMeta(step.tool);
   const label = safeLabel(rawLabel);
-  const sum = step.summary ? `：${step.summary}` : "";
+  const sum = step.summary ? step.summary : "";
   if (step.status === "running") {
-    return [{ text: "⏳ " }, { text: label, bold: true }, { text: sum }];
+    return [
+      { text: "⏳ " },
+      { text: label, bold: true },
+      ...(sum ? [{ text: "：" }, { text: sum, fontType: "Monospace" as const }] : []),
+    ];
   }
   if (step.status === "error") {
     const detail = sanitizeErrorText(step.error);
     const segs: RichSegment[] = [
       { text: "❌ " },
       { text: label, bold: true },
-      { text: sum },
+      ...(sum ? [{ text: "：" }, { text: sum, fontType: "Monospace" as const }] : []),
     ];
     if (detail) segs.push({ text: ` — ${detail}`, color: "attention" });
     return segs;
@@ -455,7 +480,7 @@ function stepSegments(step: CardStep): RichSegment[] {
   const segs: RichSegment[] = [
     { text: `${icon} ` },
     { text: label, bold: true },
-    { text: sum },
+    ...(sum ? [{ text: "：" }, { text: sum, fontType: "Monospace" as const }] : []),
   ];
   if (dur) segs.push({ text: ` · ${dur}`, color: "good" });
   return segs;
@@ -482,7 +507,7 @@ function groupSegments(group: CardStep[]): RichSegment[] {
     { text: ` × ${group.length}` },
   ];
   if (dur) segs.push({ text: ` · 共 ${dur}`, color: "good" });
-  if (lastSum) segs.push({ text: ` — 最近: ${lastSum}` });
+  if (lastSum) segs.push({ text: " — 最近: " }, { text: lastSum, fontType: "Monospace" });
   return segs;
 }
 
@@ -560,6 +585,7 @@ function renderProgressDetailBlocks(steps: CardStep[], caps: CardCaps | undefine
 function supportsTerminalCollapse(caps: CardCaps | undefined): boolean {
   return (
     cardSupports(caps, "Container") &&
+    cardSupports(caps, "ColumnSet") &&
     cardSupports(caps, "ActionSet") &&
     cardSupports(caps, "Action.ToggleVisibility")
   );
@@ -608,8 +634,102 @@ function progressSummarySegments(steps: CardStep[], total: number, visible: stri
   ];
 }
 
+function richTextBlock(segments: RichSegment[]): Record<string, unknown> {
+  return {
+    type: "RichTextBlock",
+    inlines: segments.map((s) => ({
+      type: "TextRun",
+      text: s.text,
+      ...(s.bold ? { weight: "Bolder" } : {}),
+      ...(s.subtle ? { isSubtle: true } : {}),
+      ...(s.fontType ? { fontType: s.fontType } : {}),
+      ...(s.color && s.color !== "default" ? { color: s.color } : {}),
+    })),
+  };
+}
+
+function textBlock(text: string, opts?: { bold?: boolean; subtle?: boolean; size?: "Medium" }): Record<string, unknown> {
+  return {
+    type: "TextBlock",
+    text,
+    wrap: true,
+    ...(opts?.bold ? { weight: "Bolder" } : {}),
+    ...(opts?.subtle ? { isSubtle: true } : {}),
+    ...(opts?.size ? { size: opts.size } : {}),
+  };
+}
+
+function progressHeaderSegments(state: CardProgressState, fallbackHeader: string): RichSegment[] {
+  return terminalHeaderSegments(state) ?? [{ text: fallbackHeader, bold: true }];
+}
+
+function progressSummaryText(steps: CardStep[], total: number, visible: string): string {
+  return `${progressSummary(steps, total)} · ${visible} 步`;
+}
+
+function progressHeaderItems(
+  state: CardProgressState,
+  header: string,
+  steps: CardStep[],
+  total: number,
+  visible: string,
+  canRichText: boolean,
+): Record<string, unknown>[] {
+  const items: Record<string, unknown>[] = [];
+  if (canRichText) {
+    items.push(richTextBlock(progressHeaderSegments(state, header)));
+    if (total > 0) items.push(richTextBlock(progressSummarySegments(steps, total, visible)));
+    return items;
+  }
+  items.push(textBlock(header, { bold: true, size: "Medium" }));
+  if (total > 0) items.push(textBlock(progressSummaryText(steps, total, visible), { subtle: true }));
+  return items;
+}
+
+function progressToggleColumn(startVisible: boolean): Record<string, unknown> | null {
+  return {
+    type: "Column",
+    width: "auto",
+    items: [
+      {
+        type: "ActionSet",
+        id: AGENT_PROGRESS_COLLAPSE_ID,
+        isVisible: startVisible,
+        actions: [
+          {
+            type: "Action.ToggleVisibility",
+            title: "收起推理",
+            targetElements: [
+              { elementId: AGENT_PROGRESS_DETAIL_ID, isVisible: false },
+              { elementId: AGENT_PROGRESS_COLLAPSE_ID, isVisible: false },
+              { elementId: AGENT_PROGRESS_EXPAND_ID, isVisible: true },
+            ],
+          },
+        ],
+      },
+      {
+        type: "ActionSet",
+        id: AGENT_PROGRESS_EXPAND_ID,
+        isVisible: !startVisible,
+        actions: [
+          {
+            type: "Action.ToggleVisibility",
+            title: "展开推理",
+            targetElements: [
+              { elementId: AGENT_PROGRESS_DETAIL_ID, isVisible: true },
+              { elementId: AGENT_PROGRESS_COLLAPSE_ID, isVisible: true },
+              { elementId: AGENT_PROGRESS_EXPAND_ID, isVisible: false },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+}
+
 /**
- * 渲染进度卡 —— **走 buildDisplayCard 底座**(吃自己狗粮):header 用 heading(medium)block、
+ * 渲染进度卡 —— header/toggle 使用 agent_progress_v1 专用根结构;步骤明细仍走
+ * buildDisplayCard 底座(吃自己狗粮),复用协商降级与脱敏。
  * 每步用 rich block(advertise RichTextBlock 时是 RichTextBlock 富行、否则 TextBlock 平铺 —— 一行完整,
  * 不像 ColumnSet 会被服务端权威 plain 重算成图标/文本两行)。
  * 可见步数受服务端 max_nodes 权威约束(缺省用本地上限)。
@@ -631,36 +751,51 @@ export function renderProgressCard(
   const hidden = Math.max(0, total - cap);
   const visibleSteps = hidden > 0 ? state.steps.slice(-cap) : state.steps;
   const canRichText = cardSupports(caps, "RichTextBlock");
-  const headerSegments = canRichText ? terminalHeaderSegments(state) : null;
-
-  const blocks: DisplayBlock[] = [
-    headerSegments
-      ? { type: "rich", segments: headerSegments }
-      : { type: "heading", text: header, size: "medium" },
-  ];
+  const visible = hidden > 0 ? `${visibleSteps.length}/${total}` : `${total}`;
 
   const detailBlocks: DisplayBlock[] = [];
   if (hidden > 0) detailBlocks.push({ type: "text", text: `… 省略前 ${hidden} 步` });
   detailBlocks.push(...renderProgressDetailBlocks(visibleSteps, caps));
 
-  // 运行中保持展开;终态仅在服务端明确 advertise ToggleVisibility 时折叠历史推理/工具调用。
-  // 未声明动作能力的旧部署保持原展开结构,避免多出 summary 行造成视觉/测试回归。
-  if ((state.phase === "done" || state.phase === "error") && detailBlocks.length > 0 && supportsTerminalCollapse(caps)) {
-    const visible = hidden > 0 ? `${visibleSteps.length}/${total}` : `${total}`;
-    const summary = `${progressSummary(state.steps, total)} · ${visible} 步`;
-    blocks.push({
-      type: "collapsible",
-      summary,
-      ...(canRichText ? { summarySegments: progressSummarySegments(state.steps, total, visible) } : {}),
-      blocks: detailBlocks,
-    });
-  } else {
-    blocks.push(...detailBlocks);
-  }
-
   // trusted:进度卡的每行文案已在上游逐 sink 脱敏(summarizeToolParams/sanitizeErrorText/safeLabel:
   // URL 已降级、path/shell 按 generic=false 保留 git SHA/digest)。buildDisplayCard 默认 generic=true
   // 会二次套用长 hex/高熵检测,误删含哈希的正常行、甚至把错误终态帧整卡清空 —— 故此路径关掉严格 generic。
-  const { card, plain } = buildDisplayCard({ blocks, caps, trusted: true });
+  const detail = buildDisplayCard({ blocks: detailBlocks, caps, trusted: true });
+  const headerItems = progressHeaderItems(state, header, state.steps, total, visible, canRichText);
+  const canToggle = supportsTerminalCollapse(caps);
+  const isTerminal = state.phase === "done" || state.phase === "error";
+  const detailVisible = !(canToggle && isTerminal);
+  const columns: Record<string, unknown>[] = [
+    {
+      type: "Column",
+      width: "stretch",
+      items: headerItems,
+    },
+  ];
+  if (canToggle) {
+    const toggleColumn = progressToggleColumn(detailVisible);
+    if (toggleColumn) columns.push(toggleColumn);
+  }
+
+  const card: Record<string, unknown> = {
+    type: "AdaptiveCard",
+    version: CARD_VERSION,
+    $schema: "http://adaptivecards.io/schemas/adaptive-card.json",
+    body: [
+      {
+        type: "ColumnSet",
+        columns,
+      },
+      {
+        type: "Container",
+        id: AGENT_PROGRESS_DETAIL_ID,
+        isVisible: detailVisible,
+        items: (detail.card.body as unknown[]) ?? [],
+      },
+    ],
+  };
+  card.metadata = { octo_layout: OCTO_CARD_LAYOUTS.agentProgressV1 };
+  const summaryPlain = total > 0 ? progressSummaryText(state.steps, total, visible) : "";
+  const plain = [header, summaryPlain, detail.plain].filter(Boolean).join("\n");
   return { card, plain: plain || CARD_PLACEHOLDER };
 }

--- a/src/card-render.ts
+++ b/src/card-render.ts
@@ -73,36 +73,40 @@ const SECRET_RE =
   /token|api[_-]?key|secret|password|passwd|pwd|authorization|bearer|access[_-]?key|client[_-]?secret|credential/i;
 
 /**
- * 形状检测:关键词正则只认密钥**名字**,认不出密钥**形状**。这里补一组按形状匹配的
- * 已知/通用凭据模式,与 SECRET_RE 并用 —— 覆盖「query/pattern 传入裸 token」等无关键词
- * 可循的泄露(如 grep `AKIA...`、web_search 一段 40 位 hex)。
+ * 明确前缀式凭据形状(AKIA/GitHub/Slack/OpenAI/JWT)。这些格式**在任何位置都几乎不可能
+ * 是正常内容**,故对所有策略(含 path/shell)都应用 —— 关键词正则只认密钥名字,认不出这些形状。
  */
-const SECRET_SHAPE_RES: RegExp[] = [
+const SECRET_PREFIX_RES: RegExp[] = [
   /\bAKIA[0-9A-Z]{12,}\b/,                                  // AWS access key id
   /\b(?:gh[pousr]|github_pat)_[A-Za-z0-9_]{20,}/,           // GitHub token / fine-grained PAT
   /\bxox[baprs]-[A-Za-z0-9-]{10,}/,                         // Slack token
   /\bsk-[A-Za-z0-9_-]{16,}/,                                // OpenAI-style secret key
   /\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]+/, // JWT
-  /\b[0-9a-fA-F]{32,}\b/,                                   // 长 hex(md5/sha/hex 密钥)
 ];
 
+/** 长 hex(md5/sha/hex 密钥)。也命中 git object/docker digest 等常见路径,故仅用于 query/url。 */
+const LONG_HEX_RE = /\b[0-9a-fA-F]{32,}\b/;
+
 /**
- * 高熵串:32+ 位连续 base64url 段且**同时含字母与数字**(随机 token 的特征)。只按长度
- * 会误伤长路径/长英文(如 80 个 `x`),故要求字母数字混合 —— 纯字母(词/路径)、纯数字不命中。
+ * 通用高熵串:32+ 位连续 base64url 段且**同时含字母与数字**(随机 token 特征)。会误伤
+ * webpack 缓存名/UUID 目录等常见路径,故与长 hex 一样**仅用于 query/url**(裸 token 的场景),
+ * 不套用到 path/shell。只按长度会误伤长英文(如 80 个 `x`),故要求字母数字混合。
  */
-function hasHighEntropyRun(s: string): boolean {
+function hasGenericSecretShape(s: string): boolean {
+  if (LONG_HEX_RE.test(s)) return true;
   const runs = s.match(/[A-Za-z0-9_-]{32,}/g);
   return !!runs && runs.some((r) => /[0-9]/.test(r) && /[A-Za-z]/.test(r));
 }
 
-/** 是否命中任一密钥形状(已知前缀/hex/JWT + 通用高熵串)。 */
-function looksLikeSecretShape(s: string): boolean {
-  return SECRET_SHAPE_RES.some((re) => re.test(s)) || hasHighEntropyRun(s);
-}
-
-/** 是否命中关键词或形状守卫(群卡片对全员可见,任一命中即隐藏)。 */
-function isSensitive(s: string): boolean {
-  return SECRET_RE.test(s) || looksLikeSecretShape(s);
+/**
+ * 是否命中敏感串。`generic` 为 true(query/url 策略)时额外套用长 hex/高熵检测;path/shell
+ * 只走关键词 + 明确前缀,避免把 git SHA / docker digest / 缓存哈希等正常路径误伤成空。
+ * 群卡片对全员可见,任一命中即隐藏。
+ */
+function isSensitive(s: string, generic: boolean): boolean {
+  if (SECRET_RE.test(s)) return true;
+  if (SECRET_PREFIX_RES.some((re) => re.test(s))) return true;
+  return generic && hasGenericSecretShape(s);
 }
 
 /**
@@ -205,7 +209,10 @@ export function summarizeToolParams(toolName: string | undefined, params: unknow
   }
   if (!v) return "";
   const s = v.replace(/\s+/g, " ").trim();
-  if (!s || isSensitive(s)) return ""; // 关键词 + 形状守卫:任一命中即隐藏
+  // query/url 是「裸 token」易出没处 → 额外套用通用高熵/长 hex 检测;path/shell 只走关键词
+  // + 明确前缀,避免把 git SHA / docker digest / 缓存哈希等正常路径误伤成空。
+  const generic = strategy === "query" || strategy === "url";
+  if (!s || isSensitive(s, generic)) return "";
   return s.length > SUMMARY_MAX ? s.slice(0, SUMMARY_MAX) + "…" : s;
 }
 

--- a/src/card-render.ts
+++ b/src/card-render.ts
@@ -1,0 +1,231 @@
+/**
+ * InteractiveCard(=17) 进度卡渲染 —— 把 agent 运行状态渲染成 Adaptive Cards 1.5
+ * JSON（octo/v1 profile 白名单:TextBlock/Container 等）。纯函数、无副作用、无
+ * `Date.now`（耗时由 state.elapsedMs 传入），便于单测。
+ *
+ * 波 B(卡片进度帧):卡仅承载过程/状态(C2 决策),最终答案走文本。
+ * 帧内容:工具名友好化 + 参数摘要 + 耗时,让用户看清 agent 在做什么。
+ * 视觉属性仅用端到端验证过的(weight/spacing/size/wrap),不用未验证的 color 以规避白名单。
+ */
+import { CARD_PLACEHOLDER } from "./types.js";
+
+/** 单个工具步骤的状态。 */
+export interface CardStep {
+  tool: string;
+  status: "running" | "done" | "error";
+  durationMs?: number;
+  error?: string;
+  /** 参数摘要(在读哪个文件 / 执行什么命令),来自 before_tool_call 的 params。 */
+  summary?: string;
+  /**
+   * SDK 提供的工具调用唯一 id(before/after_tool_call 都带)。用于把 after 事件
+   * 精确回填到对应步骤 —— 并发同名工具(两个 exec/process)乱序完成时,按 id 匹配
+   * 避免把 duration/error 标到错误行。缺失(旧 host)时回退按 toolName 匹配。
+   */
+  toolCallId?: string;
+}
+
+/** 进度卡的渲染状态。 */
+export interface CardProgressState {
+  phase: "thinking" | "tool" | "done" | "error";
+  steps: CardStep[];
+  elapsedMs?: number;
+  errorText?: string;
+}
+
+const MCP_TOOL_PREFIX = "mcp__";
+
+/** 常见工具 → 图标 + 中文标签;未知工具用通用图标 + 原名。 */
+const TOOL_META: Record<string, { icon: string; label: string }> = {
+  read: { icon: "📖", label: "读取文件" },
+  write: { icon: "✏️", label: "写入文件" },
+  edit: { icon: "✏️", label: "编辑文件" },
+  apply_patch: { icon: "✏️", label: "修改代码" },
+  exec: { icon: "⌨️", label: "执行命令" },
+  bash: { icon: "⌨️", label: "执行命令" },
+  shell: { icon: "⌨️", label: "执行命令" },
+  process: { icon: "⚙️", label: "运行进程" },
+  search: { icon: "🔍", label: "搜索" },
+  grep: { icon: "🔍", label: "搜索内容" },
+  glob: { icon: "🔍", label: "查找文件" },
+  ls: { icon: "📂", label: "浏览目录" },
+  fetch: { icon: "🌐", label: "抓取网页" },
+  web_search: { icon: "🌐", label: "联网搜索" },
+  octo_management: { icon: "💬", label: "Octo 操作" },
+};
+
+/** 工具名 → 图标 + 标签。MCP 工具(`mcp__server__tool`)解析 server/tool。 */
+export function resolveToolMeta(tool: string): { icon: string; label: string } {
+  if (tool.startsWith(MCP_TOOL_PREFIX)) {
+    const rest = tool.slice(MCP_TOOL_PREFIX.length).replace(/__/g, " / ");
+    return { icon: "🔌", label: `MCP ${rest}` };
+  }
+  return TOOL_META[tool] ?? { icon: "🔧", label: tool };
+}
+
+const SUMMARY_MAX = 64;
+
+/**
+ * 敏感串守卫模式。群卡片对全体成员可见 —— 摘要一旦命中即整串隐藏(fail-safe:
+ * 宁可误伤含 "token" 字样的正常文本,也不泄露 token/密钥/口令)。
+ */
+const SECRET_RE =
+  /token|api[_-]?key|secret|password|passwd|pwd|authorization|bearer|access[_-]?key|client[_-]?secret|credential/i;
+
+/**
+ * 工具 → 摘要提取策略(allowlist)。未列出的工具(含 MCP、未知工具)一律**不显示摘要**,
+ * 杜绝把任意参数直渲到群卡片的泄露面。
+ */
+type SummaryStrategy = "path" | "shell" | "url" | "query";
+const SUMMARY_STRATEGY: Record<string, SummaryStrategy> = {
+  read: "path", write: "path", edit: "path", apply_patch: "path", ls: "path", glob: "path",
+  exec: "shell", bash: "shell", shell: "shell", process: "shell",
+  fetch: "url",
+  web_search: "query", search: "query", grep: "query",
+};
+
+/** 取 keys 中首个非空字符串值。 */
+function firstString(p: Record<string, unknown>, keys: string[]): string {
+  for (const k of keys) {
+    const v = p[k];
+    if (typeof v === "string" && v.trim()) return v;
+  }
+  return "";
+}
+
+/**
+ * shell:只取程序名。跳过前缀式环境变量赋值(`VAR=value cmd ...`)—— 否则会把密钥值
+ * (如 `SLACK_WEBHOOK=https://…`、`MY_CREDS=xxx`)当成程序名原样渲染,且这类变量名多不含
+ * token/secret 等关键词,躲过 SECRET_RE。不渲染任何参数。
+ *
+ * 落定的 program token 再过一层保守形状校验:只接受 `[\w./@:+-]`(程序名/路径的合法字符)。
+ * 空白分词无法解析带引号的多词值(`TOKEN="a b" cmd` 会切成 `TOKEN="a`/`b"`/`cmd`,跳过
+ * 首个后落在片段 `b"`),含引号/空格/等号等异常字符的 token 一律判为可疑值片段 → 不展示。
+ */
+const PROGRAM_TOKEN_RE = /^[A-Za-z0-9_./@:+-]+$/;
+function summarizeShell(p: Record<string, unknown>): string {
+  const cmd = firstString(p, ["command", "cmd"]).trim();
+  if (!cmd) return "";
+  const tokens = cmd.split(/\s+/);
+  let i = 0;
+  while (i < tokens.length && /^[A-Za-z_][A-Za-z0-9_]*=/.test(tokens[i])) i++;
+  const prog = tokens[i] ?? "";
+  return PROGRAM_TOKEN_RE.test(prog) ? prog : "";
+}
+
+/**
+ * url:**只保留 scheme://host**,丢弃 path/query/userinfo。凭据既可能在 query,也常整段
+ * 嵌在 path 里(Slack/Discord incoming webhook `/services/T../B../XXXX`),且随机 token
+ * 不含关键词、躲过 SECRET_RE —— 故 path 一并不展示,只暴露主机名。
+ */
+function summarizeUrl(p: Record<string, unknown>): string {
+  const raw = firstString(p, ["url"]);
+  if (!raw) return "";
+  try {
+    const u = new URL(raw);
+    return `${u.protocol}//${u.host}`;
+  } catch {
+    return ""; // 解析失败 → 不显示(原串可能含 token)
+  }
+}
+
+/**
+ * 从工具参数提取一句人可读摘要 —— 按工具 allowlist 策略取值,未知/MCP 工具不显示,
+ * 命中敏感串则整串隐藏,最后折叠空白并截断。群卡片对全员可见,安全优先于信息量。
+ */
+export function summarizeToolParams(toolName: string | undefined, params: unknown): string {
+  if (!toolName || !params || typeof params !== "object") return "";
+  const strategy = SUMMARY_STRATEGY[toolName];
+  if (!strategy) return ""; // MCP / 未知工具:不渲染任意参数
+  const p = params as Record<string, unknown>;
+  let v: string;
+  switch (strategy) {
+    case "path": v = firstString(p, ["path", "file_path", "file"]); break;
+    case "shell": v = summarizeShell(p); break;
+    case "url": v = summarizeUrl(p); break;
+    case "query": v = firstString(p, ["query", "pattern"]); break;
+  }
+  if (!v) return "";
+  const s = v.replace(/\s+/g, " ").trim();
+  if (!s || SECRET_RE.test(s)) return ""; // 敏感串守卫:命中即隐藏
+  return s.length > SUMMARY_MAX ? s.slice(0, SUMMARY_MAX) + "…" : s;
+}
+
+/** ms → 友好耗时(<1s 用 ms,否则 x.xs)。 */
+export function fmtDuration(ms?: number): string {
+  if (typeof ms !== "number") return "";
+  return ms < 1000 ? `${ms}ms` : `${(ms / 1000).toFixed(1)}s`;
+}
+
+/** 单步 → 一行文案:图标 + 标签 + 参数摘要 + 状态/耗时。 */
+export function stepLine(step: CardStep): string {
+  const { icon, label } = resolveToolMeta(step.tool);
+  const sum = step.summary ? `：${step.summary}` : "";
+  if (step.status === "running") return `⏳ ${label}${sum}`;
+  if (step.status === "error") return `❌ ${label}${sum}${step.error ? ` — ${step.error}` : ""}`;
+  const dur = fmtDuration(step.durationMs);
+  return `${icon} ${label}${sum}${dur ? ` · ${dur}` : ""}`;
+}
+
+function headerText(state: CardProgressState): string {
+  switch (state.phase) {
+    case "thinking":
+      return "🤖 思考中…";
+    case "tool":
+      return "🤖 正在处理…";
+    case "error":
+      return `⚠️ 已中断${state.errorText ? `：${state.errorText}` : ""}`;
+    case "done": {
+      const n = state.steps.length;
+      const secs = fmtDuration(state.elapsedMs);
+      const parts = ["✅ 已完成"];
+      if (n > 0) parts.push(`${n} 步`);
+      if (secs) parts.push(secs);
+      return parts.join(" · ");
+    }
+  }
+}
+
+/**
+ * 展示步骤上限。长任务工具调用不断累积,若全量渲染成 TextBlock,卡片体积会持续膨胀,
+ * 最终可能超服务端结构上限导致 edit 400、进度冻结。这里用确定性本地上限裁剪(与服务端
+ * limits 无关,不依赖其未定义的 key schema):超出只渲染最近 N 步 + 顶部一行省略计数。
+ */
+const MAX_VISIBLE_STEPS = 12;
+
+/**
+ * 渲染进度卡。返回 `{ card, plain }`:
+ *   - `card` = Adaptive Cards 1.5 JSON(header + 每步一行,octo/v1 白名单内;不用 color/
+ *     markdown 链接,规避白名单/scheme 校验)。
+ *   - `plain` = 纯文本兜底(服务端 Finalize 会权威重算,此处保证 never empty)。
+ */
+export function renderProgressCard(state: CardProgressState): {
+  card: Record<string, unknown>;
+  plain: string;
+} {
+  const header = headerText(state);
+  const total = state.steps.length;
+  // 只展示最近 MAX_VISIBLE_STEPS 步;更早的折叠成一行计数,避免卡片无界膨胀。
+  const hidden = Math.max(0, total - MAX_VISIBLE_STEPS);
+  const visibleSteps = hidden > 0 ? state.steps.slice(-MAX_VISIBLE_STEPS) : state.steps;
+  const lines: string[] = [];
+  if (hidden > 0) lines.push(`… 省略前 ${hidden} 步`);
+  for (const s of visibleSteps) lines.push(stepLine(s));
+
+  const body: Record<string, unknown>[] = [
+    { type: "TextBlock", text: header, weight: "Bolder", size: "Medium", wrap: true },
+  ];
+  for (const line of lines) {
+    body.push({ type: "TextBlock", text: line, wrap: true, spacing: "Small" });
+  }
+
+  const card: Record<string, unknown> = {
+    type: "AdaptiveCard",
+    version: "1.5",
+    $schema: "http://adaptivecards.io/schemas/adaptive-card.json",
+    body,
+  };
+
+  const plainText = [header, ...lines].join("\n").trim();
+  return { card, plain: plainText || CARD_PLACEHOLDER };
+}

--- a/src/card-render.ts
+++ b/src/card-render.ts
@@ -222,12 +222,30 @@ export function fmtDuration(ms?: number): string {
   return ms < 1000 ? `${ms}ms` : `${(ms / 1000).toFixed(1)}s`;
 }
 
-/** 单步 → 一行文案:图标 + 标签 + 参数摘要 + 状态/耗时。 */
+/** 错误文本展示上限(比参数摘要略宽,但仍防多 KB 堆栈撑爆卡片)。 */
+const ERROR_MAX = 120;
+
+/**
+ * 清洗工具错误文本后再渲染 —— 错误串是与参数摘要**同等**的泄露 sink:常含 stderr、
+ * 失败命令输出、请求 URL/header、webhook 路径、token、文件片段,且长度不可控。故与摘要
+ * 用同一 fail-closed 策略:折叠空白 → 命中关键词/形状(generic)则整串隐藏 → 否则截断。
+ */
+export function sanitizeErrorText(err?: string): string {
+  if (!err) return "";
+  const s = err.replace(/\s+/g, " ").trim();
+  if (!s || isSensitive(s, true)) return ""; // 命中敏感 → 不展示错误详情
+  return s.length > ERROR_MAX ? s.slice(0, ERROR_MAX) + "…" : s;
+}
+
+/** 单步 → 一行文案:图标 + 标签 + 参数摘要 + 状态/耗时。错误详情经脱敏+截断。 */
 export function stepLine(step: CardStep): string {
   const { icon, label } = resolveToolMeta(step.tool);
   const sum = step.summary ? `：${step.summary}` : "";
   if (step.status === "running") return `⏳ ${label}${sum}`;
-  if (step.status === "error") return `❌ ${label}${sum}${step.error ? ` — ${step.error}` : ""}`;
+  if (step.status === "error") {
+    const detail = sanitizeErrorText(step.error);
+    return `❌ ${label}${sum}${detail ? ` — ${detail}` : ""}`;
+  }
   const dur = fmtDuration(step.durationMs);
   return `${icon} ${label}${sum}${dur ? ` · ${dur}` : ""}`;
 }
@@ -238,8 +256,10 @@ function headerText(state: CardProgressState): string {
       return "🤖 思考中…";
     case "tool":
       return "🤖 正在处理…";
-    case "error":
-      return `⚠️ 已中断${state.errorText ? `：${state.errorText}` : ""}`;
+    case "error": {
+      const detail = sanitizeErrorText(state.errorText);
+      return `⚠️ 已中断${detail ? `：${detail}` : ""}`;
+    }
     case "done": {
       const n = state.steps.length;
       const secs = fmtDuration(state.elapsedMs);

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1455,7 +1455,7 @@ export const octoPlugin: ChannelPlugin<ResolvedOctoAccount> = {
           // Also allow event messages (e.g. group_md_updated) from any source.
           if (_knownBotUids.has(msg.from_uid) && msg.channel_type === ChannelType.DM && !isEvent) return;
           // Skip unsupported message types (Location, Card), but allow event messages through
-          const supportedTypes = [MessageType.Text, MessageType.Image, MessageType.GIF, MessageType.Voice, MessageType.Video, MessageType.File, MessageType.MultipleForward, MessageType.RichText];
+          const supportedTypes = [MessageType.Text, MessageType.Image, MessageType.GIF, MessageType.Voice, MessageType.Video, MessageType.File, MessageType.MultipleForward, MessageType.RichText, MessageType.InteractiveCard];
           if (!msg.payload || (!supportedTypes.includes(msg.payload.type) && !isEvent)) return;
 
           // Defense-in-depth DM filter (kept for safety, though v0.2.28+ uses independent

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -973,6 +973,14 @@ export const octoPlugin: ChannelPlugin<ResolvedOctoAccount> = {
       // Detect @all/@所有人 in content
       const hasAtAll = /(?:^|(?<=\s))@(?:all|所有人)(?=\s|[^\w]|$)/i.test(finalContent);
 
+      // Outbound reply attribution: only honor an explicit `ctx.replyToId` from core
+      // (user/reply-mode driven). The dispatch's own final answer threads to the user's
+      // triggering message in inbound.ts (Q→A quoting, standard IM shape); this
+      // channel-level send path (proactive / message-tool) does not fabricate a reply target.
+      const replyMsgId = typeof ctx.replyToId === "string" && ctx.replyToId.trim()
+        ? ctx.replyToId.trim()
+        : undefined;
+
       const sendResult = await sendMessage({
         apiUrl: account.config.apiUrl,
         botToken: account.config.botToken,
@@ -982,6 +990,7 @@ export const octoPlugin: ChannelPlugin<ResolvedOctoAccount> = {
         ...(mentionUids.length > 0 ? { mentionUids } : {}),
         ...(mentionEntities.length > 0 ? { mentionEntities } : {}),
         mentionAll: hasAtAll || undefined,
+        ...(replyMsgId ? { replyMsgId } : {}),
       });
 
       return toDeliveryResult(ctx.to, sendResult);

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -30,6 +30,10 @@ function getAgentVersion(): string {
 }
 import { WKSocket } from "./socket.js";
 import { handleInboundMessage, type OctoStatusSink, sanitizeFilename } from "./inbound.js";
+import { runWithSessionInitRetry } from "./session-retry.js";
+
+/** 会话初始化冲突(core CAS)兜底重试参数:同群紧挨两条消息时 turn N 收尾写与 turn N+1 init 竞态。 */
+const SESSION_INIT_RETRY = { retries: 2, backoffMs: 800 } as const;
 import { ChannelType, MessageType, type BotMessage, type MessagePayload, type SendMessageResult } from "./types.js";
 import { buildEntitiesFromFallback, parseStructuredMentions, convertStructuredMentions, sanitizeOutboundMentions, MENTION_FORMAT_HINT } from "./mention-utils.js";
 import type { MentionEntity } from "./types.js";
@@ -1502,21 +1506,25 @@ export const octoPlugin: ChannelPlugin<ResolvedOctoAccount> = {
           enqueueInbound(
             inboundQueueKey,
             () =>
-              handleInboundMessage({
-                account,
-                message: msg,
-                botUid: credentials.robot_id,
-                groupHistories,
-                lastBotReplySeqMap,
-                memberMap,
-                uidToNameMap,
-                groupCacheTimestamps,
-                memberRobotMap,
-                currentGroupMembersMap,
-                groupMdCache,
-                log,
-                statusSink,
-              }),
+              runWithSessionInitRetry(
+                () =>
+                  handleInboundMessage({
+                    account,
+                    message: msg,
+                    botUid: credentials.robot_id,
+                    groupHistories,
+                    lastBotReplySeqMap,
+                    memberMap,
+                    uidToNameMap,
+                    groupCacheTimestamps,
+                    memberRobotMap,
+                    currentGroupMembersMap,
+                    groupMdCache,
+                    log,
+                    statusSink,
+                  }),
+                { ...SESSION_INIT_RETRY, log },
+              ),
             log,
           );
         },

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -30,10 +30,22 @@ function getAgentVersion(): string {
 }
 import { WKSocket } from "./socket.js";
 import { handleInboundMessage, type OctoStatusSink, sanitizeFilename } from "./inbound.js";
-import { runWithSessionInitRetry } from "./session-retry.js";
+import { runWithSessionInitRetry, isSessionInitConflict } from "./session-retry.js";
+import { notifyInboundConflictDropped } from "./inbound-conflict-notice.js";
 
-/** 会话初始化冲突(core CAS)兜底重试参数:同群紧挨两条消息时 turn N 收尾写与 turn N+1 init 竞态。 */
-const SESSION_INIT_RETRY = { retries: 2, backoffMs: 800 } as const;
+/**
+ * 会话初始化冲突(core CAS)兜底重试参数。同群紧挨两条消息时,turn N 的 session 收尾写
+ * 与 turn N+1 init 竞态。
+ *
+ * `retries=4, backoffMs=1500` 线性退避,累计等待 1.5+3+4.5+6 = **15 秒**。选这个上限是因为
+ * 真实场景观察到:进度卡 + 复杂 turn(10+ steps / 25s+)让 core 侧收尾写显著变长,原来的
+ * 2.4s 窗口不够覆盖(联调实测 3 次 attempt 全撞、消息被丢)。
+ *
+ * 若 15s 内仍不停撞车(每次 init 读到的 revision 都不同),那大概率不是瞬态冲突,而是 core
+ * 已知的 skillsSnapshot 翻转持久性 bug —— 加多少重试都救不了,需上游 core 修。此时最终抛错
+ * 让 dispatch 走既有失败路径。
+ */
+const SESSION_INIT_RETRY = { retries: 4, backoffMs: 1500 } as const;
 import { ChannelType, MessageType, type BotMessage, type MessagePayload, type SendMessageResult } from "./types.js";
 import { buildEntitiesFromFallback, parseStructuredMentions, convertStructuredMentions, sanitizeOutboundMentions, MENTION_FORMAT_HINT } from "./mention-utils.js";
 import type { MentionEntity } from "./types.js";
@@ -1505,26 +1517,46 @@ export const octoPlugin: ChannelPlugin<ResolvedOctoAccount> = {
 
           enqueueInbound(
             inboundQueueKey,
-            () =>
-              runWithSessionInitRetry(
-                () =>
-                  handleInboundMessage({
-                    account,
-                    message: msg,
-                    botUid: credentials.robot_id,
-                    groupHistories,
-                    lastBotReplySeqMap,
-                    memberMap,
-                    uidToNameMap,
-                    groupCacheTimestamps,
-                    memberRobotMap,
-                    currentGroupMembersMap,
-                    groupMdCache,
+            async () => {
+              try {
+                await runWithSessionInitRetry(
+                  () =>
+                    handleInboundMessage({
+                      account,
+                      message: msg,
+                      botUid: credentials.robot_id,
+                      groupHistories,
+                      lastBotReplySeqMap,
+                      memberMap,
+                      uidToNameMap,
+                      groupCacheTimestamps,
+                      memberRobotMap,
+                      currentGroupMembersMap,
+                      groupMdCache,
+                      log,
+                      statusSink,
+                    }),
+                  { ...SESSION_INIT_RETRY, log },
+                );
+              } catch (err) {
+                // 重试耗尽仍是 core 会话初始化冲突(已知 skillsSnapshot revision bug,
+                // upstream openclaw#101848):不再静默丢,发用户可见回执 + 独立告警打点,
+                // 然后正常返回 —— 避免 enqueueInbound 的通用失败日志再重复记录一遍。
+                // 其它错误照旧抛给 enqueueInbound 的通用失败路径。
+                if (isSessionInitConflict(err)) {
+                  await notifyInboundConflictDropped({
+                    err,
+                    msg,
+                    accountId: account.accountId,
+                    apiUrl: account.config.apiUrl,
+                    botToken: account.config.botToken,
                     log,
-                    statusSink,
-                  }),
-                { ...SESSION_INIT_RETRY, log },
-              ),
+                  });
+                  return;
+                }
+                throw err;
+              }
+            },
             log,
           );
         },

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -17,6 +17,13 @@ export const PLUGIN_ID = "octo";
 export const CHANNEL_ID = "octo";
 
 /**
+ * P1-e agent 展示卡工具名(见 `card-display-tool.ts`)。card-progress 侧据此把它排除
+ * 出进度追踪:展示卡 turn 的产出**就是那张卡本身**,不该再有旁边的"正在处理/已中断"
+ * 进度卡噪音。集中定义避免字面量漂移。
+ */
+export const DISPLAY_CARD_TOOL_NAME = "octo_send_display_card";
+
+/**
  * Separator between parent group_no and thread short_id in Octo's CommunityTopic
  * channel ID format (`<groupNo>____<shortId>`, 4 underscores). Centralized here
  * to avoid drift across modules that need to split or compose thread refs.

--- a/src/inbound-conflict-notice.test.ts
+++ b/src/inbound-conflict-notice.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  resolveConflictReceiptTarget,
+  notifyInboundConflictDropped,
+  SESSION_CONFLICT_RECEIPT,
+} from "./inbound-conflict-notice.js";
+import { ChannelType, MessageType, type BotMessage } from "./types.js";
+
+function makeMsg(overrides: Partial<BotMessage> = {}): BotMessage {
+  return {
+    message_id: "m1",
+    message_seq: 1,
+    from_uid: "u_sender",
+    channel_id: "g_123",
+    channel_type: ChannelType.Group,
+    timestamp: 0,
+    payload: { type: MessageType.Text, content: "hi" } as BotMessage["payload"],
+    ...overrides,
+  };
+}
+
+const CONFLICT = new Error("reply session initialization conflicted for agent:main:octo:group:g_123");
+
+describe("resolveConflictReceiptTarget", () => {
+  it("群消息 → channel_id + Group", () => {
+    expect(resolveConflictReceiptTarget(makeMsg())).toEqual({
+      channelId: "g_123",
+      channelType: ChannelType.Group,
+    });
+  });
+
+  it("社区话题 → 保留复合 channel_id + CommunityTopic 原样", () => {
+    const msg = makeMsg({ channel_id: "g_123____t_9", channel_type: ChannelType.CommunityTopic });
+    expect(resolveConflictReceiptTarget(msg)).toEqual({
+      channelId: "g_123____t_9",
+      channelType: ChannelType.CommunityTopic,
+    });
+  });
+
+  it("DM → from_uid + DM(忽略 DM 的 channel_id 形态)", () => {
+    const msg = makeMsg({ channel_type: ChannelType.DM, channel_id: "u_sender@u_bot", from_uid: "u_sender" });
+    expect(resolveConflictReceiptTarget(msg)).toEqual({
+      channelId: "u_sender",
+      channelType: ChannelType.DM,
+    });
+  });
+
+  it("群但 channel_id 为空 → 回落到 from_uid/DM", () => {
+    const msg = makeMsg({ channel_id: "", channel_type: ChannelType.Group });
+    expect(resolveConflictReceiptTarget(msg)).toEqual({
+      channelId: "u_sender",
+      channelType: ChannelType.DM,
+    });
+  });
+
+  it("既无群 channel 也无 from_uid → null(只打点不发)", () => {
+    const msg = makeMsg({ channel_id: "", channel_type: ChannelType.DM, from_uid: "" });
+    expect(resolveConflictReceiptTarget(msg)).toBeNull();
+  });
+});
+
+describe("notifyInboundConflictDropped", () => {
+  it("群冲突 → 发回执到 channel_id,内容为标准文案,且打独立 warn 告警", async () => {
+    const send = vi.fn(async () => undefined);
+    const warn = vi.fn();
+    await notifyInboundConflictDropped({
+      err: CONFLICT,
+      msg: makeMsg(),
+      accountId: "acc1",
+      apiUrl: "https://api",
+      botToken: "tok",
+      log: { warn },
+      send,
+      timeoutMs: 1000,
+    });
+
+    expect(send).toHaveBeenCalledTimes(1);
+    const arg = send.mock.calls[0][0];
+    expect(arg.channelId).toBe("g_123");
+    expect(arg.channelType).toBe(ChannelType.Group);
+    expect(arg.content).toBe(SESSION_CONFLICT_RECEIPT);
+    expect(arg.apiUrl).toBe("https://api");
+    expect(arg.botToken).toBe("tok");
+    expect(arg.signal).toBeInstanceOf(AbortSignal);
+
+    // 独立告警:含可检索关键词 + msg id,便于监控
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toContain("inbound DROPPED");
+    expect(warn.mock.calls[0][0]).toContain("msg=m1");
+  });
+
+  it("缺 apiUrl/botToken → 只打点不发回执", async () => {
+    const send = vi.fn(async () => undefined);
+    const warn = vi.fn();
+    await notifyInboundConflictDropped({
+      err: CONFLICT,
+      msg: makeMsg(),
+      accountId: "acc1",
+      botToken: "tok", // 缺 apiUrl
+      log: { warn },
+      send,
+    });
+    expect(send).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+
+  it("目标不可解析 → 只打点不发回执", async () => {
+    const send = vi.fn(async () => undefined);
+    await notifyInboundConflictDropped({
+      err: CONFLICT,
+      msg: makeMsg({ channel_id: "", channel_type: ChannelType.DM, from_uid: "" }),
+      accountId: "acc1",
+      apiUrl: "https://api",
+      botToken: "tok",
+      send,
+    });
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("回执发送失败 → 吞掉异常,落 error 日志,绝不上抛", async () => {
+    const send = vi.fn(async () => {
+      throw new Error("octo API 500");
+    });
+    const error = vi.fn();
+    await expect(
+      notifyInboundConflictDropped({
+        err: CONFLICT,
+        msg: makeMsg(),
+        accountId: "acc1",
+        apiUrl: "https://api",
+        botToken: "tok",
+        log: { error },
+        send,
+      }),
+    ).resolves.toBeUndefined();
+    expect(error).toHaveBeenCalledTimes(1);
+    expect(error.mock.calls[0][0]).toContain("failed to send conflict receipt");
+  });
+});

--- a/src/inbound-conflict-notice.ts
+++ b/src/inbound-conflict-notice.ts
@@ -1,0 +1,104 @@
+/**
+ * 「会话初始化冲突重试耗尽」的用户可见回执 + 独立告警打点。
+ *
+ * 背景:core 用乐观锁初始化 reply session(revision = 整条 entry 的 JSON),已知在受影响
+ * 版本上 `skillsSnapshot` 字段会在 snapshot↔commit 之间被非确定性重算 → CAS 恒失配 →
+ * 抛 `reply session initialization conflicted`(upstream openclaw#101848,已在 core 侧
+ * 收窄 revision 到身份字段修复,进 2026.7.1-beta.2+;我们线上更低版本仍会撞)。
+ *
+ * `session-retry.ts` 的线性退避只能救「真瞬态」冲突;上述持久翻转加多少重试都救不了。当重试
+ * 彻底耗尽时,历史行为是把入站 handler 的错误吞进 `enqueueInbound` 的通用 catch —— 用户端
+ * 完全没反应、像离线(对齐 upstream openclaw#102400 描述的 silent-drop 缺口)。
+ *
+ * 本模块把「丢消息」变成「一条明确回执 + 一行可告警的独立日志」:回执是直接走 `sendMessage`
+ * 的普通文本 POST(不经 core reply pipeline / session init,故不会再次触发同一冲突)。
+ */
+import { ChannelType, type BotMessage } from "./types.js";
+import { sendMessage } from "./api-fetch.js";
+
+/** 用户可见回执文案。保持简短、可操作(与 inbound.ts 的超时/异常回执同款语气)。 */
+export const SESSION_CONFLICT_RECEIPT = "⚠️ 系统繁忙，本条消息暂时无法处理，请稍后重发。";
+
+/**
+ * 回执发送的兜底超时。若 core 与 Octo API 同时不健康,这条回执 POST 绝不能无限挂住
+ * per-group 入站队列(否则又把「丢一条」放大成「卡死整群」)。
+ */
+export const RECEIPT_SEND_TIMEOUT_MS = 10_000;
+
+/** 与 `sendMessage` 同签名的可注入发送函数(测试用)。 */
+type SendFn = typeof sendMessage;
+
+/**
+ * 从原始入站消息解析回执目标。仅覆盖常规 group / 社区话题 / DM 三种,与 inbound.ts 非 obo-v2
+ * 路径的 reply-target 解析一致(group → channel_id;DM → from_uid)。obo-v2 合成消息等边缘
+ * 来源无法从原始 msg 稳妥定位,返回 null —— 那种情况只打点、不发回执。
+ */
+export function resolveConflictReceiptTarget(
+  msg: BotMessage,
+): { channelId: string; channelType: ChannelType } | null {
+  const isGroup =
+    typeof msg.channel_id === "string" &&
+    msg.channel_id.length > 0 &&
+    (msg.channel_type === ChannelType.Group ||
+      msg.channel_type === ChannelType.CommunityTopic);
+
+  if (isGroup) {
+    return { channelId: msg.channel_id as string, channelType: msg.channel_type as ChannelType };
+  }
+
+  if (typeof msg.from_uid === "string" && msg.from_uid.length > 0) {
+    return { channelId: msg.from_uid, channelType: ChannelType.DM };
+  }
+
+  return null;
+}
+
+/**
+ * 重试耗尽仍撞 core 会话初始化冲突时调用:发一条用户可见回执,并打一行与通用
+ * 「inbound handler failed」区分开的独立告警日志(便于按此串单独检索/告警)。
+ *
+ * 永不抛错 —— 它本身就是失败兜底,任何内部异常都只落日志,不得再向上冒泡。
+ */
+export async function notifyInboundConflictDropped(params: {
+  err: unknown;
+  msg: BotMessage;
+  accountId: string;
+  apiUrl?: string;
+  botToken?: string;
+  log?: { warn?: (msg: string) => void; error?: (msg: string) => void };
+  /** 测试注入;缺省真实 `sendMessage`。 */
+  send?: SendFn;
+  /** 测试注入;缺省 {@link RECEIPT_SEND_TIMEOUT_MS}。 */
+  timeoutMs?: number;
+}): Promise<void> {
+  const { err, msg, accountId, apiUrl, botToken, log } = params;
+  const send = params.send ?? sendMessage;
+  const timeoutMs = params.timeoutMs ?? RECEIPT_SEND_TIMEOUT_MS;
+  const detail = err instanceof Error ? err.message : String(err);
+
+  // 独立告警打点:与 enqueueInbound 的通用失败日志区分,方便按 "inbound DROPPED" 单独监控。
+  log?.warn?.(
+    `octo: [${accountId}] inbound DROPPED after session-init retries exhausted (core CAS conflict; ` +
+      `upstream openclaw#101848) from=${msg.from_uid} channel=${msg.channel_id ?? "DM"} ` +
+      `msg=${msg.message_id}: ${detail}`,
+  );
+
+  // 无凭据无法回执(理论上不会发生,防御式处理):已打点即可。
+  if (!apiUrl || !botToken) return;
+
+  const target = resolveConflictReceiptTarget(msg);
+  if (!target) return;
+
+  try {
+    await send({
+      apiUrl,
+      botToken,
+      channelId: target.channelId,
+      channelType: target.channelType,
+      content: SESSION_CONFLICT_RECEIPT,
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+  } catch (sendErr) {
+    log?.error?.(`octo: [${accountId}] failed to send conflict receipt: ${String(sendErr)}`);
+  }
+}

--- a/src/inbound-mention-gate.test.ts
+++ b/src/inbound-mention-gate.test.ts
@@ -335,6 +335,29 @@ describe("inbound mention-gate 免@ relaxation (human-only)", () => {
     expect(sends.length).toBeGreaterThan(0);
   });
 
+  it("§4.2: 最终答复引用用户触发消息(Q→A)—— payload.reply.message_id === 触发消息 id", async () => {
+    installRuntimeStub();
+    const { sends } = installFetchStub();
+    const msg = makeTextMessage(HUMAN_UID, "@SelfBot please answer");
+    (msg.payload as any).mention = { uids: [BOT_UID] };
+
+    await handleInboundMessage({
+      account: makeAccount(),
+      message: msg,
+      botUid: BOT_UID,
+      groupHistories: new Map(),
+      lastBotReplySeqMap: new Map(),
+      memberMap: new Map(),
+      uidToNameMap: new Map(),
+      groupCacheTimestamps: new Map(),
+    });
+
+    // 发出去的最终答复(content="hi there")必须 reply 到触发消息 m1
+    const reply = sends.find((s: any) => s?.payload?.content === "hi there");
+    expect(reply).toBeTruthy();
+    expect(reply.payload.reply).toEqual({ message_id: "m1" });
+  });
+
   it("does NOT reply to a CROSS-PROCESS bot (robot:true in member list, NOT registerKnownBot'd)", async () => {
     // Regression: the loop guard must use the
     // server-authoritative GroupMember.robot signal, not just the local

--- a/src/inbound.ts
+++ b/src/inbound.ts
@@ -26,7 +26,8 @@ import { getMentionPrefFromCache, invalidateMentionPref } from "./mention-prefs.
 import { normalizeAccountId } from "./account-id.js";
 import type { ResolvedOctoAccount } from "./accounts.js";
 import type { BotMessage } from "./types.js";
-import { ChannelType, MessageType, RICH_TEXT_BLOCK_IMAGE, RICH_TEXT_BLOCK_TEXT, RICH_TEXT_IMAGE_PLACEHOLDER } from "./types.js";
+import { setCardContext, finalizeCard } from "./card-progress.js";
+import { ChannelType, MessageType, RICH_TEXT_BLOCK_IMAGE, RICH_TEXT_BLOCK_TEXT, RICH_TEXT_IMAGE_PLACEHOLDER, CARD_PLACEHOLDER } from "./types.js";
 import type { RichTextBlock } from "./types.js";
 import { getOctoRuntime } from "./runtime.js";
 import { CHANNEL_ID, MAX_UPLOAD_SIZE } from "./constants.js";
@@ -504,6 +505,19 @@ export function buildMediaUrl(relUrl?: string, apiUrl?: string, cdnUrl?: string)
   return `${baseUrl}/file/${storagePath}`;
 }
 
+/**
+ * 提取 InteractiveCard(=17) 的服务端权威 `plain` 作为 LLM/展示文本。
+ *
+ * 服务端在 dispatch 出口重算 `plain`（octo-server Decision 8：never empty，
+ * 空 body 时回退 `[卡片]`）。adapter 只读它并防御性兜底：非字符串或空串 →
+ * `CARD_PLACEHOLDER`。adapter **不解析 `card` 树**（AC1.5 schema 由服务端
+ * `pkg/cardmsg` 权威）。
+ */
+export function resolveCardPlain(payload: { plain?: unknown } | undefined): string {
+  const plain = typeof payload?.plain === "string" ? payload.plain.trim() : "";
+  return plain !== "" ? plain : CARD_PLACEHOLDER;
+}
+
 /** Resolve inner message type to display text for MultipleForward */
 export function resolveInnerMessageText(
   payload: ForwardMessage["payload"],
@@ -537,6 +551,9 @@ export function resolveInnerMessageText(
       const rt = resolveRichTextContent(payload as any, buildUrl);
       return rt.text || "[图文消息]";
     }
+    case MessageType.InteractiveCard:
+      // 交互卡片（引用/转发预览）：取服务端权威 plain。
+      return resolveCardPlain(payload as { plain?: unknown });
     default:
       return payload.content ?? "[消息]";
   }
@@ -699,6 +716,9 @@ function resolveContent(payload: BotMessage["payload"], apiUrl?: string, log?: C
         ...(mediaUrls.length > 0 ? { mediaType: guessMime(mediaUrls[0], "image/jpeg") } : {}),
       };
     }
+    case MessageType.InteractiveCard:
+      // 交互卡片：仅取服务端权威 plain 喂 LLM（不解析 card 树）。
+      return { text: resolveCardPlain(payload as { plain?: unknown }) };
     default:
       return { text: payload.content ?? payload.url ?? "" };
   }
@@ -1205,6 +1225,7 @@ export function resolveApiMessagePlaceholder(type?: number, name?: string): stri
     case MessageType.Card: return "[名片]";
     case MessageType.MultipleForward: return "[合并转发]";
     case MessageType.RichText: return "[图文消息]";
+    case MessageType.InteractiveCard: return CARD_PLACEHOLDER;
     default: return "[消息]";
   }
 }
@@ -2507,6 +2528,16 @@ export async function handleInboundMessage(params: {
   const apiUrl = account.config.apiUrl;
   const botToken = account.config.botToken ?? "";
 
+  // 波 B:登记进度卡发送上下文(hook 侧懒发/更新时用)。route.sessionKey 桥接
+  // dispatch↔hook(H1 实证一致)。OBO(persona-clone)场景由 setCardContext 内部标记跳过。
+  setCardContext(route.sessionKey, {
+    apiUrl,
+    botToken,
+    channelId: replyChannelId,
+    channelType: replyChannelType,
+    ...(effectiveOnBehalfOf ? { onBehalfOf: effectiveOnBehalfOf } : {}),
+  });
+
   // 已读回执 + 正在输入 — fire-and-forget
   if (isOBOv2) {
     // v2: send typing to origin group with grantor identity (skip readReceipt)
@@ -2879,6 +2910,9 @@ export async function handleInboundMessage(params: {
       }
     }
     clearInterval(typingInterval);
+    // 波 B:收尾进度卡(终态帧 + 清理);fire-and-forget，不阻塞 dispatch 结束/会话释放。
+    // finalizeCard 内部同步删 Map(立即释放关联),终态 edit 后台异步发送。
+    void finalizeCard(route.sessionKey, { success: replySucceeded });
     // Safety net: clean up pending inbound context in case the hook didn't fire
     pendingInboundContext.delete(route.sessionKey);
 

--- a/src/inbound.ts
+++ b/src/inbound.ts
@@ -2011,6 +2011,11 @@ export async function handleInboundMessage(params: {
             const apiResolved = resolveContent(m.payload, account.config.apiUrl, log, account.config.cdnUrl);
             if (apiResolved.text) body = apiResolved.text;
           }
+          // For InteractiveCard(=17), backfill the server-authoritative plain text (never the
+          // card tree), same as live inbound — otherwise the card contributes only "[卡片]" to ctx.
+          if (m.type === MessageType.InteractiveCard && m.payload) {
+            body = resolveCardPlain(m.payload);
+          }
           const entry: any = {
             sender: m.from_uid,
             body,
@@ -2680,6 +2685,9 @@ export async function handleInboundMessage(params: {
       ...(replyMentionUids.length > 0 ? { mentionUids: replyMentionUids } : {}),
       ...(replyMentionEntities.length > 0 ? { mentionEntities: replyMentionEntities } : {}),
       mentionAll: hasAtAll || undefined,
+      // 引用用户原始触发消息(Q→A):即便进度卡与答复之间被他人插话,客户端仍能把答复与提问连起来。
+      // 只在有触发消息 id 时附带;OBO/转发等场景 message_id 仍是本 turn 的触发消息,语义正确。
+      ...(message.message_id ? { replyMsgId: message.message_id } : {}),
       ...(effectiveOnBehalfOf ? { onBehalfOf: effectiveOnBehalfOf } : {}),
       ...(signal ? { signal } : {}),
     });

--- a/src/session-retry.test.ts
+++ b/src/session-retry.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi } from "vitest";
+import { isSessionInitConflict, runWithSessionInitRetry } from "./session-retry.js";
+
+describe("isSessionInitConflict", () => {
+  it("命中 core 的会话初始化冲突错误", () => {
+    expect(isSessionInitConflict(new Error("reply session initialization conflicted for agent:main:octo:group:x"))).toBe(true);
+    expect(isSessionInitConflict("reply session initialization conflicted for x")).toBe(true);
+  });
+  it("其它错误不命中", () => {
+    expect(isSessionInitConflict(new Error("dispatch timed out after 60000ms"))).toBe(false);
+    expect(isSessionInitConflict(new Error("boom"))).toBe(false);
+    expect(isSessionInitConflict(undefined)).toBe(false);
+    expect(isSessionInitConflict(null)).toBe(false);
+  });
+});
+
+describe("runWithSessionInitRetry", () => {
+  const noSleep = vi.fn(async () => {});
+
+  it("首次成功 → 只跑一次,不 sleep", async () => {
+    const task = vi.fn(async () => {});
+    const sleep = vi.fn(async () => {});
+    await runWithSessionInitRetry(task, { retries: 2, backoffMs: 750, sleep });
+    expect(task).toHaveBeenCalledTimes(1);
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it("冲突后成功 → 重试,sleep 一次(线性退避)", async () => {
+    let n = 0;
+    const task = vi.fn(async () => {
+      n++;
+      if (n === 1) throw new Error("reply session initialization conflicted for x");
+    });
+    const sleep = vi.fn(async () => {});
+    await runWithSessionInitRetry(task, { retries: 2, backoffMs: 750, sleep });
+    expect(task).toHaveBeenCalledTimes(2);
+    expect(sleep).toHaveBeenCalledTimes(1);
+    expect(sleep).toHaveBeenCalledWith(750); // 第 1 次退避 = backoffMs*1
+  });
+
+  it("持续冲突超重试上限 → 最终抛,跑 retries+1 次", async () => {
+    const task = vi.fn(async () => {
+      throw new Error("reply session initialization conflicted for x");
+    });
+    const sleeps: number[] = [];
+    const sleep = vi.fn(async (ms: number) => { sleeps.push(ms); });
+    await expect(
+      runWithSessionInitRetry(task, { retries: 2, backoffMs: 750, sleep }),
+    ).rejects.toThrow(/conflicted/);
+    expect(task).toHaveBeenCalledTimes(3); // 1 + 2 retries
+    expect(sleeps).toEqual([750, 1500]); // 线性退避
+  });
+
+  it("非冲突错误 → 立即抛,不重试不 sleep", async () => {
+    const task = vi.fn(async () => {
+      throw new Error("dispatch timed out after 60000ms");
+    });
+    const sleep = vi.fn(async () => {});
+    await expect(
+      runWithSessionInitRetry(task, { retries: 2, backoffMs: 750, sleep }),
+    ).rejects.toThrow(/timed out/);
+    expect(task).toHaveBeenCalledTimes(1);
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it("retries=0 → 冲突即抛,不重试", async () => {
+    const task = vi.fn(async () => {
+      throw new Error("reply session initialization conflicted for x");
+    });
+    await expect(
+      runWithSessionInitRetry(task, { retries: 0, backoffMs: 750, sleep: noSleep }),
+    ).rejects.toThrow(/conflicted/);
+    expect(task).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/session-retry.ts
+++ b/src/session-retry.ts
@@ -1,0 +1,54 @@
+/**
+ * 会话初始化冲突的兜底重试。
+ *
+ * OpenClaw core 在 `commitReplySessionInitialization` 用 session entry 的 revision 做乐观锁 CAS
+ * (`get-reply.js`)。当同一 session(同群)两条消息紧挨着来,turn N 的异步 session 收尾写与
+ * turn N+1 的 init 提交竞态,CAS 连续两次读到脏 revision → 抛 `reply session initialization
+ * conflicted for <sessionKey>`,该条入站被静默丢弃(用户端"没反应")。
+ *
+ * 这是瞬态冲突:重试前一条的收尾写很快完成。故对**且仅对**该错误做短退避重试,把"丢消息"
+ * 变成"稍晚回复"。冲突发生在 init 阶段(进模型前、任何投递前,实测 duration≈11ms),因此重试
+ * 不会造成重复回复。其它错误(超时/网络/业务)一律立即抛,不重试。
+ */
+
+/** 是否为 core 的会话初始化冲突错误。 */
+export function isSessionInitConflict(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : typeof err === "string" ? err : "";
+  return /reply session initialization conflicted/i.test(msg);
+}
+
+interface RetryOpts {
+  /** 冲突时最多重试几次(不含首次)。 */
+  retries: number;
+  /** 退避基数(ms),第 n 次退避 = backoffMs * n(线性)。 */
+  backoffMs: number;
+  /** 可注入的 sleep(测试用);缺省真实 setTimeout。 */
+  sleep?: (ms: number) => Promise<void>;
+  log?: { warn?: (msg: string) => void };
+}
+
+const defaultSleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+/**
+ * 跑 task;仅当抛出「会话初始化冲突」且未超重试上限时,线性退避后重试。其它错误立即抛。
+ */
+export async function runWithSessionInitRetry(task: () => Promise<void>, opts: RetryOpts): Promise<void> {
+  const sleep = opts.sleep ?? defaultSleep;
+  let attempt = 0;
+  for (;;) {
+    try {
+      await task();
+      return;
+    } catch (err) {
+      if (isSessionInitConflict(err) && attempt < opts.retries) {
+        attempt++;
+        opts.log?.warn?.(
+          `octo: session init conflict, retrying (${attempt}/${opts.retries}) after ${opts.backoffMs * attempt}ms`,
+        );
+        await sleep(opts.backoffMs * attempt);
+        continue;
+      }
+      throw err;
+    }
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -150,6 +150,17 @@ export enum MessageType {
    * 顺序即图文穿插顺序；顶层 `plain` 为冗余纯文本，契约上由 server 权威生成。
    */
   RichText = 14,
+  /**
+   * 交互卡片（Adaptive Cards 1.5 子集，"octo/v1" profile）。对应 octo-server
+   * PR #525 P1 `card-message-protocol`，ContentType=17。
+   *
+   * ⚠️ 与 `Card=7`（名片/contact card）语义无关 —— octo-server Decision 1 明确
+   * InteractiveCard(17) ≠ common.Card(7)，不要把新逻辑接到 7 上。
+   *
+   * payload 信封：`{ type:17, card:{标准 AC1.5 JSON}, plain:"(server 权威重算)" }`
+   * + 顶层 `profile`/`card_version`。adapter 入站仅消费服务端权威 `plain`。
+   */
+  InteractiveCard = 17,
 }
 
 /** RichText(=14) 单个 block 类型常量（与 octo-lib RichTextBlockText/Image 对齐）。 */
@@ -188,6 +199,34 @@ export interface RichTextPayload {
   content: RichTextBlock[];
   /** 冗余纯文本，契约上由 server 生成；adapter 出站可附带，server 会覆盖。 */
   plain?: string;
+}
+
+/**
+ * InteractiveCard(=17) 展示/降级占位符（与 octo-server Decision 8 的 `[卡片]`
+ * fallback 对齐）。入站派生 `plain` 为空时使用，保证喂给 LLM 的文本 never empty。
+ */
+export const CARD_PLACEHOLDER = "[卡片]";
+
+/** InteractiveCard(=17) 协议 profile / 版本（octo-server Decision 10 协商值）。 */
+export const CARD_PROFILE = "octo/v1";
+export const CARD_VERSION = "1.5";
+
+/**
+ * InteractiveCard(=17) 消息的 payload 信封（octo-server PR #525 P1）。
+ *
+ *   - `card`  标准 Adaptive Cards 1.5 JSON，服务端按 `octo/v1` 白名单校验；
+ *     adapter 出站原样透传，不在本仓做 schema 校验（服务端 `pkg/cardmsg` 权威）。
+ *   - `plain` 服务端在 dispatch 出口权威重算（Decision 8：never empty，含
+ *     `[卡片]` fallback）。adapter 出站可附带但会被覆盖；**入站只读它**。
+ *   - `profile`/`card_version` 版本协商（Decision 10：非 `octo/v1`+`1.5` → 服务端 400）。
+ */
+export interface InteractiveCardPayload {
+  /** 标准 Adaptive Cards 1.5 JSON（octo/v1 profile）。 */
+  card: Record<string, unknown>;
+  /** 服务端权威纯文本；出站可附带（被覆盖），入站作 LLM 输入。 */
+  plain?: string;
+  profile?: string;
+  card_version?: string;
 }
 
 /**


### PR DESCRIPTION
## Background

Implements the octo-server PR #525 `card-message-protocol` (ContentType=17, Adaptive Cards 1.5, `octo/v1` display profile). Two-way InteractiveCard support: **inbound** the adapter reads the server-authoritative plain text and feeds it to the LLM; **outbound** it drives a live hook-based progress card AND lets agents actively emit rich display cards via a dedicated tool. Interactive (Submit / card_action callback) is out of scope here — deferred to wave C-2.

## Changes

### Inbound (consume)
- `types.ts`: add `MessageType.InteractiveCard=17`, `InteractiveCardPayload`, and `CARD_PLACEHOLDER` / `CARD_PROFILE` / `CARD_VERSION` constants (unrelated to contact `Card=7`, per Decision 1).
- `inbound.ts` `resolveCardPlain`: consume **only the server-authoritative `plain`** (Decision 8 never-empty); never parse the `card` tree; fall back to `[卡片]` on empty. Wired into `resolveContent`, forward preview, and the placeholder path.
- `channel.ts`: allow InteractiveCard as an inbound type.

### Outbound wire primitives
- `api-fetch.ts`: `sendCardMessage` / `editCardMessage` / `getCardProfile` (D12 capability discovery).

### Outbound — progress card (hook-driven live status)
- `card-progress.ts`: `sessionKey`-scoped state machine, hook-driven (`before_tool_call` / `after_tool_call` / `model_call_started`) with debounced frame coalescing; D12 gate; OBO (persona-clone) skip.
- `inbound.ts`: register `setCardContext` at dispatch start; `finalizeCard` in `finally` (fire-and-forget).
- `index.ts`: register the `registerCardProgress` hook.
- Row rendering (**P1-d**) — steps flow through `buildDisplayCard` (see foundation below): rich rows with `RichTextBlock` inlines (icon | bold label | :summary | · duration good/attention colored) when advertised; TextBlock flatten otherwise. **RichTextBlock chosen over ColumnSet** because the server-authoritative `plain` recompute splits column layouts across two lines, degrading non-native renderers.
- UX convergence (**P1-f**) — a real client screenshot exposed 20+ steps flattened, deep paths overflowing to three lines, and errors buried:
  - **Path shortening**: deep paths keep the last two segments (`…/bot_api/send.go`); depth ≤ 3 unchanged; last segment never truncated.
  - **Same-tool merge**: ≥2 adjacent `done` steps of the same tool collapse into `<icon> <label> × N · total <ms> — recent: <last summary>`. `running`/`error` never merge (current focus stays salient). Header's step count still uses raw `steps.length`.
  - Real im-test: a 12-step turn goes from 12 rows to 7.
- Thinking visibility (**P1-g**) — `model_call_started` now emits a running `__thinking__` step (icon 💭, label 思考). `before_tool_call` / `finalizeCard` close it (marks done + `durationMs = now - startedAt`). Adjacent thinkings collapse via P1-f's same-tool merge, so noisy loops render as `💭 思考 × N · total Xms`.

### Static display foundation — Plan B (**P1-b / P1-c**)
Shared foundation for both the progress card and agent-emitted display cards: producers describe intent as typed `DisplayBlock`s, `buildDisplayCard` translates to AC 1.5 JSON, negotiates degradation via `CardCaps`, and sanitizes every block through the same pipeline.
- Block set: `heading` / `text` / `rich` / `facts` / `group` / `collapsible`.
- Every block runs whitespace collapse → URL reduction (registrable domain only; drops subdomain / path / query / userinfo) → generic `isSensitive` (keyword + AWS/JWT/long-hex/high-entropy shapes). Blocks matching secret patterns fail-closed and render nothing. `plain` and `card` stay in sync.
- `collapsible` upgrade requires three caps together: `elements ∋ Container`, `elements ∋ ActionSet`, `actions ∋ Action.ToggleVisibility`. Any missing → degrade to `summary` heading + inner blocks expanded below (zero regression: content preserved, only the fold gesture lost). Server does not advertise `actions` today, so degrade is the current runtime path.
- Uses a `RenderCtx` for per-card unique `targetElements` ids (no `Math.random` → deterministic).
- `isSensitive` / `reduceUrlsInText` promoted to `export` for reuse.

### Agent display-card tool + SKILL docs (**P1-e**)
- New tool `octo_send_display_card` — emits a **display-type** InteractiveCard (top-level actions: none; no callback events). For structured replies / notifications / approval summaries / result displays. Strictly separated from C-2's `octo_send_card` (Submit + card_action).
- Routes through `buildDisplayCard` for negotiation + sanitization. Pre-send D12 gate: not-available / not-enabled / profile mismatch / version mismatch → fail-closed error, so the agent falls back to text instead of 400.
- Agent input is untrusted: `validateDisplayBlocks` whitelist-validates each block's structure; unknown types / malformed fields drop silently.
- `openclaw.plugin.json` `contracts.tools` registers the name.
- `skills/octo-bot-api/SKILL.md` gains a "Sending Cards" section (when to use cards vs text, feature detection, payload shape, DisplayBlock table, negotiation caveats, security, transient edits) — hand-rolled bots stay aligned.

## Concurrency / security (hardened over three review rounds)
- **finalizeCard race**: awaits the in-flight flush before taking over, and deletes the Map entry only when it is still the current registration (`cards.get(sessionKey) === entry`) — avoids losing the terminal frame / a frozen placeholder, and never wipes the next run's state.
- **gate probe window**: `inFlight` is set before any `await`, blocking a concurrent flush from sending a duplicate first frame while `messageId` is not yet set.
- **gate transient failure**: a 5xx/network blip returns a transient state that is neither cached nor permanently skipped, so one blip can't disable cards for the session/process.
- **parallel same-name tools**: `after_tool_call` matches by SDK `toolCallId` first; on a miss it discards the (stale/duplicate) event rather than falling back to name-matching, so it never mis-attributes a concurrent step.
- **cross-account isolation**: the card map is keyed by `sessionKey`, but a `sessionKey` can be shared across bot accounts. Each entry carries an identity fingerprint (`apiUrl + channelId + onBehalfOf + botToken`); on a cross-identity collision `setCardContext` fails closed (both skip) so a progress card is never sent/edited into the wrong channel.
- **group-card secret redaction**: allowlist-based parameter summary (unknown / MCP tools render nothing). URL → registrable domain only. Shell → program name only (skips `VAR=secret` env prefixes). Keyword regex + shape-based detection (AWS / GitHub / Slack / OpenAI / JWT / long-hex / high-entropy). Tool error text goes through the same redaction + length cap.
- **card growth**: steps are trimmed by `MAX_VISIBLE_STEPS`, then by server-authoritative `max_nodes`, to avoid exceeding structural limits (edit 400).

## Wave C — capability negotiation
Consumes the octo-server D12 manifest's additive capability lists (single source of truth from `pkg/cardmsg`), so the producer negotiates at **element / input / action granularity** — even while `card_version` stays `1.5`, it can detect whether a deployment actually accepts a given element / input / action.

- **P1-a — `actions` whitelist**: `CardProfileManifest.actions?: string[]` (forward-compat additive; server does not advertise it today). `CardCaps` gains `inputs` and `actions` (`ReadonlySet`); `cardSupports` dispatches by prefix (`Input.*` → inputs, `Action.*` → actions, else elements). **No baseline for inputs/actions** — when the server does not advertise them they are treated as unsupported (fail-closed), so we never optimistically emit elements an older deployment cannot render.
- **T1 — server-authoritative limits**: `getCardProfile` parses `limits`; a per-`apiUrl` caps cache (filled at gate time) derives `max_nodes` → `renderProgressCard` bounds visible steps by the server's authoritative node cap, falling back to the local `MAX_VISIBLE_STEPS` when absent.
- **T2 — element capability**: parse `elements`/`inputs`; `CardCaps` + `cardSupports` (explicit-manifest-else-baseline for elements; fail-closed for inputs/actions).
- **T3 — deprecated / replaced**: the original ColumnSet-when-advertised upgrade has been superseded by P1-d's RichTextBlock path (see "progress card" above) — column layout was rejected because the server's authoritative plain recompute splits it into two lines.

**E2E-driven fix (kept from earlier)**: an early gate required `has(ColumnSet) && has(Column)`, but the real server does not advertise `Column` independently (it is a ColumnSet child) — so the upgrade would never fire. Changed to require only `ColumnSet`. The subsequent P1-d rewrite makes this moot for the progress card (which now prefers RichTextBlock), but the shape lives on inside `buildDisplayCard`'s `columns`-block handling for future consumers.

`src/card-e2e.test.ts` is an env-gated Tier-1 live-integration harness (auto-skips without `OCTO_E2E_*`, no secrets, not in the default CI path) that drives the real D12 endpoint + send/edit to verify wire contract and server acceptance that mocked unit tests cannot.

## Tests
Four unit suites plus the env-gated e2e:
- `card-adaptation.test.ts` — inbound derivation + `getCardProfile` full-manifest parsing.
- `card-render.test.ts` — rendering / redaction / trimming / step merging / path shortening / thinking semantics.
- `card-progress.test.ts` — state machine / races / gate / `toolCallId` / thinking step lifecycle.
- `card-blocks.test.ts` — DisplayBlock builder / negotiation degradation / sanitization / collapsible / edge cases.
- `card-display-tool.test.ts` — display-card tool scaffolding + each execute branch (negotiation, fail-closed, invalid input filtering, persona passthrough).

Regression cases for every concurrency/security finding across the review rounds (overlapping flush, duplicate delivery, cross-account fail-closed, tunnel hostnames, bare-token shapes, unredacted error text, path-secret misfires on git/docker hashes, etc.).

## Test plan
- [x] `npm run type-check` clean
- [x] `npm run build` (tsc) clean
- [x] `npm test` green (40 files / **1421 tests** (+ env-gated e2e))
- [x] Integration: real octo-server (im-test) — send + transient edit + terminal frame all 200 via `src/card-e2e.test.ts` (env-gated); confirmed server advertises full 9-element / 6-input / 5-limit manifest and accepts RichTextBlock rows.
- [ ] Integration: inbound type-17 card → LLM input is the server `plain`