### PR TITLE
fix(actions): return AgentToolResult from handleAction so host tool-result conversion doesn't throw (#171)

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -58,7 +58,7 @@ const SESSION_INIT_RETRY = { retries: 4, backoffMs: 1500 } as const;
 import { ChannelType, MessageType, type BotMessage, type MessagePayload, type SendMessageResult } from "./types.js";
 import { buildEntitiesFromFallback, parseStructuredMentions, convertStructuredMentions, sanitizeOutboundMentions, MENTION_FORMAT_HINT } from "./mention-utils.js";
 import type { MentionEntity } from "./types.js";
-import { handleOctoMessageAction, parseTarget, resolveOutboundOctoTarget, normalizeOutboundChannelPrefix, extractInlineMentionUids } from "./actions.js";
+import { handleOctoMessageAction, parseTarget, resolveOutboundOctoTarget, normalizeOutboundChannelPrefix, extractInlineMentionUids, type MessageActionResult } from "./actions.js";
 import { getOrCreateGroupMdCache, registerBotGroupIds, getKnownGroupIds, writeGroupMdToDisk, extractParentGroupNo } from "./group-md.js";
 import { registerOwnerUid } from "./owner-registry.js";
 import { registerKnownBot, isKnownBot } from "./bot-registry.js";
@@ -647,6 +647,49 @@ const octoSetupAdapter = {
   },
 };
 
+/**
+ * Wrap a plugin action payload as an OpenClaw AgentToolResult.
+ *
+ * The host feeds `result.content` straight into its Codex dynamic tool-result
+ * conversion (`convertToolContents` → `content.reduce`) with no Array.isArray
+ * guard, so a bare `{ ok, data }` return (content === undefined) throws
+ * "Cannot read properties of undefined (reading 'reduce')" *after* the send
+ * already succeeded. Returning a `content[]` satisfies that contract.
+ *
+ * The raw payload is kept in `details`: the host reads `details.ok` /
+ * `details.error` to classify success vs failure, and `extractToolPayload`
+ * reads `details` for delivery evidence — so success/error semantics and
+ * downstream inspection are preserved unchanged.
+ *
+ * Compact (non-pretty) JSON on purpose: read/search/group-md payloads can carry
+ * large histories, member rosters or full GROUP.md; pretty-printing inflates
+ * them ~30% and trips the host's dynamic tool-result char cap sooner.
+ */
+export function toActionToolResult(payload: MessageActionResult): {
+  content: { type: "text"; text: string }[];
+  details: MessageActionResult;
+} {
+  let text: string;
+  try {
+    const serialized = JSON.stringify(payload);
+    // JSON.stringify can return undefined WITHOUT throwing (e.g. a root-level
+    // toJSON() returning undefined). Coerce to a fixed string so content.text
+    // is always a valid string and the host's content.reduce never breaks.
+    text = typeof serialized === "string" ? serialized : "[unserializable payload]";
+  } catch {
+    // Last-resort net: a throwing JSON.stringify (circular ref / BigInt). Use a
+    // fixed string and do NOT read back the payload here — this branch exists
+    // precisely so the helper never throws, so it must not re-invoke any
+    // payload getter/toString that could itself throw. The raw payload is still
+    // available in `details` for the host's error classification.
+    text = "[unserializable payload]";
+  }
+  return {
+    content: [{ type: "text", text }],
+    details: payload,
+  };
+}
+
 export const octoPlugin: ChannelPlugin<ResolvedOctoAccount> = {
   id: "octo",
   meta,
@@ -787,12 +830,12 @@ export const octoPlugin: ChannelPlugin<ResolvedOctoAccount> = {
         accountId,
       });
       if (!account.config.botToken) {
-        return { ok: false, error: "Octo botToken is not configured" };
+        return toActionToolResult({ ok: false, error: "Octo botToken is not configured" });
       }
       const memberMap = getOrCreateMemberMap(accountId);
       const uidToNameMap = getOrCreateUidToNameMap(accountId);
       const groupMdCache = getOrCreateGroupMdCache(accountId);
