### PR TITLE
fix(history): 历史注入尊重会话重置(/new),不再穿透污染新会话 (#155)

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -21,7 +21,7 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import { getGroupMdForPrompt } from "./src/group-md.js";
-import { pendingInboundContext, sessionAccountMap, buildSessionAccountKey } from "./src/inbound.js";
+import { pendingInboundContext, sessionAccountMap, buildSessionAccountKey, recordSessionResetWatermark } from "./src/inbound.js";
 import { resolvePersonaHintForSession } from "./src/persona-prompt.js";
 import { setOctoRuntime } from "./src/runtime.js";
 import { octoPlugin } from "./src/channel.js";
@@ -258,6 +258,19 @@ export default defineBundledChannelEntry({
         ...(contextSections.length > 0 ? { prependContext: contextSections.join('\n\n') } : {}),
         ...(systemSections.length > 0 ? { prependSystemContext: systemSections.join('\n\n') } : {}),
       };
+    });
+
+    // Session reset watermark (#155). Registering before_reset is REQUIRED: the
+    // runtime only fires it when a plugin has subscribed (hasHooks gate), and
+    // without it the plugin is blind to /new. On reset we record the instant so
+    // the inbound history injector drops pre-/new channel messages — otherwise
+    // the channel-keyed history (whose sessionId never resets) would re-inject
+    // stale, already-answered instructions into the fresh session. Belt to
+    // sessionStartedAt's braces (see resolveResetWatermarkMs): this survives even
+    // if the session store read lags, while sessionStartedAt survives restarts.
+    api.on('before_reset', (_event, ctx) => {
+      const sessionKey = (ctx as { sessionKey?: string | null } | undefined)?.sessionKey;
+      if (sessionKey) recordSessionResetWatermark(sessionKey, Date.now());
     });
 
     // 波 B:注册卡片进度 hook(before/after_tool_call、model_call_started)。

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "node": ">=22"
       },
       "peerDependencies": {
-        "openclaw": ">=2026.4.15"
+        "openclaw": ">=2026.6.9"
       },
       "peerDependenciesMeta": {
         "openclaw": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "ws": "^8.21.0"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.4.15"
+    "openclaw": ">=2026.6.9"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -76,13 +76,13 @@
     "install": {
       "clawhubSpec": "clawhub:octo",
       "defaultChoice": "clawhub",
-      "minHostVersion": ">=2026.4.15"
+      "minHostVersion": ">=2026.6.9"
     },
     "compat": {
-      "pluginApi": ">=2026.4.15"
+      "pluginApi": ">=2026.6.9"
     },
     "build": {
-      "openclawVersion": "2026.5.4"
+      "openclawVersion": "2026.6.9"
     },
     "release": {
       "publishToClawHub": true,

--- a/src/history-reset-watermark.test.ts
+++ b/src/history-reset-watermark.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Regression tests for issue #155 — history injection bleeds past /new.
+ *
+ * The plugin injects channel-level history (via segmentHistoryEntries) keyed by
+ * a channel-stable sessionId. That key never resets on /new, so after a user
+ * resets the session, messages from *before* the reset were still injected as
+ * "already answered" context — carrying stale instructions into the fresh
+ * session and polluting it.
+ *
+ * Fix: segmentHistoryEntries accepts a resetWatermarkMs (the OpenClaw session's
+ * sessionStartedAt, in ms). Entries whose timestamp predates the watermark are
+ * dropped entirely — from BOTH the answered and new segments — so a /new gives
+ * a genuine clean context boundary. Entry timestamps are normalized to ms on
+ * both the live-cache and API-backfill paths, so the comparison is unit-safe.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  segmentHistoryEntries,
+  recordSessionResetWatermark,
+  resolveResetWatermarkMs,
+  _test_clearResetWatermarks,
+} from "./inbound.js";
+
+const entry = (seq: number, tsMs: number, id = `m${seq}`) => ({
+  message_id: id,
+  message_seq: seq,
+  timestamp: tsMs,
+  sender: "u1",
+  body: `msg ${seq}`,
+});
+
+describe("issue #155 — reset watermark filters pre-/new history", () => {
+  it("drops entries older than the watermark from BOTH answered and new segments", () => {
+    // watermark = 1000ms. seqs 1,2 are before the reset; 3,4 after.
+    const entries = [
+      entry(1, 500),   // pre-reset  → drop
+      entry(2, 900),   // pre-reset  → drop
+      entry(3, 1500),  // post-reset → keep
+      entry(4, 2000),  // post-reset → keep
+    ];
+
+    const { answered, new: fresh } = segmentHistoryEntries({
+      entries,
+      cutoffSeq: 3, // seq<=3 answered, seq>3 new — regardless, pre-reset must vanish
+      resetWatermarkMs: 1000,
+    });
+
+    const seqs = [...answered, ...fresh].map((e) => e.message_seq).sort((a, b) => a! - b!);
+    expect(seqs).toEqual([3, 4]);
+    // seq 3 (ts 1500, <= cutoff 3) stays answered; seq 4 stays new.
+    expect(answered.map((e) => e.message_seq)).toEqual([3]);
+    expect(fresh.map((e) => e.message_seq)).toEqual([4]);
+  });
+
+  it("keeps an entry exactly at the watermark (>= boundary is inclusive)", () => {
+    const entries = [entry(1, 999), entry(2, 1000), entry(3, 1001)];
+    const { answered, new: fresh } = segmentHistoryEntries({
+      entries,
+      cutoffSeq: 0,
+      resetWatermarkMs: 1000,
+    });
+    // cutoffSeq 0 → everything that survives the watermark lands in `new`.
+    expect(fresh.map((e) => e.message_seq)).toEqual([2, 3]);
+    expect(answered).toEqual([]);
+  });
+
+  it("is a no-op when no watermark is provided (backward compatible)", () => {
+    const entries = [entry(1, 500), entry(2, 1500)];
+    const { answered, new: fresh } = segmentHistoryEntries({
+      entries,
+      cutoffSeq: 1,
+    });
+    expect(answered.map((e) => e.message_seq)).toEqual([1]);
+    expect(fresh.map((e) => e.message_seq)).toEqual([2]);
+  });
+
+  it("is a no-op when watermark is 0 or negative (no reset recorded)", () => {
+    const entries = [entry(1, 500), entry(2, 1500)];
+    const { answered, new: fresh } = segmentHistoryEntries({
+      entries,
+      cutoffSeq: 1,
+      resetWatermarkMs: 0,
+    });
+    expect([...answered, ...fresh].map((e) => e.message_seq)).toEqual([1, 2]);
+  });
+
+  it("still excludes the current message alongside watermark filtering", () => {
+    const entries = [entry(1, 500), entry(2, 1500), entry(3, 2000, "current")];
+    const { answered, new: fresh } = segmentHistoryEntries({
+      entries,
+      cutoffSeq: 2,
+      currentMsgId: "current",
+      resetWatermarkMs: 1000,
+    });
+    // seq1 dropped by watermark, seq3 dropped as current → only seq2 remains.
+    expect([...answered, ...fresh].map((e) => e.message_seq)).toEqual([2]);
+  });
+
+  it("drops entries missing a timestamp when a watermark is active (fail-safe)", () => {
+    // A pre-reset entry with no timestamp must not leak through the watermark.
+    const entries = [
+      { message_id: "a", message_seq: 1, sender: "u1", body: "no ts" },
+      entry(2, 1500),
+    ];
+    const { answered, new: fresh } = segmentHistoryEntries({
+      entries,
+      cutoffSeq: 0,
+      resetWatermarkMs: 1000,
+    });
+    expect([...answered, ...fresh].map((e) => e.message_seq)).toEqual([2]);
+  });
+});
+
+describe("issue #155 — reset watermark store helpers", () => {
+  it("resolveResetWatermarkMs takes the later of hook mark and sessionStartedAt", () => {
+    _test_clearResetWatermarks();
+    // no hook mark yet → falls back to sessionStartedAt
+    expect(resolveResetWatermarkMs("sk1", 5000)).toBe(5000);
+    // hook mark newer than sessionStartedAt → hook wins
+    recordSessionResetWatermark("sk1", 8000);
+    expect(resolveResetWatermarkMs("sk1", 5000)).toBe(8000);
+    // sessionStartedAt newer (e.g. a later reset the hook missed) → it wins
+    expect(resolveResetWatermarkMs("sk1", 9000)).toBe(9000);
+  });
+
+  it("recordSessionResetWatermark is monotonic (never rewinds)", () => {
+    _test_clearResetWatermarks();
+    recordSessionResetWatermark("sk2", 8000);
+    recordSessionResetWatermark("sk2", 3000); // older — must be ignored
+    expect(resolveResetWatermarkMs("sk2", 0)).toBe(8000);
+  });
+
+  it("returns 0 when nothing is known (no reset → no filtering)", () => {
+    _test_clearResetWatermarks();
+    expect(resolveResetWatermarkMs("unknown", undefined)).toBe(0);
+    expect(resolveResetWatermarkMs(undefined, undefined)).toBe(0);
+  });
+
+  it("ignores empty sessionKey and non-positive timestamps", () => {
+    _test_clearResetWatermarks();
+    recordSessionResetWatermark("", 8000);
+    recordSessionResetWatermark("sk3", 0);
+    recordSessionResetWatermark("sk3", -1);
+    expect(resolveResetWatermarkMs("sk3", 0)).toBe(0);
+  });
+});
+

--- a/src/inbound.ts
+++ b/src/inbound.ts
@@ -30,6 +30,7 @@ import { setCardContext, finalizeCard } from "./card-progress.js";
 import { ChannelType, MessageType, RICH_TEXT_BLOCK_IMAGE, RICH_TEXT_BLOCK_TEXT, RICH_TEXT_IMAGE_PLACEHOLDER, CARD_PLACEHOLDER } from "./types.js";
 import type { RichTextBlock } from "./types.js";
 import { getOctoRuntime } from "./runtime.js";
+import { getSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
 import { CHANNEL_ID, MAX_UPLOAD_SIZE } from "./constants.js";
 import { streamToFileWithCap } from "./stream-helpers.js";
 import {
@@ -197,6 +198,42 @@ export function buildSessionAccountKey(accountId: string, sessionKey: string): s
 export function recordSessionAccount(accountId: string, sessionKey: string): void {
   const id = normalizeAccountId(accountId);
   sessionAccountMap.set(buildSessionAccountKey(id, sessionKey), id);
+}
+
+// Session reset watermarks (#155). Keyed by OpenClaw host sessionKey (the same
+// key the before_prompt_build hook and pendingInboundContext use), value = the
+// reset instant in ms. The plugin's channel history is keyed by a channel-stable
+// sessionId that never resets on /new, so without a watermark a reset session
+// still gets pre-/new messages injected as "already answered" context. This map
+// is the belt to sessionStartedAt's braces: the before_reset hook writes here
+// the moment /new happens (surviving even if the session store read lags), while
+// sessionStartedAt is the persistent source of truth read at injection time.
+const sessionResetWatermarks = new Map<string, number>();
+
+/**
+ * Record a session reset instant, called from the before_reset hook. Monotonic:
+ * a later reset can only push the watermark forward, never rewind it.
+ */
+export function recordSessionResetWatermark(sessionKey: string, resetAtMs: number): void {
+  if (!sessionKey || !(resetAtMs > 0)) return;
+  const existing = sessionResetWatermarks.get(sessionKey) ?? 0;
+  if (resetAtMs > existing) sessionResetWatermarks.set(sessionKey, resetAtMs);
+}
+
+/**
+ * Resolve the effective reset watermark (ms) for a session: the later of the
+ * hook-recorded reset instant and the session store's sessionStartedAt. Returns
+ * 0 when neither is known (no reset seen → no filtering, backward compatible).
+ */
+export function resolveResetWatermarkMs(sessionKey: string | undefined, sessionStartedAt?: number): number {
+  const hookMark = sessionKey ? (sessionResetWatermarks.get(sessionKey) ?? 0) : 0;
+  const startedAt = sessionStartedAt && sessionStartedAt > 0 ? sessionStartedAt : 0;
+  return Math.max(hookMark, startedAt);
+}
+
+/** Test-only: clear recorded reset watermarks between cases. */
+export function _test_clearResetWatermarks(): void {
+  sessionResetWatermarks.clear();
 }
 
 export type OctoStatusSink = (patch: {
@@ -1431,10 +1468,24 @@ export function segmentHistoryEntries(params: {
   entries: Array<{ message_id?: string; message_seq?: number; [key: string]: any }>;
   cutoffSeq: number;
   currentMsgId?: string;
+  resetWatermarkMs?: number;
 }): { answered: typeof params.entries; new: typeof params.entries } {
-  const filtered = params.currentMsgId
+  let filtered = params.currentMsgId
     ? params.entries.filter(e => e.message_id !== params.currentMsgId)
     : params.entries;
+
+  // Session reset watermark (#155): drop everything that predates the current
+  // OpenClaw session's start. The plugin's history is channel-level and its
+  // sessionId never resets on /new, so without this filter a reset session
+  // still gets pre-/new messages injected as "already answered" context,
+  // carrying stale instructions across the reset boundary. Entry timestamps are
+  // normalized to ms on both the live-cache and API-backfill paths, so the
+  // comparison is unit-safe. Fail safe: an entry with no timestamp is dropped
+  // when a watermark is active — a pre-reset message must never leak through.
+  if (params.resetWatermarkMs && params.resetWatermarkMs > 0) {
+    const watermark = params.resetWatermarkMs;
+    filtered = filtered.filter(e => typeof e.timestamp === "number" && e.timestamp >= watermark);
+  }
 
   if (params.cutoffSeq <= 0) {
     return { answered: [], new: filtered };
@@ -2049,10 +2100,54 @@ export async function handleInboundMessage(params: {
       const cutoffSeq = lastBotReplySeqMap.get(sessionId) ?? 0;
       const currentMsgId = message.message_id;
 
+      // Session reset watermark (#155): drop any history that predates the
+      // current OpenClaw session's start, so a /new gives a clean context
+      // boundary. Two sources combine (see resolveResetWatermarkMs): the
+      // before_reset hook mark (pure in-memory, cannot throw) and the session
+      // store's sessionStartedAt (read here). The hook mark is the belt to the
+      // store read's braces — so the pure-memory lookup MUST survive even when
+      // getSessionEntry throws (locked/corrupt/permission-denied store file),
+      // otherwise a store read error would silently disable filtering and let
+      // #155 recur. So we scope the try to ONLY the store read, and always run
+      // resolveResetWatermarkMs (which folds in the hook mark) afterwards.
+      //
+      // Clock domain: hook mark and sessionStartedAt are host wall-clock ms;
+      // entry.timestamp is Octo server ms. A sub-second host/server skew cannot
+      // flip the boundary in practice (pre-reset messages are already stale by
+      // minutes, post-reset ones arrive seconds+ later after a human types), and
+      // is negligible under NTP.
+      let resetWatermarkMs = 0;
+      let wmSessionKey: string | undefined;
+      let wmStartedAt: number | undefined;
+      try {
+        const wmCore = getOctoRuntime();
+        const wmConfig = wmCore.config.loadConfig() as OpenClawConfig;
+        const wmRoute = wmCore.channel.routing.resolveAgentRoute({
+          cfg: wmConfig,
+          channel: CHANNEL_ID,
+          accountId: account.accountId,
+          peer: { kind: isGroup ? "group" : "direct", id: sessionId },
+        });
+        wmSessionKey = wmRoute.sessionKey;
+        const wmStorePath = wmCore.channel.session.resolveStorePath(wmConfig.session?.store, {
+          agentId: wmRoute.agentId,
+        });
+        wmStartedAt = getSessionEntry({
+          storePath: wmStorePath,
+          sessionKey: wmRoute.sessionKey,
+        })?.sessionStartedAt;
+      } catch (wmErr) {
+        log?.warn?.(`octo: [MENTION] reset watermark store read failed (falling back to hook mark): ${String(wmErr)}`);
+      }
+      // Always fold in the in-memory hook mark, even if the store read above
+      // threw — this is the whole point of the belt-and-braces design.
+      resetWatermarkMs = resolveResetWatermarkMs(wmSessionKey, wmStartedAt);
+
       const { answered: answeredEntries, new: newEntries } = segmentHistoryEntries({
         entries,
         cutoffSeq,
         currentMsgId,
+        resetWatermarkMs,
       });
 
       const formatEntries = (items: any[]) => JSON.stringify(items.map((e: any) => {
@@ -2096,7 +2191,11 @@ export async function handleInboundMessage(params: {
               .replace("{messages}", formatEntries([...answeredEntries, ...newEntries]))
               .replace("{count}", String(answeredEntries.length + newEntries.length));
           } else {
-            const filteredEntries = entries.filter((e: any) => e.message_id !== currentMsgId);
+            // Reuse the watermark-filtered, current-excluded entries — NOT the
+            // raw `entries` — so the legacy {messages}/{count} template also
+            // honors the session reset boundary (#155). Reading raw entries here
+            // would re-inject pre-/new messages the segmenting already dropped.
+            const filteredEntries = [...answeredEntries, ...newEntries];
             const allFormatted = formatEntries(filteredEntries);
             const legacyPreamble = answeredEntries.length > 0
               ? `[Note: The first ${answeredEntries.length} message(s) below have already been answered. Do NOT re-answer them.]\n`


### PR DESCRIPTION
## 修改内容

- `segmentHistoryEntries` 新增 `resetWatermarkMs` 参数:过滤掉时间戳早于 watermark 的历史条目,**answered / new 两段全过滤**,并覆盖 legacy `{messages}` 模板路径(此前旧模板分支会从原始 entries 重读、绕过过滤)。
- `index.ts` 注册 `before_reset` hook:按宿主 `sessionKey` 记录 reset 时刻(`recordSessionResetWatermark`)。runtime 有 `hasHooks` 守卫,插件必须注册该 hook 信号才会触发,否则对 `/new` 完全无感知。
- `handleInboundMessage` 历史构建处:读取 `getSessionEntry().sessionStartedAt`(session store)与内存 hook mark,取较大值作 watermark 传入过滤。
- belt-and-braces:内存 hook mark 的折算移到 store-read try 之外——`getSessionEntry` 抛错(文件锁/损坏)时不会连带丢弃 hook mark 而静默关闭过滤。
- fail-safe:entry 缺时间戳时在 watermark 激活下丢弃;watermark 解析异常降级为不过滤(而非丢弃整段历史注入)。

## 根因

插件注入的是**频道级**历史,其 `sessionId` 绑定 IM 频道/用户,**跨 `/new` 稳定不变**;`lastBotReplySeqMap` 是 module-level 持久 map、只增不减,`/new` 完全不碰它。插件此前未注册任何 session 生命周期 hook,对 `/new` 无感知——导致 reset 前的旧消息(含旧指令)仍以「已回答历史」身份注入新会话,污染上下文,`/new` 的硬边界语义被打破。

时间戳单位:live-cache 与 API-backfill 两条路径的 `entry.timestamp` 均已归一化为 ms,与 watermark(宿主墙钟 ms)可安全比较。

## 测试验证

- `npm run type-check`
- `npm test`(45 files / 1536 tests passed)
- 本地 A/B 对照(同一群 `/new` 后发新任务):
  - 修复版:reset 后首次 @ 日志 `历史条目全部被过滤 | answered=0 new=0`,bot 不再沿用旧约束。
  - 基线版(v1.0.19):reset 后仍 `已注入历史 answered=2 new=2`,旧约束穿透复现。

Closes #155