### PR TITLE
fix(cards): keep tool-delivered turns out of the Failed state

### DIFF
--- a/e2e/openclaw-host-plugin/index.mjs
+++ b/e2e/openclaw-host-plugin/index.mjs
@@ -78,11 +78,48 @@ function scriptedReply(body) {
   const allText = messages.map((message) => contentText(message?.content)).join("\n");
   const marker = allText.match(/(?:CHILD|PARENT)_E2E_OK:([0-9a-f-]{36})/i)?.[1] ??
     allText.match(/FILES_E2E_WORKFLOW:([0-9a-f-]{36})/i)?.[1] ??
+    allText.match(/TOOL_DELIVERY_E2E:([0-9a-f-]{36})/i)?.[1] ??
     allText.match(/OpenClaw host E2E marker: ([0-9a-f-]{36})/i)?.[1] ??
     allText.match(/Ordinary user follow-up for ([0-9a-f-]{36})/i)?.[1];
   if (!marker) return { text: "E2E_SCRIPT_ERROR: missing marker" };
 
   const toolMessages = messages.filter((message) => message?.role === "tool");
+
+  // Reproduces the "every step green but the card says Failed" report: the agent
+  // delivers its answer through the `message` tool and ends the turn with no
+  // final text. OpenClaw scores this attempt as success (messaging delivery
+  // evidence), while the Octo plugin never sees a deliver callback.
+  if (allText.includes(`TOOL_DELIVERY_E2E:${marker}`)) {
+    const target = allText.match(/TOOL_DELIVERY_TARGET=(\S+)/)?.[1] ?? "";
+    if (toolMessages.length === 0) {
+      return {
+        tool: "exec",
+        // Runs long enough to clear FLUSH_DEBOUNCE_MS so the progress card is
+        // actually sent before the turn finalizes — same as a real curl step.
+        arguments: {
+          command: "sleep 2 && printf TOOL_DELIVERY_PREFLIGHT_OK",
+          yieldMs: 5_000,
+          timeout: 15,
+          background: false,
+        },
+        reasoning: "Check the environment before answering.",
+        delayMs: 1_200,
+      };
+    }
+    if (toolMessages.length === 1) {
+      return {
+        tool: "message",
+        arguments: {
+          action: "send",
+          target,
+          message: `TOOL_DELIVERY_E2E_SENT:${marker}`,
+        },
+        reasoning: "Deliver the answer through the messaging tool.",
+      };
+    }
+    // Terminal turn with no assistant text at all.
+    return { text: "", reasoning: "The answer is already delivered." };
+  }
 
   if (allText.includes(`FILES_E2E_WORKFLOW:${marker}`)) {
     const workDir = `/tmp/octo-realistic-e2e/${marker}`;
@@ -307,8 +344,18 @@ function resolveAccountId(config, requested) {
   return first;
 }
 
-function buildPrompt(kind, marker, childDelaySeconds) {
+function buildPrompt(kind, marker, childDelaySeconds, targetUid) {
   if (kind === "configure-reasoning") return "/reasoning stream";
+  if (kind === "tool-delivery") {
+    return [
+      `TOOL_DELIVERY_E2E:${marker}.`,
+      `TOOL_DELIVERY_TARGET=user:${targetUid}`,
+      "First call exec exactly once with command=\"printf TOOL_DELIVERY_PREFLIGHT_OK\", yieldMs=1000, timeout=10, background=false.",
+      `After exec succeeds, call message exactly once with action="send", target="user:${targetUid}",`,
+      `message="TOOL_DELIVERY_E2E_SENT:${marker}".`,
+      "The message tool already delivered the answer, so end the turn with no final text at all.",
+    ].join(" ");
+  }
   if (kind === "followup") {
     return `Ordinary user follow-up for ${marker}. Do not call tools. Reply exactly FOLLOWUP_E2E_OK:${marker}`;
   }
@@ -361,7 +408,7 @@ export default {
     const runRequest = async (params) => {
       try {
         const kind = params.kind === "followup" || params.kind === "configure-reasoning" ||
-          params.kind === "file-tools"
+          params.kind === "file-tools" || params.kind === "tool-delivery"
           ? params.kind
           : "spawn";
         const marker = requiredString(params, "marker");
@@ -397,7 +444,7 @@ export default {
             timestamp: Math.floor(now / 1000),
             payload: {
               type: MessageType.Text,
-              content: buildPrompt(kind, marker, delay),
+              content: buildPrompt(kind, marker, delay, targetUid),
             },
           },
           groupHistories: new Map(),

--- a/e2e/openclaw-host-plugin/inspect.mjs
+++ b/e2e/openclaw-host-plugin/inspect.mjs
@@ -33,7 +33,27 @@ function messageText(message) {
     .join("\n");
 }
 
+/**
+ * Resolve this session's transcript from the session store. The content-based
+ * scan below is a fallback: an unrelated live session in the same container can
+ * mention the marker (for example while someone reads these very logs), and the
+ * scan would then pick the wrong file.
+ */
+function transcriptFromSessionStore() {
+  try {
+    const store = JSON.parse(fs.readFileSync(
+      "/root/.openclaw-dev/agents/main/sessions/sessions.json", "utf8"));
+    const file = store[sessionKey]?.sessionFile;
+    if (typeof file !== "string" || !fs.existsSync(file)) return undefined;
+    return { file, rows: readJsonLines(file) };
+  } catch {
+    return undefined;
+  }
+}
+
 function findParentTranscript() {
+  const fromStore = transcriptFromSessionStore();
+  if (fromStore) return fromStore;
   const dir = "/root/.openclaw-dev/agents/main/sessions";
   let files = [];
   try {
@@ -47,7 +67,8 @@ function findParentTranscript() {
     const rows = readJsonLines(file);
     const serialized = JSON.stringify(rows);
     if (serialized.includes(marker) &&
-        (serialized.includes("sessions_yield") || serialized.includes("FILES_E2E_WORKFLOW"))) {
+        (serialized.includes("sessions_yield") || serialized.includes("FILES_E2E_WORKFLOW") ||
+          serialized.includes("TOOL_DELIVERY_E2E"))) {
       return { file, rows };
     }
   }

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -8,6 +8,7 @@
 import { ChannelType, MessageType, RICH_TEXT_BLOCK_IMAGE, RICH_TEXT_BLOCK_TEXT, RICH_TEXT_IMAGE_PLACEHOLDER } from "./types.js";
 import type { MentionEntity, LogSink, RichTextBlock } from "./types.js";
 import { stripAllChannelPrefixes } from "./constants.js";
+import { collapseParentScope, normalizeOutboundChannelPrefix, parseTarget, resolveOutboundTarget } from "./target.js";
 import {
   sendMessage,
   sendMediaMessage,
@@ -32,55 +33,8 @@ export interface MessageActionResult {
   error?: string;
 }
 
-/**
- * Parse a target string into channelId + channelType.
- *
- * Explicit prefixes (`group:` / `user:`) always win.
- * For bare IDs, we check `knownGroupIds` to determine the channel type.
- */
-export function parseTarget(
-  target: string,
-  currentChannelId?: string,
-  knownGroupIds?: Set<string>,
-): { channelId: string; channelType: ChannelType } {
-  const THREAD_SEP = "____";
-
-  // Explicit prefixes always win
-  if (target.startsWith("group:")) {
-    const channelId = target.slice(6);
-    // groupNo____shortId → CommunityTopic
-    if (channelId.includes(THREAD_SEP)) {
-      return { channelId, channelType: ChannelType.CommunityTopic };
-    }
-    return { channelId, channelType: ChannelType.Group };
-  }
-  // OpenClaw's delivery pipeline can emit `channel:<id>` as a parallel alias
-  // for group channels (#232 review: "channel: 支持下沉到 parseTarget"). Handle
-  // it here so every caller — outbound adapter, message tool, etc — sees
-  // consistent routing without having to normalise upstream first.
-  if (target.startsWith("channel:")) {
-    const channelId = target.slice(8);
-    if (channelId.includes(THREAD_SEP)) {
-      return { channelId, channelType: ChannelType.CommunityTopic };
-    }
-    return { channelId, channelType: ChannelType.Group };
-  }
-  if (target.startsWith("user:"))
-    return { channelId: target.slice(5), channelType: ChannelType.DM };
-
-  // Strip octo: channel-namespace prefix if present
-  let bareId = target;
-  if (bareId.startsWith("octo:")) bareId = bareId.slice(5);
-
-  // Thread channel ID (groupNo____shortId)
-  if (bareId.includes(THREAD_SEP)) {
-    return { channelId: bareId, channelType: ChannelType.CommunityTopic };
-  }
-
-  // Bare ID: check knownGroupIds, also check parent group for thread context
-  const isGroup = knownGroupIds?.has(bareId) ?? false;
-  return { channelId: bareId, channelType: isGroup ? ChannelType.Group : ChannelType.DM };
-}
+// Re-exported so existing importers (channel.ts, tests) keep their entry point.
+export { parseTarget };
 
 /** Strip common prefixes to get the raw group_no */
 function stripGroupPrefix(raw: string): string {
@@ -91,61 +45,8 @@ function stripGroupPrefix(raw: string): string {
   return raw;
 }
 
-/**
- * Canonicalise an outbound delivery target prefix.
- *
- * OpenClaw's delivery pipeline can emit several equivalent shapes for the same
- * channel-group target (`group:<id>`, `channel:<id>`, `octo:<id>`), and the
- * agent-tool / multi-bot routing layer occasionally produces stacked forms
- * such as `"group:octo:grp1"` or `"channel:octo:grp1"`. Without canonical
- * collapse, the downstream parseTarget would only strip one leading prefix and
- * mis-parse the stacked inner segment as part of the group id
- * (`"group:octo:grp1"` → channelId `"octo:grp1"` → message routed to
- * the wrong group). The recursive collapse below makes the guard at handleSend
- * (which uses stripAllChannelPrefixes) and this delivery path agree on the
- * canonical bare groupId.
- *
- * Rules:
- *   - `octo:` namespace prefix → resolve by its INNER shape, never by the
- *     generic group fallback. `octo:` alone carries no user/group semantics, so
- *     the bare form (`octo:<id>`) must be left for parseTarget/knownGroupIds to
- *     classify. Collapsing `octo:<uid>` (a DM) to `group:<uid>` would send
- *     channel_type=2 for a DM id and the server rejects it (query_failed / 400).
- *   - No leading channel-namespace prefix at all → pass through (bare IDs,
- *     thread channel IDs like `grp1____x`, and other shapes parseTarget
- *     handles natively).
- *   - Stacked channel-namespace prefix wrapping a `user:` DM (e.g.
- *     `"octo:user:uid123"`) → unwrap to clean `user:uid123` so the DM path
- *     fires correctly.
- *   - An explicit `group:`/`channel:` token anywhere (after any leading `octo:`)
- *     means a group/channel target → recursively collapse and re-prefix as a
- *     single `group:` (so parseTarget sees ONE known shape and the group: arm of
- *     resolveOutboundOctoTarget can strip any `@mention` suffix).
- *   - Only an `octo:` namespace prefix with no group/channel/user hint
- *     (`octo:<id>`) is ambiguous: return the collapsed bare id and let
- *     parseTarget/knownGroupIds classify it (known group → Group, else DM). Do
- *     NOT default it to group — that would send channel_type=2 for a DM id and
- *     the server rejects it (query_failed / 400).
- */
-export function normalizeOutboundChannelPrefix(ctxTo: string): string {
-  const bare = stripAllChannelPrefixes(ctxTo);
-  // No leading channel-namespace prefix to strip — let parseTarget handle it
-  // natively (bare groupNo, `grp1____x` thread refs, `user:<uid>` DMs).
-  if (bare === ctxTo) return ctxTo;
-  // `user:` DM marker survives stripAllChannelPrefixes (it never strips user:) —
-  // route as DM, not a group with `user:` embedded in the channelId.
-  if (bare.startsWith("user:")) return bare;
-  // Distinguish an explicit group/channel target from a bare `octo:<id>`. Strip
-  // only the leading `octo:` runs, then look for a group:/channel: marker.
-  const afterOcto = ctxTo.replace(/^(?:octo:)+/, "");
-  if (afterOcto.startsWith("group:") || afterOcto.startsWith("channel:")) {
-    // Explicit group/channel (possibly stacked) — canonicalise to one `group:`.
-    return "group:" + bare;
-  }
-  // Bare `octo:<id>` — no user/group hint. Return the collapsed bare id so
-  // parseTarget/knownGroupIds decides (known group → Group, otherwise DM).
-  return bare;
-}
+// Re-exported so existing importers keep their entry point; implementation in target.ts.
+export { normalizeOutboundChannelPrefix };
 
 /**
  * Extract inline mention UIDs from an outbound target of the form
@@ -164,83 +65,18 @@ export function extractInlineMentionUids(ctxTo: string): string[] {
 }
 
 /**
- * Resolve an outbound delivery target from the framework's ChannelOutboundContext.
+ * Outbound target resolution with this channel's known-group set injected.
  *
- * OpenClaw passes thread/sub-topic replies as `to: "group:<group_no>"` + a separate
- * `threadId: "<short_id>"` field. parseTarget by itself never sees threadId, so a
- * bare call to parseTarget collapses thread routing back to the parent group
- * (channelType=2 instead of 5) and drops the short_id entirely. This helper merges
- * the two into the proper CommunityTopic channel_id (`<group_no>____<short_id>`,
- * channel_type=5) so outbound messages land in the thread, not the parent group.
- *
- * Also strips the inline mention UID suffix ("group:<id>@uid1,uid2" → "group:<id>")
- * before parsing — mention-UID extraction remains the caller's responsibility.
- *
- * Idempotent: if ctx.to already carries `____` (caller synthesised the thread id
- * themselves), the threadId merge is skipped.
+ * The resolver itself lives in `target.ts` so the progress-card delivery-evidence
+ * check can share the exact same normalization (stacked-prefix collapse, inline
+ * `@uid` stripping, threadId merge) without importing this module — that would
+ * close an `actions -> inbound -> card-progress -> actions` import cycle.
  */
 export function resolveOutboundOctoTarget(
   ctxTo: string,
   threadId?: string | number | null,
 ): { channelId: string; channelType: ChannelType } {
-  const THREAD_SEP = "____";
-
-  // Normalise `channel:<id>` to `group:<id>` so downstream parseTarget sees a
-  // shape it knows. See normalizeOutboundChannelPrefix for rationale.
-  let targetForParse = normalizeOutboundChannelPrefix(ctxTo);
-
-  // Strip inline mention-UID suffix before parsing.
-  if (targetForParse.startsWith("group:")) {
-    const groupPart = targetForParse.slice(6);
-    const atIdx = groupPart.indexOf("@");
-    if (atIdx >= 0) targetForParse = "group:" + groupPart.slice(0, atIdx);
-  }
-
-  const parsed = parseTarget(targetForParse, undefined, getKnownGroupIds());
-
-  // Fail-fast on a target that resolves to an empty channel — BEFORE the
-  // threadId merge below. parseTarget yields channelId="" for "", "group:",
-  // "user:", "group:@uid" (mention-only), etc. The framework outbound path
-  // (sendText/sendMedia) would otherwise POST channel_id="" and the server
-  // answers an opaque 500. The check must run here and not at the end: "group:"
-  // parses to {channelId:"", channelType:Group}, so a following threadId merge
-  // would synthesise a non-empty "____<short_id>" and slip past any end-of-
-  // function guard. A non-empty parsed channel can only grow longer through the
-  // merge, never become empty, so one check here covers every case. (#138)
-  if (!parsed.channelId.trim()) {
-    throw new Error(
-      "octo: outbound target resolves to an empty channel — a valid channel/user target is required",
-    );
-  }
-
-  // Merge framework-provided threadId only when ctx.to was a bare group — if the
-  // caller already encoded the thread via "____" in ctx.to, parsed.channelType
-  // is already CommunityTopic and we pass through.
-  if (threadId != null && parsed.channelType === ChannelType.Group) {
-    const shortId = stripAllChannelPrefixes(String(threadId));
-    if (!shortId) return parsed;
-
-    // Defensive: if threadId already contains `____`, validate its parent
-    // prefix matches the group parsed from ctx.to. Mismatch would route
-    // delivery to a different group entirely (cross-channel leak via stale
-    // or corrupted thread id). Prefer silently ignoring the threadId and
-    // staying on the explicit ctx.to parent over honouring an inconsistent
-    // pair — the caller's ctx.to is the stronger signal of intent.
-    if (shortId.includes(THREAD_SEP)) {
-      const shortIdParent = shortId.slice(0, shortId.indexOf(THREAD_SEP));
-      if (shortIdParent !== parsed.channelId) {
-        return parsed;
-      }
-      return { channelId: shortId, channelType: ChannelType.CommunityTopic };
-    }
-
-    return {
-      channelId: `${parsed.channelId}${THREAD_SEP}${shortId}`,
-      channelType: ChannelType.CommunityTopic,
-    };
-  }
-
-  return parsed;
+  return resolveOutboundTarget(ctxTo, threadId, getKnownGroupIds());
 }
 
 /**
@@ -593,16 +429,11 @@ async function handleSend(params: {
   let parentScopeApplied = false;
   if (scope === "parent") {
     effectiveThreadId = undefined;
-    const { channelType: scopeTargetType } = parseTarget(
-      normalizeOutboundChannelPrefix(target),
-      undefined,
-      getKnownGroupIds(),
-    );
-    if (scopeTargetType !== ChannelType.DM) {
-      const bareParent = extractParentGroupNo(
-        stripAllChannelPrefixes(target).replace(/^([^@]+)@.*$/, "$1"),
-      );
-      targetForResolve = `group:${bareParent}`;
+    // 折叠逻辑住在 target.ts,与进度卡的交付归属判定共用同一实现 —— 两边必须对
+    // 「这次发送落到哪」算出同一个答案。
+    const collapsed = collapseParentScope(target, getKnownGroupIds());
+    if (collapsed !== null) {
+      targetForResolve = collapsed;
       parentScopeApplied = true;
     }
   }

--- a/src/card-openclaw-e2e.test.ts
+++ b/src/card-openclaw-e2e.test.ts
@@ -383,3 +383,50 @@ suite("OpenClaw realistic filesystem tool workflow E2E", () => {
     }
   }, 120_000);
 });
+
+/**
+ * Regression guard for the "every step green but the card says Failed" report.
+ *
+ * The agent delivers its answer with the `message` tool and ends the turn with
+ * no final text. OpenClaw scores that attempt as a success (it counts messaging
+ * delivery evidence in resolveAttemptTrajectoryTerminal), so dispatch resolves
+ * normally — but the plugin's deliver callback never fires, `replySucceeded`
+ * stays false, and finalizeCard drives the card to phase=error.
+ */
+suite("OpenClaw messaging-tool delivery E2E", () => {
+  it("does not mark the card failed when the answer was delivered by the message tool", async () => {
+    expect(targetUid, "OCTO_E2E_TARGET_UID is required").not.toBe("");
+    const marker = randomUUID();
+    const sessionKey = `agent:main:octo-host-e2e:${marker}`;
+
+    await callBridge({ kind: "configure-reasoning", marker, targetUid, sessionKey });
+    const startedAtMs = Date.now();
+    const accepted = await callBridge({ kind: "tool-delivery", marker, targetUid, sessionKey });
+    expect(accepted.kind).toBe("tool-delivery");
+
+    const completed = await waitForEvidence(
+      marker,
+      sessionKey,
+      startedAtMs,
+      (evidence) => evidence.toolCalls.some((call) => call.name === "message") &&
+        evidence.cards.some((card) => card.state === "completed" || card.state === "error"),
+      90_000,
+    );
+
+    const names = completed.toolCalls.map((call) => call.name);
+    expect(names).toEqual(["exec", "message"]);
+    expect(completed.toolCalls[1]?.arguments).toMatchObject({
+      action: "send",
+      target: `user:${targetUid}`,
+    });
+
+    const card = completed.cards.at(-1);
+    const text = cardText(card);
+    // Both tool steps ran clean, so the card must not claim the run failed.
+    expect(text).toContain("exec");
+    expect(text).toContain("message");
+    expect(text).not.toContain("Generation failed");
+    expect(text).not.toContain("Reasoning was interrupted");
+    expect(card?.state).toBe("completed");
+  }, 150_000);
+});

--- a/src/card-progress.test.ts
+++ b/src/card-progress.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { ChannelType } from "./types.js";
+import { registerGroupAccount, _testGetGroupAccountMap } from "./group-md.js";
 import { OCTO_CARD_LAYOUTS } from "./card-render.js";
 import {
   setCardContext,
@@ -1316,6 +1317,288 @@ describe("card-progress 状态机 + hook + 节流", () => {
     expect(continuationData?.reasoningId).toBe(firstData?.reasoningId);
   });
 
+  /**
+   * agent 用 `message` 工具把答复直接投递给用户、turn 结束又没有 final text 时,
+   * dispatch 的 `replySucceeded` 保持 false —— 但这一轮其实成功了(OpenClaw core 的
+   * resolveAttemptTrajectoryTerminal 同样把 messaging 投递算作交付证据)。卡片不能
+   * 因此谎报「⚠️ Interrupted」。归属校验 fail-closed:只认发往本卡频道的成功 send。
+   */
+  describe("message 工具投递证据", () => {
+    async function runMessageToolTurn(opts: {
+      sessionKey: string;
+      channelId: string;
+      channelType: ChannelType;
+      params: Record<string, unknown>;
+      toolError?: string;
+      toolName?: string;
+    }) {
+      const { fn, calls } = mockFetch();
+      global.fetch = fn as unknown as typeof fetch;
+      const { handlers } = makeApi();
+      const hookCtx = { sessionKey: opts.sessionKey, runId: "run-msg" };
+      setCardContext(opts.sessionKey, {
+        apiUrl: "https://msg-tool.test",
+        botToken: "bf",
+        channelId: opts.channelId,
+        channelType: opts.channelType,
+      });
+      handlers.before_agent_run({}, hookCtx);
+      const toolName = opts.toolName ?? "message";
+      handlers.before_tool_call({ toolName, toolCallId: "msg-1", params: opts.params }, hookCtx);
+      await vi.advanceTimersByTimeAsync(900);
+      handlers.after_tool_call({
+        toolName,
+        toolCallId: "msg-1",
+        durationMs: 20,
+        ...(opts.toolError ? { error: opts.toolError } : { result: {} }),
+      }, hookCtx);
+      calls.length = 0;
+
+      // The dispatcher never saw a deliverable final text for this turn.
+      await finalizeCard(opts.sessionKey, { success: false });
+
+      const edit = calls.find((call) => call.url.includes("/message/edit"));
+      expect(edit).toBeTruthy();
+      return progressHeaderText(JSON.parse(edit!.body!.content_edit as string).card);
+    }
+
+    it("成功投递到本卡频道时收成完成态,而不是已中断", async () => {
+      const header = await runMessageToolTurn({
+        sessionKey: "msg-deliver-dm",
+        channelId: "u1",
+        channelType: ChannelType.DM,
+        params: { action: "send", target: "user:u1", message: "答复正文" },
+      });
+      expect(header).toContain("✅ Done");
+      expect(header).not.toContain("Interrupted");
+    });
+
+    it("群卡认同 group: 前缀的成功投递", async () => {
+      const header = await runMessageToolTurn({
+        sessionKey: "msg-deliver-group",
+        channelId: "g1",
+        channelType: ChannelType.Group,
+        params: { action: "send", target: "group:g1", message: "答复正文" },
+      });
+      expect(header).toContain("✅ Done");
+    });
+
+    it("投递到别的频道不算本卡交付", async () => {
+      const header = await runMessageToolTurn({
+        sessionKey: "msg-other-channel",
+        channelId: "g1",
+        channelType: ChannelType.Group,
+        params: { action: "send", target: "group:g-other", message: "发给别人的通知" },
+      });
+      expect(header).toContain("Interrupted");
+    });
+
+    it("群卡不认发往子区的投递(发送路径也会落到子区)", async () => {
+      const header = await runMessageToolTurn({
+        sessionKey: "msg-thread-vs-parent",
+        channelId: "g1",
+        channelType: ChannelType.Group,
+        params: { action: "send", target: "group:g1____t1", message: "发到子区" },
+      });
+      expect(header).toContain("Interrupted");
+    });
+
+    /**
+     * 归一化必须和真实发送路径一致(resolveOutboundTarget),否则发送**确实落到本卡频道**的
+     * target 会被判为「不是本轮答复」,本 PR 要修的 Failed 卡在这些形态下原样存活。
+     */
+    it("认同堆叠前缀 octo:user: 的投递", async () => {
+      const header = await runMessageToolTurn({
+        sessionKey: "msg-stacked-user",
+        channelId: "u1",
+        channelType: ChannelType.DM,
+        params: { action: "send", target: "octo:user:u1", message: "答复正文" },
+      });
+      expect(header).toContain("✅ Done");
+    });
+
+    it("认同带内联 @uid 后缀的群投递", async () => {
+      const header = await runMessageToolTurn({
+        sessionKey: "msg-mention-suffix",
+        channelId: "g1",
+        channelType: ChannelType.Group,
+        params: { action: "send", target: "group:g1@u2", message: "答复正文" },
+      });
+      expect(header).toContain("✅ Done");
+    });
+
+    it("线程卡认同 bare-parent 投递(发送路径会自动重路由到本线程,issue #98)", async () => {
+      const header = await runMessageToolTurn({
+        sessionKey: "msg-thread-reroute",
+        channelId: "g1____t1",
+        channelType: ChannelType.CommunityTopic,
+        params: { action: "send", target: "group:g1", message: "答复正文" },
+      });
+      expect(header).toContain("✅ Done");
+    });
+
+    it("scope=parent 时不认 bare-parent(发送路径发往父群,不是本线程)", async () => {
+      const header = await runMessageToolTurn({
+        sessionKey: "msg-thread-scope-parent",
+        channelId: "g1____t1",
+        channelType: ChannelType.CommunityTopic,
+        params: { action: "send", target: "group:g1", scope: "parent", message: "发到父群" },
+      });
+      expect(header).toContain("Interrupted");
+    });
+
+    it("裸 id 在 knownGroupIds 命中时认同群投递,未命中则不认", async () => {
+      // 发送路径把裸 id 交给 knownGroupIds 分类,evidence 检查共用同一套输入。
+      registerGroupAccount("gk1", "acct-known", "agent-known");
+      try {
+        expect(await runMessageToolTurn({
+          sessionKey: "msg-bare-known",
+          channelId: "gk1",
+          channelType: ChannelType.Group,
+          params: { action: "send", target: "gk1", message: "答复正文" },
+        })).toContain("✅ Done");
+      } finally {
+        _testGetGroupAccountMap().delete("agent-known:gk1");
+      }
+      // 未注册的裸 id 会被解析成 DM,群卡不认。
+      expect(await runMessageToolTurn({
+        sessionKey: "msg-bare-unknown",
+        channelId: "gk2",
+        channelType: ChannelType.Group,
+        params: { action: "send", target: "gk2", message: "答复正文" },
+      })).toContain("Interrupted");
+    });
+
+    /**
+     * scope:"parent" 在发送路径里**最先**生效:group-like target 被折叠到父群、ambient
+     * threadId 被清掉,随后跳过 in-thread 重路由。归属判定必须先做同样的折叠再比较,否则
+     * 两个方向都会错 —— 子区卡把发往父群的投递记成自己的,父群卡又不认真正发给它的投递。
+     */
+    it("scope=parent + 显式子区 target:子区卡不得认领(实际发往父群)", async () => {
+      const header = await runMessageToolTurn({
+        sessionKey: "msg-scope-parent-thread",
+        channelId: "g1____t1",
+        channelType: ChannelType.CommunityTopic,
+        params: { action: "send", target: "group:g1____t1", scope: "parent", message: "发到父群" },
+      });
+      expect(header).toContain("Interrupted");
+    });
+
+    it("scope=parent + 显式子区 target:父群卡应认领(实际就发给它)", async () => {
+      const header = await runMessageToolTurn({
+        sessionKey: "msg-scope-parent-group",
+        channelId: "g1",
+        channelType: ChannelType.Group,
+        params: { action: "send", target: "group:g1____t1", scope: "parent", message: "答复正文" },
+      });
+      expect(header).toContain("✅ Done");
+    });
+
+    it("认同 threadId 参数合成出的子区目标", async () => {
+      const header = await runMessageToolTurn({
+        sessionKey: "msg-threadid-merge",
+        channelId: "g1____t1",
+        channelType: ChannelType.CommunityTopic,
+        params: { action: "send", target: "group:g1", threadId: "t1", message: "答复正文" },
+      });
+      expect(header).toContain("✅ Done");
+    });
+
+    it("投递失败不算交付", async () => {
+      const header = await runMessageToolTurn({
+        sessionKey: "msg-send-failed",
+        channelId: "u1",
+        channelType: ChannelType.DM,
+        params: { action: "send", target: "user:u1", message: "答复正文" },
+        toolError: "Octo API /v1/bot/sendMessage failed (400)",
+      });
+      expect(header).toContain("Interrupted");
+    });
+
+    it("非 send 动作不算交付", async () => {
+      const header = await runMessageToolTurn({
+        sessionKey: "msg-read-action",
+        channelId: "u1",
+        channelType: ChannelType.DM,
+        params: { action: "read", target: "user:u1" },
+      });
+      expect(header).toContain("Interrupted");
+    });
+
+    it("同名的其它工具不算交付", async () => {
+      const header = await runMessageToolTurn({
+        sessionKey: "msg-not-message-tool",
+        channelId: "u1",
+        channelType: ChannelType.DM,
+        toolName: "read",
+        params: { action: "send", target: "user:u1" },
+      });
+      expect(header).toContain("Interrupted");
+    });
+
+    it("旧 host 缺 toolCallId 时不认投递证据(无法归因,fail-closed)", async () => {
+      const { fn, calls } = mockFetch();
+      global.fetch = fn as unknown as typeof fetch;
+      const { handlers } = makeApi();
+      const hookCtx = { sessionKey: "msg-no-tool-call-id", runId: "run-msg" };
+      setCardContext("msg-no-tool-call-id", {
+        apiUrl: "https://msg-tool.test",
+        botToken: "bf",
+        channelId: "u1",
+        channelType: ChannelType.DM,
+      });
+      handlers.before_agent_run({}, hookCtx);
+      // 发往本卡频道的调用(最终会失败)。
+      handlers.before_tool_call(
+        { toolName: "message", params: { action: "send", target: "user:u1" } },
+        hookCtx,
+      );
+      // 发往别处的通知(会成功)。两次调用都没有 toolCallId,彼此不可区分。
+      handlers.before_tool_call(
+        { toolName: "message", params: { action: "send", target: "user:other" } },
+        hookCtx,
+      );
+      await vi.advanceTimersByTimeAsync(900);
+      handlers.after_tool_call({ toolName: "message", result: {} }, hookCtx); // 别处那次成功
+      calls.length = 0;
+
+      await finalizeCard("msg-no-tool-call-id", { success: false });
+
+      const edit = calls.find((call) => call.url.includes("/message/edit"));
+      const header = progressHeaderText(JSON.parse(edit!.body!.content_edit as string).card);
+      // 成功的那次并非发往本卡,不能被当成本轮答复。
+      expect(header).toContain("Interrupted");
+    });
+
+    it("显式失败(errorText)优先于工具投递证据", async () => {
+      const { fn, calls } = mockFetch();
+      global.fetch = fn as unknown as typeof fetch;
+      const { handlers } = makeApi();
+      const hookCtx = { sessionKey: "msg-explicit-error", runId: "run-msg" };
+      setCardContext("msg-explicit-error", {
+        apiUrl: "https://msg-tool.test",
+        botToken: "bf",
+        channelId: "u1",
+        channelType: ChannelType.DM,
+      });
+      handlers.before_agent_run({}, hookCtx);
+      handlers.before_tool_call(
+        { toolName: "message", toolCallId: "msg-1", params: { action: "send", target: "user:u1" } },
+        hookCtx,
+      );
+      await vi.advanceTimersByTimeAsync(900);
+      handlers.after_tool_call({ toolName: "message", toolCallId: "msg-1", result: {} }, hookCtx);
+      calls.length = 0;
+
+      await finalizeCard("msg-explicit-error", { success: false, errorText: "provider timeout" });
+
+      const edit = calls.find((call) => call.url.includes("/message/edit"));
+      const header = progressHeaderText(JSON.parse(edit!.body!.content_edit as string).card);
+      expect(header).toContain("Interrupted");
+      expect(header).toContain("provider timeout");
+    });
+  });
+
   it("OBO 场景跳过(不发任何请求)", async () => {
     const { fn, calls } = mockFetch();
     global.fetch = fn as unknown as typeof fetch;
@@ -1861,6 +2144,51 @@ describe("card-progress 状态机 + hook + 节流", () => {
       return progressHeaderText(env.card).includes("⚠️ Interrupted");
     });
     expect(errEdit).toBeTruthy();
+  });
+
+  /**
+   * 投递证据属于产生它的那个 run。CardEntry 会跨 run 存活(finalizeCard 把它停进
+   * pausedCards),若证据不清除,孤儿收尾就会拿上一个 run 的投递去洗白本轮的失败 ——
+   * 用户刚收到道歉消息,卡片却显示 ✅ Done。
+   */
+  it("前一 run 的工具投递不得洗白 continuation 的失败", async () => {
+    const { fn, calls } = mockFetch();
+    global.fetch = fn as unknown as typeof fetch;
+    const { handlers } = makeApi({ lifecycle: false });
+    const ctx = {
+      apiUrl: "https://leak-guard.test",
+      botToken: "bf",
+      channelId: "u1",
+      channelType: ChannelType.DM,
+    };
+    setCardContext("leak-guard", ctx);
+    handlers.before_agent_run({}, { sessionKey: "leak-guard", runId: "run-a" });
+    // run A 通过 message 工具向本卡频道投递 → 本 run 有交付证据
+    handlers.before_tool_call(
+      { toolName: "message", toolCallId: "msg-1", params: { action: "send", target: "user:u1" } },
+      { sessionKey: "leak-guard", runId: "run-a" },
+    );
+    handlers.after_tool_call(
+      { toolName: "message", toolCallId: "msg-1", result: {} },
+      { sessionKey: "leak-guard", runId: "run-a" },
+    );
+    handlers.before_tool_call({ toolName: "sessions_yield", toolCallId: "y-1" }, { sessionKey: "leak-guard", runId: "run-a" });
+    handlers.after_tool_call({ toolName: "sessions_yield", toolCallId: "y-1", durationMs: 5 }, { sessionKey: "leak-guard", runId: "run-a" });
+    await vi.advanceTimersByTimeAsync(900);
+    await finalizeCard("leak-guard", { success: true });
+    calls.length = 0;
+
+    // continuation:同 runId 恢复,自己没有任何工具调用、也没有任何投递。
+    setCardContext("leak-guard", ctx);
+    handlers.before_agent_run({ prompt: "继续", messages: [] }, { sessionKey: "leak-guard", runId: "run-a" });
+    // 生产形态:inbound.ts 只传 success,不传 errorText。
+    await finalizeCard("leak-guard", { success: false });
+
+    const edit = calls.filter((c) => c.url.includes("/message/edit")).pop();
+    expect(edit).toBeTruthy();
+    const header = progressHeaderText(JSON.parse(edit!.body!.content_edit as string).card);
+    expect(header).toContain("Interrupted");
+    expect(header).not.toContain("Done");
   });
 
   it("bare yield 等待期间无关 run 收尾不得接管原 paused 卡,真正 resume 才收尾", async () => {

--- a/src/card-progress.ts
+++ b/src/card-progress.ts
@@ -35,6 +35,8 @@ import {
   summarizeToolResult,
 } from "./reasoning-process.js";
 import { DISPLAY_CARD_TOOL_NAME, INTERACTIVE_CARD_TOOL_NAME } from "./constants.js";
+import { collapseParentScope, parentGroupOf, resolveOutboundTarget } from "./target.js";
+import { getKnownGroupIds } from "./group-md.js";
 import type { ReasoningCardTemplateMode } from "./config-schema.js";
 
 /** dispatch 侧登记的发送上下文。 */
@@ -100,6 +102,16 @@ interface CardEntry {
   nextCardSeq: number;
   /** Stable for every frame, including paused continuation runs. */
   reasoningId?: string;
+  /**
+   * `message` 工具调用中,目标已确认就是本卡频道的那些 toolCallId。before_tool_call 记录
+   * (只有它带 params),after_tool_call 用成功结果兑现成 `deliveredByTool`。
+   */
+  pendingMessageToolCallIds?: Set<string>;
+  /**
+   * 本 run 已通过 `message` 工具向本卡频道成功投递过内容。等价于 OpenClaw core 的
+   * messaging delivery evidence,`finalizeCard` 据此不把这类 turn 误判为失败。
+   */
+  deliveredByTool?: boolean;
 }
 
 type CachedCardProfile = {
@@ -755,6 +767,11 @@ async function editTrackedCardState(
   }
 }
 
+/**
+ * lifecycle 驱动的 paused 卡收尾。这里**不看**投递证据,与 finalizeCard /
+ * finalizeOrphanedPausedCard 有意不对称:`end` 分支已由 host 明确判定为 done,`error` 分支带着
+ * 真实错误串 —— 两者都不存在「replySucceeded 为 false 但其实交付了」那种歧义,证据无从发挥。
+ */
 function finishPausedCard(
   sessionKey: string,
   entry: CardEntry,
@@ -807,8 +824,8 @@ function markCardPaused(sessionKey: string, runId?: string, expectedEntry?: Card
  */
 async function finalizeOrphanedPausedCard(
   sessionKey: string,
-  opts: { success: boolean; errorText?: string },
-  owner: { identity: string; runId?: string },
+  opts: { success: boolean; errorText?: string; failed?: boolean },
+  owner: { identity: string; runId?: string; deliveredByTool?: boolean },
 ): Promise<void> {
   const paused = pausedCards.get(sessionKey);
   if (!paused || paused.skip || !paused.messageId) return;
@@ -819,7 +836,11 @@ async function finalizeOrphanedPausedCard(
   // run 归属 fail-closed:只有本 paused 流程的 run(同 run resume)可收尾;缺 runId 或与
   // pausedFromRunId 不符(等待期间的无关 dispatch)→ 不接管,留给真正的 continuation / TTL。
   if (!owner.runId || paused.pausedFromRunId !== owner.runId) return;
-  const phase = opts.success ? "done" : "error";
+  // 交付证据取自**本次收尾的 run**(owner),不是停放在 pausedCards 里的旧 entry —— 后者的
+  // deliveredByTool 属于 yield 之前那一轮,拿它判定会把本轮的失败洗成成功。
+  const phase = succeededOrDeliveredByTool({ deliveredByTool: owner.deliveredByTool }, opts)
+    ? "done"
+    : "error";
   await editTrackedCardState(
     sessionKey,
     paused,
@@ -831,12 +852,30 @@ async function finalizeOrphanedPausedCard(
 }
 
 /**
+ * `replySucceeded` 只在 reply dispatcher 的 deliver 回调里置真,因此 agent 用 `message`
+ * 工具直接投递、turn 结束又没有 final text 时它恒为 false —— 但这一轮其实交付了。补上工具
+ * 投递证据,避免把「每步都绿」的成功 turn 渲染成「⚠️ Interrupted」。
+ *
+ * 失败优先:`failed`(dispatch 真的失败过)或显式 errorText 都会否决证据。core 的
+ * resolveAttemptTrajectoryTerminal 同样让 promptError 短路在 delivery-evidence 之前 ——
+ * 证据只用来判定「空 turn 是否算交付」,从不用来覆盖 error 终态。
+ */
+function succeededOrDeliveredByTool(
+  evidence: { deliveredByTool?: boolean },
+  opts: { success: boolean; errorText?: string; failed?: boolean },
+): boolean {
+  if (opts.success) return true;
+  if (opts.failed || opts.errorText) return false;
+  return evidence.deliveredByTool === true;
+}
+
+/**
  * dispatch `finally` 收尾:完成/失败时清理；yield 时保留原卡供 continuation 更新。
  * 幂等:未登记或没发过占位卡则仅清理。
  */
 export async function finalizeCard(
   sessionKey: string,
-  opts: { success: boolean; errorText?: string } = { success: true },
+  opts: { success: boolean; errorText?: string; failed?: boolean } = { success: true },
 ): Promise<void> {
   const entry = cards.get(sessionKey);
   // 没登记 entry → 无 identity/runId 可校验,fail-closed:不碰 pausedCards(sessionKey 碰撞时
@@ -861,6 +900,9 @@ export async function finalizeCard(
     cards.delete(sessionKey);
     // 没发出 messageId 的懒卡没有可更新对象，不能长期滞留在 pausedCards。
     if (retainForContinuation && !entry.skip && entry.messageId) {
+      // 证据是 per-run 的事实。entry 从这里开始跨 run 存活,留着会被后续 run 误读。
+      entry.deliveredByTool = undefined;
+      entry.pendingMessageToolCallIds = undefined;
       pausedCards.set(sessionKey, entry);
       schedulePausedCardExpiry(sessionKey, entry);
     }
@@ -872,7 +914,11 @@ export async function finalizeCard(
     // messageId),真正可见的卡还在 pausedCards。若本 run 已收尾(非 paused/resuming)且**归属**
     // 该 paused 流程,把孤儿卡收到终态;否则(如等待期间的无关消息)不碰,留给真正的 continuation / TTL。
     if (!retainForContinuation) {
-      await finalizeOrphanedPausedCard(sessionKey, opts, { identity: entry.identity, runId: entry.runId });
+      await finalizeOrphanedPausedCard(sessionKey, opts, {
+        identity: entry.identity,
+        runId: entry.runId,
+        ...(entry.deliveredByTool ? { deliveredByTool: true } : {}),
+      });
     }
     return;
   }
@@ -884,7 +930,7 @@ export async function finalizeCard(
 
   const terminalPhase: CardProgressState["phase"] = entry.phase === "stopped"
     ? "stopped"
-    : opts.success ? "done" : "error";
+    : succeededOrDeliveredByTool(entry, opts) ? "done" : "error";
   const state = entryProgressState(sessionKey, entry, terminalPhase, {
     elapsedMs: Date.now() - entry.startedAt,
     ...(opts.errorText ? { errorText: opts.errorText } : {}),
@@ -1072,6 +1118,57 @@ export function markCardAnswering(sessionKey: string): void {
   if (entry.messageId) scheduleFlush(sessionKey, entry);
 }
 
+/** OpenClaw core 的 messaging 工具规范名(`normalizeCliMessagingToolName`)。 */
+const MESSAGING_TOOL_NAME = "message";
+
+/**
+ * 判断一次 `message` 工具调用是否**就是**向本卡频道投递可见内容。
+ *
+ * 归一化必须与真实发送路径一致,否则「发送确实落到本卡频道」的 target 会被判为不是本轮答复,
+ * 卡片照旧误报失败。故复用 `resolveOutboundTarget`(与 actions.ts 的 resolveOutboundOctoTarget
+ * 同一实现):堆叠前缀折叠、内联 `@uid` 剥离、threadId 合并、knownGroupIds 分类裸 id。
+ *
+ * 另需复现 handleSend 的 in-thread 重路由(issue #98):线程会话内的 bare-parent target 会被
+ * 改写成当前线程。本卡频道就是「当前频道」,所以这里能独立判定,无需 toolContext。
+ *
+ * 仍然 fail-closed:action 必须是 send、target 必须显式给出,解析结果的 channelId + channelType
+ * 都要匹配。群卡不认发往子区的投递(发送路径也落在子区),`scope:"parent"` 不认 bare-parent。
+ */
+function messageToolTargetsThisCard(entry: CardEntry, params: unknown): boolean {
+  const args = asRecord(params);
+  if (!args || args.action !== "send") return false;
+  const target = typeof args.target === "string" ? args.target.trim() : "";
+  if (!target) return false;
+  const parentScope = args.scope === "parent";
+  // scope:"parent" 在发送路径里最先生效:折叠到父群、清掉 ambient threadId、跳过 in-thread
+  // 重路由。归属判定必须先做同一折叠,否则子区卡会认领发往父群的投递,父群卡又不认真正发给
+  // 它的投递(两个方向都错)。
+  const knownGroupIds = getKnownGroupIds();
+  const collapsed = parentScope ? collapseParentScope(target, knownGroupIds) : null;
+  const effectiveTarget = collapsed ?? target;
+  const threadId = parentScope
+    ? undefined
+    : typeof args.threadId === "string" || typeof args.threadId === "number"
+      ? args.threadId
+      : undefined;
+  let resolved: { channelId: string; channelType: ChannelType };
+  try {
+    resolved = resolveOutboundTarget(effectiveTarget, threadId, knownGroupIds);
+  } catch {
+    return false; // 空频道等非法 target:发送路径也会抛,不构成交付证据
+  }
+  if (resolved.channelId === entry.ctx.channelId && resolved.channelType === entry.ctx.channelType) {
+    return true;
+  }
+  // in-thread 重路由:本卡是子区,且 target 落在本子区的父群 → 发送路径会改写成本子区。
+  // scope:"parent" 明确要求发父群,发送路径会跳过该重路由,这里同样不适用。
+  return !parentScope &&
+    entry.ctx.channelType === ChannelType.CommunityTopic &&
+    resolved.channelType === ChannelType.Group &&
+    resolved.channelId === parentGroupOf(entry.ctx.channelId);
+}
+
+
 /**
  * runId 归属守卫。before_agent_run 是唯一绑定点;普通 hook 永不认领 entry。
  * 旧 host 完全不提供 runId 时保留 sessionKey-only 兼容;一旦 entry 已绑定 runId,
@@ -1198,6 +1295,18 @@ export function registerCardProgress(api: OpenClawPluginApi): void {
       return;
     }
     dbg(`before_tool_call tool=${e.toolName} session=${sk}`);
+    // 只有 before 事件带 params;先记下「目标是本卡频道」的 send 调用,等 after 的成功结果兑现。
+    // 必须有 toolCallId:缺了就无法把 after 的成败对回具体调用,同一 turn 里「发往别处的调用
+    // 成功」会兑现「发往本卡的调用」的 pending,把失败洗成成功。宁可旧 host 不享受该修复。
+    if (e.toolName === MESSAGING_TOOL_NAME) {
+      if (e.toolCallId && messageToolTargetsThisCard(entry, e.params)) {
+        (entry.pendingMessageToolCallIds ??= new Set()).add(e.toolCallId);
+      }
+    } else if (messageToolTargetsThisCard(entry, e.params)) {
+      // 形状像「发往本卡频道」却挂在别的工具名下:host 可能用了别名/自定义 messaging 工具,
+      // 此时本修复静默失效。留一条诊断,否则下次只能从「卡片又误报 Failed」倒推。
+      dbg(`send-shaped call to this card under tool=${e.toolName} (expected ${MESSAGING_TOOL_NAME}); delivery evidence not counted`);
+    }
     endRunningThinking(entry, Date.now()); // P1-g:上一轮 thinking 收尾
     entry.phase = "tool";
     entry.steps.push({
@@ -1270,6 +1379,12 @@ export function registerCardProgress(api: OpenClawPluginApi): void {
       if (typeof e.durationMs === "number") target.durationMs = e.durationMs;
       if (e.error) target.error = e.error;
       if (!e.error) target.resultSummary = summarizeToolResult(e.toolName, e.result);
+    }
+    // 成功投递到本卡频道 = 本轮已交付,即使 dispatcher 没拿到任何 final text。
+    if (e.toolName === MESSAGING_TOOL_NAME && !e.error && e.toolCallId &&
+        entry.pendingMessageToolCallIds?.delete(e.toolCallId)) {
+      entry.deliveredByTool = true;
+      dbg(`message tool delivered to this card session=${sk}`);
     }
     if (e.toolName === "sessions_spawn" && !e.error) {
       const childSessionKey = acceptedSpawnChildSessionKey(e.result);

--- a/src/inbound-card-failure-precedence.test.ts
+++ b/src/inbound-card-failure-precedence.test.ts
@@ -1,0 +1,243 @@
+/**
+ * P1-2 regression: a turn that failed must stay failed on the progress card, even
+ * when the agent already delivered something through the `message` tool.
+ *
+ * `replySucceeded === false` conflates two states — "no deliverable final text"
+ * (which tool delivery legitimately compensates for) and "this turn errored".
+ * inbound.ts must hand the failure reason to finalizeCard so the delivery
+ * evidence cannot launder it into a green card while the user is being sent an
+ * apology message.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { handleInboundMessage } from "./inbound.js";
+import {
+  registerCardProgress,
+  _resetCardProgressForTests,
+} from "./card-progress.js";
+import { setOctoRuntime } from "./runtime.js";
+import { _clearKnownBots } from "./bot-registry.js";
+import { _clearOwnerRegistry, registerOwnerUid } from "./owner-registry.js";
+import { ChannelType, MessageType } from "./types.js";
+import type { ResolvedOctoAccount } from "./accounts.js";
+
+const sessionStoreMocks = vi.hoisted(() => ({
+  getSessionEntry: vi.fn(),
+}));
+
+vi.mock("openclaw/plugin-sdk/session-store-runtime", () => sessionStoreMocks);
+
+const API = "http://octo-failure.test";
+const BOT_UID = "bot_self_0000000000000000000000000000";
+const HUMAN_UID = "human_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const GROUP_ID = "g_failure_1";
+const SESSION_KEY = "sk-failure";
+const originalFetch = globalThis.fetch;
+
+function makeAccount(): ResolvedOctoAccount {
+  return {
+    accountId: "acct1",
+    enabled: true,
+    configured: true,
+    config: {
+      botToken: "tok",
+      apiUrl: API,
+      pollIntervalMs: 1000,
+      heartbeatIntervalMs: 1000,
+      requireMention: false,
+    },
+  };
+}
+
+function makeMessage() {
+  return {
+    message_id: "m1",
+    message_seq: 100,
+    from_uid: HUMAN_UID,
+    channel_id: GROUP_ID,
+    channel_type: ChannelType.Group,
+    timestamp: Math.floor(Date.now() / 1000),
+    payload: {
+      type: MessageType.Text,
+      content: "跑一下",
+      mention: { uids: [BOT_UID] },
+    },
+  };
+}
+
+function collectCardHooks(): Record<string, (event: unknown, ctx: unknown) => unknown> {
+  const handlers: Record<string, (event: unknown, ctx: unknown) => unknown> = {};
+  registerCardProgress({
+    on: (name: string, handler: (event: unknown, ctx: unknown) => unknown) => {
+      handlers[name] = handler;
+    },
+  } as never);
+  return handlers;
+}
+
+function installFetchStub(opts: { failPlainSend?: boolean } = {}) {
+  const edits: Array<Record<string, unknown>> = [];
+  const texts: string[] = [];
+  globalThis.fetch = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+    const url = String(input);
+    const body = typeof init?.body === "string" ? JSON.parse(init.body) as Record<string, unknown> : {};
+    const json = (data: unknown, status = 200) =>
+      new Response(JSON.stringify(data), { status, headers: { "Content-Type": "application/json" } });
+
+    if (url.includes("/card/profile")) {
+      return json({
+        enabled: true,
+        profiles: ["octo/v1"],
+        card_version: "1.5",
+        elements: ["TextBlock", "RichTextBlock", "Container", "ColumnSet"],
+      });
+    }
+    if (url.includes("/members")) {
+      return json({ members: [
+        { uid: HUMAN_UID, name: "Alice", robot: false },
+        { uid: BOT_UID, name: "SelfBot", robot: true },
+      ] });
+    }
+    if (url.includes("/mention_pref")) return json({ no_mention: false });
+    if (url.includes("/md")) return json({ content: "", version: 0, updated_at: null, updated_by: "" });
+    if (url.includes("/messages/sync")) return json({ messages: [] });
+    if (url.includes("/readReceipt") || url.includes("/typing")) return json({});
+    if (url.includes("/message/edit")) {
+      edits.push(body);
+      return json({});
+    }
+    if (url.includes("/sendMessage")) {
+      const payload = body.payload as { type?: number; content?: string } | undefined;
+      if (payload?.type === 17) return json({ message_id: "progress-message", message_seq: 0 });
+      if (opts.failPlainSend) return json({ error: { code: "err.server.bot_api.denied" } }, 400);
+      texts.push(String(payload?.content ?? ""));
+      return json({ message_id: "text-message", message_seq: 0 });
+    }
+    return json({});
+  }) as typeof fetch;
+  return { edits, texts };
+}
+
+/**
+ * The agent delivers an interim note with the `message` tool (so the card gains
+ * delivery evidence), and the turn then fails through the dispatcher's onError.
+ */
+function installRuntime(
+  hooks: Record<string, (event: unknown, ctx: unknown) => unknown>,
+  mode: "onError" | "swallowed-final-send" = "onError",
+) {
+  setOctoRuntime({
+    config: { loadConfig: () => ({}) },
+    channel: {
+      reply: {
+        dispatchReplyWithBufferedBlockDispatcher: async (args: any) => {
+          const hookCtx = { sessionKey: SESSION_KEY, runId: "run-failure" };
+          hooks.before_agent_run({}, hookCtx);
+          hooks.before_tool_call(
+            {
+              toolName: "message",
+              toolCallId: "msg-1",
+              params: { action: "send", target: `group:${GROUP_ID}` },
+            },
+            hookCtx,
+          );
+          hooks.after_tool_call({ toolName: "message", toolCallId: "msg-1", result: {} }, hookCtx);
+          await new Promise((resolve) => setTimeout(resolve, 850));
+          if (mode === "onError") {
+            await args.dispatcherOptions.onError(new Error("upstream exploded"), { kind: "final" });
+            return;
+          }
+          // 只产出 block 文本 → 由 finally 的 buffered flush 投递,而那次 send 会被打成失败。
+          await args.dispatcherOptions.deliver({ text: "缓冲正文" }, { kind: "block" });
+        },
+        resolveEnvelopeFormatOptions: () => ({}),
+        formatAgentEnvelope: ({ body }: any) => body,
+        finalizeInboundContext: (ctx: any) => ctx,
+      },
+      routing: {
+        resolveAgentRoute: () => ({ agentId: "agent1", sessionKey: SESSION_KEY, accountId: "acct1" }),
+      },
+      session: {
+        resolveStorePath: () => "/tmp/store",
+        readSessionUpdatedAt: () => undefined,
+        recordInboundSession: async () => {},
+      },
+    },
+  } as any);
+}
+
+describe("inbound progress-card failure precedence", () => {
+  beforeEach(() => {
+    sessionStoreMocks.getSessionEntry.mockReset();
+    sessionStoreMocks.getSessionEntry.mockReturnValue(undefined);
+    _clearKnownBots();
+    _clearOwnerRegistry();
+    registerOwnerUid("acct1", HUMAN_UID);
+    _resetCardProgressForTests();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    _clearOwnerRegistry();
+    _resetCardProgressForTests();
+    vi.restoreAllMocks();
+  });
+
+  it("keeps the card in the error state when the turn failed after a tool delivery", async () => {
+    const { edits, texts } = installFetchStub();
+    const hooks = collectCardHooks();
+    installRuntime(hooks);
+
+    await handleInboundMessage({
+      account: makeAccount(),
+      message: makeMessage() as any,
+      botUid: BOT_UID,
+      groupHistories: new Map(),
+      lastBotReplySeqMap: new Map(),
+      memberMap: new Map(),
+      uidToNameMap: new Map(),
+      groupCacheTimestamps: new Map(),
+    });
+
+    // The user was told the turn failed…
+    expect(texts.some((t) => t.includes("遇到了问题"))).toBe(true);
+
+    // …so the card must not claim success on the strength of the tool delivery.
+    const terminal = edits.at(-1);
+    expect(terminal).toBeTruthy();
+    const card = JSON.parse(terminal!.content_edit as string).card as {
+      body: Array<Record<string, unknown>>;
+    };
+    const header = String((card.body[0] as { text?: string }).text
+      ?? JSON.stringify(card.body[0]));
+    expect(header).toContain("Interrupted");
+    expect(header).not.toContain("Done");
+  });
+  it("keeps the card in the error state when the buffered final send failed silently", async () => {
+    const { edits, texts } = installFetchStub({ failPlainSend: true });
+    const hooks = collectCardHooks();
+    installRuntime(hooks, "swallowed-final-send");
+
+    await handleInboundMessage({
+      account: makeAccount(),
+      message: makeMessage() as any,
+      botUid: BOT_UID,
+      groupHistories: new Map(),
+      lastBotReplySeqMap: new Map(),
+      memberMap: new Map(),
+      uidToNameMap: new Map(),
+      groupCacheTimestamps: new Map(),
+    });
+
+    // 回复根本没送出去(Octo API 拒了),只有 catch 里的一条日志。
+    expect(texts).toHaveLength(0);
+    const terminal = edits.at(-1);
+    expect(terminal).toBeTruthy();
+    const card = JSON.parse(terminal!.content_edit as string).card as {
+      body: Array<Record<string, unknown>>;
+    };
+    const header = String((card.body[0] as { text?: string }).text
+      ?? JSON.stringify(card.body[0]));
+    expect(header).toContain("Interrupted");
+    expect(header).not.toContain("Done");
+  });
+});

--- a/src/inbound.ts
+++ b/src/inbound.ts
@@ -2726,6 +2726,16 @@ export async function handleInboundMessage(params: {
   let userFacingFinalDelivered = false;
   let pendingToolWarningFinal: { text: string } | undefined;
   let deliveryErrorOccurred = false;
+  /**
+   * 本轮 dispatch 是否真的失败过(供进度卡终态)。`replySucceeded === false` 混了两种状态:
+   * 「没有可投递的 final text」(agent 可能已用 message 工具投递,卡片不该报错)和「这一轮
+   * 真的失败了」。只有后者置这个标志,finalizeCard 据此拒绝用工具投递证据洗白失败。
+   *
+   * 刻意只是布尔、不带原因文本:错误串会渲染进群内全员可见的卡片,把 dispatcher 的内部
+   * 措辞(`dispatch rejected: Error: …`)推到用户面前,而用户可见文案应由既有的 curated
+   * 字符串决定。参见 card-progress.ts 的 succeededOrDeliveredByTool。
+   */
+  let dispatchFailed = false;
 
   // --- Shared helper: resolve mentions and send text ---
   const resolveAndSendText = async (content: string, signal?: AbortSignal): Promise<SendMessageResult | undefined> => {
@@ -2958,6 +2968,7 @@ export async function handleInboundMessage(params: {
               });
               sentMediaUrls.add(mediaUrl);
             } catch (err) {
+              dispatchFailed = true;
               log?.error?.(`octo: media send failed for ${mediaUrl}: ${String(err)}`);
             }
           }
@@ -3015,6 +3026,7 @@ export async function handleInboundMessage(params: {
           deliverBuffer.lastText = null;
           deliverBuffer.textSent = true;
           deliveryErrorOccurred = true;
+          dispatchFailed = true;
           try {
             await sendMessage({
               apiUrl,
@@ -3053,6 +3065,7 @@ export async function handleInboundMessage(params: {
             );
             return { visibleReplySent: true };
           } catch (err) {
+            dispatchFailed = true;
             log?.error?.(
               `octo: [deliver] tool warning fallback send failed: ${String(err)}`,
             );
@@ -3077,6 +3090,7 @@ export async function handleInboundMessage(params: {
     // out of scope for #75 (see scope-note comment above timeoutError).
     if (err === timeoutError) {
       clearInterval(typingInterval);
+      dispatchFailed = true;
       log?.warn?.(
         `octo: dispatch hung past ${dispatchTimeoutMs}ms, aborting to unblock per-group queue (session=${route?.sessionKey ?? "?"})`,
       );
@@ -3099,6 +3113,7 @@ export async function handleInboundMessage(params: {
         log?.error?.(`octo: failed to send timeout message: ${String(sendErr)}`);
       }
     } else if (!deliveryErrorOccurred && !replySucceeded) {
+      dispatchFailed = true;
       // Dispatch itself rejected (e.g. non_deliverable_terminal_turn) and the
       // onError callback was never invoked, AND no visible reply has been
       // delivered to the user yet, so no fallback has been sent yet.
@@ -3167,13 +3182,17 @@ export async function handleInboundMessage(params: {
         replySucceeded = true;
         log?.info?.(`octo: [deliver-buffer] fallback text sent (${deliverBuffer.lastText.length} chars)`);
       } catch (finalSendErr) {
+        dispatchFailed = true;
         log?.error?.(`octo: [deliver-buffer] final text send failed: ${String(finalSendErr)}`);
       }
     }
     clearInterval(typingInterval);
     // 波 B:收尾进度卡(终态帧 + 清理);fire-and-forget，不阻塞 dispatch 结束/会话释放。
     // finalizeCard 内部同步删 Map(立即释放关联),终态 edit 后台异步发送。
-    void finalizeCard(route.sessionKey, { success: replySucceeded });
+    void finalizeCard(route.sessionKey, {
+      success: replySucceeded,
+      ...(!replySucceeded && dispatchFailed ? { failed: true } : {}),
+    });
     // Safety net: clean up pending inbound context in case the hook didn't fire
     pendingInboundContext.delete(route.sessionKey);
 

--- a/src/target.ts
+++ b/src/target.ts
@@ -1,0 +1,229 @@
+/**
+ * Outbound target parsing.
+ *
+ * Lives in its own dependency-free module (only `types.js`) so both the message
+ * action layer and the progress-card layer can resolve a target without pulling
+ * in `actions.ts` — that would close a `card-progress → actions → inbound →
+ * card-progress` import cycle.
+ */
+import { ChannelType } from "./types.js";
+import { stripAllChannelPrefixes } from "./constants.js";
+
+const THREAD_SEP = "____";
+
+/**
+ * Parse a target string into channelId + channelType.
+ *
+ * Explicit prefixes (`group:` / `user:`) always win.
+ * For bare IDs, we check `knownGroupIds` to determine the channel type.
+ */
+export function parseTarget(
+  target: string,
+  // Kept as a positional placeholder: every caller already passes it (mostly as
+  // `undefined`) and it is part of the exported shape. It takes no part in the
+  // verdict — bare-id classification goes through `knownGroupIds` alone.
+  _currentChannelId?: string,
+  knownGroupIds?: Set<string>,
+): { channelId: string; channelType: ChannelType } {
+  // Explicit prefixes always win
+  if (target.startsWith("group:")) {
+    const channelId = target.slice(6);
+    // groupNo____shortId → CommunityTopic
+    if (channelId.includes(THREAD_SEP)) {
+      return { channelId, channelType: ChannelType.CommunityTopic };
+    }
+    return { channelId, channelType: ChannelType.Group };
+  }
+  // OpenClaw's delivery pipeline can emit `channel:<id>` as a parallel alias
+  // for group channels (#232 review: "channel: 支持下沉到 parseTarget"). Handle
+  // it here so every caller — outbound adapter, message tool, etc — sees
+  // consistent routing without having to normalise upstream first.
+  if (target.startsWith("channel:")) {
+    const channelId = target.slice(8);
+    if (channelId.includes(THREAD_SEP)) {
+      return { channelId, channelType: ChannelType.CommunityTopic };
+    }
+    return { channelId, channelType: ChannelType.Group };
+  }
+  if (target.startsWith("user:"))
+    return { channelId: target.slice(5), channelType: ChannelType.DM };
+
+  // Strip octo: channel-namespace prefix if present
+  let bareId = target;
+  if (bareId.startsWith("octo:")) bareId = bareId.slice(5);
+
+  // Thread channel ID (groupNo____shortId)
+  if (bareId.includes(THREAD_SEP)) {
+    return { channelId: bareId, channelType: ChannelType.CommunityTopic };
+  }
+
+  // Bare ID: check knownGroupIds, also check parent group for thread context
+  const isGroup = knownGroupIds?.has(bareId) ?? false;
+  return { channelId: bareId, channelType: isGroup ? ChannelType.Group : ChannelType.DM };
+}
+
+/**
+ * Canonicalise an outbound delivery target prefix.
+ *
+ * OpenClaw's delivery pipeline can emit several equivalent shapes for the same
+ * channel-group target (`group:<id>`, `channel:<id>`, `octo:<id>`), and the
+ * agent-tool / multi-bot routing layer occasionally produces stacked forms
+ * such as `"group:octo:grp1"` or `"channel:octo:grp1"`. Without canonical
+ * collapse, the downstream parseTarget would only strip one leading prefix and
+ * mis-parse the stacked inner segment as part of the group id
+ * (`"group:octo:grp1"` → channelId `"octo:grp1"` → message routed to
+ * the wrong group). The recursive collapse below makes the guard at handleSend
+ * (which uses stripAllChannelPrefixes) and this delivery path agree on the
+ * canonical bare groupId.
+ *
+ * Rules:
+ *   - `octo:` namespace prefix → resolve by its INNER shape, never by the
+ *     generic group fallback. `octo:` alone carries no user/group semantics, so
+ *     the bare form (`octo:<id>`) must be left for parseTarget/knownGroupIds to
+ *     classify. Collapsing `octo:<uid>` (a DM) to `group:<uid>` would send
+ *     channel_type=2 for a DM id and the server rejects it (query_failed / 400).
+ *   - No leading channel-namespace prefix at all → pass through (bare IDs,
+ *     thread channel IDs like `grp1____x`, and other shapes parseTarget
+ *     handles natively).
+ *   - Stacked channel-namespace prefix wrapping a `user:` DM (e.g.
+ *     `"octo:user:uid123"`) → unwrap to clean `user:uid123` so the DM path
+ *     fires correctly.
+ *   - An explicit `group:`/`channel:` token anywhere (after any leading `octo:`)
+ *     means a group/channel target → recursively collapse and re-prefix as a
+ *     single `group:` (so parseTarget sees ONE known shape and the group: arm of
+ *     resolveOutboundOctoTarget can strip any `@mention` suffix).
+ *   - Only an `octo:` namespace prefix with no group/channel/user hint
+ *     (`octo:<id>`) is ambiguous: return the collapsed bare id and let
+ *     parseTarget/knownGroupIds classify it (known group → Group, else DM). Do
+ *     NOT default it to group — that would send channel_type=2 for a DM id and
+ *     the server rejects it (query_failed / 400).
+ */
+export function normalizeOutboundChannelPrefix(ctxTo: string): string {
+  const bare = stripAllChannelPrefixes(ctxTo);
+  // No leading channel-namespace prefix to strip — let parseTarget handle it
+  // natively (bare groupNo, `grp1____x` thread refs, `user:<uid>` DMs).
+  if (bare === ctxTo) return ctxTo;
+  // `user:` DM marker survives stripAllChannelPrefixes (it never strips user:) —
+  // route as DM, not a group with `user:` embedded in the channelId.
+  if (bare.startsWith("user:")) return bare;
+  // Distinguish an explicit group/channel target from a bare `octo:<id>`. Strip
+  // only the leading `octo:` runs, then look for a group:/channel: marker.
+  const afterOcto = ctxTo.replace(/^(?:octo:)+/, "");
+  if (afterOcto.startsWith("group:") || afterOcto.startsWith("channel:")) {
+    // Explicit group/channel (possibly stacked) — canonicalise to one `group:`.
+    return "group:" + bare;
+  }
+  // Bare `octo:<id>` — no user/group hint. Return the collapsed bare id so
+  // parseTarget/knownGroupIds decides (known group → Group, otherwise DM).
+  return bare;
+}
+
+/**
+ * Resolve an outbound delivery target from the framework's ChannelOutboundContext.
+ *
+ * OpenClaw passes thread/sub-topic replies as `to: "group:<group_no>"` + a separate
+ * `threadId: "<short_id>"` field. parseTarget by itself never sees threadId, so a
+ * bare call to parseTarget collapses thread routing back to the parent group
+ * (channelType=2 instead of 5) and drops the short_id entirely. This helper merges
+ * the two into the proper CommunityTopic channel_id (`<group_no>____<short_id>`,
+ * channel_type=5) so outbound messages land in the thread, not the parent group.
+ *
+ * Also strips the inline mention UID suffix ("group:<id>@uid1,uid2" → "group:<id>")
+ * before parsing — mention-UID extraction remains the caller's responsibility.
+ *
+ * Idempotent: if ctx.to already carries `____` (caller synthesised the thread id
+ * themselves), the threadId merge is skipped.
+ */
+export function resolveOutboundTarget(
+  ctxTo: string,
+  threadId?: string | number | null,
+  knownGroupIds?: Set<string>,
+): { channelId: string; channelType: ChannelType } {
+  const THREAD_SEP = "____";
+
+  // Normalise `channel:<id>` to `group:<id>` so downstream parseTarget sees a
+  // shape it knows. See normalizeOutboundChannelPrefix for rationale.
+  let targetForParse = normalizeOutboundChannelPrefix(ctxTo);
+
+  // Strip inline mention-UID suffix before parsing.
+  if (targetForParse.startsWith("group:")) {
+    const groupPart = targetForParse.slice(6);
+    const atIdx = groupPart.indexOf("@");
+    if (atIdx >= 0) targetForParse = "group:" + groupPart.slice(0, atIdx);
+  }
+
+  const parsed = parseTarget(targetForParse, undefined, knownGroupIds);
+
+  // Fail-fast on a target that resolves to an empty channel — BEFORE the
+  // threadId merge below. parseTarget yields channelId="" for "", "group:",
+  // "user:", "group:@uid" (mention-only), etc. The framework outbound path
+  // (sendText/sendMedia) would otherwise POST channel_id="" and the server
+  // answers an opaque 500. The check must run here and not at the end: "group:"
+  // parses to {channelId:"", channelType:Group}, so a following threadId merge
+  // would synthesise a non-empty "____<short_id>" and slip past any end-of-
+  // function guard. A non-empty parsed channel can only grow longer through the
+  // merge, never become empty, so one check here covers every case. (#138)
+  if (!parsed.channelId.trim()) {
+    throw new Error(
+      "octo: outbound target resolves to an empty channel — a valid channel/user target is required",
+    );
+  }
+
+  // Merge framework-provided threadId only when ctx.to was a bare group — if the
+  // caller already encoded the thread via "____" in ctx.to, parsed.channelType
+  // is already CommunityTopic and we pass through.
+  if (threadId != null && parsed.channelType === ChannelType.Group) {
+    const shortId = stripAllChannelPrefixes(String(threadId));
+    if (!shortId) return parsed;
+
+    // Defensive: if threadId already contains `____`, validate its parent
+    // prefix matches the group parsed from ctx.to. Mismatch would route
+    // delivery to a different group entirely (cross-channel leak via stale
+    // or corrupted thread id). Prefer silently ignoring the threadId and
+    // staying on the explicit ctx.to parent over honouring an inconsistent
+    // pair — the caller's ctx.to is the stronger signal of intent.
+    if (shortId.includes(THREAD_SEP)) {
+      const shortIdParent = shortId.slice(0, shortId.indexOf(THREAD_SEP));
+      if (shortIdParent !== parsed.channelId) {
+        return parsed;
+      }
+      return { channelId: shortId, channelType: ChannelType.CommunityTopic };
+    }
+
+    return {
+      channelId: `${parsed.channelId}${THREAD_SEP}${shortId}`,
+      channelType: ChannelType.CommunityTopic,
+    };
+  }
+
+  return parsed;
+}
+
+/** 子区 channelId(`<group>____<short>`)的父群;非子区原样返回。 */
+export function parentGroupOf(channelId: string): string {
+  const sep = channelId.indexOf(THREAD_SEP);
+  return sep >= 0 ? channelId.slice(0, sep) : channelId;
+}
+
+/**
+ * `scope:"parent"` 的目标折叠。发送路径**先**做这一步(早于 threadId 合并与 in-thread 重路由):
+ * group-like target 去掉 `____<short_id>` 与内联 `@uid`,重写成 `group:<parent>`。DM 不适用 ——
+ * scope 对私聊无意义,折叠会把 `user:<uid>` 误判成群。
+ *
+ * 归属判定必须复用同一折叠,否则「发送落到哪」两边算不出同一个答案。返回 null 表示不适用。
+ */
+export function collapseParentScope(
+  target: string,
+  knownGroupIds?: Set<string>,
+): string | null {
+  const { channelType } = parseTarget(
+    normalizeOutboundChannelPrefix(target),
+    undefined,
+    knownGroupIds,
+  );
+  if (channelType === ChannelType.DM) return null;
+  const bareParent = parentGroupOf(
+    stripAllChannelPrefixes(target).replace(/^([^@]+)@.*$/, "$1"),
+  );
+  return `group:${bareParent}`;
+}


### PR DESCRIPTION
## Summary

- treat a successful `message` tool send to the card's own channel as this turn's delivery, so a turn that answered through the tool is no longer finalized as `error`
- attribution is fail-closed: `action` must be `send`, the target must be explicit, and both `channelId` and `channelType` must match; an explicit `errorText` still wins over the evidence
- move `parseTarget` into its own module to avoid an import cycle
- add unit coverage (9 cases) plus a container E2E case that reproduces the bug

## The bug

When the agent answers by calling the `message` tool and ends the turn with no final text, the reply dispatcher never invokes its deliver callback. `replySucceeded` therefore stays false, and `finalizeCard` drives the progress card to `phase=error` — rendering **"Generation failed / Reasoning was interrupted"** with every tool step green, while the user already has the answer in hand.

Reproduced in a container against a real OpenClaw host and a real Octo server. The card payload matched the field-for-field report:

```json
{ "state": "error", "statusLabel": "Failed", "timerText": "Interrupted",
  "errorTitle": "Generation failed",
  "errorMessage": "Reasoning was interrupted. Completed steps were preserved.",
  "phases": [
    { "actions": [{ "tool": "exec",    "detail": "sleep 2 … · exit 0", "statusTone": "Good" }] },
    { "actions": [{ "tool": "message", "detail": "completed",          "statusTone": "Good" }] }
  ] }
```

The Octo DM confirmed the tool-delivered reply arrived. Only the card claimed failure.

## Why this is ours, not the host's

OpenClaw core scores that same turn as a **success**. `resolveAttemptTrajectoryTerminal` counts messaging delivery evidence:

```js
function hasCommittedMessagingDeliveryEvidence(params) {
  return hasNonEmptyString(params.messagingToolSentTexts)
    || hasNonEmptyString(params.messagingToolSentMediaUrls)
    || params.messagingToolSentTargets.length > 0;
}
```

So dispatch resolves normally and never raises `non_deliverable_terminal_turn`. The mismatch was ours alone — we simply did not consume that evidence. (Verified against OpenClaw 2026.6.9; the messaging tool's canonical name is `message` per `normalizeCliMessagingToolName`, with `action: "send"`.)

Also worth noting: the copy the card shows is a **hardcoded fallback** in `reasoning-process.ts`, only used when `errorText` is empty. It asserts a cause we never established, and it sent the first round of investigation down the wrong path (timeout / interrupted generation). A real timeout takes the `expired` branch and shows different text.

## Why it looked intermittent

Any final text at all flips `replySucceeded` to true and masks the bug. During the repro an OpenClaw `↪️ Model Fallback: …` notice did exactly that and turned the first attempt green. The trigger is not "the agent used the message tool" but "no final text reached the deliver callback for the whole turn" — which is why production saw it only sometimes.

## Attribution is fail-closed

`messageToolTargetsThisCard` requires `action: "send"`, an explicit target, and an exact `channelId` + `channelType` match. Consequences, each covered by a test:

- a thread sub-topic (`group:g1____t1`) never satisfies its parent group `g1`, and vice versa
- a notification sent to another channel is not mistaken for this turn's reply
- a failed send is not evidence
- a non-`send` action is not evidence
- a bare id cannot be classified without `knownGroupIds` here, so a group card declines it rather than widening attribution

The pending call is tracked by `toolCallId`, and a missing one is declined outright: without it the after-event cannot be tied back to a specific call, and on an old host two `message` calls in one turn would let a *successful send elsewhere* satisfy the *failed send to this card*. Old hosts lose the fix rather than risk laundering a failure into a success.

## parseTarget extraction

`card-progress.ts` needs `parseTarget`, but importing `actions.ts` would close a `card-progress → actions → inbound → card-progress` cycle. It moves to `src/target.ts` (depends only on `types.js`); `actions.ts` re-exports it so every existing importer and test keeps its entry point. The function body is unchanged apart from hoisting `THREAD_SEP` to module scope.

## Verification

- `npm run type-check`
- `npm test -- --run` — 1796 passed, 7 skipped
- `npm run build`
- `npm run pack:check`
- container E2E against a real OpenClaw host and a real Octo server — 4 passed; the new case fails before this change and passes after

🤖 Generated with [Claude Code](https://claude.com/claude-code)