### PR TITLE
ci: add .gitleaks.toml to allowlist doc and test fixtures

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,27 @@
+# gitleaks configuration for openclaw-channel-octo.
+#
+# Extends the upstream default ruleset (useDefault = true) and only allowlists
+# paths that hold deliberately fake credentials — unit-test fixtures and API
+# documentation examples. These are placeholders, never real secrets, and
+# production source (src/*.ts, non-test) stays fully scanned.
+#
+# The org reusable secret-scan workflow auto-detects this file
+# (`if [ -f .gitleaks.toml ]; then --config .gitleaks.toml`).
+title = "openclaw-channel-octo gitleaks config"
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Test fixtures and documentation examples use fake credentials, not real secrets."
+paths = [
+  # Unit tests seed bots/accounts with fabricated tokens
+  # (e.g. "tok-…_bot", "bf_secret", "app_EXAMPLE_dummy_app_bot_token").
+  '''.*\.test\.ts''',
+  # API skill docs demonstrate curl calls with placeholder Authorization headers.
+  '''skills/.*\.md''',
+]
+regexes = [
+  # Fake bot-token convention, in case it appears outside the paths above.
+  '''tok-[A-Za-z0-9_-]{6,}''',
+]


### PR DESCRIPTION
## What

Add a repo-level `.gitleaks.toml` so `secret-scan / Secret Scan (gitleaks)` stops failing repo-wide.

## Why

`secret-scan` is currently `FAILURE` on **`main` itself** (push events) and on **every open PR** — it is a pre-existing, repo-wide breakage, not introduced by any single PR.

Root cause: the repo ships **no gitleaks config**, so the org reusable workflow (`Mininglamp-OSS/.github` `reusable-secret-scan.yml@v1`) runs gitleaks' default ruleset with no allowlist. Combined with the workflow's `fetch-depth: 2` shallow checkout — which makes gitleaks attribute the whole tree to the PR head commit — 20 known-fake credentials get flagged:

- **18×** `curl-auth-header` — placeholder `Authorization` headers in `skills/octo-bot-api/SKILL.md` curl examples.
- **2×** `generic-api-key` — fake fixtures in `src/agent-tools.test.ts` (`botToken: "tok-…_bot"`, `botToken: "tok-secondary-secret-123"`).

None are real secrets.

## Fix

The reusable workflow auto-detects a repo config (`if [ -f .gitleaks.toml ]; then --config .gitleaks.toml`). This PR adds one that:

- keeps the upstream default ruleset (`[extend] useDefault = true`);
- allowlists only paths that hold deliberately fake credentials — unit-test fixtures (`*.test.ts`) and API skill docs (`skills/**.md`);
- keeps a `tok-…` regex allowlist for the fake bot-token convention if it appears elsewhere.

Production source (`src/*.ts`, non-test) stays fully scanned.

## Verification

Validated locally with **gitleaks 8.30.1** (the version pinned by the reusable workflow): the fixtures are flagged without the config and clear (`no leaks found`) with it.

Once merged, `main` goes green; open PRs pick it up on rebase/merge (e.g. #189).

Closes #190
