### PR TITLE
feat(cards): add account-level progress and display switches

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ Bot accounts are stored in `~/.openclaw/openclaw.json` under `channels.octo.acco
 
 Configuration fields per account:
 
+`cardProgress` and `cardDisplay` may also be set directly under `channels.octo` as defaults for every account. An explicit per-account `true` or `false` overrides the corresponding top-level value.
+
 - `botToken` (required): Bot token. Either a User Bot token from BotFather (`bf_` prefix, full group + thread access) or an App Bot token from the Octo admin console (`app_` prefix, direct-message only — server-enforced).
 - `apiUrl` (required): Octo server REST API base URL (e.g. `https://your-server/api`). The default `http://localhost:8090/api` only works for a local Octo dev server with the standard `/api` mount.
 - `wsUrl` (optional): WebSocket URL. Auto-detected from `apiUrl` if omitted.

--- a/README.md
+++ b/README.md
@@ -69,8 +69,27 @@ Configuration fields per account:
 - `wsUrl` (optional): WebSocket URL. Auto-detected from `apiUrl` if omitted.
 - `cdnUrl` (optional): CDN base URL for media files
 - `requireMention` (optional): Only respond when @mentioned in groups
+- `cardProgress` (optional): Set `false` to force-disable automatic progress cards for this account. Omitted or `true` follows the server card capability gate.
+- `cardDisplay` (optional): Set `false` to hide and reject the `octo_send_display_card` tool for this account. Omitted or `true` follows the server card capability gate.
 - `historyLimit` (optional): Group chat history message limit (default: 20)
 - `dispatchTimeoutMs` (optional): Per-inbound dispatch timeout in milliseconds — an infrastructure backstop that releases the per-group message queue if an upstream dispatch hangs. When unset, it is derived from OpenClaw's `agents.defaults.timeoutSeconds` (600 if unset) as `timeoutSeconds * 1000 + 60000`, so it always fires *after* the agent-run timeout: the agent terminates gracefully first, and this timeout only catches genuinely hung dispatches. Set explicitly only if you need to decouple it from the agent timeout.
+
+For example, to suppress intermediate progress frames while keeping final display cards available:
+
+```json
+{
+  "channels": {
+    "octo": {
+      "accounts": {
+        "my_bot": {
+          "cardProgress": false,
+          "cardDisplay": true
+        }
+      }
+    }
+  }
+}
+```
 
 ## Agent tools
 

--- a/docs/superpowers/specs/2026-07-14-progress-card-config-design.md
+++ b/docs/superpowers/specs/2026-07-14-progress-card-config-design.md
@@ -56,7 +56,7 @@ config `true` 永远不能把 `existingCardGate === false` 翻成 `true`。
    - 配置禁用只属于 per-account / per-session 决策,**绝不能写入**当前按 `apiUrl` 共享的 `gateCache` / `capsCache`。否则账号 A 关闭会污染同部署账号 B。共享缓存仍只保存服务端能力事实。
 
 5. **`src/card-display-tool.ts`(`createDisplayCardTool`)** —— 已接收 `cfg` / `agentAccountId`,同源解析 `cardDisplay`,同时做两层守卫:
-   - discovery 阶段能可靠解析当前账号且其 `cardDisplay === false` 时,不注册工具,避免向模型 offer 不可用能力;多账号且当前账号不明确时允许保留工具。
+   - discovery 阶段能可靠解析当前账号且其 `cardDisplay === false` 时,不注册工具,避免向模型 offer 不可用能力。多账号且当前账号不明确时,若所有可用账号均解析为 `false` 则隐藏;只要至少一个账号允许展示卡就保留工具,避免误伤混合配置。
    - `execute` 内以可信 `deliveryContext.accountId` / `agentAccountId` 解析账号后,在 manifest 探测前再次检查;显式关闭则立即 `err(...)` 提示改用纯文本。执行时检查是最终权威,用于覆盖 tool schema 缓存、热更新和直接调用场景。
 
 6. **`README.md`** —— 在账号配置说明与示例中增加两个字段及三态语义,让运维侧可发现。
@@ -90,6 +90,7 @@ config `true` 永远不能把 `existingCardGate === false` 翻成 `true`。
 `src/card-display-tool.test.ts`:
 
 - 已知当前账号 `cardDisplay:false` → discovery 不注册工具。
+- 多账号且 discovery 无法确定当前账号时,所有可用账号均为 `false` → 不注册工具;任一账号为省略 / `true` → 保留工具。
 - discovery 无法确定账号但 execute 解析到 `cardDisplay:false` → 返回 `err`(提示改用纯文本),且不探测 manifest、不发送。
 - 省略 → 现有行为不变(回归)。
 

--- a/docs/superpowers/specs/2026-07-14-progress-card-config-design.md
+++ b/docs/superpowers/specs/2026-07-14-progress-card-config-design.md
@@ -25,7 +25,7 @@
 
 ## 设计
 
-新增两个**三态布尔**账号级配置项(顶层默认 + `accounts.<id>` 覆盖,与现有 `requireMention` / `ignoreMentionAll` 同款分层):
+新增两个**三态布尔**账号级配置项(顶层默认 + `accounts.<id>` 覆盖,与现有 `requireMention` 同款分层):
 
 | 配置项 | 作用面 | 语义 |
 |---|---|---|
@@ -34,30 +34,38 @@
 
 **三态语义(关键):** 只有显式 `false` 才关;`true` 与省略都等价于「跟随服务端」,不改变现状。命名为 kill-switch 而非 enable-switch —— 默认行为与今天完全一致,升级无感。
 
-**最终门 = `serverGate && configAllows`(与运算,只收窄):**
+**最终门 = `existingCardGate && configAllows`(与运算,只收窄):** `existingCardGate` 指现有完整门控,包括 manifest 能力判断,以及 `available:false` 时保留的 env 兼容回退。
 
 ```
-finalEnabled = serverManifestGate(...) && (config.cardProgress !== false)
+finalEnabled = existingCardGate(...) && (config.cardProgress !== false)
 ```
 
-config `true` 永远不能把 `serverManifestGate === false` 翻成 `true`。
+config `true` 永远不能把 `existingCardGate === false` 翻成 `true`。
 
 ### 改动点
 