-      return handleOctoMessageAction({
+      const result = await handleOctoMessageAction({
         action: ctx.action,
         args: ctx.params ?? {},
         apiUrl: account.config.apiUrl,
@@ -806,6 +849,10 @@ export const octoPlugin: ChannelPlugin<ResolvedOctoAccount> = {
         accountId,
         log: ctx.log,
       });
+      // Exceptions are intentionally not caught here: the host wraps tool
+      // execution in its own try/catch and depends on the throw for the
+      // after-tool-call error hook and failed-idempotency-key retention.
+      return toActionToolResult(result);
     },
   } as any, // TODO: remove when SDK types support this
   agentPrompt: {

--- a/src/handleaction-tool-result.test.ts
+++ b/src/handleaction-tool-result.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Regression tests for #171: handleAction must return a valid AgentToolResult
+ * ({ content: [...], details }) on every return path, so the OpenClaw host's
+ * Codex tool-result conversion (convertToolContents → content.reduce, no
+ * Array.isArray guard) does not throw "Cannot read properties of undefined
+ * (reading 'reduce')" after a send succeeds.
+ *
+ * Exceptions are intentionally NOT wrapped: the host wraps tool execution in
+ * its own try/catch (failedToolResult) and relies on the throw for the
+ * after-tool-call error hook + failed-idempotency-key retention. handleAction
+ * must let exceptions propagate — test 6 locks that contract in.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.clearAllMocks();
+});
+
+// Only override handleOctoMessageAction; keep the rest of actions.js real so
+// channel.ts's other handlers (which import parseTarget/resolveOutboundOctoTarget
+// etc. from the same module) still load correctly.
+vi.mock("./actions.js", async (importActual) => {
+  const actual = await importActual<typeof import("./actions.js")>();
+  return { ...actual, handleOctoMessageAction: vi.fn() };
+});
+
+type ToolResult = {
+  content: { type: string; text: string }[];
+  details: { ok: boolean; data?: unknown; error?: string };
+};
+
+// cfg whose resolved account HAS a botToken → reaches the delegated path.
+function cfgWithToken() {
+  return {
+    channels: {
+      octo: { accounts: { default: { botToken: "tok", apiUrl: "http://api" } } },
+    },
+  };
+}
+
+// cfg whose resolved account has NO botToken → config-error branch.
+function cfgWithoutToken() {
+  return {
+    channels: {
+      octo: { accounts: { default: { apiUrl: "http://api" } } },
+    },
+  };
+}
+
+function makeCtx(overrides: Record<string, unknown> = {}) {
+  return {
+    accountId: "default",
+    action: "send" as const,
+    channel: "octo",
+    params: { target: "user:u1", text: "hi" },
+    // No currentChannelId → skip the accountId-correction branch.
+    toolContext: {},
+    cfg: cfgWithToken(),
+    log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    ...overrides,
+  };
+}
+
+// Mirror of the host's unguarded aggregation (convertToolContents in
+// openclaw dist provider-capabilities-*.js): if content is not an array this
+// throws — the exact bug #171 fixes. Kept in sync manually with the SDK.
+function hostReduce(content: unknown): number {
+  return (content as { type: string; text: string }[]).reduce(
+    (total, item) => total + (item.type === "text" ? item.text.length : 0),
+    0,
+  );
+}
+
+// Mirror of the host's error classification (isToolResultError in openclaw
+// dist embedded-agent-message-tool-source-reply-*.js) — it reads details.ok /
+// details.error. Kept in sync manually with the SDK.
+function hostIsToolResultError(result: ToolResult): boolean {
+  const d = result.details;
+  if (d?.ok === false) return true;
+  if (d?.error) return true;
+  return false;
+}
+
+describe("toActionToolResult (helper)", () => {
+  it("wraps any payload into content[] + details, and host reduce does not throw", async () => {
+    const { toActionToolResult } = await import("./channel.js");
+
+    for (const payload of [
+      { ok: true, data: { messageId: "m1" } },
+      { ok: false, error: "boom" },
+    ] as const) {
+      const r = toActionToolResult(payload) as ToolResult;
+      expect(Array.isArray(r.content)).toBe(true);
+      expect(r.content[0]).toMatchObject({ type: "text" });
+      expect(typeof r.content[0].text).toBe("string");
+      expect(r.details).toEqual(payload);
+      expect(() => hostReduce(r.content)).not.toThrow();
+    }
+  });
+
+  it("never throws while building content, even on an unserializable payload", async () => {
+    const { toActionToolResult } = await import("./channel.js");
+    const circular: Record<string, unknown> = { ok: false, error: "boom" };
+    circular.self = circular; // JSON.stringify would throw on this
+
+    let r!: ToolResult;
+    expect(() => {
+      r = toActionToolResult(circular as any) as ToolResult;
+    }).not.toThrow();
+    expect(Array.isArray(r.content)).toBe(true);
+    expect(typeof r.content[0].text).toBe("string");
+    expect(() => hostReduce(r.content)).not.toThrow();
+  });
+
+  it("content.text is always a string, even when JSON.stringify returns undefined", async () => {
+    const { toActionToolResult } = await import("./channel.js");
+    // A root-level toJSON()→undefined makes JSON.stringify return undefined
+    // WITHOUT throwing — the guard must still yield a string.
+    const payload = { ok: true, toJSON: () => undefined };
+
+    const r = toActionToolResult(payload as any) as ToolResult;
+
+    expect(typeof r.content[0].text).toBe("string");
+    expect(r.content[0].text.length).toBeGreaterThan(0);
+    expect(() => hostReduce(r.content)).not.toThrow();
+  });
+});
+
+describe("handleAction returns AgentToolResult (#171)", () => {
+  it("success branch: content is an array and details preserves ok/data", async () => {
+    const { octoPlugin } = await import("./channel.js");
+    const { handleOctoMessageAction } = await import("./actions.js");
+    vi.mocked(handleOctoMessageAction).mockResolvedValue({
+      ok: true,
+      data: { messageId: "m1" },
+    });
+
+    const r = (await octoPlugin.actions!.handleAction!(makeCtx() as any)) as ToolResult;
+
+    expect(Array.isArray(r.content)).toBe(true);
+    expect(() => hostReduce(r.content)).not.toThrow();
+    expect(r.details).toMatchObject({ ok: true, data: { messageId: "m1" } });
+  });
+
+  it("config-error branch (no botToken): valid AgentToolResult with details.ok=false", async () => {
+    const { octoPlugin } = await import("./channel.js");
+    const { handleOctoMessageAction } = await import("./actions.js");
+
+    const r = (await octoPlugin.actions!.handleAction!(
+      makeCtx({ cfg: cfgWithoutToken() }) as any,
+    )) as ToolResult;
+
+    expect(Array.isArray(r.content)).toBe(true);
+    expect(r.details.ok).toBe(false);
+    expect(r.details.error).toMatch(/botToken/i);
+    // config-error short-circuits before delegating.
+    expect(handleOctoMessageAction).not.toHaveBeenCalled();
+  });
+
+  it("unknown-action branch: delegated error still wrapped as AgentToolResult", async () => {
+    const { octoPlugin } = await import("./channel.js");
+    const { handleOctoMessageAction } = await import("./actions.js");
+    vi.mocked(handleOctoMessageAction).mockResolvedValue({
+      ok: false,
+      error: "Unknown action: bogus",
+    });
+
+    const r = (await octoPlugin.actions!.handleAction!(
+      makeCtx({ action: "bogus" }) as any,
+    )) as ToolResult;
+
+    expect(Array.isArray(r.content)).toBe(true);
+    expect(() => hostReduce(r.content)).not.toThrow();
+    expect(r.details.ok).toBe(false);
+    expect(r.details.error).toMatch(/unknown action/i);
+  });
+
+  it("error classification: wrapper does not swallow errors nor mislabel success", async () => {
+    const { toActionToolResult } = await import("./channel.js");
+
+    expect(hostIsToolResultError(toActionToolResult({ ok: false, error: "x" }) as ToolResult)).toBe(true);
+    expect(hostIsToolResultError(toActionToolResult({ ok: true, data: {} }) as ToolResult)).toBe(false);
+  });
+
+  it("exception propagates (not swallowed) so the host can handle it", async () => {
+    const { octoPlugin } = await import("./channel.js");
+    const { handleOctoMessageAction } = await import("./actions.js");
+    vi.mocked(handleOctoMessageAction).mockRejectedValue(new Error("network down"));
+
+    await expect(
+      octoPlugin.actions!.handleAction!(makeCtx() as any),
+    ).rejects.toThrow("network down");
+  });
+
+  it("large payload is serialized compactly (no pretty-print indentation)", async () => {
+    const { octoPlugin } = await import("./channel.js");
+    const { handleOctoMessageAction } = await import("./actions.js");
+    const history = Array.from({ length: 50 }, (_, i) => ({ id: i, text: `msg ${i}` }));
+    vi.mocked(handleOctoMessageAction).mockResolvedValue({ ok: true, data: { history } });
+
+    const r = (await octoPlugin.actions!.handleAction!(makeCtx({ action: "read" }) as any)) as ToolResult;
+
+    // Pretty-print (JSON.stringify(x, null, 2)) would insert "\n  "; compact must not.
+    expect(r.content[0].text).not.toMatch(/\n {2}/);
+    expect(JSON.parse(r.content[0].text)).toMatchObject({ ok: true });
+  });
+});


