### PR TITLE
fix(outbound): accept bare absolute file paths in sendMedia

### DIFF
--- a/src/channel.test.ts
+++ b/src/channel.test.ts
@@ -643,6 +643,83 @@ describe("outbound.sendMedia — threadId wiring", () => {
   });
 });
 
+// #183: OpenClaw tools (e.g. image generation) hand sendMedia a bare local
+// absolute path — no file:// scheme. It must go through the local-file read +
+// presigned-upload path, NOT the HTTP branch's `new URL(mediaUrl)` (which
+// throws `TypeError: Invalid URL` on a leading-slash path and drops the media).
+describe("outbound.sendMedia — bare local absolute path (#183)", () => {
+  const cfg = {
+    channels: {
+      octo: {
+        apiUrl: "https://api.example",
+        accounts: {
+          default: { botToken: "bf_test", apiUrl: "https://api.example" },
+        },
+      },
+    },
+  };
+
+  let tmpFile: string;
+
+  beforeEach(async () => {
+    const { mkdtempSync, writeFileSync } = await import("node:fs");
+    const { tmpdir } = await import("node:os");
+    const nodePath = await import("node:path");
+    const dir = mkdtempSync(nodePath.join(tmpdir(), "octo-sendmedia-"));
+    tmpFile = nodePath.join(dir, "image-1---abcd.jpg");
+    writeFileSync(tmpFile, Buffer.from("fake-jpeg-bytes"));
+
+    const apiFetch = await import("./api-fetch.js");
+    (apiFetch.sendMediaMessage as any).mockClear();
+    (apiFetch.getUploadPresign as any).mockClear();
+    (apiFetch.uploadFileToPresignedUrl as any).mockClear();
+  });
+
+  afterEach(async () => {
+    const { rmSync } = await import("node:fs");
+    const nodePath = await import("node:path");
+    try {
+      rmSync(nodePath.dirname(tmpFile), { recursive: true, force: true });
+    } catch { /* best-effort */ }
+  });
+
+  it("uploads a bare absolute path via the local-file branch (no Invalid URL)", async () => {
+    const { octoPlugin } = await import("./channel.js");
+    const { getUploadPresign, uploadFileToPresignedUrl, sendMediaMessage } =
+      await import("./api-fetch.js");
+
+    // Drain the lazily-opened read stream inside sendMedia's await so the fd is
+    // consumed and closed before afterEach removes the temp dir (otherwise the
+    // deferred open() races the rmSync and surfaces a spurious ENOENT).
+    (uploadFileToPresignedUrl as any).mockImplementationOnce(async (arg: any) => {
+      const body = arg.fileBody;
+      if (body && typeof body.on === "function") {
+        await new Promise<void>((resolve, reject) => {
+          body.on("data", () => {});
+          body.on("end", resolve);
+          body.on("error", reject);
+        });
+      }
+      return { url: "https://cdn.example/file.jpg" };
+    });
+
+    await octoPlugin.outbound!.sendMedia!({
+      cfg,
+      to: "group:grp1",
+      text: "",
+      mediaUrl: tmpFile,
+      accountId: "default",
+    } as any);
+
+    // Presign is called with the basename — proving we treated it as a local
+    // file, not an HTTP URL (which would have thrown before reaching presign).
+    expect(getUploadPresign).toHaveBeenCalledTimes(1);
+    const presignArgs = (getUploadPresign as any).mock.calls[0][0];
+    expect(presignArgs.filename).toBe("image-1---abcd.jpg");
+    expect(sendMediaMessage).toHaveBeenCalledTimes(1);
+  });
+});
+
 /**
  * Streaming size cap for the outbound HTTP-URL branch.
  *

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1083,8 +1083,14 @@ export const octoPlugin: ChannelPlugin<ResolvedOctoAccount> = {
         if ((ctx as Record<string, unknown>).filename) {
           filename = String((ctx as Record<string, unknown>).filename);
         }
-      } else if (mediaUrl.startsWith("file://")) {
-        const filePath = decodeURIComponent(mediaUrl.slice(7));
+      } else if (mediaUrl.startsWith("file://") || path.isAbsolute(mediaUrl)) {
+        // Local file — either a file:// URL or a bare absolute path. OpenClaw
+        // tools (e.g. image generation) hand us the latter with no scheme
+        // (#183); it must read from disk, not fall through to `new URL()`,
+        // which throws `TypeError: Invalid URL` on a leading-slash path.
+        const filePath = mediaUrl.startsWith("file://")
+          ? decodeURIComponent(mediaUrl.slice(7))
+          : mediaUrl;
         const st = statSync(filePath);
         if (st.size > MAX_UPLOAD_SIZE) {
           throw new Error(`File too large (${st.size} bytes, max ${MAX_UPLOAD_SIZE})`);


### PR DESCRIPTION
## 问题

在 Octo 中调用图片生成等工具时，图片能正常生成，但 `sendMedia` 投递失败并抛 `TypeError: Invalid URL`，生成结果丢失（#183）。

## 根因

`sendMedia`（`src/channel.ts`）只显式识别 `data:` 与 `file://` 两类本地媒体，其余一律落到 HTTP 分支的 `new URL(mediaUrl)`。OpenClaw 工具交来的是**裸的本地绝对路径**（如 `/home/com/.openclaw/media/tool-image-generation/xxx.jpg`），无 scheme，`new URL()` 对前导斜杠路径直接抛 `TypeError: Invalid URL`，媒体从未被上传投递。

## 修复

把 `path.isAbsolute()` 的 mediaUrl 与 `file://` 同等对待：从磁盘读取、走预签名上传路径，而不是丢进 URL parser。改动最小，仅扩展本地文件分支的判定条件。

支持的媒体形态现在覆盖：`data:` URI、`file://` URL、裸绝对路径、HTTP(S) URL。

## 测试

- 新增回归：`src/channel.test.ts` — 裸绝对路径经本地文件分支上传（presign 收到 basename），修复前该用例复现 `Invalid URL`。
- `npm run type-check` 通过
- `npm test`：1675 passed / 5 skipped

Closes #183