-1. **`openclaw.plugin.json`** —— 配置 schema 加 `cardProgress` / `cardDisplay`(`boolean`,可选,无 default = 三态),顶层与 `accounts.*` 两处都加,附 description 说明「省略/true=跟随服务端,false=强制关」。
+1. **`openclaw.plugin.json` + `src/config-schema.ts`** —— manifest schema、运行时 TypeScript 配置类型与 `OctoConfigJsonSchema` 同步加 `cardProgress` / `cardDisplay`(`boolean`,可选,无 default = 三态),顶层与 `accounts.*` 两处都加,附 description 说明「省略/true=跟随服务端,false=强制关」。两套 schema 必须保持 key 与 description 一致,继续通过 `manifest-schema-sync.test.ts`。
 
-2. **`src/inbound.ts:2538`(`setCardContext`)** —— 该处已持有 `account.config`,把解析后的 `cardProgress` 结果(顶层默认与账号覆盖合并后)塞进 `CardContext`。
+2. **`src/accounts.ts`** —— `ResolvedOctoAccount.config` 加两个可选字段,在 `resolveOctoAccount` 用 `accountConfig.cardProgress ?? channel.cardProgress` / `cardDisplay` 做顶层默认 + 账号覆盖。显式 `true` 必须能覆盖顶层 `false`,显式 `false` 也必须能覆盖顶层 `true`。
 
-3. **`src/card-progress.ts`**
-   - `CardContext` 加可选字段(如 `progressDisabled?: boolean`)。
-   - `gateEnabled` 开头:配置显式关 → 直接返回 `false` 且**可缓存/skip**(与「明确禁用」同级),连 manifest 探测都省。
+3. **`src/inbound.ts:2538`(`setCardContext`)** —— 该处已持有解析完成的 `account.config`,把 `cardProgress` 原值塞进 `CardContext`。
 
-4. **`src/card-display-tool.ts`(`createDisplayCardTool`)** —— 已接收 `cfg` / `agentAccountId`,同源解析 `cardDisplay`:关闭时工具在 discovery 阶段不注册 / 或调用即返回 `err(...)` 提示改用纯文本(与现有 gate 拒绝路径一致)。
+4. **`src/card-progress.ts`**
+   - `CardContext` 加可选字段 `cardProgress?: boolean`,保留三态原值,避免正反语义转换。
+   - `setCardContext` 创建本 session entry 时,`cardProgress === false` 直接置 `skip`;连 manifest 探测都省。
+   - 配置禁用只属于 per-account / per-session 决策,**绝不能写入**当前按 `apiUrl` 共享的 `gateCache` / `capsCache`。否则账号 A 关闭会污染同部署账号 B。共享缓存仍只保存服务端能力事实。
+
+5. **`src/card-display-tool.ts`(`createDisplayCardTool`)** —— 已接收 `cfg` / `agentAccountId`,同源解析 `cardDisplay`,同时做两层守卫:
+   - discovery 阶段能可靠解析当前账号且其 `cardDisplay === false` 时,不注册工具,避免向模型 offer 不可用能力;多账号且当前账号不明确时允许保留工具。
+   - `execute` 内以可信 `deliveryContext.accountId` / `agentAccountId` 解析账号后,在 manifest 探测前再次检查;显式关闭则立即 `err(...)` 提示改用纯文本。执行时检查是最终权威,用于覆盖 tool schema 缓存、热更新和直接调用场景。
+
+6. **`README.md`** —— 在账号配置说明与示例中增加两个字段及三态语义,让运维侧可发现。
 
 ### 不改
 
 - manifest 探测、`deriveCardCaps`、版本协商(精确匹配 `octo/v1` + `1.5`,Decision 10)全部保留,配置只在其结果上做 `&&`。
-- OBO(persona-clone)仍无条件跳过卡片,不受本开关影响。
+- 进度卡继续在当前 turn 的可信 `effectiveOnBehalfOf` 存在时无条件 skip,不受本开关影响。
+- 展示卡维持当前身份边界:始终以 bot 自身身份发送,不接受/透传模型提供的 OBO 身份。它当前并非「所有 persona 账号一律 skip」;若未来要求 OBO turn 禁止展示卡,需另行把可信 turn 级 OBO 上下文接入工具。
 
 ## 备选(已否决)
 
@@ -66,13 +74,23 @@ config `true` 永远不能把 `serverManifestGate === false` 翻成 `true`。
 
 ## 测试
 
+`src/__tests__/accounts.test.ts` 新增配置继承用例:
+
+- 顶层 `cardProgress/cardDisplay:false` + 账号省略 → 解析为 `false`。
+- 顶层 `false` + 账号显式 `true` → 解析为 `true`。
+- 顶层 `true` + 账号显式 `false` → 解析为 `false`。
+
 `src/card-progress.test.ts` 新增门控用例:
 
-- `cardProgress: false` + 服务端 `enabled:true` → `gateEnabled` 返回 `false`(强制关,回归 fail-closed)。
+- `cardProgress:false` → session 直接 skip,`getCardProfile` / send / edit 均不调用。
 - `cardProgress` 省略 + 服务端 `enabled:true` → 返回 `true`(跟随服务端,现状不变)。
 - `cardProgress: true` + 服务端不兼容(`card_version` 不匹配)→ 仍 `false`(配置不能强开,守住 400 底线)。
+- 同一 `apiUrl` 下账号 A `false`、账号 B 省略 / `true` + 服务端兼容 → B 仍正常发卡(证明配置禁用未污染共享 gate cache)。
 
 `src/card-display-tool.test.ts`:
 
-- `cardDisplay: false` → 工具调用返回 `err`(提示改用纯文本),不发送。
+- 已知当前账号 `cardDisplay:false` → discovery 不注册工具。
+- discovery 无法确定账号但 execute 解析到 `cardDisplay:false` → 返回 `err`(提示改用纯文本),且不探测 manifest、不发送。
 - 省略 → 现有行为不变(回归)。
+
+`src/manifest-schema-sync.test.ts` 保持通过,并覆盖两个新字段在 manifest / 运行时 schema 的顶层与账号层 description 一致。