### PR DESCRIPTION
## What

After a `message`-tool send **succeeds**, the tool card failed with `Cannot read properties of undefined (reading 'reduce')`. Independent of #170 (different layer/root cause). Fixes #171.

## Root cause

`handleAction` returned bare business JSON (`{ ok, data }`) with no `content` field. The host feeds `result.content` straight into its Codex dynamic tool-result conversion (`convertToolContents` → `content.reduce`) with **no `Array.isArray` guard**, so `undefined.reduce` threw *after* the message had already been delivered.

Verified against the installed `openclaw` dist:
- `convertToolContents(result.content, …)` reduces `result.content` unguarded;
- error classification (`isToolResultError` / `isCodexToolResultError`) reads `details.ok` / `details.error`;
- `extractToolPayload` reads `details` first.

## Fix

Wrap both `handleAction` return paths (config-error + delegated result) in a new `toActionToolResult` helper producing a valid `AgentToolResult`:

- `content[]` satisfies the host contract → the reduce no longer throws;
- the raw payload is kept in `details`, so the host's success/error classification and downstream payload extraction are unchanged;
- compact JSON avoids inflating large `read`/`search`/`group-md` payloads;
- serialization is guarded (try/catch + a `typeof` string check for the `JSON.stringify`-returns-`undefined` case) so the helper always emits a string and never itself fails after a successful send.

Exceptions are intentionally **not** caught here: the host wraps tool execution in its own try/catch and relies on the throw for the after-tool-call error hook and failed-idempotency-key retention.

## Tests

`src/handleaction-tool-result.test.ts` (9 cases): success, config-error, unknown-action, error classification (no swallow / no mislabel), exception propagation, compact serialization, and non-throwing / always-string serialization guards. The host's unguarded `content.reduce` is mirrored in-test to assert it no longer throws.

## Verification

- `tsc --noEmit` clean; full suite `1657 passed / 3 skipped`.
- Built, packed, and installed into a local gateway; Octo channel `OK`; structural assertions pass against the shipped dist artifact.
- Note: the throwing site is Codex-runtime-specific; end-to-end confirmation of the reduce is best done on a Codex runtime. Local validation is source-level + structural per that constraint.

## Scope

Touches only `src/channel.ts` (`handleAction` + the `toActionToolResult` helper) and its new test. Does not change the Bot API request or `actions.ts` business logic — orthogonal to #170.