### PR TITLE
fix(cards): finalize orphaned paused card for correlated continuation

### DIFF
--- a/src/card-progress.test.ts
+++ b/src/card-progress.test.ts
@@ -1566,6 +1566,162 @@ describe("card-progress 状态机 + hook + 节流", () => {
     expect(progressHeaderText(env.card)).toContain("⏱️ Wait timed out");
   });
 
+  it("yield 后 continuation 只产出 final text 时,兜底把孤儿 paused 卡收到已完成", async () => {
+    const { fn, calls } = mockFetch();
+    global.fetch = fn as unknown as typeof fetch;
+    const { handlers } = makeApi({ lifecycle: false });
+    const ctx = {
+      apiUrl: "https://yield-bare.test",
+      botToken: "bf",
+      channelId: "g1",
+      channelType: ChannelType.Group,
+    };
+    // run-a:真实工具发出占位卡,随后 bare sessions_yield(无 spawn)→ paused
+    setCardContext("yield-bare", ctx);
+    handlers.before_agent_run({}, { sessionKey: "yield-bare", runId: "run-a" });
+    handlers.before_tool_call({ toolName: "run_command", toolCallId: "cmd-1" }, { sessionKey: "yield-bare", runId: "run-a" });
+    handlers.after_tool_call({ toolName: "run_command", toolCallId: "cmd-1", durationMs: 10 }, { sessionKey: "yield-bare", runId: "run-a" });
+    handlers.before_tool_call({ toolName: "sessions_yield", toolCallId: "yield-1" }, { sessionKey: "yield-bare", runId: "run-a" });
+    handlers.after_tool_call({ toolName: "sessions_yield", toolCallId: "yield-1", durationMs: 5 }, { sessionKey: "yield-bare", runId: "run-a" });
+    await vi.advanceTimersByTimeAsync(900);
+    await finalizeCard("yield-bare", { success: false });
+    calls.length = 0;
+
+    // 同一 run resume 后的 continuation:新 dispatch 重置 context(空 entry、无 messageId),
+    // before_agent_run 用原 runId 重新绑定(resumed run 保留 runId),只产出 final text。
+    setCardContext("yield-bare", ctx);
+    handlers.before_agent_run({ prompt: "继续:这是最终战报,没有 completion event", messages: [] }, { sessionKey: "yield-bare", runId: "run-a" });
+    await finalizeCard("yield-bare", { success: true });
+
+    const doneEdit = calls.find((call) => {
+      if (!call.url.includes("/message/edit")) return false;
+      const env = JSON.parse(call.body!.content_edit as string);
+      return progressHeaderText(env.card).includes("✅ Done");
+    });
+    expect(doneEdit).toBeTruthy();
+
+    // 孤儿卡已释放:TTL 到期后不再有 edit(不会把成功任务误标为「等待超时」)
+    calls.length = 0;
+    await vi.advanceTimersByTimeAsync(3_600_100);
+    expect(calls.some((call) => call.url.includes("/message/edit"))).toBe(false);
+  });
+
+  it("continuation 失败时兜底把孤儿 paused 卡收到已中断", async () => {
+    const { fn, calls } = mockFetch();
+    global.fetch = fn as unknown as typeof fetch;
+    const { handlers } = makeApi({ lifecycle: false });
+    const ctx = {
+      apiUrl: "https://yield-bare-err.test",
+      botToken: "bf",
+      channelId: "g1",
+      channelType: ChannelType.Group,
+    };
+    setCardContext("yield-bare-err", ctx);
+    handlers.before_agent_run({}, { sessionKey: "yield-bare-err", runId: "run-a" });
+    handlers.before_tool_call({ toolName: "run_command", toolCallId: "cmd-1" }, { sessionKey: "yield-bare-err", runId: "run-a" });
+    handlers.after_tool_call({ toolName: "run_command", toolCallId: "cmd-1", durationMs: 10 }, { sessionKey: "yield-bare-err", runId: "run-a" });
+    handlers.before_tool_call({ toolName: "sessions_yield", toolCallId: "yield-1" }, { sessionKey: "yield-bare-err", runId: "run-a" });
+    handlers.after_tool_call({ toolName: "sessions_yield", toolCallId: "yield-1", durationMs: 5 }, { sessionKey: "yield-bare-err", runId: "run-a" });
+    await vi.advanceTimersByTimeAsync(900);
+    await finalizeCard("yield-bare-err", { success: false });
+    calls.length = 0;
+
+    setCardContext("yield-bare-err", ctx);
+    handlers.before_agent_run({ prompt: "继续", messages: [] }, { sessionKey: "yield-bare-err", runId: "run-a" });
+    await finalizeCard("yield-bare-err", { success: false, errorText: "boom" });
+
+    const errEdit = calls.find((call) => {
+      if (!call.url.includes("/message/edit")) return false;
+      const env = JSON.parse(call.body!.content_edit as string);
+      return progressHeaderText(env.card).includes("⚠️ Interrupted");
+    });
+    expect(errEdit).toBeTruthy();
+  });
+
+  it("bare yield 等待期间无关 run 收尾不得接管原 paused 卡,真正 resume 才收尾", async () => {
+    const { fn, calls } = mockFetch();
+    global.fetch = fn as unknown as typeof fetch;
+    const { handlers } = makeApi({ lifecycle: false });
+    const ctx = {
+      apiUrl: "https://yield-bare-intervene.test",
+      botToken: "bf",
+      channelId: "g1",
+      channelType: ChannelType.Group,
+    };
+    // run-a:真实工具发卡 → bare sessions_yield → paused(pausedFromRunId=run-a)
+    setCardContext("yield-bare-intervene", ctx);
+    handlers.before_agent_run({}, { sessionKey: "yield-bare-intervene", runId: "run-a" });
+    handlers.before_tool_call({ toolName: "run_command", toolCallId: "cmd-1" }, { sessionKey: "yield-bare-intervene", runId: "run-a" });
+    handlers.after_tool_call({ toolName: "run_command", toolCallId: "cmd-1", durationMs: 10 }, { sessionKey: "yield-bare-intervene", runId: "run-a" });
+    handlers.before_tool_call({ toolName: "sessions_yield", toolCallId: "yield-1" }, { sessionKey: "yield-bare-intervene", runId: "run-a" });
+    handlers.after_tool_call({ toolName: "sessions_yield", toolCallId: "yield-1", durationMs: 5 }, { sessionKey: "yield-bare-intervene", runId: "run-a" });
+    await vi.advanceTimersByTimeAsync(900);
+    await finalizeCard("yield-bare-intervene", { success: false });
+    calls.length = 0;
+
+    // 等待期间到达的**无关** run(不同 runId)只产出 final text 并收尾 ——
+    // 缺乏 run 归属,绝不能把原 paused 任务误标 done 并移除。
+    setCardContext("yield-bare-intervene", ctx);
+    handlers.before_agent_run({ prompt: "等待期间的无关用户消息", messages: [] }, { sessionKey: "yield-bare-intervene", runId: "run-unrelated" });
+    await finalizeCard("yield-bare-intervene", { success: true });
+    expect(calls.some((call) => call.url.includes("/message/edit"))).toBe(false);
+
+    // 真正的 resume(原 run 保留 runId)收尾时,才把 paused 卡收到终态
+    calls.length = 0;
+    setCardContext("yield-bare-intervene", ctx);
+    handlers.before_agent_run({ prompt: "真正 resume 后的最终战报", messages: [] }, { sessionKey: "yield-bare-intervene", runId: "run-a" });
+    await finalizeCard("yield-bare-intervene", { success: true });
+    const doneEdit = calls.find((call) => {
+      if (!call.url.includes("/message/edit")) return false;
+      const env = JSON.parse(call.body!.content_edit as string);
+      return progressHeaderText(env.card).includes("✅ Done");
+    });
+    expect(doneEdit).toBeTruthy();
+  });
+
+  it("兜底不得劫持仍在等子任务的 subagent-yield paused 卡", async () => {
+    const { fn, calls } = mockFetch();
+    global.fetch = fn as unknown as typeof fetch;
+    const { handlers } = makeApi({ lifecycle: false });
+    const childSessionKey = "agent:main:subagent:child-guard";
+    const ctx = {
+      apiUrl: "https://yield-guard.test",
+      botToken: "bf",
+      channelId: "g1",
+      channelType: ChannelType.Group,
+    };
+    setCardContext("yield-guard", ctx);
+    handlers.before_agent_run({}, { sessionKey: "yield-guard", runId: "run-a" });
+    handlers.before_tool_call({ toolName: "sessions_spawn", toolCallId: "spawn-1" }, { sessionKey: "yield-guard", runId: "run-a" });
+    handlers.after_tool_call(
+      { toolName: "sessions_spawn", toolCallId: "spawn-1", result: { details: { status: "accepted", childSessionKey, runId: "child-run" } } },
+      { sessionKey: "yield-guard", runId: "run-a" },
+    );
+    handlers.before_tool_call({ toolName: "sessions_yield", toolCallId: "yield-1" }, { sessionKey: "yield-guard", runId: "run-a" });
+    handlers.after_tool_call({ toolName: "sessions_yield", toolCallId: "yield-1" }, { sessionKey: "yield-guard", runId: "run-a" });
+    await vi.advanceTimersByTimeAsync(900);
+    await finalizeCard("yield-guard", { success: false });
+    calls.length = 0;
+
+    // 等待期间无关 run 只产出 final text 并收尾 —— 不得把仍在等子任务的卡关掉
+    setCardContext("yield-guard", ctx);
+    handlers.before_agent_run({ prompt: "等待期间的无关消息", messages: [] }, { sessionKey: "yield-guard", runId: "run-user" });
+    await finalizeCard("yield-guard", { success: true });
+    expect(calls.some((call) => call.url.includes("/message/edit"))).toBe(false);
+
+    // 真正的 completion run 回来仍能把卡收到已完成
+    calls.length = 0;
+    handlers.before_agent_run({ prompt: completionPrompt(childSessionKey), messages: [] }, { sessionKey: "yield-guard", runId: "run-b" });
+    await vi.runAllTicks();
+    await handlers.agent_end({ runId: "run-b", messages: [], success: true }, { sessionKey: "yield-guard", runId: "run-b" });
+    const doneEdit = calls.find((call) => {
+      if (!call.url.includes("/message/edit")) return false;
+      const env = JSON.parse(call.body!.content_edit as string);
+      return progressHeaderText(env.card).includes("✅ Done");
+    });
+    expect(doneEdit).toBeTruthy();
+  });
+
   it("paused 窗口的跨身份同 sessionKey 碰撞必须 fail-closed", async () => {
     const { fn, calls } = mockFetch();
     global.fetch = fn as unknown as typeof fetch;

--- a/src/card-progress.ts
+++ b/src/card-progress.ts
@@ -729,6 +729,49 @@ function markCardPaused(sessionKey: string, runId?: string, expectedEntry?: Card
 }
 
 /**
+ * 收尾兜底:把滞留在 pausedCards 里、由**本次收尾 run 拥有**的孤儿卡直接收到终态。
+ *
+ * 背景:一段 run 走过 sessions_yield 后收尾时把可见卡移入 pausedCards;它 resume 后是新的
+ * dispatch,`setCardContext` 为其新建一张空 entry(无 messageId)。若该 continuation 只产出
+ * final text、没有新工具调用,这张空 entry 永远拿不到 messageId,`finalizeCard` 正常分支因
+ * `!messageId` 早退,真正可见的 paused 卡永不推进终态 → 冻结在「正在处理/等待任务结果」,
+ * 直到 1h TTL 才误标为「等待超时」——即便任务其实成功。
+ *
+ * **归属校验(fail-closed)**:paused 卡可能在等待期间与无关消息交错,绝不能被任意后续
+ * dispatch 收尾。只有能证明本次收尾 run **就是**该 paused 流程的 run 才接管:
+ *   - `owner.runId === paused.pausedFromRunId`:同一 run resume 后收尾(bare yield 主场景;
+ *     resumed run 保留原 runId,与 handleCardLifecycleEvent 的 error/finish 归属判定一致)。
+ * 其余守卫:同 identity(防跨账号)、有 messageId、未 skip,且**不属于**仍在等子任务
+ * (`childSessionKeys` 非空)或已被 continuation 认领(`continuationRunId` 已设)的 subagent-yield
+ * 流程——后者仍由 lifecycle / agent_end 的 finishPausedCard 收尾,不能在这里抢先关闭。
+ * 缺 `owner.runId`(旧 host 不提供 runId)时同样 fail-closed,不接管。
+ */
+async function finalizeOrphanedPausedCard(
+  sessionKey: string,
+  opts: { success: boolean; errorText?: string },
+  owner: { identity: string; runId?: string },
+): Promise<void> {
+  const paused = pausedCards.get(sessionKey);
+  if (!paused || paused.skip || !paused.messageId) return;
+  // subagent-yield 流程:仍在等子任务或已被 continuation 认领 → 交给 lifecycle/agent_end,不抢占。
+  if (paused.continuationRunId || paused.childSessionKeys.size > 0) return;
+  // 跨账号 fail-closed:身份必须一致。
+  if (paused.identity !== owner.identity) return;
+  // run 归属 fail-closed:只有本 paused 流程的 run(同 run resume)可收尾;缺 runId 或与
+  // pausedFromRunId 不符(等待期间的无关 dispatch)→ 不接管,留给真正的 continuation / TTL。
+  if (!owner.runId || paused.pausedFromRunId !== owner.runId) return;
+  const phase = opts.success ? "done" : "error";
+  await editTrackedCardState(
+    sessionKey,
+    paused,
+    phase,
+    opts.errorText ? { errorText: opts.errorText } : {},
+  );
+  releasePausedCard(sessionKey, paused, `finalized orphaned paused card phase=${phase}`);
+  dbg(`finalized orphaned paused card session=${sessionKey} phase=${phase} run=${owner.runId}`);
+}
+
+/**
  * dispatch `finally` 收尾:完成/失败时清理；yield 时保留原卡供 continuation 更新。
  * 幂等:未登记或没发过占位卡则仅清理。
  */
@@ -737,6 +780,8 @@ export async function finalizeCard(
   opts: { success: boolean; errorText?: string } = { success: true },
 ): Promise<void> {
   const entry = cards.get(sessionKey);
+  // 没登记 entry → 无 identity/runId 可校验,fail-closed:不碰 pausedCards(sessionKey 碰撞时
+  // 可能是另一身份的卡)。正常 continuation dispatch 都会先 setCardContext,entry 必存在。
   if (!entry) return;
   // 等待 in-flight flush 落定后再接管。否则:首帧 send 尚未 return 时 messageId 未就绪,
   // 直接删 entry 会跳过终态帧,占位卡「🤖 Working…」永久冻结;若有 in-flight 中间帧
@@ -763,7 +808,15 @@ export async function finalizeCard(
   }
 
   // 从没发过卡(skip / 无工具调用)→ 无需收尾帧。
-  if (entry.skip || !entry.messageId) return;
+  if (entry.skip || !entry.messageId) {
+    // 常见于 yield 后同一 run resume 的 continuation:setCardContext 为其新建空 entry(无
+    // messageId),真正可见的卡还在 pausedCards。若本 run 已收尾(非 paused/resuming)且**归属**
+    // 该 paused 流程,把孤儿卡收到终态;否则(如等待期间的无关消息)不碰,留给真正的 continuation / TTL。
+    if (!retainForContinuation) {
+      await finalizeOrphanedPausedCard(sessionKey, opts, { identity: entry.identity, runId: entry.runId });
+    }
+    return;
+  }
 
   if (retainForContinuation) {
     await editTrackedCardState(sessionKey, entry, entry.phase);


### PR DESCRIPTION
## 问题

多工具 + final text 的任务经过 `sessions_yield` 后,进度卡永久冻结在「正在处理」——最后一步图标从未变成完成态,直到 1h TTL 才被误标为「等待超时」,即便任务其实成功。

## 根因

yielding run 收尾时把带 `messageId` 的可见卡移入 `pausedCards`;它 resume 后是一次新 dispatch,`setCardContext` 为其新建一张空 entry(无 `messageId`)。若该 continuation 只产出 final text、没有新工具调用,这张空 entry 拿不到 `messageId`,`finalizeCard` 命中 `!messageId` 早退,躺在 `pausedCards` 里的真卡从未被推进到终态。非 subagent 的 bare yield 没有 completion event 认领 `continuationRunId`,lifecycle / `agent_end` 的 `finishPausedCard` 也不会触发。

## 修复

给 `finalizeCard` 加收尾兜底 `finalizeOrphanedPausedCard`:当本 run 无法承载终态帧(`!messageId`)、本 run 已收尾(非 paused/resuming)、且能证明本次收尾 run 归属该 paused 流程时,把 `pausedCards` 里的孤儿卡收到 done/error。

归属校验 fail-closed:run 归属(`owner.runId === paused.pausedFromRunId`)、同身份(防跨账号)、不抢占仍在等子任务或已被 `continuationRunId` 认领的 subagent-yield 流程、no-entry 分支直接返回不碰 `pausedCards`。

## 验证

- 新增 4 个回归测试。**在 1.1.2 基线上**先证伪:continuation 只产 final text / continuation 失败两条用例均红(卡片收不到终态);打上修复后转绿。
- `type-check` + 全量 `test`(1774 passed / 6 skipped)+ `build` 全绿,基于最新 `main`(已含 #184)。

Closes #180