--- a/docs/superpowers/specs/2026-07-14-progress-card-config-design.md
+++ b/docs/superpowers/specs/2026-07-14-progress-card-config-design.md
@@ -1,0 +1,78 @@
+# 新增卡片开关配置项(进度卡 / 展示卡)
+
+## 背景
+
+当前进度卡(`src/card-progress.ts`)与展示卡工具(`src/card-display-tool.ts`)的「发不发」**只由服务端 manifest 决定**,插件侧没有任何账号级开关:
+
+- 门控唯一来源是 `GET /v1/bot/card/profile` 的 manifest:`available / enabled / profiles / card_version / elements`(`card-progress.ts` 的 `gateEnabled`,约 `:135`;`card-display-tool.ts` 的 `gateReason`,约 `:106`,两处共用 `deriveCardCaps`)。
+- 唯一旁路旋钮是**进程级** env `OCTO_CARD_MESSAGE_ENABLED`,且**仅在 manifest 端点缺失(`available:false`)时**才被读取(`card-progress.ts:142`、`card-display-tool.ts:108`)。一旦服务端部署了端点并 `enabled:true`,进程内所有 bot 强制开卡,插件侧关不掉。
+
+由此产生三个缺口:
+
+1. **无 per-account / per-bot 开关。** 多 bot 单进程(v0.2.30+ 独立连接隔离)下,翻译 bot 想纯文本、正式 bot 想发卡,做不到——env 是进程级,一刀切。
+2. **进度卡与展示卡共用一个门。** 进度卡是自动、`transient`、高频 edit 的中间帧,噪音 / token / edit 频率成本明显高于最终展示卡;想「保留最终卡、关掉过程帧」当前无法拆分。
+3. **缺干净的 kill-switch。** 服务端端点已部署时,想临时关进度卡只能改服务端 `manifest.enabled=false`(波及所有 bot),env 那条此时又不生效。
+
+## 目标
+
+给插件加**账号级**卡片开关,让运维 / bot 作者能在不动服务端的前提下,按 bot 关闭进度卡或展示卡。开关只作**收窄**(强制关),能力上限仍由服务端 manifest 决定。
+
+## 非目标
+
+- **不**让配置强开卡片。开关不能绕过 manifest 的 `profiles / card_version / TextBlock` 兼容校验——绕过会稳定撞 server 400。这是 fail-closed 底线。
+- **不**在插件侧复制服务端能力判断。manifest 仍是能力权威,配置只在其之上做减法。
+- **不**改 env `OCTO_CARD_MESSAGE_ENABLED` 的现有语义(`available:false` 回退开关),保持向后兼容。
+
+## 设计
+
+新增两个**三态布尔**账号级配置项(顶层默认 + `accounts.<id>` 覆盖,与现有 `requireMention` / `ignoreMentionAll` 同款分层):
+
+| 配置项 | 作用面 | 语义 |
+|---|---|---|
+| `cardProgress` | 自动进度卡(hook 链路) | `false` = 强制关;`true` / 省略 = 跟随服务端 manifest |
+| `cardDisplay` | `octo_send_display_card` 工具 | `false` = 工具不 offer / 直接拒;`true` / 省略 = 跟随服务端 manifest |
+
+**三态语义(关键):** 只有显式 `false` 才关;`true` 与省略都等价于「跟随服务端」,不改变现状。命名为 kill-switch 而非 enable-switch —— 默认行为与今天完全一致,升级无感。
+
+**最终门 = `serverGate && configAllows`(与运算,只收窄):**
+
+```
+finalEnabled = serverManifestGate(...) && (config.cardProgress !== false)
+```
+
+config `true` 永远不能把 `serverManifestGate === false` 翻成 `true`。
+
+### 改动点
+
+1. **`openclaw.plugin.json`** —— 配置 schema 加 `cardProgress` / `cardDisplay`(`boolean`,可选,无 default = 三态),顶层与 `accounts.*` 两处都加,附 description 说明「省略/true=跟随服务端,false=强制关」。
+
+2. **`src/inbound.ts:2538`(`setCardContext`)** —— 该处已持有 `account.config`,把解析后的 `cardProgress` 结果(顶层默认与账号覆盖合并后)塞进 `CardContext`。
+
+3. **`src/card-progress.ts`**
+   - `CardContext` 加可选字段(如 `progressDisabled?: boolean`)。
+   - `gateEnabled` 开头:配置显式关 → 直接返回 `false` 且**可缓存/skip**(与「明确禁用」同级),连 manifest 探测都省。
+
+4. **`src/card-display-tool.ts`(`createDisplayCardTool`)** —— 已接收 `cfg` / `agentAccountId`,同源解析 `cardDisplay`:关闭时工具在 discovery 阶段不注册 / 或调用即返回 `err(...)` 提示改用纯文本(与现有 gate 拒绝路径一致)。
+
+### 不改
+
+- manifest 探测、`deriveCardCaps`、版本协商(精确匹配 `octo/v1` + `1.5`,Decision 10)全部保留,配置只在其结果上做 `&&`。
+- OBO(persona-clone)仍无条件跳过卡片,不受本开关影响。
+
+## 备选(已否决)
+
+- **单一 `cards` 布尔开关**:实现更省,但把进度卡与展示卡绑死,无法满足「关过程帧、留最终卡」这一主要诉求(缺口 2),否决。
+- **嵌套 `cards: { progress, display }` 对象**:分组更清晰,但与现有扁平 camelCase 账号配置(`requireMention` 等)不一致;为一致性选扁平两字段。若后续卡片配置项增多,可再收敛为嵌套对象。
+
+## 测试
+
+`src/card-progress.test.ts` 新增门控用例:
+
+- `cardProgress: false` + 服务端 `enabled:true` → `gateEnabled` 返回 `false`(强制关,回归 fail-closed)。
+- `cardProgress` 省略 + 服务端 `enabled:true` → 返回 `true`(跟随服务端,现状不变)。
+- `cardProgress: true` + 服务端不兼容(`card_version` 不匹配)→ 仍 `false`(配置不能强开,守住 400 底线)。
+
+`src/card-display-tool.test.ts`:
+
+- `cardDisplay: false` → 工具调用返回 `err`(提示改用纯文本),不发送。
+- 省略 → 现有行为不变(回归)。

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -70,6 +70,14 @@
           "historyPromptTemplate": {
             "type": "string"
           },
