### PR TITLE
fix(routing): resolve octo:<uid> DM target as DM, not group (#170)

### DIFF
--- a/src/actions.test.ts
+++ b/src/actions.test.ts
@@ -3540,6 +3540,71 @@ describe("resolveOutboundOctoTarget", () => {
     expect(resolveOutboundOctoTarget("group:grp1", "").channelType).toBe(ChannelType.Group);
   });
 
+  // DM routing regression: a DM target (octo:<uid>) must resolve to DM
+  // (channel_type=1). Collapsing it to group sends channel_type=2 for a DM id
+  // and the server rejects it (query_failed / 400).
+  it("routes bare octo:<uid> (not a known group) as a DM", async () => {
+    const { resolveOutboundOctoTarget } = await import("./actions.js");
+    _resetGroupMd();
+    registerBotGroupIds(["grp1"]); // uid1 is NOT a known group
+    const r = resolveOutboundOctoTarget("octo:uid1");
+    expect(r.channelId).toBe("uid1");
+    expect(r.channelType).toBe(ChannelType.DM);
+  });
+
+  it("routes octo:user:<uid> and user:<uid> as DM", async () => {
+    const { resolveOutboundOctoTarget } = await import("./actions.js");
+    _resetGroupMd();
+    expect(resolveOutboundOctoTarget("octo:user:uid1").channelType).toBe(ChannelType.DM);
+    expect(resolveOutboundOctoTarget("user:uid1").channelType).toBe(ChannelType.DM);
+  });
+
+  // Negative regression: the DM fix must NOT turn real groups into DMs.
+  it("keeps known groups as Group across octo:/bare/group:/octo:channel: forms", async () => {
+    const { resolveOutboundOctoTarget } = await import("./actions.js");
+    _resetGroupMd();
+    registerBotGroupIds(["grp1"]);
+    expect(resolveOutboundOctoTarget("octo:grp1").channelType).toBe(ChannelType.Group);
+    expect(resolveOutboundOctoTarget("grp1").channelType).toBe(ChannelType.Group);
+    expect(resolveOutboundOctoTarget("group:grp1").channelType).toBe(ChannelType.Group);
+    expect(resolveOutboundOctoTarget("octo:channel:grp1").channelType).toBe(ChannelType.Group);
+  });
+
+  // Regression: stacked namespace prefixes must still collapse to a clean
+  // channelId (not leave inner `octo:`/`group:` fragments in the id).
+  it("collapses stacked octo:group:/octo:channel: prefixes to a clean group id", async () => {
+    const { resolveOutboundOctoTarget } = await import("./actions.js");
+    _resetGroupMd();
+    registerBotGroupIds(["grp1"]);
+    for (const t of ["octo:group:octo:grp1", "octo:channel:group:grp1", "octo:group:grp1"]) {
+      const r = resolveOutboundOctoTarget(t);
+      expect(r.channelId).toBe("grp1");
+      expect(r.channelType).toBe(ChannelType.Group);
+    }
+  });
+
+  // Regression: a group/channel target carrying an @mention suffix must have the
+  // suffix stripped from the channelId (goes through the group: arm).
+  it("strips @mention suffix from octo:channel:<group>@uids", async () => {
+    const { resolveOutboundOctoTarget } = await import("./actions.js");
+    _resetGroupMd();
+    registerBotGroupIds(["grp1"]);
+    const r = resolveOutboundOctoTarget("octo:channel:grp1@uid1,uid2");
+    expect(r.channelId).toBe("grp1");
+    expect(r.channelType).toBe(ChannelType.Group);
+  });
+
+  it("preserves Community Topic (channel_type=5) and thread id across octo: forms", async () => {
+    const { resolveOutboundOctoTarget } = await import("./actions.js");
+    _resetGroupMd();
+    registerBotGroupIds(["grp1"]);
+    for (const t of ["octo:group:grp1____topicA", "octo:channel:grp1____topicA", "octo:grp1____topicA"]) {
+      const r = resolveOutboundOctoTarget(t);
+      expect(r.channelId).toBe("grp1____topicA");
+      expect(r.channelType).toBe(ChannelType.CommunityTopic);
+    }
+  });
+
   it("strips inline mention-UID suffix before parsing", async () => {
     const { resolveOutboundOctoTarget } = await import("./actions.js");
     registerBotGroupIds(["grp1"]);
@@ -3752,6 +3817,31 @@ describe("normalizeOutboundChannelPrefix", () => {
     expect(normalizeOutboundChannelPrefix("group:grp1")).toBe("group:grp1");
     expect(normalizeOutboundChannelPrefix("user:uid1")).toBe("user:uid1");
     expect(normalizeOutboundChannelPrefix("bare_id")).toBe("bare_id");
+  });
+
+  // octo: is a namespace prefix, not a channel-kind marker. A DM target
+  // octo:<uid> must NOT be collapsed to group:<uid> (that sends channel_type=2
+  // for a DM id → server query_failed / 400). Resolve by inner shape instead.
+  it("resolves octo:user:<uid> to a clean DM target", async () => {
+    const { normalizeOutboundChannelPrefix } = await import("./actions.js");
+    expect(normalizeOutboundChannelPrefix("octo:user:uid1")).toBe("user:uid1");
+  });
+
+  it("canonicalises octo:group: / octo:channel: to a single group: form", async () => {
+    const { normalizeOutboundChannelPrefix } = await import("./actions.js");
+    expect(normalizeOutboundChannelPrefix("octo:group:grp1")).toBe("group:grp1");
+    // channel: is a group-channel alias → canonicalised to group: (same as the
+    // existing `channel:<id>` → `group:<id>` behaviour), never left as octo:.
+    expect(normalizeOutboundChannelPrefix("octo:channel:grp1")).toBe("group:grp1");
+    // Stacked forms collapse recursively rather than leaving inner fragments.
+    expect(normalizeOutboundChannelPrefix("octo:group:octo:grp1")).toBe("group:grp1");
+  });
+
+  it("collapses bare octo:<id> to a clean bare id (no octo: prefix, not forced to group)", async () => {
+    const { normalizeOutboundChannelPrefix } = await import("./actions.js");
+    // Output never carries octo:; the bare id is left for parseTarget/knownGroupIds
+    // to classify (DM unless it is a known group).
+    expect(normalizeOutboundChannelPrefix("octo:uid1")).toBe("uid1");
   });
 });
 

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -106,26 +106,45 @@ function stripGroupPrefix(raw: string): string {
  * canonical bare groupId.
  *
  * Rules:
+ *   - `octo:` namespace prefix → resolve by its INNER shape, never by the
+ *     generic group fallback. `octo:` alone carries no user/group semantics, so
+ *     the bare form (`octo:<id>`) must be left for parseTarget/knownGroupIds to
+ *     classify. Collapsing `octo:<uid>` (a DM) to `group:<uid>` would send
+ *     channel_type=2 for a DM id and the server rejects it (query_failed / 400).
  *   - No leading channel-namespace prefix at all → pass through (bare IDs,
  *     thread channel IDs like `grp1____x`, and other shapes parseTarget
  *     handles natively).
  *   - Stacked channel-namespace prefix wrapping a `user:` DM (e.g.
  *     `"octo:user:uid123"`) → unwrap to clean `user:uid123` so the DM path
  *     fires correctly.
- *   - Any other leading channel-namespace prefix(es) → strip recursively and
- *     re-prefix canonically as `group:` so parseTarget sees ONE known shape.
+ *   - An explicit `group:`/`channel:` token anywhere (after any leading `octo:`)
+ *     means a group/channel target → recursively collapse and re-prefix as a
+ *     single `group:` (so parseTarget sees ONE known shape and the group: arm of
+ *     resolveOutboundOctoTarget can strip any `@mention` suffix).
+ *   - Only an `octo:` namespace prefix with no group/channel/user hint
+ *     (`octo:<id>`) is ambiguous: return the collapsed bare id and let
+ *     parseTarget/knownGroupIds classify it (known group → Group, else DM). Do
+ *     NOT default it to group — that would send channel_type=2 for a DM id and
+ *     the server rejects it (query_failed / 400).
  */
 export function normalizeOutboundChannelPrefix(ctxTo: string): string {
   const bare = stripAllChannelPrefixes(ctxTo);
-  // No channel-namespace prefix to strip — let parseTarget handle it natively
-  // (covers bare groupNo, `grp1____x` thread refs, `user:<uid>` DMs).
+  // No leading channel-namespace prefix to strip — let parseTarget handle it
+  // natively (bare groupNo, `grp1____x` thread refs, `user:<uid>` DMs).
   if (bare === ctxTo) return ctxTo;
-  // Stacked channel-namespace prefix wrapping a user: DM — return the clean
-  // user: form so parseTarget routes it as DM, not as a group with `user:` in
-  // the channelId.
+  // `user:` DM marker survives stripAllChannelPrefixes (it never strips user:) —
+  // route as DM, not a group with `user:` embedded in the channelId.
   if (bare.startsWith("user:")) return bare;
-  // Channel-group target — canonicalise to a single leading `group:`.
-  return "group:" + bare;
+  // Distinguish an explicit group/channel target from a bare `octo:<id>`. Strip
+  // only the leading `octo:` runs, then look for a group:/channel: marker.
+  const afterOcto = ctxTo.replace(/^(?:octo:)+/, "");
+  if (afterOcto.startsWith("group:") || afterOcto.startsWith("channel:")) {
+    // Explicit group/channel (possibly stacked) — canonicalise to one `group:`.
+    return "group:" + bare;
+  }
+  // Bare `octo:<id>` — no user/group hint. Return the collapsed bare id so
+  // parseTarget/knownGroupIds decides (known group → Group, otherwise DM).
+  return bare;
 }
 
 /**


### PR DESCRIPTION
## What

Fix DM sends via the generic `message` tool failing with `400 err.server.bot_api.query_failed`.

Closes #170.

## Root cause

A DM target arrives as `octo:<uid>`. `normalizeOutboundChannelPrefix` fell through to the generic group fallback (`return "group:" + bare`), so the outbound request carried `channel_type=2` for a DM id. The server queries the DM uid as a group, finds nothing, and returns `query_failed` (HTTP 400).

Plain DM replies were unaffected — they pin `ChannelType.DM` directly in the inbound path. Only the `message(action=send)` path (`handleSend → resolveOutboundOctoTarget → normalizeOutboundChannelPrefix`) hit the bug, which is why it surfaced for tool-driven / proactive sends but not normal replies.

## Fix

`octo:` is a namespace prefix, not a channel-kind marker. Resolve targets by inner shape while keeping the recursive `stripAllChannelPrefixes` collapse:

- `user:` marker (incl. `octo:user:`) → DM
- an explicit `group:`/`channel:` token (incl. stacked `octo:group:` / `octo:channel:`) → canonicalise to a single `group:` (so the `group:` arm strips any `@mention` suffix and stacked prefixes collapse to a clean id)
- a bare `octo:<id>` with no user/group hint → return the collapsed bare id and let `parseTarget`/`knownGroupIds` classify it (known group → Group, otherwise DM)

Output no longer carries `octo:`, removing the implicit dependency on `parseTarget` re-stripping it. DM cards benefit too — they share `resolveOutboundOctoTarget`.

## Tests

Routing regression added and green (full suite passes, `tsc --noEmit` clean):

- `octo:<uid>` / `octo:user:<uid>` → DM (`channel_type=1`)
- known group stays Group across `octo:` / bare / `group:` / `octo:channel:` forms
- stacked prefixes (`octo:group:octo:grp1`) collapse to a clean group id
- `@mention` suffix on `octo:channel:<group>@uids` stripped
- Community Topic (`channel_type=5`) and thread id preserved across `octo:` forms
- per-test group-state reset for isolation

## Verification

- Unit: full test suite green; `tsc --noEmit` clean.
- End-to-end: installed the built plugin into a live gateway and sent via the `message` tool with `target=octo:<uid>` — previously `400 query_failed`, now delivers successfully with a real `messageId`. Group replies remain `channel_type=2`.

## Scope

Single-purpose: only `normalizeOutboundChannelPrefix` and its tests. No behavior change for `group:` / `channel:` / `user:` / bare-id inputs beyond the DM fix.
