### PR TITLE
test(e2e): stop pinning the reasoning template version

### DIFF
--- a/src/card-openclaw-e2e.test.ts
+++ b/src/card-openclaw-e2e.test.ts
@@ -71,6 +71,17 @@ function cardText(card: CardEvidence | undefined): string {
   ].filter((value): value is string => typeof value === "string" && value.length > 0).join(" · ");
 }
 
+/**
+ * Assert the card was authored from the Registry reasoning template without
+ * pinning its version. The plugin deliberately trusts whatever version the Bot
+ * catalog advertises (`cd0538a`), so hardcoding one here just goes red the next
+ * time the server rolls the catalog forward — as it did going 0.2.0 → 0.3.0.
+ */
+function expectReasoningTemplateRef(ref: CardEvidence["templateRef"]): void {
+  expect(ref?.id).toBe("ai.reasoning-process");
+  expect(ref?.version).toMatch(/^\d+\.\d+\.\d+$/);
+}
+
 function expectStrictlyIncreasing(values: number[]): void {
   expect(values.length).toBeGreaterThan(0);
   for (let index = 1; index < values.length; index++) {
@@ -258,7 +269,7 @@ async function runLifecycleFlow({
   });
   expect(completed.cards).toHaveLength(1);
   expect(completed.cards[0]?.messageId).toBe(paused.cards[0]?.messageId);
-  expect(completed.cards[0]?.templateRef).toEqual({ id: "ai.reasoning-process", version: "0.2.0" });
+  expectReasoningTemplateRef(completed.cards[0]?.templateRef);
   expect(completed.cards[0]?.state).toBe("completed");
   expect(completed.cards[0]?.transient).toBe(false);
   expectStrictlyIncreasing(completed.cards[0]?.editCardSeqs ?? []);
@@ -350,7 +361,7 @@ suite("OpenClaw realistic filesystem tool workflow E2E", () => {
       expect(report).toBe("Processed: alpha=7\n");
       expect(completed.cards).toHaveLength(1);
       const text = cardText(completed.cards[0]);
-      expect(completed.cards[0]?.templateRef).toEqual({ id: "ai.reasoning-process", version: "0.2.0" });
+      expectReasoningTemplateRef(completed.cards[0]?.templateRef);
       expect(completed.cards[0]?.state).toBe("completed");
       expect(completed.cards[0]?.transient).toBe(false);
       expectStrictlyIncreasing(completed.cards[0]?.editCardSeqs ?? []);


### PR DESCRIPTION
## Summary

- replace the exact `templateRef` object assertion with `expectReasoningTemplateRef()`: the template id is still matched exactly, the version only by shape
- unblocks the container E2E suite, which currently fails on the version literal alone

## Why

#188 removed the local `0.1.0` / `0.2.0` allowlist so the plugin renders whatever version the Bot catalog advertises, unchanged. The E2E suite kept asserting `version: "0.2.0"` literally, which contradicts that contract: any catalog roll-forward turns the suite red without a single line of plugin behaviour changing.

That is exactly what happened. The server now advertises `0.3.0`, and both `sessions_spawn + sessions_yield card lifecycle` and `realistic filesystem tool workflow` fail on this assertion **after** passing every assertion that actually exercises the plugin (card count, message-id continuity across the paused/resumed card, terminal state, `card_seq` monotonicity, rendered step text):

```
AssertionError: expected { id: 'ai.reasoning-process', …(1) } to deeply equal { id: 'ai.reasoning-process', …(1) }
- "version": "0.2.0"
+ "version": "0.3.0"
```

Pinning the version here does not protect anything the plugin promises. What matters is that the card was authored from the Registry template rather than falling back to Model B — that is the template **id**, which stays an exact match. The version is asserted by shape (`/^\d+\.\d+\.\d+$/`) so a malformed or missing ref still fails.

## Verification

- `npm run type-check`
- `npm test -- --run` — 1787 passed, 6 skipped
- `npm run build`
- `npm run pack:check`
- container E2E against a real OpenClaw host and a real Octo server — 4 passed, including both previously failing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)