### PR TITLE
fix(cards): keep yielded progress cards updateable (#176)

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,25 @@ to paste a secret in plaintext. Whether to adjust the configuration is up to you
 - Configuration is read from `channels.octo` in OpenClaw's config; the plugin
   hot-reloads when that block changes
 
+## Development
+
+Run the real container E2E for yielded progress cards with a configured Octo
+DM user. The runner builds this checkout, installs a test-only inbound bridge in
+the `ocprobe` container, restarts the real OpenClaw gateway, exercises
+`sessions_spawn` + `sessions_yield` + protected completion, and removes the
+bridge/config again even when the test fails.
+
+The bridge includes a loopback OpenAI-compatible scripted provider so tool
+choices are deterministic. OpenClaw's tool execution, subagent scheduler,
+lifecycle stream, and Octo send/edit HTTP requests remain the real host paths.
+
+```bash
+OCTO_E2E_TARGET_UID=<octo-user-uid> npm run test:e2e:openclaw
+```
+
+Override the default container with `OCTO_E2E_CONTAINER` when needed. The
+target user receives progress-card messages during the test.
+
 ## Disconnect
 
 To disconnect a bot, send `/disconnect` to BotFather in Octo. This invalidates

--- a/e2e/openclaw-host-plugin/index.mjs
+++ b/e2e/openclaw-host-plugin/index.mjs
@@ -1,0 +1,377 @@
+/**
+ * Test-only OpenClaw plugin. It injects a synthetic Octo DM into the real
+ * adapter so the host, sessions_spawn/yield lifecycle, and Octo HTTP edits are
+ * all exercised without requiring a second human/bot account to send inbound.
+ * A loopback OpenAI-compatible provider scripts only the model outputs; host
+ * tool execution, subagent scheduling, lifecycle, and channel I/O stay real.
+ *
+ * Install beside the active plugin:
+ *   ~/.openclaw-dev/extensions/octo-host-e2e
+ *
+ * Never ship this directory in the octo package. The runner enables it only
+ * for the duration of an explicit container E2E and removes it afterwards.
+ */
+import { resolveOctoAccount } from "../octo/dist/src/accounts.js";
+import { handleInboundMessage } from "../octo/dist/src/inbound.js";
+import { setOctoRuntime } from "../octo/dist/src/runtime.js";
+import { ChannelType, MessageType } from "../octo/dist/src/types.js";
+import fs from "node:fs";
+import http from "node:http";
+import path from "node:path";
+import { randomUUID } from "node:crypto";
+
+const SESSION_PREFIX = "agent:main:octo-host-e2e:";
+const PROVIDER = "octo-e2e";
+const MODEL = "scripted";
+const MODEL_REF = `${PROVIDER}/${MODEL}`;
+const MODEL_PORT = 19123;
+const REQUEST_DIR = "/tmp/octo-host-e2e";
+const EDIT_LOG = `${REQUEST_DIR}/card-edits.jsonl`;
+const MODEL_SERVER = Symbol.for("octo.host-e2e.model-server");
+const EDIT_OBSERVER = Symbol.for("octo.host-e2e.edit-observer");
+
+function ensureEditObserver(api) {
+  if (globalThis[EDIT_OBSERVER] || typeof globalThis.fetch !== "function") return;
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input, init) => {
+    const response = await originalFetch(input, init);
+    const url = typeof input === "string" || input instanceof URL
+      ? String(input)
+      : input?.url ?? "";
+    if (url.endsWith("/v1/bot/message/edit") && typeof init?.body === "string") {
+      try {
+        const request = JSON.parse(init.body);
+        const envelope = JSON.parse(request.content_edit);
+        fs.mkdirSync(REQUEST_DIR, { recursive: true });
+        fs.appendFileSync(EDIT_LOG, JSON.stringify({
+          timestampMs: Date.now(),
+          messageId: String(request.message_id ?? ""),
+          status: response.status,
+          ok: response.ok,
+          transient: envelope.transient === true,
+          plain: typeof envelope.plain === "string" ? envelope.plain : "",
+        }) + "\n");
+      } catch (error) {
+        api.logger.warn(`octo-host-e2e edit observer: ${error}`);
+      }
+    }
+    return response;
+  };
+  globalThis[EDIT_OBSERVER] = true;
+}
+
+function contentText(content) {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  return content.map((part) => typeof part?.text === "string" ? part.text : "").join("\n");
+}
+
+function scriptedReply(body) {
+  const messages = Array.isArray(body?.messages) ? body.messages : [];
+  const allText = messages.map((message) => contentText(message?.content)).join("\n");
+  const marker = allText.match(/(?:CHILD|PARENT)_E2E_OK:([0-9a-f-]{36})/i)?.[1] ??
+    allText.match(/OpenClaw host E2E marker: ([0-9a-f-]{36})/i)?.[1] ??
+    allText.match(/Ordinary user follow-up for ([0-9a-f-]{36})/i)?.[1];
+  if (!marker) return { text: "E2E_SCRIPT_ERROR: missing marker" };
+
+  if (allText.includes("<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>") &&
+      allText.includes(`CHILD_E2E_OK:${marker}`)) {
+    return { text: `PARENT_E2E_OK:${marker}` };
+  }
+  if (allText.includes(`Ordinary user follow-up for ${marker}`)) {
+    return { text: `FOLLOWUP_E2E_OK:${marker}` };
+  }
+
+  const isChild = allText.includes("[Subagent Task]");
+  const toolMessages = messages.filter((message) => message?.role === "tool");
+  if (isChild) {
+    if (toolMessages.length > 0) return { text: `CHILD_E2E_OK:${marker}` };
+    const delay = Number(allText.match(/sleep (\d+)/)?.[1] ?? 10);
+    return {
+      tool: "exec",
+      arguments: {
+        command: `sleep ${delay}`,
+        yieldMs: (delay + 5) * 1_000,
+        timeout: delay + 15,
+        background: false,
+      },
+    };
+  }
+
+  const spawnFinished = toolMessages.some((message) =>
+    message?.name === "sessions_spawn" || contentText(message?.content).includes("childSessionKey"));
+  if (spawnFinished) {
+    return {
+      tool: "sessions_yield",
+      arguments: { message: "Waiting for protected child completion event." },
+      delayMs: 2_000,
+    };
+  }
+  const delay = Number(allText.match(/sleep (\d+)/)?.[1] ?? 10);
+  return {
+    tool: "sessions_spawn",
+    arguments: {
+      task: `E2E child. Run sleep ${delay}, then return CHILD_E2E_OK:${marker}`,
+      label: `octo-host-e2e-${marker}`,
+      taskName: "octo_host_e2e_child",
+      runtime: "subagent",
+      mode: "run",
+      context: "isolated",
+      model: MODEL_REF,
+      cleanup: "delete",
+    },
+  };
+}
+
+function sendScriptedResponse(res, body, reply) {
+  const id = `chatcmpl-${randomUUID()}`;
+  const created = Math.floor(Date.now() / 1_000);
+  const model = typeof body?.model === "string" ? body.model : MODEL;
+  const toolCall = reply.tool ? {
+    id: `call_${randomUUID().replaceAll("-", "")}`,
+    type: "function",
+    function: { name: reply.tool, arguments: JSON.stringify(reply.arguments ?? {}) },
+  } : undefined;
+  const finishReason = toolCall ? "tool_calls" : "stop";
+
+  if (body?.stream === true) {
+    res.writeHead(200, {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+    });
+    const emit = (chunk) => res.write(`data: ${JSON.stringify(chunk)}\n\n`);
+    emit({ id, object: "chat.completion.chunk", created, model, choices: [{ index: 0, delta: { role: "assistant" }, finish_reason: null }] });
+    emit({
+      id,
+      object: "chat.completion.chunk",
+      created,
+      model,
+      choices: [{
+        index: 0,
+        delta: toolCall
+          ? { tool_calls: [{ index: 0, ...toolCall }] }
+          : { content: reply.text ?? "" },
+        finish_reason: null,
+      }],
+    });
+    emit({ id, object: "chat.completion.chunk", created, model, choices: [{ index: 0, delta: {}, finish_reason: finishReason }] });
+    if (body?.stream_options?.include_usage) {
+      emit({ id, object: "chat.completion.chunk", created, model, choices: [], usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 } });
+    }
+    res.end("data: [DONE]\n\n");
+    return;
+  }
+
+  res.writeHead(200, { "Content-Type": "application/json" });
+  res.end(JSON.stringify({
+    id,
+    object: "chat.completion",
+    created,
+    model,
+    choices: [{
+      index: 0,
+      message: {
+        role: "assistant",
+        content: toolCall ? null : reply.text ?? "",
+        ...(toolCall ? { tool_calls: [toolCall] } : {}),
+      },
+      finish_reason: finishReason,
+    }],
+    usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+  }));
+}
+
+function ensureModelServer(api) {
+  if (globalThis[MODEL_SERVER]) return;
+  const server = http.createServer((req, res) => {
+    if (req.method !== "POST" || req.url !== "/v1/chat/completions") {
+      res.writeHead(404).end();
+      return;
+    }
+    const chunks = [];
+    let size = 0;
+    req.on("data", (chunk) => {
+      size += chunk.length;
+      if (size <= 2 * 1024 * 1024) chunks.push(chunk);
+      else req.destroy();
+    });
+    req.on("end", () => {
+      try {
+        const body = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+        const reply = scriptedReply(body);
+        setTimeout(() => sendScriptedResponse(res, body, reply), reply.delayMs ?? 0);
+      } catch (error) {
+        res.writeHead(400, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: { message: error instanceof Error ? error.message : String(error) } }));
+      }
+    });
+  });
+  server.on("error", (error) => {
+    if (error?.code !== "EADDRINUSE") api.logger.error(`octo-host-e2e model server: ${error}`);
+  });
+  server.listen(MODEL_PORT, "127.0.0.1", () => {
+    api.logger.info(`octo-host-e2e: scripted model ready on 127.0.0.1:${MODEL_PORT}`);
+  });
+  globalThis[MODEL_SERVER] = server;
+}
+
+function requiredString(params, key) {
+  const value = typeof params[key] === "string" ? params[key].trim() : "";
+  if (!value) throw new Error(`missing ${key}`);
+  return value;
+}
+
+function resolveAccountId(config, requested) {
+  if (requested) return requested;
+  const accounts = config.channels?.octo?.accounts;
+  const first = accounts && typeof accounts === "object" ? Object.keys(accounts)[0] : undefined;
+  if (!first) throw new Error("no configured Octo account");
+  return first;
+}
+
+function buildPrompt(kind, marker, childDelaySeconds) {
+  if (kind === "followup") {
+    return `Ordinary user follow-up for ${marker}. Do not call tools. Reply exactly FOLLOWUP_E2E_OK:${marker}`;
+  }
+  const childResult = `CHILD_E2E_OK:${marker}`;
+  const childTask = [
+    `Call exec exactly once with arguments {\"command\":\"sleep ${childDelaySeconds}\",\"yieldMs\":${(childDelaySeconds + 5) * 1_000},\"timeout\":${childDelaySeconds + 15},\"background\":false}.`,
+    "Do not use process or any other tool.",
+    `Only after exec reports exit code 0, reply exactly ${childResult}.`,
+    "If exec fails or is interrupted, reply CHILD_E2E_FAILED instead.",
+  ].join(" ");
+  return [
+    `OpenClaw host E2E marker: ${marker}.`,
+    `You MUST call sessions_spawn exactly once with runtime=\"subagent\", mode=\"run\", context=\"isolated\", model=\"${MODEL_REF}\".`,
+    "Call sessions_spawn as your first tool. Do not call agents_list; omit agentId.",
+    `Set the child task exactly to ${JSON.stringify(childTask)}.`,
+    "After spawn succeeds, do not poll with sessions_list, sessions_history, exec sleep, or any other tool.",
+    "Call sessions_yield and end this turn while waiting for the protected completion event.",
+    `When that protected child completion event arrives, reply exactly PARENT_E2E_OK:${marker}`,
+  ].join(" ");
+}
+
+export default {
+  id: "octo-host-e2e",
+  name: "Octo Host E2E Bridge",
+  version: "0.0.0",
+  register(api) {
+    ensureEditObserver(api);
+    ensureModelServer(api);
+    setOctoRuntime(api.runtime);
+    let watcher;
+
+    // Keep the test deterministic and avoid mutating the operator's default
+    // model. The child gets the same explicit model in sessions_spawn.
+    api.on("before_model_resolve", (_event, ctx) => {
+      if (!ctx.sessionKey?.startsWith(SESSION_PREFIX)) return;
+      return { providerOverride: PROVIDER, modelOverride: MODEL };
+    });
+
+    const runRequest = async (params) => {
+      try {
+        const kind = params.kind === "followup" ? "followup" : "spawn";
+        const marker = requiredString(params, "marker");
+        const targetUid = requiredString(params, "targetUid");
+        const sessionKey = requiredString(params, "sessionKey");
+        if (!sessionKey.startsWith(SESSION_PREFIX)) {
+          throw new Error(`sessionKey must start with ${SESSION_PREFIX}`);
+        }
+        const delay = Number(params.childDelaySeconds ?? 25);
+        if (!Number.isInteger(delay) || delay < 10 || delay > 90) {
+          throw new Error("childDelaySeconds must be an integer between 10 and 90");
+        }
+
+        const config = api.runtime.config.loadConfig();
+        const accountId = resolveAccountId(
+          config,
+          typeof params.accountId === "string" ? params.accountId.trim() : "",
+        );
+        const account = resolveOctoAccount({ cfg: config, accountId });
+        if (!account.configured || !account.config.botToken) {
+          throw new Error(`Octo account ${accountId} is not configured`);
+        }
+
+        const now = Date.now();
+        await handleInboundMessage({
+          account,
+          botUid: accountId,
+          message: {
+            message_id: `host-e2e-${kind}-${marker}`,
+            message_seq: now,
+            from_uid: targetUid,
+            channel_id: targetUid,
+            channel_type: ChannelType.DM,
+            timestamp: Math.floor(now / 1000),
+            payload: {
+              type: MessageType.Text,
+              content: buildPrompt(kind, marker, delay),
+            },
+          },
+          groupHistories: new Map(),
+          lastBotReplySeqMap: new Map(),
+          memberMap: new Map([["E2E User", targetUid]]),
+          uidToNameMap: new Map([[targetUid, "E2E User"]]),
+          groupCacheTimestamps: new Map(),
+          memberRobotMap: new Map([[targetUid, false]]),
+          routeOverride: { sessionKey, agentId: "main" },
+          log: api.logger,
+        });
+        return { ok: true, accepted: true, kind, marker, sessionKey };
+      } catch (error) {
+        return { ok: false, error: error instanceof Error ? error.message : String(error) };
+      }
+    };
+
+    const processRequests = () => {
+      let names = [];
+      try { names = fs.readdirSync(REQUEST_DIR); } catch { return; }
+      for (const name of names) {
+        if (!name.endsWith(".request.json")) continue;
+        const requestPath = path.join(REQUEST_DIR, name);
+        const processingPath = path.join(
+          REQUEST_DIR,
+          name.replace(/\.request\.json$/, ".processing.json"),
+        );
+        try {
+          // OpenClaw can register this test plugin in both gateway and embedded
+          // agent runtimes. Rename is the cross-instance claim: exactly one
+          // watcher gets to inject a given synthetic inbound message.
+          fs.renameSync(requestPath, processingPath);
+        } catch {
+          continue;
+        }
+        void (async () => {
+          const resultPath = path.join(REQUEST_DIR, name.replace(/\.request\.json$/, ".result.json"));
+          try {
+            const params = JSON.parse(fs.readFileSync(processingPath, "utf8"));
+            const result = await runRequest(params);
+            fs.writeFileSync(resultPath, JSON.stringify(result));
+          } catch (error) {
+            fs.writeFileSync(resultPath, JSON.stringify({
+              ok: false,
+              error: error instanceof Error ? error.message : String(error),
+            }));
+          } finally {
+            try { fs.unlinkSync(processingPath); } catch {}
+          }
+        })();
+      }
+    };
+
+    const startWatcher = () => {
+      fs.mkdirSync(REQUEST_DIR, { recursive: true });
+      watcher?.close();
+      watcher = fs.watch(REQUEST_DIR, processRequests);
+      processRequests();
+      api.logger.info("octo-host-e2e: request bridge ready");
+    };
+    startWatcher();
+    api.on("gateway_start", startWatcher);
+    api.on("gateway_stop", () => {
+      watcher?.close();
+      watcher = undefined;
+    });
+  },
+};