+          "cardProgress": {
+            "type": "boolean",
+            "description": "When omitted or true, follow the server card capability gate; false force-disables automatic progress cards. Per-account values override the top-level value."
+          },
+          "cardDisplay": {
+            "type": "boolean",
+            "description": "When omitted or true, follow the server card capability gate; false force-disables the octo_send_display_card tool. Per-account values override the top-level value."
+          },
           "accounts": {
             "type": "object",
             "additionalProperties": {
@@ -119,6 +127,14 @@
                 },
                 "historyPromptTemplate": {
                   "type": "string"
+                },
+                "cardProgress": {
+                  "type": "boolean",
+                  "description": "When omitted or true, follow the server card capability gate; false force-disables automatic progress cards. Per-account values override the top-level value."
+                },
+                "cardDisplay": {
+                  "type": "boolean",
+                  "description": "When omitted or true, follow the server card capability gate; false force-disables the octo_send_display_card tool. Per-account values override the top-level value."
                 },
                 "onBehalfOf": {
                   "type": "string",

--- a/skills/octo-bot-api/SKILL.md
+++ b/skills/octo-bot-api/SKILL.md
@@ -162,11 +162,11 @@ Interactive-card details are intentionally kept out of this main skill file. Bef
 Hard rules to remember even before opening the reference:
 
 - Display cards (`payload.type=17`, `profile="octo/v1"`) are structured, non-callback output. Submit/click-back cards use `octo/v2` and require event polling.
-- Feature-detect with `GET /v1/bot/card/profile`. `available:true, enabled:false` is an explicit disable; `available:false` is a legacy-endpoint absence and may use the adapter compatibility switch documented in the reference. Otherwise fall back to text.
+- The `octo_send_display_card` tool feature-detects, degrades, and fail-closed rejects on its own — just pass `{ title?, blocks[] }`. On the raw API path, feature-detect with `GET /v1/bot/card/profile`: `available:true, enabled:false` is an explicit disable; `available:false` (endpoint not deployed) sends only when `OCTO_CARD_MESSAGE_ENABLED=1`; `card_version` must match `1.5` exactly. Otherwise fall back to text.
 - Keep one title, a compact first screen, truthful `plain`, and no raw logs or secrets.
 - Normal information cards should be quiet IM content: avoid large `good/warning/attention` blocks, excessive Bolder headings, and strong CTA-looking copy buttons.
 - Agent progress cards use `metadata.octo_layout = "agent_progress_v1"` with `[ColumnSet, Container#timeline_detail]` only when those elements are supported. The reference defines the flat-card fallback.
-- `octo/v2` callback cards and `octo_send_card` are not delivered by the current P1 branch; their implementation lives on the separate local `feat/card-interaction-c2` branch.
+- `octo/v2` callback cards and `octo_send_card` are not delivered by the current release; they require an `octo/v2` producer plus callback consumer, which the display-card surface does not provide.
 
 ## Real-time Features
 

--- a/skills/octo-bot-api/references/interactive-card-messages.md
+++ b/skills/octo-bot-api/references/interactive-card-messages.md
@@ -8,6 +8,13 @@ Use this reference when sending or editing `payload.type=17` InteractiveCard mes
 - `octo/v2` submit-interactive cards use a separate callback workflow. Mentions of `octo/v2` below describe the protocol boundary, not a tool provided by the `octo/v1` display-card surface.
 - `octo_send_card`, `card_action` polling, and callback-driven agent continuation require an `octo/v2` producer and callback consumer; do not infer them from `octo/v1` availability.
 
+### Two Integration Paths
+
+Read the rest of this file according to how you send cards — the manual steps below apply to only one of them:
+
+- **Tool path (`octo_send_display_card`).** The tool probes the profile, fail-closed rejects on an unusable deployment, degrades unsupported elements to plain text, and redacts secrets for you. You do **not** need to `curl` the profile endpoint, check capability lists, or enforce `limits.*` yourself — pass `{ title?, blocks[] }` and read the outcome. The DisplayBlock schema below is exactly this tool's `blocks` input.
+- **Raw API path (hand-written HTTP client).** You own everything the tool would otherwise do: feature-detect, respect `limits.*` recursively, degrade unsupported elements, and implement the security guardrails at the end of this file. The manual "always feature-detect" / "respect limits" instructions target this path.
+
 ## When To Use Cards
 
 - Plain text (`payload.type=1`): conversational replies, short answers, follow-ups.
@@ -16,7 +23,7 @@ Use this reference when sending or editing `payload.type=17` InteractiveCard mes
 
 Do not overuse card messages. Plain text is the default. Use cards only when structure materially improves comprehension, such as weather, status, lists, comparisons, or detail fields. Keep ordinary chat, short answers, and follow-up replies as plain text. Do not use a blanket "use cards whenever possible" rule.
 
-Always feature-detect before sending cards:
+On the **raw API path**, always feature-detect before sending cards (the `octo_send_display_card` tool already does this for you — skip it there):
 
 ```bash
 curl <apiUrl>/v1/bot/card/profile -H "Authorization: Bearer $TOKEN"
@@ -38,7 +45,8 @@ Important profile fields:
 ```
 
 - `available:true` with `enabled:false` is an explicit server-side disable. Do not send cards.
-- `available:false` means the profile endpoint is not deployed, not that card delivery is explicitly disabled. P1 compatibility code may send only when `OCTO_CARD_MESSAGE_ENABLED=1`; otherwise fall back to text.
+- `available:false` means the profile endpoint is not deployed, not that card delivery is explicitly disabled. In this case sending is governed by the `OCTO_CARD_MESSAGE_ENABLED=1` environment switch (the same gate the tool and the hook progress-card path use); when it is unset, fall back to text.
+- `card_version` is matched **exactly**: the client is pinned to `1.5` (Decision 10), so a server advertising any other version — including a higher one such as `1.6` — is rejected fail-closed rather than assumed backward-compatible. Fall back to text on any mismatch.
 - `elements` / `inputs` / `actions` are authoritative when present, including an explicitly empty array. Missing support can produce server 400.
 - `elements` lists renderable card elements such as `ColumnSet` and `Table`; it does not need to list child schemas such as `Column`, `TableRow`, or `TableCell`.
 - Old deployments may omit capability lists; fall back to `TextBlock` / `Container` / `ColumnSet` / `FactSet` / `Image`, and no actions.
@@ -48,7 +56,7 @@ Important profile fields:
 
 Think IM summary card + expandable details, not logs converted into a card.
 
-For final answers, prefer one display card message. If the answer needs a process affordance, put process as the first block inside that same card; do not send or leave a separate final process-only card.
+For final answers, prefer one display card message. If the answer needs a process affordance, put process as the first block inside that same card; do not send or leave a separate final process-only card. A card is a side effect, not the conversational reply — after sending it you must still close the turn with a short text message stating the result (see "Always Close the Turn with Text" in SKILL.md).
 
 Visible first screen should normally be 3-6 lines. If process information is included, show only a compact process summary plus answer content; detailed process opens under `查看过程`.
 
@@ -63,6 +71,8 @@ Do not send raw `tool_events` as the card structure. Convert them into `reasonin
 `plain` is first-class output. Generate it from the same source as the card, keep exactly one title, and do not dump raw logs into it.
 
 ## Preferred DisplayBlock Shape
+
+This `{ title?, blocks[] }` object is the `octo_send_display_card` tool input, and `blocks` uses the [DisplayBlock schema](#displayblock-reference) below. The tool runs it through `buildDisplayCard`, which compiles the high-level `blocks` into the low-level AdaptiveCard `card.body` shown under [Low-Level Payload](#low-level-payload) and derives the truthful `plain` fallback. Author `blocks` (not raw `card.body`) unless you are on the raw API path and building AdaptiveCards by hand.
 
 ```jsonc
 {
@@ -183,8 +193,8 @@ Rules:
 ```jsonc
 POST /v1/bot/sendMessage
 {
-  "channel_id": "<groupId or uid>",
-  "channel_type": 2,
+  "channel_id": "<groupId, uid, or thread channel_id>",
+  "channel_type": 2,               // must match the target: 1=DM, 2=group, 5=thread — take both from the received event
   "payload": {
     "type": 17,
     "profile": "octo/v1",
@@ -217,3 +227,4 @@ POST /v1/bot/message/edit
 - `plain` is what non-card clients and history search see. Keep it truthful and do not include anything absent from the card.
 - `buildDisplayCard` degrades embedded URLs to `scheme://<registrable-domain>` and drops blocks matching known secret shapes; hand-written clients must implement equivalent guardrails.
 - Agent tools that reply to the current conversation must derive the target from trusted runtime delivery context. A model-supplied `channelId`, group id, uid, or thread id is routing input, not authorization, and must not enable cross-conversation sends.
+- Display cards always send under the bot's own identity. Sender identity / OBO (persona-clone) is never taken from model input; a hand-written client must likewise not let untrusted model output pick the sending persona, or a group-visible card becomes a persona-impersonation sink.

--- a/src/__tests__/accounts.test.ts
+++ b/src/__tests__/accounts.test.ts
@@ -27,6 +27,73 @@ function buildCfg(accounts: Record<string, unknown>): unknown {
 }
 
 describe("resolveOctoAccount", () => {
+  describe("card feature switch inheritance", () => {
+    it("inherits top-level card switches when the account omits them", () => {
+      const cfg = {
+        channels: {
+          octo: {
+            cardProgress: false,
+            cardDisplay: false,
+            accounts: {
+              [MIXED_CASE_ID]: { botToken: "bf_cards_inherit" },
+            },
+          },
+        },
+      };
+
+      const account = resolveOctoAccount({ cfg: cfg as never, accountId: MIXED_CASE_ID });
+
+      expect(account.config.cardProgress).toBe(false);
+      expect(account.config.cardDisplay).toBe(false);
+    });
+
+    it("allows an account true to override a top-level false", () => {
+      const cfg = {
+        channels: {
+          octo: {
+            cardProgress: false,
+            cardDisplay: false,
+            accounts: {
+              [MIXED_CASE_ID]: {
+                botToken: "bf_cards_enable",
+                cardProgress: true,
+                cardDisplay: true,
+              },
+            },
+          },
+        },
+      };
+
+      const account = resolveOctoAccount({ cfg: cfg as never, accountId: MIXED_CASE_ID });
+
+      expect(account.config.cardProgress).toBe(true);
+      expect(account.config.cardDisplay).toBe(true);
+    });
+
+    it("allows an account false to override a top-level true", () => {
+      const cfg = {
+        channels: {
+          octo: {
+            cardProgress: true,
+            cardDisplay: true,
+            accounts: {
+              [MIXED_CASE_ID]: {
+                botToken: "bf_cards_disable",
+                cardProgress: false,
+                cardDisplay: false,
+              },
+            },
+          },
+        },
+      };
+
+      const account = resolveOctoAccount({ cfg: cfg as never, accountId: MIXED_CASE_ID });
+
+      expect(account.config.cardProgress).toBe(false);
+      expect(account.config.cardDisplay).toBe(false);
+    });
+  });
+
   describe("strict (case-sensitive) match — primary path", () => {
     it("returns account config when accountId matches the configured key exactly", () => {
       const cfg = buildCfg({

--- a/src/accounts.ts
+++ b/src/accounts.ts
@@ -18,6 +18,8 @@ export type ResolvedOctoAccount = {
     requireMention?: boolean;
     historyLimit?: number;  // 群聊历史消息条数限制
     historyPromptTemplate?: string;  // Template for group history context injection
+    cardProgress?: boolean;  // false disables automatic progress cards for this account
+    cardDisplay?: boolean;  // false disables the display-card tool for this account
     onBehalfOf?: string;  // Persona clone: grantor uid
     secretsFileRoot?: string;  // Jail root for write-secret file writes
     dispatchTimeoutMs?: number;  // Explicit dispatch-timeout override; unset = derive from agents.defaults.timeoutSeconds (issue #113)
@@ -101,6 +103,8 @@ export function resolveOctoAccount(params: {
       requireMention: accountConfig.requireMention ?? channel.requireMention,
       historyLimit: accountConfig.historyLimit ?? channel.historyLimit ?? 20,
       historyPromptTemplate: accountConfig.historyPromptTemplate ?? channel.historyPromptTemplate,
+      cardProgress: accountConfig.cardProgress ?? channel.cardProgress,
+      cardDisplay: accountConfig.cardDisplay ?? channel.cardDisplay,
       onBehalfOf: accountConfig.onBehalfOf ?? channel.onBehalfOf,
       secretsFileRoot: accountConfig.secretsFileRoot ?? channel.secretsFileRoot,
       dispatchTimeoutMs: accountConfig.dispatchTimeoutMs ?? channel.dispatchTimeoutMs,

--- a/src/card-display-tool.test.ts
+++ b/src/card-display-tool.test.ts
@@ -123,6 +123,24 @@ describe("createDisplayCardTool 骨架", () => {
     } as DisplayToolParams)).toEqual([]);
   });
 
+  it("无当前账号上下文但只有一个配置账号时也按 cardDisplay:false 隐藏工具", () => {
+    vi.mocked(resolveOctoAccount).mockReturnValue({
+      accountId: "only-account",
+      enabled: true,
+      configured: true,
+      config: {
+        botToken: "tok",
+        apiUrl: "https://api.test",
+        pollIntervalMs: 2000,
+        heartbeatIntervalMs: 30000,
+        cardDisplay: false,
+      },
+    } as never);
+    vi.mocked(listOctoAccountIds).mockReturnValue(["only-account"]);
+
+    expect(createDisplayCardTool({ cfg: mockCfg } as DisplayToolParams)).toEqual([]);
+  });
+
   it("tool 元数据:name=octo_send_display_card,description 涵盖『展示型』『不回流』", () => {
     const t = getTool();
     expect(t.name).toBe("octo_send_display_card");

--- a/src/card-display-tool.test.ts
+++ b/src/card-display-tool.test.ts
@@ -101,6 +101,28 @@ describe("createDisplayCardTool 骨架", () => {
     } as DisplayToolParams)).toEqual([]);
   });
 
+  it("已知当前账号 cardDisplay:false 时 discovery 不注册工具", () => {
+    vi.mocked(resolveOctoAccount).mockReturnValue({
+      accountId: "default",
+      enabled: true,
+      configured: true,
+      config: {
+        botToken: "tok",
+        apiUrl: "https://api.test",
+        pollIntervalMs: 2000,
+        heartbeatIntervalMs: 30000,
+        cardDisplay: false,
+      },
+    } as never);
+
+    expect(createDisplayCardTool({
+      cfg: mockCfg,
+      agentAccountId: "default",
+      deliveryContext: CURRENT_DELIVERY,
+      messageChannel: "octo",
+    } as DisplayToolParams)).toEqual([]);
+  });
+
   it("tool 元数据:name=octo_send_display_card,description 涵盖『展示型』『不回流』", () => {
     const t = getTool();
     expect(t.name).toBe("octo_send_display_card");
@@ -173,6 +195,31 @@ describe("execute:发展示卡", () => {
     // 展示型 → 顶层无 actions
     expect(call.card).not.toHaveProperty("actions");
     expect(res.content[0].text).toContain("m1"); // 返回 message_id
+  });
+
+  it("execute 再检查热更新后的 cardDisplay:false,不探测 manifest 也不发送", async () => {
+    const tool = getTool();
+    vi.mocked(resolveOctoAccount).mockReturnValue({
+      accountId: "default",
+      enabled: true,
+      configured: true,
+      config: {
+        botToken: "tok",
+        apiUrl: "https://api.test",
+        pollIntervalMs: 2000,
+        heartbeatIntervalMs: 30000,
+        cardDisplay: false,
+      },
+    } as never);
+    vi.mocked(getCardProfile).mockClear();
+
+    const res = await tool.execute("display-disabled-after-discovery", {
+      blocks: [{ type: "text", text: "must use plain text" }],
+    });
+
+    expect(res.content[0].text).toMatch(/disabled|plain text/i);
+    expect(getCardProfile).not.toHaveBeenCalled();
+    expect(sendCardMessage).not.toHaveBeenCalled();
   });
 
   it("服务端成功响应缺 message_id 时保持稳定空值结果", async () => {

--- a/src/card-display-tool.test.ts
+++ b/src/card-display-tool.test.ts
@@ -141,6 +141,42 @@ describe("createDisplayCardTool 骨架", () => {
     expect(createDisplayCardTool({ cfg: mockCfg } as DisplayToolParams)).toEqual([]);
   });
 
+  it("多账号且 discovery 无法确定当前账号时,全部 cardDisplay:false 则隐藏工具", () => {
+    vi.mocked(listOctoAccountIds).mockReturnValue(["account-a", "account-b"]);
+    vi.mocked(resolveOctoAccount).mockImplementation(({ accountId }: { accountId?: string }) => ({
+      accountId: accountId ?? "default",
+      enabled: true,
+      configured: true,
+      config: {
+        botToken: `tok-${accountId}`,
+        apiUrl: "https://api.test",
+        pollIntervalMs: 2000,
+        heartbeatIntervalMs: 30000,
+        cardDisplay: false,
+      },
+    }) as never);
+
+    expect(createDisplayCardTool({ cfg: mockCfg } as DisplayToolParams)).toEqual([]);
+  });
+
+  it("多账号且 discovery 无法确定当前账号时,任一账号允许展示卡则保留工具", () => {
+    vi.mocked(listOctoAccountIds).mockReturnValue(["account-a", "account-b"]);
+    vi.mocked(resolveOctoAccount).mockImplementation(({ accountId }: { accountId?: string }) => ({
+      accountId: accountId ?? "default",
+      enabled: true,
+      configured: true,
+      config: {
+        botToken: `tok-${accountId}`,
+        apiUrl: "https://api.test",
+        pollIntervalMs: 2000,
+        heartbeatIntervalMs: 30000,
+        cardDisplay: accountId === "account-a" ? false : true,
+      },
+    }) as never);
+
+    expect(createDisplayCardTool({ cfg: mockCfg } as DisplayToolParams)).toHaveLength(1);
+  });
+
   it("tool 元数据:name=octo_send_display_card,description 涵盖『展示型』『不回流』", () => {
     const t = getTool();
     expect(t.name).toBe("octo_send_display_card");

--- a/src/card-display-tool.ts
+++ b/src/card-display-tool.ts
@@ -157,7 +157,9 @@ export function createDisplayCardTool(params: Params): Array<{
     // Best-effort discovery filtering: when the runtime identifies the current
     // account, do not offer a tool that account explicitly disabled. Execution
     // checks again because config may hot-reload after tool discovery.
-    const discoveryAccountId = deliveryContext?.accountId ?? agentAccountId;
+    const discoveryAccountId = deliveryContext?.accountId
+      ?? agentAccountId
+      ?? (ids.length === 1 ? ids[0] : undefined);
     if (discoveryAccountId) {
       const discoveryAccount = resolveOctoAccount({ cfg, accountId: discoveryAccountId });
       if (discoveryAccount.config.cardDisplay === false) return [];

--- a/src/card-display-tool.ts
+++ b/src/card-display-tool.ts
@@ -149,20 +149,23 @@ export function createDisplayCardTool(params: Params): Array<{
   if (ambientChannel && ambientChannel !== CHANNEL_ID) return [];
   try {
     const ids = listOctoAccountIds(cfg);
-    const hasConfigured = ids.some((id) => {
-      const acct = resolveOctoAccount({ cfg, accountId: id });
-      return acct.enabled && acct.configured && !!acct.config.botToken;
-    });
-    if (!hasConfigured) return [];
+    const configuredAccounts = ids
+      .map((id) => resolveOctoAccount({ cfg, accountId: id }))
+      .filter((acct) => acct.enabled && acct.configured && !!acct.config.botToken);
+    if (configuredAccounts.length === 0) return [];
     // Best-effort discovery filtering: when the runtime identifies the current
     // account, do not offer a tool that account explicitly disabled. Execution
-    // checks again because config may hot-reload after tool discovery.
+    // checks again because config may hot-reload after tool discovery. When a
+    // multi-account discovery has no current account, hide only if every usable
+    // account disables the tool; a mixed set must keep it available.
     const discoveryAccountId = deliveryContext?.accountId
       ?? agentAccountId
       ?? (ids.length === 1 ? ids[0] : undefined);
     if (discoveryAccountId) {
       const discoveryAccount = resolveOctoAccount({ cfg, accountId: discoveryAccountId });
       if (discoveryAccount.config.cardDisplay === false) return [];
+    } else if (configuredAccounts.every((account) => account.config.cardDisplay === false)) {
+      return [];
     }
   } catch {
     return [];

--- a/src/card-display-tool.ts
+++ b/src/card-display-tool.ts
@@ -154,6 +154,14 @@ export function createDisplayCardTool(params: Params): Array<{
       return acct.enabled && acct.configured && !!acct.config.botToken;
     });
     if (!hasConfigured) return [];
+    // Best-effort discovery filtering: when the runtime identifies the current
+    // account, do not offer a tool that account explicitly disabled. Execution
+    // checks again because config may hot-reload after tool discovery.
+    const discoveryAccountId = deliveryContext?.accountId ?? agentAccountId;
+    if (discoveryAccountId) {
+      const discoveryAccount = resolveOctoAccount({ cfg, accountId: discoveryAccountId });
+      if (discoveryAccount.config.cardDisplay === false) return [];
+    }
   } catch {
     return [];
   }
@@ -251,6 +259,9 @@ export function createDisplayCardTool(params: Params): Array<{
         const acct = resolveOctoAccount({ cfg, accountId: requestedAccountId });
         if (!acct.enabled || !acct.configured || !acct.config.botToken) {
           return err("Octo account is not fully configured");
+        }
+        if (acct.config.cardDisplay === false) {
+          return err("display cards are disabled for this Octo account. Send your reply as a plain text message instead.");
         }
         const apiUrl = acct.config.apiUrl;
         const botToken = acct.config.botToken;

--- a/src/card-progress.test.ts
+++ b/src/card-progress.test.ts
@@ -110,6 +110,87 @@ describe("card-progress 状态机 + hook + 节流", () => {
     expect(calls.length).toBe(0);
   });
 
+  it("cardProgress:false 在 session 入口直接跳过,不探测 manifest 也不发送", async () => {
+    const { fn, calls } = mockFetch();
+    global.fetch = fn as unknown as typeof fetch;
+    const { handlers } = makeApi();
+
+    setCardContext("progress-disabled", {
+      apiUrl: "https://shared-card-gate.test",
+      botToken: "disabled-account",
+      channelId: "g-disabled",
+      channelType: ChannelType.Group,
+      cardProgress: false,
+    });
+    handlers.before_tool_call({ toolName: "read" }, { sessionKey: "progress-disabled" });
+    await vi.advanceTimersByTimeAsync(900);
+
+    expect(calls).toEqual([]);
+  });
+
+  it("账号级关闭不污染同 apiUrl 的共享 gate cache", async () => {
+    const { fn, calls } = mockFetch();
+    global.fetch = fn as unknown as typeof fetch;
+    const { handlers } = makeApi();
+
+    setCardContext("progress-disabled-account", {
+      apiUrl: "https://shared-card-gate.test",
+      botToken: "disabled-account",
+      channelId: "g-disabled",
+      channelType: ChannelType.Group,
+      cardProgress: false,
+    });
+    handlers.before_tool_call({ toolName: "read" }, { sessionKey: "progress-disabled-account" });
+    await vi.advanceTimersByTimeAsync(900);
+
+    setCardContext("progress-enabled-account", {
+      apiUrl: "https://shared-card-gate.test",
+      botToken: "enabled-account",
+      channelId: "g-enabled",
+      channelType: ChannelType.Group,
+      cardProgress: true,
+    });
+    handlers.before_tool_call({ toolName: "read" }, { sessionKey: "progress-enabled-account" });
+    await vi.advanceTimersByTimeAsync(900);
+
+    expect(calls.filter((call) => call.url.includes("/card/profile"))).toHaveLength(1);
+    expect(calls.filter((call) => call.url.includes("/sendMessage"))).toHaveLength(1);
+  });
+
+  it("cardProgress:true 仍不能绕过不兼容 card_version", async () => {
+    const calls: Array<{ url: string }> = [];
+    global.fetch = vi.fn().mockImplementation(async (url: string) => {
+      calls.push({ url: String(url) });
+      if (String(url).includes("/card/profile")) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            enabled: true,
+            profiles: ["octo/v1"],
+            card_version: "1.6",
+            elements: ["TextBlock"],
+          }),
+        };
+      }
+      return { ok: true, status: 200, text: async () => JSON.stringify({ message_id: "must-not-send" }) };
+    }) as unknown as typeof fetch;
+    const { handlers } = makeApi();
+
+    setCardContext("progress-incompatible", {
+      apiUrl: "https://incompatible-card-version.test",
+      botToken: "enabled-account",
+      channelId: "g-enabled",
+      channelType: ChannelType.Group,
+      cardProgress: true,
+    });
+    handlers.before_tool_call({ toolName: "read" }, { sessionKey: "progress-incompatible" });
+    await vi.advanceTimersByTimeAsync(900);
+
+    expect(calls.some((call) => call.url.includes("/card/profile"))).toBe(true);
+    expect(calls.some((call) => call.url.includes("/sendMessage"))).toBe(false);
+  });
+
   it("未登记 session 的事件 no-op(天然过滤非 octo run)", async () => {
     const { fn, calls } = mockFetch();
     global.fetch = fn as unknown as typeof fetch;

--- a/src/card-progress.ts
+++ b/src/card-progress.ts
@@ -25,6 +25,8 @@ export interface CardContext {
   botToken: string;
   channelId: string;
   channelType: ChannelType;
+  /** false force-disables automatic progress cards for this account/session. */
+  cardProgress?: boolean;
   /** persona-clone 身份;存在则跳过卡片(服务端拒 type-17 OBO)。 */
   onBehalfOf?: string;
 }
@@ -122,7 +124,10 @@ export function setCardContext(sessionKey: string, ctx: CardContext): void {
     startedAt: Date.now(),
     dirty: false,
     inFlight: false,
-    skip: collision || !!ctx.onBehalfOf,
+    // Account config is a per-session narrowing decision. Keep it out of the
+    // apiUrl-keyed gate/caps caches, which contain deployment capability facts
+    // shared by multiple accounts.
+    skip: collision || !!ctx.onBehalfOf || ctx.cardProgress === false,
   });
   dbg(`context set session=${sessionKey} channel=${ctx.channelId} obo=${!!ctx.onBehalfOf} collision=${collision}`);
 }

--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -28,6 +28,8 @@ export interface OctoAccountConfig {
   botUid?: string;
   historyLimit?: number;  // 群聊历史消息条数限制（默认20）
   historyPromptTemplate?: string;  // Template for group history context injection
+  cardProgress?: boolean;  // false force-disables automatic progress cards; true/unset follows server capabilities
+  cardDisplay?: boolean;  // false force-disables the display-card tool; true/unset follows server capabilities
   onBehalfOf?: string;  // Persona clone: grantor uid — bot acts on behalf of this human
   secretsFileRoot?: string;  // Jail root for write-secret: secret files may only be written under this path. When unset, defaults to the agent's workspace (agents.list[].workspace matched to the agent, else agents.defaults.workspace); if neither resolves, write-secret fails closed (no process.cwd() fallback).
   dispatchTimeoutMs?: number;  // Explicit per-inbound dispatch timeout override (ms). Unset = derived from agents.defaults.timeoutSeconds + 60s buffer (issue #113).
@@ -46,6 +48,8 @@ export interface OctoConfig {
   botUid?: string;
   historyLimit?: number;  // 群聊历史消息条数限制（默认20）
   historyPromptTemplate?: string;  // Template for group history context injection
+  cardProgress?: boolean;  // Top-level default for automatic progress cards
+  cardDisplay?: boolean;  // Top-level default for the display-card tool
   onBehalfOf?: string;  // Persona clone: grantor uid — bot acts on behalf of this human
   secretsFileRoot?: string;  // Jail root for write-secret (see OctoAccountConfig)
   dispatchTimeoutMs?: number;  // Explicit per-inbound dispatch timeout override (ms); see OctoAccountConfig
@@ -71,6 +75,12 @@ export const SECRETS_FILE_ROOT_DESCRIPTION =
 // fires strictly after OpenClaw core's own agent-run timeout.
 export const DISPATCH_TIMEOUT_MS_DESCRIPTION =
   "Per-inbound dispatch timeout in milliseconds (infrastructure backstop that releases the per-group queue when an upstream dispatch hangs). When unset, derived from agents.defaults.timeoutSeconds (default 600) as timeoutSeconds*1000 + 60000, so it always fires after the agent-run timeout. Set explicitly only when you need to decouple it from the agent timeout.";
+
+export const CARD_PROGRESS_DESCRIPTION =
+  "When omitted or true, follow the server card capability gate; false force-disables automatic progress cards. Per-account values override the top-level value.";
+
+export const CARD_DISPLAY_DESCRIPTION =
+  "When omitted or true, follow the server card capability gate; false force-disables the octo_send_display_card tool. Per-account values override the top-level value.";
 
 // Shared description for commands.fork.scope, kept identical to the wording in
 // openclaw.plugin.json (manifest-schema-sync.test.ts asserts key-level sync).
@@ -112,6 +122,8 @@ export const OctoConfigJsonSchema = {
       botUid: { type: "string" },
       historyLimit: { type: "number", minimum: 1, maximum: 100 },
       historyPromptTemplate: { type: "string" },
+      cardProgress: { type: "boolean", description: CARD_PROGRESS_DESCRIPTION },
+      cardDisplay: { type: "boolean", description: CARD_DISPLAY_DESCRIPTION },
       onBehalfOf: { type: "string" },
       secretsFileRoot: { type: "string", description: SECRETS_FILE_ROOT_DESCRIPTION },
       dispatchTimeoutMs: { type: "number", minimum: 1000, description: DISPATCH_TIMEOUT_MS_DESCRIPTION },
@@ -133,6 +145,8 @@ export const OctoConfigJsonSchema = {
             botUid: { type: "string" },
             historyLimit: { type: "number", minimum: 1, maximum: 100 },
             historyPromptTemplate: { type: "string" },
+            cardProgress: { type: "boolean", description: CARD_PROGRESS_DESCRIPTION },
+            cardDisplay: { type: "boolean", description: CARD_DISPLAY_DESCRIPTION },
             onBehalfOf: { type: "string" },
             secretsFileRoot: { type: "string", description: SECRETS_FILE_ROOT_DESCRIPTION },
             dispatchTimeoutMs: { type: "number", minimum: 1000, description: DISPATCH_TIMEOUT_MS_DESCRIPTION },

--- a/src/inbound.ts
+++ b/src/inbound.ts
@@ -2540,6 +2540,7 @@ export async function handleInboundMessage(params: {
     botToken,
     channelId: replyChannelId,
     channelType: replyChannelType,
+    cardProgress: account.config.cardProgress,
     ...(effectiveOnBehalfOf ? { onBehalfOf: effectiveOnBehalfOf } : {}),
   });
 

--- a/src/manifest-schema-sync.test.ts
+++ b/src/manifest-schema-sync.test.ts
@@ -34,6 +34,25 @@ describe("openclaw.plugin.json channelConfigs", () => {
     );
   });
 
+  it.each(["cardProgress", "cardDisplay"])(
+    "%s description matches at top-level and per-account",
+    (key) => {
+      const manifestProps = manifest.channelConfigs.octo.schema.properties;
+      const manifestAccountProps = manifestProps.accounts.additionalProperties.properties;
+      const tsProps = OctoConfigJsonSchema.schema.properties as Record<string, any>;
+      const tsAccountProps = (tsProps.accounts as any).additionalProperties.properties;
+      const description = tsProps[key]?.description as string | undefined;
+
+      expect(description).toBeDefined();
+      expect(manifestProps[key]?.description).toBe(description);
+      expect(tsAccountProps[key]?.description).toBe(description);
+      expect(manifestAccountProps[key]?.description).toBe(description);
+      expect(description).toMatch(/omitted|true/i);
+      expect(description).toMatch(/false/i);
+      expect(description).toMatch(/server/i);
+    },
+  );
+
   // Description drift guard: secretsFileRoot carries operator-facing semantics
   // (the write-secret jail default + fail-closed behavior). A stale manifest
   // description here drifts from the schema, so pin both copies to


### PR DESCRIPTION
## Summary

- clarify the tool and raw-API integration paths for interactive card messages
- add account-level `cardProgress` and `cardDisplay` switches at both the channel default and per-account override layers
- keep both switches narrowing-only: omitted or `true` follows the existing server capability gate, while explicit `false` disables the corresponding card path
- hide disabled display-card tools during discovery when the account is known or every usable account is disabled, and enforce the switch again at execution time
- skip disabled progress cards before manifest probing without polluting the shared deployment capability cache
- document the configuration and design decisions

## Validation

- `npm run type-check`
- `npm test` — 44 test files passed, 1 skipped; 1539 tests passed, 2 skipped
- targeted Vitest coverage — 87.6% statements, 83.28% branches, 89.18% functions, 89.4% lines