--- a/e2e/openclaw-host-plugin/inspect.mjs
+++ b/e2e/openclaw-host-plugin/inspect.mjs
@@ -1,0 +1,172 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const marker = process.argv[2];
+const sessionKey = process.argv[3];
+const targetUid = process.argv[4];
+const startedAtMs = Number(process.argv[5]);
+
+if (!marker || !sessionKey || !targetUid || !Number.isFinite(startedAtMs)) {
+  throw new Error("usage: inspect.mjs <marker> <sessionKey> <targetUid> <startedAtMs>");
+}
+
+function readJsonLines(file) {
+  try {
+    return fs.readFileSync(file, "utf8")
+      .split("\n")
+      .filter(Boolean)
+      .flatMap((line) => {
+        try { return [JSON.parse(line)]; } catch { return []; }
+      });
+  } catch {
+    return [];
+  }
+}
+
+function messageText(message) {
+  const content = message?.content;
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  return content
+    .filter((part) => part?.type === "text" && typeof part.text === "string")
+    .map((part) => part.text)
+    .join("\n");
+}
+
+function findParentTranscript() {
+  const dir = "/root/.openclaw-dev/agents/main/sessions";
+  let files = [];
+  try {
+    files = fs.readdirSync(dir).filter((name) =>
+      name.endsWith(".jsonl") && !name.endsWith(".trajectory.jsonl"));
+  } catch {
+    return { file: undefined, rows: [] };
+  }
+  for (const name of files) {
+    const file = path.join(dir, name);
+    const rows = readJsonLines(file);
+    const serialized = JSON.stringify(rows);
+    if (serialized.includes(marker) && serialized.includes("sessions_yield")) return { file, rows };
+  }
+  return { file: undefined, rows: [] };
+}
+
+function findChildTrajectory() {
+  const dir = "/root/.openclaw-dev/agents/main/sessions";
+  let files = [];
+  try {
+    files = fs.readdirSync(dir).filter((name) => name.endsWith(".trajectory.jsonl"));
+  } catch {
+    return [];
+  }
+  for (const name of files) {
+    const rows = readJsonLines(path.join(dir, name));
+    if (!rows.some((row) => row?.sessionKey?.includes(":subagent:"))) continue;
+    if (JSON.stringify(rows).includes(marker)) return rows;
+  }
+  return [];
+}
+
+function readGatewayLogs() {
+  const candidates = [];
+  for (const dir of ["/tmp/openclaw", "/tmp"]) {
+    try {
+      for (const name of fs.readdirSync(dir)) {
+        if (!name.endsWith(".log")) continue;
+        if (dir === "/tmp" && !name.startsWith("gw")) continue;
+        candidates.push(path.join(dir, name));
+      }
+    } catch {
+      // Optional log location.
+    }
+  }
+  return candidates.map((file) => {
+    try { return fs.readFileSync(file, "utf8"); } catch { return ""; }
+  }).join("\n");
+}
+
+function latestAcceptedEdit(messageId) {
+  const edits = readJsonLines("/tmp/octo-host-e2e/card-edits.jsonl")
+    .filter((row) => row?.ok === true && row?.messageId === messageId &&
+      Number(row?.timestampMs ?? 0) >= startedAtMs - 5_000)
+    .sort((a, b) => Number(a.timestampMs ?? 0) - Number(b.timestampMs ?? 0));
+  return edits.at(-1);
+}
+
+async function recentCards() {
+  const config = JSON.parse(fs.readFileSync("/root/.openclaw-dev/openclaw.json", "utf8"));
+  const account = Object.values(config.channels?.octo?.accounts ?? {})[0];
+  if (!account?.apiUrl || !account?.botToken) return [];
+  const response = await fetch(`${account.apiUrl.replace(/\/+$/, "")}/v1/bot/messages/sync`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${account.botToken}`,
+    },
+    body: JSON.stringify({
+      channel_id: targetUid,
+      channel_type: 1,
+      limit: 100,
+      start_message_seq: 0,
+      end_message_seq: 0,
+      pull_mode: 1,
+    }),
+  });
+  if (!response.ok) return [];
+  const body = await response.json();
+  return (body.messages ?? []).flatMap((message) => {
+    try {
+      const payload = JSON.parse(Buffer.from(message.payload, "base64").toString("utf8"));
+      const timestampMs = Number(message.timestamp ?? 0) * 1000;
+      if (payload.type !== 17 || timestampMs < startedAtMs - 5_000) return [];
+      const messageId = String(message.message_idstr ?? message.message_id ?? "");
+      const edit = latestAcceptedEdit(messageId);
+      return [{
+        messageId,
+        timestampMs,
+        plain: typeof edit?.plain === "string"
+          ? edit.plain
+          : typeof payload.plain === "string" ? payload.plain : "",
+        plainSource: edit ? "accepted-edit" : "original-message",
+      }];
+    } catch {
+      return [];
+    }
+  });
+}
+
+const { file, rows } = findParentTranscript();
+const trajectoryFile = file?.replace(/\.jsonl$/, ".trajectory.jsonl");
+const trajectoryRows = trajectoryFile ? readJsonLines(trajectoryFile) : [];
+const childTrajectoryText = JSON.stringify(findChildTrajectory());
+const toolCalls = rows.flatMap((row) => {
+  if (row.message?.role !== "assistant" || !Array.isArray(row.message.content)) return [];
+  return row.message.content
+    .filter((part) => part?.type === "toolCall")
+    .map((part) => ({ name: part.name, arguments: part.arguments }));
+});
+const texts = rows.map((row) => ({ role: row.message?.role, text: messageText(row.message) }));
+const trajectoryText = JSON.stringify(trajectoryRows);
+const gatewayLogs = readGatewayLogs();
+const cards = await recentCards();
+
+const phaseEvidence = {
+  paused: gatewayLogs.includes(`finalized session=${sessionKey} phase=paused`) ||
+    gatewayLogs.includes(`transitioned session=${sessionKey} phase=paused`),
+  resuming: gatewayLogs.includes(`transitioned session=${sessionKey} phase=resuming`),
+  done: gatewayLogs.includes(`transitioned session=${sessionKey} phase=done`),
+};
+
+console.log(JSON.stringify({
+  transcriptFile: file,
+  toolCalls,
+  completionEvent: trajectoryText.includes("<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>") &&
+    trajectoryText.includes(`CHILD_E2E_OK:${marker}`),
+  childExec: childTrajectoryText.includes('"toolName":"exec"') &&
+    (childTrajectoryText.includes('"exitCode":0') ||
+      childTrajectoryText.includes('"status":"completed"')),
+  followupReply: texts.some(({ role, text }) => role === "assistant" && text.includes(`FOLLOWUP_E2E_OK:${marker}`)),
+  parentReply: texts.some(({ role, text }) => role === "assistant" && text.includes(`PARENT_E2E_OK:${marker}`)),
+  phases: ["paused", "resuming", "done"].filter((phase) => phaseEvidence[phase]),
+  cards,
+}));

--- a/e2e/openclaw-host-plugin/openclaw.plugin.json
+++ b/e2e/openclaw-host-plugin/openclaw.plugin.json
@@ -1,0 +1,18 @@
+{
+  "id": "octo-host-e2e",
+  "name": "Octo Host E2E Bridge",
+  "version": "0.0.0",
+  "activation": {
+    "onStartup": true
+  },
+  "contracts": {
+    "gatewayMethodDispatch": [
+      "authenticated-request"
+    ]
+  },
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/e2e/openclaw-host-plugin/package.json
+++ b/e2e/openclaw-host-plugin/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "octo-host-e2e",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "openclaw": {
+    "extensions": [
+      "./index.mjs"
+    ]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "type-check": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:e2e:openclaw": "node scripts/run-openclaw-card-e2e.mjs",
     "prepack": "npm run build",
     "pack:check": "npm pack --dry-run 2>&1 | tee /tmp/octo-pack.txt && grep -q 'dist/index.js' /tmp/octo-pack.txt && grep -q 'dist/setup-entry.js' /tmp/octo-pack.txt && echo '✓ dist/ included in tarball'"
   },

--- a/scripts/run-openclaw-card-e2e.mjs
+++ b/scripts/run-openclaw-card-e2e.mjs
@@ -1,0 +1,297 @@
+#!/usr/bin/env node
+
+import { execFile, spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+const repoRoot = path.resolve(fileURLToPath(new URL("..", import.meta.url)));
+const container = process.env.OCTO_E2E_CONTAINER ?? "ocprobe";
+const targetUid = process.env.OCTO_E2E_TARGET_UID?.trim() ?? "";
+const stateRoot = process.env.OCTO_E2E_STATE_ROOT ?? "/root/.openclaw-dev";
+const configPath = `${stateRoot}/openclaw.json`;
+const extensionsRoot = `${stateRoot}/extensions`;
+const octoRoot = `${extensionsRoot}/octo`;
+const companionRoot = `${extensionsRoot}/octo-host-e2e`;
+const requestRoot = "/tmp/octo-host-e2e";
+const configStatePath = "/tmp/octo-host-e2e-config-state.json";
+const gatewayLog = "/tmp/gw-openclaw-card-host-e2e.log";
+const gatewayToken = process.env.OCTO_E2E_GATEWAY_TOKEN ?? "octo-card-e2e";
+const sessionsDir = `${stateRoot}/agents/main/sessions`;
+const sessionsStore = `${sessionsDir}/sessions.json`;
+
+const CONFIG_HELPER = String.raw`
+const fs = require("node:fs");
+const mode = process.argv[1];
+const configPath = process.argv[2];
+const statePath = process.argv[3];
+const pluginId = "octo-host-e2e";
+const providerId = "octo-e2e";
+const modelRef = "octo-e2e/scripted";
+const config = JSON.parse(fs.readFileSync(configPath, "utf8"));
+config.plugins ??= {};
+config.plugins.entries ??= {};
+config.models ??= {};
+config.models.providers ??= {};
+config.agents ??= {};
+config.agents.defaults ??= {};
+config.agents.defaults.models ??= {};
+if (mode === "setup") {
+  const state = {
+    hadEntry: Object.prototype.hasOwnProperty.call(config.plugins.entries, pluginId),
+    entry: config.plugins.entries[pluginId],
+    hadAllow: Object.prototype.hasOwnProperty.call(config.plugins, "allow"),
+    allow: config.plugins.allow,
+    hadProvider: Object.prototype.hasOwnProperty.call(config.models.providers, providerId),
+    provider: config.models.providers[providerId],
+    hadAgentModel: Object.prototype.hasOwnProperty.call(config.agents.defaults.models, modelRef),
+    agentModel: config.agents.defaults.models[modelRef],
+  };
+  fs.writeFileSync(statePath, JSON.stringify(state));
+  config.plugins.entries[pluginId] = {
+    enabled: true,
+    hooks: { allowConversationAccess: true },
+  };
+  const allow = Array.isArray(config.plugins.allow) ? config.plugins.allow : [];
+  config.plugins.allow = [...new Set([...allow, pluginId])];
+  config.models.providers[providerId] = {
+    baseUrl: "http://127.0.0.1:19123/v1",
+    apiKey: "octo-host-e2e",
+    request: { allowPrivateNetwork: true },
+    models: [{ id: "scripted", name: "Octo Host E2E Scripted", api: "openai-completions" }],
+  };
+  config.agents.defaults.models[modelRef] = {};
+} else {
+  let state;
+  try { state = JSON.parse(fs.readFileSync(statePath, "utf8")); } catch { state = {}; }
+  if (state.hadEntry) config.plugins.entries[pluginId] = state.entry;
+  else delete config.plugins.entries[pluginId];
+  if (state.hadAllow) config.plugins.allow = state.allow;
+  else delete config.plugins.allow;
+  if (state.hadProvider) config.models.providers[providerId] = state.provider;
+  else delete config.models.providers[providerId];
+  if (state.hadAgentModel) config.agents.defaults.models[modelRef] = state.agentModel;
+  else delete config.agents.defaults.models[modelRef];
+  try { fs.unlinkSync(statePath); } catch {}
+}
+const tmp = configPath + ".octo-host-e2e-" + process.pid;
+fs.writeFileSync(tmp, JSON.stringify(config, null, 2) + "\n", { mode: 0o600 });
+fs.renameSync(tmp, configPath);
+`;
+
+const SESSION_CLEANUP_HELPER = String.raw`
+const fs = require("node:fs");
+const storePath = process.argv[1];
+const sessionsDir = process.argv[2];
+const prefix = "agent:main:octo-host-e2e:";
+let store;
+try { store = JSON.parse(fs.readFileSync(storePath, "utf8")); } catch { process.exit(0); }
+const removedKeys = new Set(Object.keys(store).filter((key) => key.startsWith(prefix)));
+let changed = true;
+while (changed) {
+  changed = false;
+  for (const [key, entry] of Object.entries(store)) {
+    if (removedKeys.has(key)) continue;
+    const parents = [entry?.spawnedBy, entry?.spawnedByKey, entry?.requesterSessionKey,
+      entry?.parentSessionKey, entry?.completionOwnerKey];
+    if (parents.some((parent) => typeof parent === "string" && removedKeys.has(parent))) {
+      removedKeys.add(key);
+      changed = true;
+    }
+  }
+}
+const sessionIds = [];
+for (const key of removedKeys) {
+  const id = store[key]?.sessionId;
+  if (typeof id === "string" && id) sessionIds.push(id);
+  delete store[key];
+}
+if (removedKeys.size > 0) {
+  const tmp = storePath + ".octo-host-e2e-" + process.pid;
+  fs.writeFileSync(tmp, JSON.stringify(store, null, 2) + "\n", { mode: 0o600 });
+  fs.renameSync(tmp, storePath);
+}
+let names = [];
+try { names = fs.readdirSync(sessionsDir); } catch {}
+for (const name of names) {
+  if (!name.endsWith(".trajectory.jsonl")) continue;
+  try {
+    const content = fs.readFileSync(sessionsDir + "/" + name, "utf8");
+    if (content.includes("agent:main:subagent:") && content.includes("octo-host-e2e")) {
+      sessionIds.push(name.slice(0, -".trajectory.jsonl".length));
+    }
+  } catch {}
+}
+for (const id of sessionIds) {
+  for (const name of names) {
+    if (name.startsWith(id + ".")) fs.rmSync(sessionsDir + "/" + name, { force: true });
+  }
+}
+process.stdout.write(String(removedKeys.size));
+`;
+
+function info(message) {
+  process.stdout.write(`[openclaw-e2e] ${message}\n`);
+}
+
+async function run(file, args, options = {}) {
+  return await execFileAsync(file, args, {
+    cwd: repoRoot,
+    timeout: options.timeout ?? 120_000,
+    maxBuffer: 8 * 1024 * 1024,
+    env: options.env ?? process.env,
+  });
+}
+
+async function runStreaming(file, args, options = {}) {
+  await new Promise((resolve, reject) => {
+    const child = spawn(file, args, {
+      cwd: repoRoot,
+      env: options.env ?? process.env,
+      stdio: "inherit",
+    });
+    child.once("error", reject);
+    child.once("exit", (code, signal) => {
+      if (code === 0) resolve();
+      else reject(new Error(`${file} exited with ${signal ?? code}`));
+    });
+  });
+}
+
+async function docker(args, options) {
+  return await run("docker", args, options);
+}
+
+async function mutateConfig(mode) {
+  await docker([
+    "exec", container, "node", "-e", CONFIG_HELPER,
+    mode, configPath, configStatePath,
+  ]);
+}
+
+async function removeContainerPaths(paths) {
+  const script = "const fs=require('node:fs');for(const p of process.argv.slice(1))fs.rmSync(p,{recursive:true,force:true})";
+  await docker(["exec", container, "node", "-e", script, ...paths]);
+}
+
+async function cleanupE2ESessions() {
+  const { stdout } = await docker([
+    "exec", container, "node", "-e", SESSION_CLEANUP_HELPER,
+    sessionsStore, sessionsDir,
+  ]);
+  info(`removed ${stdout.trim() || "0"} prior E2E session(s)`);
+}
+
+async function stopGateway() {
+  await docker([
+    "exec", container, "sh", "-lc",
+    "pkill -TERM -x openclaw 2>/dev/null || true",
+  ]);
+  await new Promise((resolve) => setTimeout(resolve, 500));
+}
+
+async function startGateway(debug) {
+  await docker([
+    "exec", container, "node", "-e",
+    "require('node:fs').writeFileSync(process.argv[1], '')", gatewayLog,
+  ]);
+  const envArgs = ["-e", `OPENCLAW_GATEWAY_TOKEN=${gatewayToken}`];
+  if (debug) envArgs.push("-e", "OCTO_CARD_DEBUG=1");
+  await docker([
+    "exec", "-d", ...envArgs, container,
+    "sh", "-lc",
+    `openclaw --dev gateway run --allow-unconfigured >> ${gatewayLog} 2>&1`,
+  ]);
+
+  const deadline = Date.now() + 30_000;
+  while (Date.now() < deadline) {
+    try {
+      await docker([
+        "exec", container, "node", "-e",
+        "const fs=require('node:fs');const p=process.argv[1];if(!fs.existsSync(p)||!fs.readFileSync(p,'utf8').includes('[gateway] ready'))process.exit(2)",
+        gatewayLog,
+      ], { timeout: 5_000 });
+      return;
+    } catch {
+      await new Promise((resolve) => setTimeout(resolve, 500));
+    }
+  }
+  const { stdout = "" } = await docker([
+    "exec", container, "node", "-e",
+    "const fs=require('node:fs');const p=process.argv[1];if(fs.existsSync(p))process.stdout.write(fs.readFileSync(p,'utf8').slice(-8000))",
+    gatewayLog,
+  ]).catch(() => ({ stdout: "" }));
+  throw new Error(`gateway did not become ready within 30s\n${stdout}`);
+}
+
+async function installCurrentBuildAndCompanion() {
+  await removeContainerPaths([`${octoRoot}/dist`, companionRoot, requestRoot]);
+  await docker(["exec", container, "mkdir", "-p", `${octoRoot}/dist`, companionRoot, requestRoot]);
+  await docker(["cp", `${repoRoot}/dist/.`, `${container}:${octoRoot}/dist/`]);
+  await docker(["cp", `${repoRoot}/e2e/openclaw-host-plugin/.`, `${container}:${companionRoot}/`]);
+  await docker(["exec", container, "chown", "-R", "root:root", `${octoRoot}/dist`, companionRoot, requestRoot]);
+}
+
+async function cleanup(configured) {
+  info("cleaning companion plugin and restoring config");
+  await stopGateway();
+  await cleanupE2ESessions();
+  if (configured) await mutateConfig("cleanup");
+  await removeContainerPaths([companionRoot, requestRoot]);
+  await startGateway(false);
+}
+
+async function main() {
+  if (!targetUid) {
+    throw new Error("OCTO_E2E_TARGET_UID is required (the Octo DM user that receives test cards)");
+  }
+
+  info(`checking container ${container}`);
+  await docker(["inspect", container], { timeout: 10_000 });
+  info("building current checkout");
+  await runStreaming("npm", ["run", "build"]);
+
+  let configured = false;
+  let preparationStarted = false;
+  let failure;
+  try {
+    preparationStarted = true;
+    await stopGateway();
+    await cleanupE2ESessions();
+    await mutateConfig("setup");
+    configured = true;
+    await installCurrentBuildAndCompanion();
+    info("restarting real OpenClaw gateway with card lifecycle diagnostics");
+    await startGateway(true);
+    info("running Octo inbound -> spawn -> yield -> follow-up -> completion E2E");
+    await runStreaming("npx", [
+      "vitest", "run", "src/card-openclaw-e2e.test.ts", "--reporter=verbose",
+    ], {
+      env: {
+        ...process.env,
+        OCTO_OPENCLAW_E2E: "1",
+        OCTO_E2E_CONTAINER: container,
+        OCTO_E2E_TARGET_UID: targetUid,
+      },
+    });
+  } catch (error) {
+    failure = error;
+  }
+
+  if (preparationStarted) {
+    try {
+      await cleanup(configured);
+    } catch (cleanupError) {
+      if (!failure) throw cleanupError;
+      process.stderr.write(`[openclaw-e2e] cleanup failed: ${cleanupError}\n`);
+    }
+  }
+  if (failure) throw failure;
+  info("GREEN; companion removed and gateway restarted cleanly");
+}
+
+main().catch((error) => {
+  process.stderr.write(`[openclaw-e2e] ${error instanceof Error ? error.stack : String(error)}\n`);
+  process.exitCode = 1;
+});

--- a/src/card-openclaw-e2e.test.ts
+++ b/src/card-openclaw-e2e.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Real OpenClaw host E2E (container + real Octo server), explicitly gated.
+ *
+ * The companion plugin under e2e/openclaw-host-plugin injects a synthetic
+ * Octo DM into handleInboundMessage. A loopback scripted model makes tool
+ * choices deterministic; OpenClaw tool/subagent execution, sessions_yield,
+ * protected completion, lifecycle hooks, and Octo send/edit HTTP calls are real.
+ *
+ * Required setup is automated by scripts/run-openclaw-card-e2e.mjs.
+ */
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { randomUUID } from "node:crypto";
+import { describe, expect, it } from "vitest";
+
+const execFileAsync = promisify(execFile);
+const enabled = process.env.OCTO_OPENCLAW_E2E === "1";
+const suite = enabled ? describe : describe.skip;
+
+type Evidence = {
+  transcriptFile?: string;
+  toolCalls: Array<{ name?: string; arguments?: Record<string, unknown> }>;
+  completionEvent: boolean;
+  childExec: boolean;
+  followupReply: boolean;
+  parentReply: boolean;
+  phases: string[];
+  cards: Array<{
+    messageId: string;
+    timestampMs: number;
+    plain: string;
+    plainSource?: "original-message" | "accepted-edit";
+  }>;
+};
+
+const container = process.env.OCTO_E2E_CONTAINER ?? "ocprobe";
+const targetUid = process.env.OCTO_E2E_TARGET_UID ?? "";
+
+async function dockerExec(args: string[], timeout = 120_000): Promise<string> {
+  const { stdout } = await execFileAsync("docker", ["exec", ...args], {
+    timeout,
+    maxBuffer: 4 * 1024 * 1024,
+  });
+  return stdout;
+}
+
+async function callBridge(params: Record<string, unknown>): Promise<void> {
+  const requestId = `${String(params.kind)}-${String(params.marker)}`;
+  const requestPath = `/tmp/octo-host-e2e/${requestId}.request.json`;
+  const resultPath = `/tmp/octo-host-e2e/${requestId}.result.json`;
+  const encoded = Buffer.from(JSON.stringify(params)).toString("base64");
+  await dockerExec([
+    container,
+    "node", "-e",
+    "const fs=require('fs');const p=process.argv[1];fs.mkdirSync('/tmp/octo-host-e2e',{recursive:true});fs.writeFileSync(p+'.tmp',Buffer.from(process.argv[2],'base64'));fs.renameSync(p+'.tmp',p)",
+    requestPath,
+    encoded,
+  ]);
+  const deadline = Date.now() + 120_000;
+  while (Date.now() < deadline) {
+    let output: string;
+    try {
+      output = await dockerExec([
+        container,
+        "node", "-e",
+        "const fs=require('fs');const p=process.argv[1];if(!fs.existsSync(p))process.exit(2);process.stdout.write(fs.readFileSync(p,'utf8'))",
+        resultPath,
+      ]);
+    } catch {
+      await new Promise((resolve) => setTimeout(resolve, 500));
+      continue;
+    }
+    const result = JSON.parse(output) as { ok?: boolean; sessionKey?: string; error?: string };
+    expect(result.ok, result.error).toBe(true);
+    expect(result.sessionKey).toBe(params.sessionKey);
+    return;
+  }
+  throw new Error(`bridge request timed out: ${requestId}`);
+}
+
+async function inspect(marker: string, sessionKey: string, startedAtMs: number): Promise<Evidence> {
+  const output = await dockerExec([
+    container,
+    "node", "/root/.openclaw-dev/extensions/octo-host-e2e/inspect.mjs",
+    marker, sessionKey, targetUid, String(startedAtMs),
+  ], 30_000);
+  return JSON.parse(output) as Evidence;
+}
+
+async function waitForEvidence(
+  marker: string,
+  sessionKey: string,
+  startedAtMs: number,
+  predicate: (evidence: Evidence) => boolean,
+  timeoutMs: number,
+): Promise<Evidence> {
+  const deadline = Date.now() + timeoutMs;
+  let latest: Evidence | undefined;
+  while (Date.now() < deadline) {
+    latest = await inspect(marker, sessionKey, startedAtMs);
+    if (predicate(latest)) return latest;
+    await new Promise((resolve) => setTimeout(resolve, 1_000));
+  }
+  throw new Error(`OpenClaw E2E timed out; latest evidence=${JSON.stringify(latest)}`);
+}
+
+type LifecycleFlowOptions = {
+  childDelaySeconds: number;
+  pausedCheckpointDelayMs?: number;
+};
+
+async function runLifecycleFlow({
+  childDelaySeconds,
+  pausedCheckpointDelayMs,
+}: LifecycleFlowOptions): Promise<void> {
+  expect(targetUid, "OCTO_E2E_TARGET_UID is required").not.toBe("");
+  const marker = randomUUID();
+  const sessionKey = `agent:main:octo-host-e2e:${marker}`;
+  const startedAtMs = Date.now();
+
+  await callBridge({
+    kind: "spawn",
+    marker,
+    targetUid,
+    sessionKey,
+    // The child performs a foreground exec with a longer yield/timeout,
+    // leaving enough room for the unrelated follow-up before completion.
+    childDelaySeconds,
+  });
+
+  const paused = await waitForEvidence(
+    marker,
+    sessionKey,
+    startedAtMs,
+    (evidence) => evidence.phases.includes("paused") && evidence.cards.length === 1,
+    60_000,
+  );
+  expect(paused.cards).toHaveLength(1);
+
+  // A normal user run starts on the same session while the child is still
+  // sleeping. It must not claim or finish the retained background-task card.
+  await callBridge({ kind: "followup", marker, targetUid, sessionKey });
+  const afterFollowup = await waitForEvidence(
+    marker,
+    sessionKey,
+    startedAtMs,
+    (evidence) => evidence.followupReply,
+    15_000,
+  );
+  expect(afterFollowup.followupReply).toBe(true);
+  expect(afterFollowup.completionEvent).toBe(false);
+  expect(afterFollowup.phases).toEqual(["paused"]);
+  expect(afterFollowup.cards).toHaveLength(1);
+  expect(afterFollowup.cards[0]?.messageId).toBe(paused.cards[0]?.messageId);
+
+  if (pausedCheckpointDelayMs !== undefined) {
+    await new Promise((resolve) => setTimeout(resolve, pausedCheckpointDelayMs));
+    const checkpoint = await inspect(marker, sessionKey, startedAtMs);
+    expect(checkpoint.completionEvent).toBe(false);
+    expect(checkpoint.phases).toEqual(["paused"]);
+    expect(checkpoint.cards).toHaveLength(1);
+    expect(checkpoint.cards[0]?.messageId).toBe(paused.cards[0]?.messageId);
+    expect(checkpoint.cards[0]?.plainSource).toBe("accepted-edit");
+    expect(checkpoint.cards[0]?.plain).toContain("⏳ 等待子任务");
+  }
+
+  const completed = await waitForEvidence(
+    marker,
+    sessionKey,
+    startedAtMs,
+    (evidence) => evidence.completionEvent && evidence.parentReply &&
+      evidence.phases.includes("resuming") && evidence.phases.includes("done") &&
+      evidence.cards.length === 1,
+    120_000,
+  );
+
+  const names = completed.toolCalls.map((call) => call.name);
+  expect(names.filter((name) => name === "sessions_spawn")).toHaveLength(1);
+  expect(names.filter((name) => name === "sessions_yield")).toHaveLength(1);
+  expect(names).not.toContain("sessions_list");
+  expect(names).not.toContain("sessions_history");
+  const spawn = completed.toolCalls.find((call) => call.name === "sessions_spawn");
+  expect(spawn?.arguments).toMatchObject({
+    runtime: "subagent",
+    mode: "run",
+    context: "isolated",
+    model: "octo-e2e/scripted",
+  });
+  expect(completed.cards).toHaveLength(1);
+  expect(completed.cards[0]?.messageId).toBe(paused.cards[0]?.messageId);
+  if (pausedCheckpointDelayMs !== undefined) {
+    expect(completed.cards[0]?.plainSource).toBe("accepted-edit");
+    const waitDuration = completed.cards[0]?.plain.match(/等待子任务 · ([\d.]+)s/)?.[1];
+    expect(waitDuration, completed.cards[0]?.plain).toBeDefined();
+    expect(Number(waitDuration)).toBeGreaterThanOrEqual(pausedCheckpointDelayMs / 1_000);
+  }
+  expect(completed.phases).toEqual(["paused", "resuming", "done"]);
+  expect(completed.childExec).toBe(true);
+}
+
+suite("OpenClaw sessions_spawn + sessions_yield card lifecycle E2E", () => {
+  it("keeps the paused card through an unrelated run, then resumes and completes it", async () => {
+    await runLifecycleFlow({
+      childDelaySeconds: 10,
+    });
+  }, 210_000);
+
+  it("keeps the same paused card while a subagent runs longer than one minute", async () => {
+    await runLifecycleFlow({
+      childDelaySeconds: 75,
+      pausedCheckpointDelayMs: 60_000,
+    });
+  }, 240_000);
+});

--- a/src/card-progress.test.ts
+++ b/src/card-progress.test.ts
@@ -10,12 +10,58 @@ import {
   _resetCardProgressForTests,
 } from "./card-progress.js";
 
-/** 收集 registerCardProgress 注册的 hook handler。 */
-function makeApi(): { handlers: Record<string, (e: unknown, c: unknown) => unknown> } {
+type AgentEvent = {
+  runId: string;
+  sessionKey?: string;
+  stream: string;
+  data: Record<string, unknown>;
+};
+
+/** 收集 registerCardProgress 注册的 hook 与 lifecycle handler。 */
+function makeApi(opts: { lifecycle?: boolean } = {}): {
+  handlers: Record<string, (e: unknown, c: unknown) => unknown>;
+  emitLifecycle: (event: AgentEvent) => Promise<void>;
+} {
   const handlers: Record<string, (e: unknown, c: unknown) => unknown> = {};
-  const api = { on: (name: string, fn: (e: unknown, c: unknown) => unknown) => { handlers[name] = fn; } };
+  let lifecycleHandler: ((event: AgentEvent) => void | Promise<void>) | undefined;
+  const api: Record<string, unknown> = {
+    on: (name: string, fn: (e: unknown, c: unknown) => unknown) => { handlers[name] = fn; },
+  };
+  if (opts.lifecycle !== false) {
+    api.agent = {
+      events: {
+        registerAgentEventSubscription: (subscription: {
+          streams?: string[];
+          handle: (event: AgentEvent) => void | Promise<void>;
+        }) => {
+          expect(subscription.streams).toEqual(["lifecycle"]);
+          lifecycleHandler = subscription.handle;
+        },
+      },
+    };
+  }
   registerCardProgress(api as never);
-  return { handlers };
+  return {
+    handlers,
+    emitLifecycle: async (event) => {
+      expect(lifecycleHandler).toBeTypeOf("function");
+      await lifecycleHandler!(event);
+    },
+  };
+}
+
+function completionPrompt(childSessionKey: string): string {
+  return [
+    "<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>",
+    "OpenClaw runtime context (internal):",
+    "This context is runtime-generated, not user-authored. Keep internal details private.",
+    "",
+    "[Internal task completion event]",
+    "source: subagent",
+    `session_key: ${childSessionKey}`,
+    "status: completed",
+    "<<<END_OPENCLAW_INTERNAL_CONTEXT>>>",
+  ].join("\n");
 }
 
 /** mock fetch,按 url 分派 getCardProfile / sendMessage / message-edit,记录请求。 */
@@ -242,6 +288,418 @@ describe("card-progress 状态机 + hook + 节流", () => {
     const env = JSON.parse(edit!.body!.content_edit as string);
     expect(progressHeaderText(env.card)).toContain("✅ 已完成");
     expect(env.transient).toBeUndefined(); // 终态帧进修订历史(不带 transient)
+  });
+
+  it("sessions_yield 成功后显示等待任务结果,而不是已中断", async () => {
+    const { fn, calls } = mockFetch();
+    global.fetch = fn as unknown as typeof fetch;
+    const { handlers } = makeApi();
+    setCardContext("yield-fallback", {
+      apiUrl: "https://yield.test",
+      botToken: "bf",
+      channelId: "g1",
+      channelType: ChannelType.Group,
+    });
+    handlers.before_agent_run({}, { sessionKey: "yield-fallback", runId: "run-a" });
+    handlers.before_tool_call(
+      { toolName: "sessions_yield", toolCallId: "yield-1" },
+      { sessionKey: "yield-fallback", runId: "run-a" },
+    );
+    await vi.advanceTimersByTimeAsync(900);
+    handlers.after_tool_call(
+      { toolName: "sessions_yield", toolCallId: "yield-1", durationMs: 20 },
+      { sessionKey: "yield-fallback", runId: "run-a" },
+    );
+    calls.length = 0;
+
+    await finalizeCard("yield-fallback", { success: false });
+
+    const edit = calls.find((call) => call.url.includes("/message/edit"));
+    expect(edit).toBeTruthy();
+    const env = JSON.parse(edit!.body!.content_edit as string);
+    expect(progressHeaderText(env.card)).toContain("⏸️ 等待任务结果");
+    expect(progressHeaderText(env.card)).not.toContain("已中断");
+  });
+
+  it("yielded lifecycle 后保留原卡,后续 run 开始时整理、结束时完成", async () => {
+    const { fn, calls } = mockFetch();
+    global.fetch = fn as unknown as typeof fetch;
+    const { handlers, emitLifecycle } = makeApi();
+    setCardContext("yield-lifecycle", {
+      apiUrl: "https://yield-lifecycle.test",
+      botToken: "bf",
+      channelId: "g1",
+      channelType: ChannelType.Group,
+    });
+    handlers.before_agent_run({}, { sessionKey: "yield-lifecycle", runId: "run-a" });
+    handlers.before_tool_call(
+      { toolName: "sessions_spawn", toolCallId: "spawn-1" },
+      { sessionKey: "yield-lifecycle", runId: "run-a" },
+    );
+    handlers.after_tool_call(
+      {
+        toolName: "sessions_spawn",
+        toolCallId: "spawn-1",
+        durationMs: 30,
+        result: {
+          content: [{ type: "text", text: '{"status":"accepted","childSessionKey":"agent:main:subagent:child-1","runId":"child-run-1"}' }],
+        },
+      },
+      { sessionKey: "yield-lifecycle", runId: "run-a" },
+    );
+    await vi.advanceTimersByTimeAsync(900);
+    calls.length = 0;
+
+    await emitLifecycle({
+      runId: "run-a",
+      sessionKey: "yield-lifecycle",
+      stream: "lifecycle",
+      data: { phase: "end", yielded: true, livenessState: "paused" },
+    });
+    await finalizeCard("yield-lifecycle", { success: false });
+    const pausedEdit = calls.find((call) => {
+      if (!call.url.includes("/message/edit")) return false;
+      const env = JSON.parse(call.body!.content_edit as string);
+      return progressHeaderText(env.card).includes("⏸️ 等待任务结果");
+    });
+    expect(pausedEdit).toBeTruthy();
+    expect(progressCardText(JSON.parse(pausedEdit!.body!.content_edit as string).card))
+      .toContain("⏳ 等待子任务");
+
+    await vi.advanceTimersByTimeAsync(65_000);
+
+    calls.length = 0;
+    await emitLifecycle({
+      runId: "run-b",
+      sessionKey: "yield-lifecycle",
+      stream: "lifecycle",
+      data: { phase: "start" },
+    });
+    handlers.before_agent_run(
+      { prompt: completionPrompt("agent:main:subagent:child-1"), messages: [] },
+      { sessionKey: "yield-lifecycle", runId: "run-b" },
+    );
+    await vi.runAllTicks();
+    const resumingEdit = calls.find((call) => {
+      if (!call.url.includes("/message/edit")) return false;
+      const env = JSON.parse(call.body!.content_edit as string);
+      return progressHeaderText(env.card).includes("🤖 正在整理结果");
+    });
+    expect(resumingEdit).toBeTruthy();
+    expect(progressCardText(JSON.parse(resumingEdit!.body!.content_edit as string).card))
+      .toContain("⏸️ 等待子任务 · 65.0s");
+
+    calls.length = 0;
+    await emitLifecycle({
+      runId: "run-b",
+      sessionKey: "yield-lifecycle",
+      stream: "lifecycle",
+      data: { phase: "end" },
+    });
+    const completed = calls.find((call) => call.url.includes("/message/edit"));
+    expect(completed).toBeTruthy();
+    const completedEnv = JSON.parse(completed!.body!.content_edit as string);
+    expect(progressHeaderText(completedEnv.card)).toContain("✅ 已完成");
+  });
+
+  it("无关用户 run 不得劫持 paused 卡,真正 completion run 仍可继续更新", async () => {
+    const { fn, calls } = mockFetch();
+    global.fetch = fn as unknown as typeof fetch;
+    const { handlers, emitLifecycle } = makeApi();
+    const childSessionKey = "agent:main:subagent:child-unrelated";
+    const target = {
+      apiUrl: "https://yield-unrelated.test",
+      botToken: "bf",
+      channelId: "g1",
+      channelType: ChannelType.Group,
+    };
+
+    setCardContext("yield-unrelated", target);
+    handlers.before_agent_run({}, { sessionKey: "yield-unrelated", runId: "run-a" });
+    handlers.before_tool_call(
+      { toolName: "sessions_spawn", toolCallId: "spawn-1" },
+      { sessionKey: "yield-unrelated", runId: "run-a" },
+    );
+    handlers.after_tool_call(
+      {
+        toolName: "sessions_spawn",
+        toolCallId: "spawn-1",
+        result: { details: { status: "accepted", childSessionKey, runId: "child-run" } },
+      },
+      { sessionKey: "yield-unrelated", runId: "run-a" },
+    );
+    handlers.before_tool_call(
+      { toolName: "sessions_yield", toolCallId: "yield-1" },
+      { sessionKey: "yield-unrelated", runId: "run-a" },
+    );
+    handlers.after_tool_call(
+      { toolName: "sessions_yield", toolCallId: "yield-1" },
+      { sessionKey: "yield-unrelated", runId: "run-a" },
+    );
+    await vi.advanceTimersByTimeAsync(900);
+    await finalizeCard("yield-unrelated", { success: false });
+
+    calls.length = 0;
+    setCardContext("yield-unrelated", target);
+    await emitLifecycle({
+      runId: "run-user",
+      sessionKey: "yield-unrelated",
+      stream: "lifecycle",
+      data: { phase: "start" },
+    });
+    handlers.before_agent_run(
+      { prompt: "用户在等待期间发来的普通追问", messages: [] },
+      { sessionKey: "yield-unrelated", runId: "run-user" },
+    );
+    await emitLifecycle({
+      runId: "run-user",
+      sessionKey: "yield-unrelated",
+      stream: "lifecycle",
+      data: { phase: "end" },
+    });
+    expect(calls.some((call) => call.url.includes("/message/edit"))).toBe(false);
+
+    await emitLifecycle({
+      runId: "run-continuation",
+      sessionKey: "yield-unrelated",
+      stream: "lifecycle",
+      data: { phase: "start" },
+    });
+    handlers.before_agent_run(
+      { prompt: completionPrompt(childSessionKey), messages: [] },
+      { sessionKey: "yield-unrelated", runId: "run-continuation" },
+    );
+    await vi.runAllTicks();
+    expect(calls.some((call) => {
+      if (!call.url.includes("/message/edit")) return false;
+      const env = JSON.parse(call.body!.content_edit as string);
+      return progressHeaderText(env.card).includes("🤖 正在整理结果");
+    })).toBe(true);
+
+    calls.length = 0;
+    await emitLifecycle({
+      runId: "run-continuation",
+      sessionKey: "yield-unrelated",
+      stream: "lifecycle",
+      data: { phase: "end" },
+    });
+    const finalEdit = calls.find((call) => call.url.includes("/message/edit"));
+    expect(finalEdit).toBeTruthy();
+    expect(progressHeaderText(JSON.parse(finalEdit!.body!.content_edit as string).card)).toContain("✅ 已完成");
+  });
+
+  it("乱序 start/end 编辑必须串行,最终不能被迟到的 resuming 覆盖", async () => {
+    const calls: Array<{ url: string; body: Record<string, unknown> | undefined }> = [];
+    const appliedHeaders: string[] = [];
+    const resumingReached = makeDeferred();
+    const releaseResuming = makeDeferred();
+    global.fetch = vi.fn().mockImplementation(async (url: string, init?: { body?: string }) => {
+      const body = init?.body ? JSON.parse(init.body) : undefined;
+      calls.push({ url: String(url), body });
+      if (String(url).includes("/card/profile")) {
+        return { ok: true, status: 200, json: async () => ({ enabled: true, profiles: ["octo/v1"] }) };
+      }
+      if (String(url).includes("/sendMessage")) {
+        return { ok: true, status: 200, text: async () => JSON.stringify({ message_id: "race-card" }) };
+      }
+      if (String(url).includes("/message/edit")) {
+        const env = JSON.parse(body.content_edit as string);
+        const header = progressHeaderText(env.card);
+        if (header.includes("正在整理结果")) {
+          resumingReached.resolve();
+          await releaseResuming.promise;
+        }
+        appliedHeaders.push(header);
+      }
+      return { ok: true, status: 200, text: async () => "" };
+    }) as unknown as typeof fetch;
+
+    const { handlers, emitLifecycle } = makeApi();
+    const childSessionKey = "agent:main:subagent:child-race";
+    setCardContext("yield-race", {
+      apiUrl: "https://yield-race.test",
+      botToken: "bf",
+      channelId: "g1",
+      channelType: ChannelType.Group,
+    });
+    handlers.before_agent_run({}, { sessionKey: "yield-race", runId: "run-a" });
+    handlers.before_tool_call({ toolName: "sessions_spawn", toolCallId: "spawn-1" }, { sessionKey: "yield-race", runId: "run-a" });
+    handlers.after_tool_call(
+      { toolName: "sessions_spawn", toolCallId: "spawn-1", result: { details: { status: "accepted", childSessionKey, runId: "child-run" } } },
+      { sessionKey: "yield-race", runId: "run-a" },
+    );
+    handlers.before_tool_call({ toolName: "sessions_yield", toolCallId: "yield-1" }, { sessionKey: "yield-race", runId: "run-a" });
+    handlers.after_tool_call({ toolName: "sessions_yield", toolCallId: "yield-1" }, { sessionKey: "yield-race", runId: "run-a" });
+    await vi.advanceTimersByTimeAsync(900);
+    await finalizeCard("yield-race", { success: false });
+    calls.length = 0;
+
+    const startEvent = emitLifecycle({
+      runId: "run-b",
+      sessionKey: "yield-race",
+      stream: "lifecycle",
+      data: { phase: "start" },
+    });
+    handlers.before_agent_run(
+      { prompt: completionPrompt(childSessionKey), messages: [] },
+      { sessionKey: "yield-race", runId: "run-b" },
+    );
+    await resumingReached.promise;
+    const endEvent = emitLifecycle({
+      runId: "run-b",
+      sessionKey: "yield-race",
+      stream: "lifecycle",
+      data: { phase: "end" },
+    });
+    await vi.runAllTicks();
+    releaseResuming.resolve();
+    await Promise.all([startEvent, endEvent]);
+
+    expect(appliedHeaders.length).toBeGreaterThanOrEqual(2);
+    expect(appliedHeaders.at(-1)).toContain("✅ 已完成");
+  });
+
+  it("旧 host 无 lifecycle API 时仍可由受信 completion prompt + agent_end 完成卡片", async () => {
+    const { fn, calls } = mockFetch();
+    global.fetch = fn as unknown as typeof fetch;
+    const { handlers } = makeApi({ lifecycle: false });
+    const childSessionKey = "agent:main:subagent:child-legacy";
+    setCardContext("yield-legacy", {
+      apiUrl: "https://yield-legacy.test",
+      botToken: "bf",
+      channelId: "g1",
+      channelType: ChannelType.Group,
+    });
+    handlers.before_agent_run({}, { sessionKey: "yield-legacy", runId: "run-a" });
+    handlers.before_tool_call({ toolName: "sessions_spawn", toolCallId: "spawn-1" }, { sessionKey: "yield-legacy", runId: "run-a" });
+    handlers.after_tool_call(
+      { toolName: "sessions_spawn", toolCallId: "spawn-1", result: { details: { status: "accepted", childSessionKey, runId: "child-run" } } },
+      { sessionKey: "yield-legacy", runId: "run-a" },
+    );
+    handlers.before_tool_call({ toolName: "sessions_yield", toolCallId: "yield-1" }, { sessionKey: "yield-legacy", runId: "run-a" });
+    handlers.after_tool_call({ toolName: "sessions_yield", toolCallId: "yield-1" }, { sessionKey: "yield-legacy", runId: "run-a" });
+    await vi.advanceTimersByTimeAsync(900);
+    await finalizeCard("yield-legacy", { success: false });
+    calls.length = 0;
+
+    handlers.before_agent_run(
+      { prompt: completionPrompt(childSessionKey), messages: [] },
+      { sessionKey: "yield-legacy", runId: "run-b" },
+    );
+    await vi.runAllTicks();
+    await handlers.agent_end(
+      { runId: "run-b", messages: [], success: true },
+      { sessionKey: "yield-legacy", runId: "run-b" },
+    );
+
+    const edits = calls.filter((call) => call.url.includes("/message/edit"));
+    const lastEnv = JSON.parse(edits.at(-1)!.body!.content_edit as string);
+    expect(progressHeaderText(lastEnv.card)).toContain("✅ 已完成");
+  });
+
+  it("无 continuation 的 paused 卡到期后显示等待超时并释放追踪", async () => {
+    const { fn, calls } = mockFetch();
+    global.fetch = fn as unknown as typeof fetch;
+    const { handlers } = makeApi({ lifecycle: false });
+    setCardContext("yield-expire", {
+      apiUrl: "https://yield-expire.test",
+      botToken: "bf",
+      channelId: "g1",
+      channelType: ChannelType.Group,
+    });
+    handlers.before_agent_run({}, { sessionKey: "yield-expire", runId: "run-a" });
+    handlers.before_tool_call({ toolName: "sessions_yield", toolCallId: "yield-1" }, { sessionKey: "yield-expire", runId: "run-a" });
+    handlers.after_tool_call({ toolName: "sessions_yield", toolCallId: "yield-1" }, { sessionKey: "yield-expire", runId: "run-a" });
+    await vi.advanceTimersByTimeAsync(900);
+    await finalizeCard("yield-expire", { success: false });
+    calls.length = 0;
+
+    await vi.advanceTimersByTimeAsync(3_600_100);
+
+    const edit = calls.find((call) => call.url.includes("/message/edit"));
+    expect(edit).toBeTruthy();
+    const env = JSON.parse(edit!.body!.content_edit as string);
+    expect(progressHeaderText(env.card)).toContain("⏱️ 等待超时");
+  });
+
+  it("paused 窗口的跨身份同 sessionKey 碰撞必须 fail-closed", async () => {
+    const { fn, calls } = mockFetch();
+    global.fetch = fn as unknown as typeof fetch;
+    const { handlers, emitLifecycle } = makeApi();
+    const childSessionKey = "agent:main:subagent:child-collision";
+    setCardContext("yield-collision", {
+      apiUrl: "https://yield-collision.test",
+      botToken: "bot-a",
+      channelId: "group-a",
+      channelType: ChannelType.Group,
+    });
+    handlers.before_agent_run({}, { sessionKey: "yield-collision", runId: "run-a" });
+    handlers.before_tool_call({ toolName: "sessions_spawn", toolCallId: "spawn-1" }, { sessionKey: "yield-collision", runId: "run-a" });
+    handlers.after_tool_call(
+      { toolName: "sessions_spawn", toolCallId: "spawn-1", result: { details: { status: "accepted", childSessionKey, runId: "child-run" } } },
+      { sessionKey: "yield-collision", runId: "run-a" },
+    );
+    handlers.before_tool_call({ toolName: "sessions_yield", toolCallId: "yield-1" }, { sessionKey: "yield-collision", runId: "run-a" });
+    handlers.after_tool_call({ toolName: "sessions_yield", toolCallId: "yield-1" }, { sessionKey: "yield-collision", runId: "run-a" });
+    await vi.advanceTimersByTimeAsync(900);
+    await finalizeCard("yield-collision", { success: false });
+    calls.length = 0;
+
+    setCardContext("yield-collision", {
+      apiUrl: "https://yield-collision.test",
+      botToken: "bot-b",
+      channelId: "group-b",
+      channelType: ChannelType.Group,
+    });
+    await emitLifecycle({
+      runId: "run-b",
+      sessionKey: "yield-collision",
+      stream: "lifecycle",
+      data: { phase: "start" },
+    });
+    handlers.before_agent_run(
+      { prompt: completionPrompt(childSessionKey), messages: [] },
+      { sessionKey: "yield-collision", runId: "run-b" },
+    );
+    await emitLifecycle({
+      runId: "run-b",
+      sessionKey: "yield-collision",
+      stream: "lifecycle",
+      data: { phase: "end" },
+    });
+
+    expect(calls.some((call) => call.url.includes("/message/edit"))).toBe(false);
+  });
+
+  it("失败的 sessions_yield 不进入等待状态", async () => {
+    const { fn, calls } = mockFetch();
+    global.fetch = fn as unknown as typeof fetch;
+    const { handlers } = makeApi();
+    setCardContext("yield-error", {
+      apiUrl: "https://yield-error.test",
+      botToken: "bf",
+      channelId: "g1",
+      channelType: ChannelType.Group,
+    });
+    handlers.before_agent_run({}, { sessionKey: "yield-error", runId: "run-a" });
+    handlers.before_tool_call(
+      { toolName: "sessions_yield", toolCallId: "yield-1" },
+      { sessionKey: "yield-error", runId: "run-a" },
+    );
+    await vi.advanceTimersByTimeAsync(900);
+    handlers.after_tool_call(
+      { toolName: "sessions_yield", toolCallId: "yield-1", error: "yield failed" },
+      { sessionKey: "yield-error", runId: "run-a" },
+    );
+    calls.length = 0;
+
+    await finalizeCard("yield-error", { success: false });
+
+    const edit = calls.find((call) => call.url.includes("/message/edit"));
+    expect(edit).toBeTruthy();
+    const env = JSON.parse(edit!.body!.content_edit as string);
+    expect(progressHeaderText(env.card)).toContain("已中断");
+    expect(progressHeaderText(env.card)).not.toContain("等待任务结果");
   });
 
   it("finalizeCard 未发过占位卡 → 仅清理不发", async () => {

--- a/src/card-progress.ts
+++ b/src/card-progress.ts
@@ -6,6 +6,7 @@
  *     (apiUrl/botToken/channel/onBehalfOf),`finally` 里 `finalizeCard(sessionKey, success)`。
  *   - 本模块订阅 hook(before/after_tool_call、model_call_started),用 `ctx.sessionKey`
  *     查 Map:首个工具事件懒发占位卡 → 后续就地 `editCardMessage`,节流合帧。
+ *   - sessions_yield 将已发出的卡移入 pausedCards；后续 lifecycle run 继续编辑同一张卡。
  *   - `sessionKey` 桥接 dispatch 与 hook(H1 实证一致)。Map 只含 octo dispatch 登记的
  *     session → hook 查不到即 return,**天然过滤**非 octo run,无需 messageProvider 判断。
  *
@@ -16,7 +17,7 @@ import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import { ChannelType, CARD_PROFILE, CARD_VERSION } from "./types.js";
 import { sendCardMessage, editCardMessage, getCardProfile, httpStatusFromApiFetchError } from "./api-fetch.js";
 import { deriveCardCaps } from "./card-caps.js";
-import { renderProgressCard, renderProgressResponseCard, summarizeToolParams, type CardStep, type CardProgressState, type CardCaps } from "./card-render.js";
+import { renderProgressCard, renderProgressResponseCard, summarizeToolParams, SUBAGENT_WAIT_STEP_TOOL, type CardStep, type CardProgressState, type CardCaps } from "./card-render.js";
 import { DISPLAY_CARD_TOOL_NAME, INTERACTIVE_CARD_TOOL_NAME } from "./constants.js";
 
 /** dispatch 侧登记的发送上下文。 */
@@ -45,6 +46,12 @@ interface CardEntry {
    * 只能校验、不能认领,避免旧 run 的迟到 hook first-hook-wins 抢占新 entry。
    */
   runId?: string;
+  /** 调用 sessions_yield 后结束、正在等待后续 continuation 的 run。 */
+  pausedFromRunId?: string;
+  /** paused 后在同一 session 上启动的 continuation run。 */
+  continuationRunId?: string;
+  /** 当前 run 成功创建、可用于识别受信 completion prompt 的子 session。 */
+  childSessionKeys: Set<string>;
   messageId?: string;
   phase: CardProgressState["phase"];
   steps: CardStep[];
@@ -55,12 +62,23 @@ interface CardEntry {
   flushTimer?: ReturnType<typeof setTimeout>;
   /** 当前 in-flight flush 的 promise;finalizeCard 据此等待首帧 send/中间帧 edit 落定。 */
   flushPromise?: Promise<void>;
+  /** paused/resuming/done 跨-run edit 的串行尾指针。 */
+  stateEditPromise?: Promise<void>;
+  stateEditAbort?: AbortController;
+  /** paused 卡的有界回收定时器。 */
+  pausedExpiryTimer?: ReturnType<typeof setTimeout>;
   /** replacement/clear 时主动取消 profile/send/edit,缩小 stale side-effect 窗口。 */
   flushAbort?: AbortController;
 }
 
 /** key = sessionKey(H1 实证:全 hook 一致)。跨账号碰撞由 entry.identity + fail-closed 兜底。 */
 const cards = new Map<string, CardEntry>();
+
+/**
+ * 已经结束当前 dispatch、但仍等待 continuation 的卡片。与 cards 分开保存，避免下一条
+ * inbound 的 setCardContext 覆盖 messageId，导致后台任务回来后无法更新原卡。
+ */
+const pausedCards = new Map<string, CardEntry>();
 
 /** D12 gate 结果缓存,key = apiUrl(同部署同结果),避免每 session 重复探测。 */
 const gateCache = new Map<string, boolean>();
@@ -74,6 +92,10 @@ const capsCache = new Map<string, CardCaps>();
 
 const FLUSH_DEBOUNCE_MS = 800;
 const EDIT_TIMEOUT_MS = 10_000;
+const PAUSED_CARD_TTL_MS = 60 * 60 * 1000;
+const INTERNAL_CONTEXT_BEGIN = "<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>";
+const INTERNAL_CONTEXT_END = "<<<END_OPENCLAW_INTERNAL_CONTEXT>>>";
+const INTERNAL_CONTEXT_NOTICE = "This context is runtime-generated, not user-authored. Keep internal details private.";
 
 // 进度卡失败不影响主回复流程 —— 仅告警,不抛。
 // eslint-disable-next-line no-console -- 波 B 进度卡诊断,失败降级不阻断主流程
@@ -104,7 +126,8 @@ export function setCardContext(sessionKey: string, ctx: CardContext): void {
   if (!sessionKey) return;
   const identity = contextIdentity(ctx);
   const existing = cards.get(sessionKey);
-  const collision = !!existing && existing.identity !== identity;
+  const paused = pausedCards.get(sessionKey);
+  const collision = [existing, paused].some((entry) => !!entry && entry.identity !== identity);
   // 任何 replacement 都清掉旧 entry 的 debounce timer。旧 entry 若已有 messageId,其
   // fire-and-forget finalize 仍可收尾;但定时中间帧不得跨 generation 泄漏到新 run。
   if (existing?.flushTimer) {
@@ -113,12 +136,14 @@ export function setCardContext(sessionKey: string, ctx: CardContext): void {
   }
   existing?.flushAbort?.abort(new Error("card entry replaced"));
   if (collision) {
-    existing!.skip = true; // 冻结旧 run 的卡:后续 flush/finalize 不再发送
+    if (existing) existing.skip = true;
+    if (paused) releasePausedCard(sessionKey, paused, "cross-identity collision");
     warn(`sessionKey collision across identities; failing closed for session=${sessionKey}`);
   }
   cards.set(sessionKey, {
     ctx,
     identity,
+    childSessionKeys: new Set(),
     phase: "thinking",
     steps: [],
     startedAt: Date.now(),
@@ -292,8 +317,149 @@ function isCurrentEntry(sessionKey: string, entry: CardEntry): boolean {
   return cards.get(sessionKey) === entry && !entry.skip;
 }
 
+function isTrackedEntry(sessionKey: string, entry: CardEntry): boolean {
+  return (cards.get(sessionKey) === entry || pausedCards.get(sessionKey) === entry) && !entry.skip;
+}
+
+function releasePausedCard(sessionKey: string, entry: CardEntry, reason: string): void {
+  if (entry.pausedExpiryTimer) {
+    clearTimeout(entry.pausedExpiryTimer);
+    entry.pausedExpiryTimer = undefined;
+  }
+  entry.stateEditAbort?.abort(new Error(`paused card released: ${reason}`));
+  entry.stateEditAbort = undefined;
+  entry.skip = true;
+  if (cards.get(sessionKey) === entry) cards.delete(sessionKey);
+  if (pausedCards.get(sessionKey) === entry) pausedCards.delete(sessionKey);
+}
+
+function schedulePausedCardExpiry(sessionKey: string, entry: CardEntry): void {
+  if (entry.pausedExpiryTimer) clearTimeout(entry.pausedExpiryTimer);
+  entry.pausedExpiryTimer = setTimeout(() => {
+    entry.pausedExpiryTimer = undefined;
+    if (pausedCards.get(sessionKey) !== entry || entry.skip) return;
+    void (async () => {
+      await editTrackedCardState(sessionKey, entry, "expired");
+      releasePausedCard(sessionKey, entry, "ttl expired");
+    })();
+  }, PAUSED_CARD_TTL_MS);
+}
+
+function startSubagentWait(entry: CardEntry, now: number): void {
+  const last = entry.steps[entry.steps.length - 1];
+  if (last?.tool === SUBAGENT_WAIT_STEP_TOOL && last.status === "running") return;
+  entry.steps.push({ tool: SUBAGENT_WAIT_STEP_TOOL, status: "running", startedAt: now });
+}
+
+function endSubagentWait(entry: CardEntry, now: number): void {
+  for (let i = entry.steps.length - 1; i >= 0; i--) {
+    const step = entry.steps[i];
+    if (step.tool !== SUBAGENT_WAIT_STEP_TOOL || step.status !== "running") continue;
+    step.status = "done";
+    step.durationMs = Math.max(0, now - (step.startedAt ?? now));
+    return;
+  }
+}
+
+/** 直接编辑一张已存在的进度卡；用于 paused continuation 的跨-run状态迁移。 */
+async function editTrackedCardState(
+  sessionKey: string,
+  entry: CardEntry,
+  phase: CardProgressState["phase"],
+  opts: { transient?: boolean; errorText?: string } = {},
+): Promise<void> {
+  const previous = entry.stateEditPromise;
+  const work = (async () => {
+    if (previous) {
+      try { await previous; } catch { /* previous transition already logged */ }
+    }
+    if (entry.flushPromise) {
+      try { await entry.flushPromise; } catch { /* flush already logged */ }
+    }
+    if (entry.flushTimer) {
+      clearTimeout(entry.flushTimer);
+      entry.flushTimer = undefined;
+    }
+    if (!isTrackedEntry(sessionKey, entry) || !entry.messageId) return;
+
+    const now = Date.now();
+    endRunningThinking(entry, now);
+    if (phase !== "paused") endSubagentWait(entry, now);
+    entry.phase = phase;
+    const state: CardProgressState = {
+      phase,
+      steps: entry.steps,
+      elapsedMs: Date.now() - entry.startedAt,
+      ...(opts.errorText ? { errorText: opts.errorText } : {}),
+    };
+    const abort = new AbortController();
+    entry.stateEditAbort = abort;
+    try {
+      const { card, plain } = renderProgressCard(state, capsCache.get(entry.ctx.apiUrl));
+      if (!Array.isArray(card.body) || card.body.length === 0) return;
+      await editCardMessage({
+        apiUrl: entry.ctx.apiUrl,
+        botToken: entry.ctx.botToken,
+        messageId: entry.messageId,
+        channelId: entry.ctx.channelId,
+        channelType: entry.ctx.channelType,
+        card,
+        plain,
+        ...(opts.transient ? { transient: true } : {}),
+        ...(entry.ctx.onBehalfOf ? { onBehalfOf: entry.ctx.onBehalfOf } : {}),
+        signal: AbortSignal.any([abort.signal, AbortSignal.timeout(EDIT_TIMEOUT_MS)]),
+      });
+      dbg(`transitioned session=${sessionKey} phase=${phase}`);
+    } catch (err: unknown) {
+      if (!abort.signal.aborted) {
+        warn(`state transition failed: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    } finally {
+      if (entry.stateEditAbort === abort) entry.stateEditAbort = undefined;
+    }
+  })();
+  entry.stateEditPromise = work;
+  try {
+    await work;
+  } finally {
+    if (entry.stateEditPromise === work) entry.stateEditPromise = undefined;
+  }
+}
+
+function finishPausedCard(
+  sessionKey: string,
+  entry: CardEntry,
+  phase: "done" | "error",
+  errorText?: string,
+): Promise<void> {
+  return (async () => {
+    await editTrackedCardState(sessionKey, entry, phase, errorText ? { errorText } : {});
+    releasePausedCard(sessionKey, entry, `continuation ${phase}`);
+  })();
+}
+
+/** sessions_yield 的 lifecycle 元数据在旧 host/Codex lane 可能缺失；成功工具结果作为兼容兜底。 */
+function markCardPaused(sessionKey: string, runId?: string, expectedEntry?: CardEntry): void {
+  const entry = expectedEntry ?? cards.get(sessionKey) ?? pausedCards.get(sessionKey);
+  if (!entry || entry.skip) return;
+  if (runId && entry.runId &&
+      entry.runId !== runId && entry.pausedFromRunId !== runId && entry.continuationRunId !== runId) return;
+  const now = Date.now();
+  endRunningThinking(entry, now);
+  startSubagentWait(entry, now);
+  entry.pausedFromRunId = runId ?? entry.continuationRunId ?? entry.runId;
+  entry.continuationRunId = undefined;
+  entry.phase = "paused";
+  if (cards.get(sessionKey) === entry) {
+    scheduleFlush(sessionKey, entry);
+  } else {
+    schedulePausedCardExpiry(sessionKey, entry);
+    void editTrackedCardState(sessionKey, entry, "paused");
+  }
+}
+
 /**
- * dispatch `finally` 收尾:渲染终态帧(✅ 已完成 / ⚠️ 中断),清理 Map。
+ * dispatch `finally` 收尾:完成/失败时清理；yield 时保留原卡供 continuation 更新。
  * 幂等:未登记或没发过占位卡则仅清理。
  */
 export async function finalizeCard(
@@ -313,13 +479,26 @@ export async function finalizeCard(
   // P1-g:若仍有 running thinking(agent 收尾时最后一次 model_call 之后未再调工具),
   // 用当前时间把它标 done + 算 duration —— 终态帧不留 ⏳。
   endRunningThinking(entry, Date.now());
+  const retainForContinuation = entry.phase === "paused" || entry.phase === "resuming";
   // 只在 entry 仍是当前登记项时删除。finalize 是 fire-and-forget 且上面 await 了 in-flight
   // flush;await 期间 per-group 队列可能推进,同 sessionKey 的下一 run setCardContext 已把
   // Map 换成新 entry —— 那时删 key 会误删新 run 的状态,使其全程无卡。终态帧仍发本 run。
-  if (cards.get(sessionKey) === entry) cards.delete(sessionKey);
+  if (cards.get(sessionKey) === entry) {
+    cards.delete(sessionKey);
+    // 没发出 messageId 的懒卡没有可更新对象，不能长期滞留在 pausedCards。
+    if (retainForContinuation && !entry.skip && entry.messageId) {
+      pausedCards.set(sessionKey, entry);
+      schedulePausedCardExpiry(sessionKey, entry);
+    }
+  }
 
   // 从没发过卡(skip / 无工具调用)→ 无需收尾帧。
   if (entry.skip || !entry.messageId) return;
+
+  if (retainForContinuation) {
+    await editTrackedCardState(sessionKey, entry, entry.phase);
+    return;
+  }
 
   const state: CardProgressState = {
     phase: opts.success ? "done" : "error",
@@ -407,19 +586,29 @@ export async function finalizeCardWithResponse(
 /** 硬清理(不发收尾帧),用于异常兜底。 */
 export function clearCard(sessionKey: string): void {
   const entry = cards.get(sessionKey);
-  if (!entry) return;
-  if (entry.flushTimer) clearTimeout(entry.flushTimer);
-  entry.flushAbort?.abort(new Error("card entry cleared"));
+  const paused = pausedCards.get(sessionKey);
+  for (const tracked of new Set([entry, paused].filter((item): item is CardEntry => !!item))) {
+    if (tracked.flushTimer) clearTimeout(tracked.flushTimer);
+    if (tracked.pausedExpiryTimer) clearTimeout(tracked.pausedExpiryTimer);
+    tracked.flushAbort?.abort(new Error("card entry cleared"));
+    tracked.stateEditAbort?.abort(new Error("card entry cleared"));
+    tracked.skip = true;
+  }
   cards.delete(sessionKey);
+  pausedCards.delete(sessionKey);
 }
 
 /** 测试辅助:清空全部状态。 */
 export function _resetCardProgressForTests(): void {
-  for (const e of cards.values()) {
+  for (const e of new Set([...cards.values(), ...pausedCards.values()])) {
     if (e.flushTimer) clearTimeout(e.flushTimer);
+    if (e.pausedExpiryTimer) clearTimeout(e.pausedExpiryTimer);
     e.flushAbort?.abort(new Error("card progress reset"));
+    e.stateEditAbort?.abort(new Error("card progress reset"));
+    e.skip = true;
   }
   cards.clear();
+  pausedCards.clear();
   gateCache.clear();
   capsCache.clear();
 }
@@ -462,10 +651,89 @@ export function bindCardRun(sessionKey: string | undefined, runId: string | unde
   if (entry.runId === undefined) entry.runId = runId;
 }
 
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined;
+}
+
+/** 兼容新 host 的 result.details 与旧 host content[].text 中的 JSON 工具结果。 */
+function acceptedSpawnChildSessionKey(result: unknown): string | undefined {
+  const root = asRecord(result);
+  if (!root) return undefined;
+  const candidates: Record<string, unknown>[] = [root];
+  const details = asRecord(root.details);
+  if (details) candidates.push(details);
+  if (Array.isArray(root.content)) {
+    for (const item of root.content) {
+      const text = asRecord(item)?.text;
+      if (typeof text !== "string") continue;
+      try {
+        const parsed = asRecord(JSON.parse(text));
+        if (!parsed) continue;
+        candidates.push(parsed);
+        const parsedDetails = asRecord(parsed.details);
+        if (parsedDetails) candidates.push(parsedDetails);
+      } catch {
+        // 非 JSON 文本不是 sessions_spawn 的结构化结果。
+      }
+    }
+  }
+  for (const candidate of candidates) {
+    const childSessionKey = typeof candidate.childSessionKey === "string"
+      ? candidate.childSessionKey.trim()
+      : "";
+    if (candidate.status === "accepted" && childSessionKey) return childSessionKey;
+  }
+  return undefined;
+}
+
+/**
+ * 仅信任 OpenClaw 生成的 protected internal-context completion event。用户文本中的
+ * 同名字段不会命中：host 会转义用户提供的 BEGIN/END delimiter。
+ */
+function matchingCompletionChildSessionKey(prompt: unknown, expected: Set<string>): string | undefined {
+  if (typeof prompt !== "string" || expected.size === 0) return undefined;
+  const escapedBegin = INTERNAL_CONTEXT_BEGIN.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const escapedEnd = INTERNAL_CONTEXT_END.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const blockPattern = new RegExp(
+    `(?:^|\\r?\\n)${escapedBegin}\\r?\\n([\\s\\S]*?)\\r?\\n${escapedEnd}(?=\\r?\\n|$)`,
+    "g",
+  );
+  for (const blockMatch of prompt.matchAll(blockPattern)) {
+    const block = blockMatch[1] ?? "";
+    if (!block.includes(INTERNAL_CONTEXT_NOTICE)) continue;
+    const eventPattern = /(?:^|\r?\n)\[Internal task completion event\]\r?\nsource:\s*subagent\s*\r?\nsession_key:\s*([^\r\n]+)(?=\r?\n|$)/g;
+    for (const eventMatch of block.matchAll(eventPattern)) {
+      const childSessionKey = (eventMatch[1] ?? "").trim();
+      if (expected.has(childSessionKey)) return childSessionKey;
+    }
+  }
+  return undefined;
+}
+
+function bindPausedContinuation(
+  sessionKey: string | undefined,
+  runId: string | undefined,
+  prompt: unknown,
+): void {
+  if (!sessionKey || !runId) return;
+  const entry = pausedCards.get(sessionKey);
+  if (!entry || entry.skip || !entry.pausedFromRunId || runId === entry.pausedFromRunId) return;
+  if (entry.continuationRunId) return;
+  const childSessionKey = matchingCompletionChildSessionKey(prompt, entry.childSessionKeys);
+  if (!childSessionKey) return;
+  endSubagentWait(entry, Date.now());
+  entry.childSessionKeys.delete(childSessionKey);
+  entry.continuationRunId = runId;
+  void editTrackedCardState(sessionKey, entry, "resuming", { transient: true });
+}
+
 export function registerCardProgress(api: OpenClawPluginApi): void {
-  api.on("before_agent_run", (_event: unknown, ctx: unknown) => {
+  api.on("before_agent_run", (event: unknown, ctx: unknown) => {
     const { sessionKey, runId } = (ctx ?? {}) as { sessionKey?: string; runId?: string };
     bindCardRun(sessionKey, runId);
+    bindPausedContinuation(sessionKey, runId, asRecord(event)?.prompt);
     // before_agent_run 是 fail-closed gate。必须显式 pass,不能依赖不同 host 对 void 的解释。
     return { outcome: "pass" } as const;
   });
@@ -496,7 +764,13 @@ export function registerCardProgress(api: OpenClawPluginApi): void {
   });
 
   api.on("after_tool_call", (event: unknown, ctx: unknown) => {
-    const e = (event ?? {}) as { toolName?: string; error?: string; durationMs?: number; toolCallId?: string };
+    const e = (event ?? {}) as {
+      toolName?: string;
+      error?: string;
+      durationMs?: number;
+      toolCallId?: string;
+      result?: unknown;
+    };
     const sk = (ctx as { sessionKey?: string })?.sessionKey;
     const entry = sk ? cards.get(sk) : undefined;
     if (!entry || entry.skip) return;
@@ -520,6 +794,13 @@ export function registerCardProgress(api: OpenClawPluginApi): void {
       if (typeof e.durationMs === "number") target.durationMs = e.durationMs;
       if (e.error) target.error = e.error;
     }
+    if (e.toolName === "sessions_spawn" && !e.error) {
+      const childSessionKey = acceptedSpawnChildSessionKey(e.result);
+      if (childSessionKey) entry.childSessionKeys.add(childSessionKey);
+    }
+    if (e.toolName === "sessions_yield" && !e.error) {
+      markCardPaused(sk!, (ctx as { runId?: string })?.runId);
+    }
     scheduleFlush(sk!, entry);
   });
 
@@ -541,4 +822,105 @@ export function registerCardProgress(api: OpenClawPluginApi): void {
     // 并在收尾时 finalize 成误导性的"⚠️ 已中断",正是 P1-h 想消除的噪音。
     if (entry.messageId || hadRealStep) scheduleFlush(sk!, entry);
   });
+
+  const hasLifecycleSubscription = registerCardLifecycleSubscription(api);
+  if (!hasLifecycleSubscription) {
+    api.on("agent_end", (event: unknown, ctx: unknown) => {
+      const e = (event ?? {}) as { runId?: string; success?: boolean; error?: string };
+      const { sessionKey, runId: contextRunId } = (ctx ?? {}) as { sessionKey?: string; runId?: string };
+      const runId = e.runId ?? contextRunId;
+      if (!sessionKey || !runId) return;
+      const entry = pausedCards.get(sessionKey);
+      if (!entry || entry.continuationRunId !== runId) return;
+      return finishPausedCard(sessionKey, entry, e.success === true ? "done" : "error", e.error);
+    });
+  }
+}
+
+type CardLifecycleEvent = {
+  runId: string;
+  sessionKey?: string;
+  stream: string;
+  data: Record<string, unknown>;
+};
+
+type CardLifecycleSubscription = {
+  id: string;
+  description?: string;
+  streams?: string[];
+  handle: (event: CardLifecycleEvent) => void | Promise<void>;
+};
+
+/**
+ * 2026.7.x 提供 nested agent.events facade；旧 SDK 没有该字段，因此运行时 feature-detect，
+ * 并保留 flat API 兼容。旧 host 至少仍可通过成功的 sessions_yield tool hook 显示 paused。
+ */
+function registerCardLifecycleSubscription(api: OpenClawPluginApi): boolean {
+  const compat = api as unknown as {
+    agent?: {
+      events?: {
+        registerAgentEventSubscription?: (subscription: CardLifecycleSubscription) => void;
+      };
+    };
+    registerAgentEventSubscription?: (subscription: CardLifecycleSubscription) => void;
+  };
+  const nested = compat.agent?.events?.registerAgentEventSubscription;
+  const flat = compat.registerAgentEventSubscription;
+  const register = nested
+    ? (subscription: CardLifecycleSubscription) => nested.call(compat.agent!.events, subscription)
+    : flat
+      ? (subscription: CardLifecycleSubscription) => flat.call(compat, subscription)
+      : undefined;
+  if (!register) {
+    dbg("agent lifecycle subscription API unavailable; using sessions_yield tool fallback");
+    return false;
+  }
+  register({
+    id: "octo-card-progress-lifecycle",
+    description: "Keep yielded Octo progress cards in sync with continuation runs",
+    streams: ["lifecycle"],
+    handle: handleCardLifecycleEvent,
+  });
+  return true;
+}
+
+function findPausedFlowEntry(sessionKey: string, runId: string): CardEntry | undefined {
+  const candidates = [pausedCards.get(sessionKey), cards.get(sessionKey)];
+  return candidates.find((entry) => !!entry?.pausedFromRunId &&
+    (entry.pausedFromRunId === runId || entry.continuationRunId === runId));
+}
+
+async function handleCardLifecycleEvent(event: CardLifecycleEvent): Promise<void> {
+  if (event.stream !== "lifecycle" || !event.sessionKey || !event.runId) return;
+  const phase = typeof event.data.phase === "string" ? event.data.phase : "";
+  const sessionKey = event.sessionKey;
+
+  // Error is authoritative even if a malformed/legacy event also carries yielded.
+  if (phase === "error") {
+    const entry = findPausedFlowEntry(sessionKey, event.runId);
+    if (!entry) return;
+    await finishPausedCard(
+      sessionKey,
+      entry,
+      "error",
+      typeof event.data.error === "string" ? event.data.error : undefined,
+    );
+    return;
+  }
+
+  if (phase === "end" && event.data.yielded === true) {
+    const entry = findPausedFlowEntry(sessionKey, event.runId) ?? cards.get(sessionKey);
+    if (entry?.runId === event.runId || entry?.continuationRunId === event.runId) {
+      markCardPaused(sessionKey, event.runId, entry);
+    }
+    return;
+  }
+
+  // start 不含 parent/continuation 关联证据，不能据此认领 paused 卡。
+  if (phase === "start") return;
+
+  const entry = findPausedFlowEntry(sessionKey, event.runId);
+  if (phase === "end" && entry?.continuationRunId === event.runId) {
+    await finishPausedCard(sessionKey, entry, "done");
+  }
 }

--- a/src/card-render.test.ts
+++ b/src/card-render.test.ts
@@ -508,6 +508,16 @@ describe("renderProgressCard", () => {
     expect(progressHeaderText(card)).toContain("✅ 已完成 · 1 步 · 2.5s");
   });
 
+  it("yield 暂停与恢复使用短状态文案", () => {
+    const paused = renderProgressCard({ phase: "paused", steps: [] });
+    const resuming = renderProgressCard({ phase: "resuming", steps: [] });
+    const expired = renderProgressCard({ phase: "expired", steps: [] });
+
+    expect(progressHeaderText(paused.card)).toBe("⏸️ 等待任务结果");
+    expect(progressHeaderText(resuming.card)).toBe("🤖 正在整理结果");
+    expect(progressHeaderText(expired.card)).toBe("⏱️ 等待超时");
+  });
+
   it("error 收尾", () => {
     const { card } = renderProgressCard({ phase: "error", steps: [], errorText: "超时" });
     expect(progressHeaderText(card)).toContain("⚠️ 已中断");
@@ -766,6 +776,23 @@ describe("cardSupports / CardCaps 渲染协商(波 C)", () => {
       steps: [{ tool: "__thinking__", status: "running" }],
     });
     expect(progressDetailText(running.card)).toContain("⏳ 思考");
+  });
+
+  it("子任务等待作为独立明细展示,不能误算成工具耗时", () => {
+    const { card, plain } = renderProgressCard({
+      phase: "done",
+      elapsedMs: 67_300,
+      steps: [
+        { tool: "__thinking__", status: "done", durationMs: 2_000 },
+        { tool: "sessions_spawn", status: "done", durationMs: 50 },
+        { tool: "sessions_yield", status: "done", durationMs: 10 },
+        { tool: "__subagent_wait__", status: "done", durationMs: 65_000 },
+      ],
+    });
+
+    expect(progressDetailText(card)).toContain("⏸️ 等待子任务 · 65.0s");
+    expect(plain).toContain("任务过程 · 思考 1 · 工具 2 · 等待 1 · 4 步");
+    expect(plain).not.toContain("工具 3");
   });
 
   it("P1-g: 连续 thinking done 触发同类合并 → 💭 思考 × N", () => {

--- a/src/card-render.ts
+++ b/src/card-render.ts
@@ -47,22 +47,23 @@ export interface CardStep {
    */
   toolCallId?: string;
   /**
-   * hook 侧记录的开始时间(ms epoch)。目前只对 P1-g 的 __thinking__ 步骤有意义:
-   * SDK 无 `model_call_ended` hook,thinking 结束时机由外部信号(before_tool_call / finalize)
-   * 决定,duration = now - startedAt。渲染层只看 durationMs,该字段仅 hook 侧内部使用。
+   * hook 侧记录的开始时间(ms epoch)。用于没有成对 end hook 的内部步骤:
+   * `__thinking__` 由 before_tool_call/finalize 收尾，`__subagent_wait__` 由受信 completion
+   * continuation 收尾，duration = now - startedAt。渲染层只看 durationMs。
    */
   startedAt?: number;
 }
 
 /** 进度卡的渲染状态。 */
 export interface CardProgressState {
-  phase: "thinking" | "tool" | "done" | "error";
+  phase: "thinking" | "tool" | "paused" | "resuming" | "expired" | "done" | "error";
   steps: CardStep[];
   elapsedMs?: number;
   errorText?: string;
 }
 
 const MCP_TOOL_PREFIX = "mcp__";
+export const SUBAGENT_WAIT_STEP_TOOL = "__subagent_wait__";
 
 /** 常见工具 → 图标 + 中文标签;未知工具用通用图标 + 原名。 */
 const TOOL_META: Record<string, { icon: string; label: string }> = {
@@ -89,6 +90,7 @@ const TOOL_META: Record<string, { icon: string; label: string }> = {
 export function resolveToolMeta(tool: string): { icon: string; label: string } {
   // 特殊内部 tool 名:agent 一轮 model_call = 一步"思考"(P1-g)。以 __ 前缀,agent 侧无冲突可能。
   if (tool === "__thinking__") return { icon: "💭", label: "思考" };
+  if (tool === SUBAGENT_WAIT_STEP_TOOL) return { icon: "⏸️", label: "等待子任务" };
   if (tool.startsWith(MCP_TOOL_PREFIX)) {
     const rest = tool.slice(MCP_TOOL_PREFIX.length).replace(/__/g, " / ");
     return { icon: "🔌", label: `MCP ${rest}` };
@@ -395,6 +397,12 @@ function headerText(state: CardProgressState): string {
       return "🤖 思考中…";
     case "tool":
       return "🤖 正在处理…";
+    case "paused":
+      return "⏸️ 等待任务结果";
+    case "resuming":
+      return "🤖 正在整理结果";
+    case "expired":
+      return "⏱️ 等待超时";
     case "error": {
       const detail = sanitizeErrorText(state.errorText);
       return `⚠️ 已中断${detail ? `：${detail}` : ""}`;
@@ -611,11 +619,13 @@ function supportsTerminalCollapse(caps: CardCaps | undefined): boolean {
 
 function progressSummary(steps: CardStep[], total: number): string {
   const thinking = steps.filter((s) => s.tool === "__thinking__").length;
-  const tools = total - thinking;
-  const parts = ["推理与工具调用"];
+  const waiting = steps.filter((s) => s.tool === SUBAGENT_WAIT_STEP_TOOL).length;
+  const tools = total - thinking - waiting;
+  const parts = [waiting > 0 ? "任务过程" : "推理与工具调用"];
   if (thinking > 0) parts.push(`思考 ${thinking}`);
   if (tools > 0) parts.push(`工具 ${tools}`);
-  if (thinking === 0 && tools === 0) parts.push(`${total} 步`);
+  if (waiting > 0) parts.push(`等待 ${waiting}`);
+  if (thinking === 0 && tools === 0 && waiting === 0) parts.push(`${total} 步`);
   return parts.join(" · ");
 }
 
@@ -641,13 +651,15 @@ function terminalHeaderSegments(state: CardProgressState): RichSegment[] | null 
 
 function progressSummarySegments(steps: CardStep[], total: number, visible: string): RichSegment[] {
   const thinking = steps.filter((s) => s.tool === "__thinking__").length;
-  const tools = total - thinking;
+  const waiting = steps.filter((s) => s.tool === SUBAGENT_WAIT_STEP_TOOL).length;
+  const tools = total - thinking - waiting;
   const stats: string[] = [];
   if (thinking > 0) stats.push(`思考 ${thinking}`);
   if (tools > 0) stats.push(`工具 ${tools}`);
+  if (waiting > 0) stats.push(`等待 ${waiting}`);
   stats.push(`${visible} 步`);
   return [
-    { text: "推理与工具调用", bold: true },
+    { text: waiting > 0 ? "任务过程" : "推理与工具调用", bold: true },
     { text: ` · ${stats.join(" · ")}`, subtle: true },
   ];
 }
@@ -803,7 +815,7 @@ export function renderProgressCard(
   const detail = buildDisplayCard({ blocks: detailBlocks, caps, trusted: true });
   const headerItems = progressHeaderItems(state, header, state.steps, total, visible, canRichText);
   const canToggle = supportsTerminalCollapse(caps);
-  const isTerminal = state.phase === "done" || state.phase === "error";
+  const isTerminal = state.phase === "done" || state.phase === "error" || state.phase === "expired";
   const detailVisible = !(canToggle && isTerminal);
   const columns: Record<string, unknown>[] = [
     {


### PR DESCRIPTION
## Summary

- treat successful `sessions_yield` as a paused run instead of finalizing the progress card as interrupted
- retain and safely correlate the same card across protected subagent completion runs, lifecycle races, unrelated follow-ups, legacy hosts, and expiry
- show subagent wait time as a separate progress detail and add a real OpenClaw host E2E with a subagent running longer than one minute

## Behavior

```text
yielded/paused       -> ⏸️ 等待任务结果
continuation started -> 🤖 正在整理结果
continuation ended   -> ✅ 已完成
```

The terminal card also reports the background interval as `⏸️ 等待子任务 · <duration>` instead of leaving most of the end-to-end duration unexplained.

## Testing

- `npm run type-check`
- `npm test -- --exclude ".context/**"` — 1674 passed, 5 skipped
- `OCTO_E2E_TARGET_UID=<uid> npm run test:e2e:openclaw` — 2 passed, including a 75-second subagent and a 60-second paused-card checkpoint
- verified E2E cleanup restores config, removes the companion/provider/test sessions, and restarts the gateway

Fixes #176