### PR TITLE
fix(cards): scope render capabilities per bot, not per deployment

### DIFF
--- a/src/card-progress.test.ts
+++ b/src/card-progress.test.ts
@@ -1316,6 +1316,74 @@ describe("card-progress 状态机 + hook + 节流", () => {
     expect(continuationData?.reasoningId).toBe(firstData?.reasoningId);
   });
 
+  /**
+   * D12 manifest 目前对同一部署的所有 bot 返回同一份能力清单,但服务端一旦把 elements /
+   * limits 按 bot 分化(套餐配额、灰度),只按 apiUrl 缓存的渲染 caps 就会跨 bot 污染:
+   * 同部署上先探测的那个 bot 的裁剪上限会被另一个 bot 直接复用,可能发出对方不支持的元素。
+   * 本仓明确支持多 bot 共存(identity 指纹 / 跨账号 fail-closed),故 caps 必须按 bot 隔离。
+   */
+  it("同部署不同 bot 的渲染能力互不污染(caps 按 bot 隔离)", async () => {
+    const apiUrl = "https://shared-deployment.test";
+    const calls: Array<{ url: string; token: string; body: Record<string, unknown> | undefined }> = [];
+    const fn = vi.fn().mockImplementation(async (
+      url: string,
+      init?: { body?: string; headers?: Record<string, string> },
+    ) => {
+      const token = (init?.headers?.Authorization ?? "").replace("Bearer ", "");
+      calls.push({ url: String(url), token, body: init?.body ? JSON.parse(init.body) : undefined });
+      if (String(url).includes("/card/profile")) {
+        // bot-a 的部署没有 RichTextBlock;bot-b 有。两者共享同一个 apiUrl。
+        const elements = token === "token-b"
+          ? ["TextBlock", "RichTextBlock", "Container", "ColumnSet"]
+          : ["TextBlock", "Container", "ColumnSet"];
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ enabled: true, profiles: ["octo/v1"], elements, limits: { max_nodes: 200 } }),
+        };
+      }
+      if (String(url).includes("/sendMessage")) {
+        return { ok: true, status: 200, text: async () => JSON.stringify({ message_id: `card-${token}` }) };
+      }
+      return { ok: true, status: 200, text: async () => "" };
+    });
+    global.fetch = fn as unknown as typeof fetch;
+    const { handlers } = makeApi();
+
+    // bot-a 先跑,把它的 caps 探测进缓存。
+    setCardContext("caps-a1", { apiUrl, botToken: "token-a", channelId: "g1", channelType: ChannelType.Group });
+    handlers.before_tool_call({ toolName: "exec", params: { command: "ls" } }, { sessionKey: "caps-a1" });
+    await vi.advanceTimersByTimeAsync(900);
+    // bot-b 紧随其后,同一个 apiUrl —— 它的探测会覆盖 apiUrl 键上的 caps。
+    setCardContext("caps-b", { apiUrl, botToken: "token-b", channelId: "g2", channelType: ChannelType.Group });
+    handlers.before_tool_call({ toolName: "exec", params: { command: "ls" } }, { sessionKey: "caps-b" });
+    await vi.advanceTimersByTimeAsync(900);
+    // bot-a 在自己的 profile 缓存 TTL 内再发一张卡:不会重探 profile,因此只能读缓存里的 caps。
+    // 这一步才是污染暴露点 —— apiUrl-only 的键会让它读到 bot-b 写入的能力集。
+    setCardContext("caps-a2", { apiUrl, botToken: "token-a", channelId: "g3", channelType: ChannelType.Group });
+    handlers.before_tool_call({ toolName: "exec", params: { command: "ls" } }, { sessionKey: "caps-a2" });
+    await vi.advanceTimersByTimeAsync(900);
+
+    const stepRenderType = (channelId: string): string | undefined => {
+      const send = calls.find((c) =>
+        c.url.includes("/sendMessage") && (c.body as { channel_id?: string })?.channel_id === channelId);
+      const card = (send?.body?.payload as {
+        card?: { body?: Array<{ items?: Array<{ type?: string; items?: Array<{ type?: string }> }> }> };
+      })?.card;
+      const stepRow = card?.body?.[1]?.items?.[0];
+      // 未 advertise RichTextBlock 时步骤行直接是 TextBlock;advertise 后包一层 Container。
+      return stepRow?.type === "Container" ? stepRow.items?.[0]?.type : stepRow?.type;
+    };
+
+    // 每个 bot 各探一次 profile(bot 级缓存),bot-a 的第二张卡命中缓存不重探。
+    expect(calls.filter((c) => c.url.includes("/card/profile")).map((c) => c.token))
+      .toEqual(["token-a", "token-b"]);
+    expect(stepRenderType("g1")).toBe("TextBlock");
+    expect(stepRenderType("g2")).toBe("RichTextBlock");
+    // 污染时这里会变成 RichTextBlock —— bot-a 用上了 bot-b 的能力集。
+    expect(stepRenderType("g3")).toBe("TextBlock");
+  });
+
   it("OBO 场景跳过(不发任何请求)", async () => {
     const { fn, calls } = mockFetch();
     global.fetch = fn as unknown as typeof fetch;

--- a/src/card-progress.ts
+++ b/src/card-progress.ts
@@ -150,7 +150,7 @@ const pausedCards = sharedState.pausedCards;
 const profileCache = sharedState.profileCache;
 
 /**
- * D12 能力(elements/limits 派生的渲染 caps)缓存,key = apiUrl(部署级,同 gate)。gateEnabled
+ * D12 能力(elements/limits 派生的渲染 caps)缓存,key 见 capsCacheKey(按 bot 隔离)。gateEnabled
  * 探测 manifest 时一并填充;渲染时按元素以及节点/深度/字节上限裁剪。旧部署无这些字段 → caps 为空 → 渲染
  * 走保守默认(等同今天行为)。
  */
@@ -186,6 +186,21 @@ function contextIdentity(ctx: CardContext): string {
 
 /** Profile enabled/catalog facts are authorized by botToken, not shared by an apiUrl deployment. */
 function profileCacheKey(ctx: CardContext): string {
+  return JSON.stringify([ctx.apiUrl, ctx.botToken]);
+}
+
+/**
+ * 渲染能力(elements/inputs/actions/limits)的缓存键。
+ *
+ * `/v1/bot/card/profile` 是 bot 鉴权端点(无 token 返回 401),返回的是**该 bot 的**卡片配置,
+ * 未单独设置时回落到部署默认值。因此这些字段本就是 bot 维度的事实 —— 原先按 apiUrl 缓存是
+ * 错误假设,只因当前所有 bot 都落在同一份默认值上才没显现。任何一个 bot 被单独配置(能力灰度、
+ * 套餐配额)就会触发:同部署上先探测的 bot 之后读到的是后探测者写入的能力集。
+ *
+ * 本仓明确支持多 bot 共存(见 contextIdentity 的跨账号 fail-closed),故按 bot 隔离。与
+ * profileCacheKey 同形,但语义不同:一个是授权事实,一个是渲染能力。
+ */
+function capsCacheKey(ctx: CardContext): string {
   return JSON.stringify([ctx.apiUrl, ctx.botToken]);
 }
 
@@ -244,8 +259,8 @@ async function gateEnabled(ctx: CardContext, signal?: AbortSignal): Promise<bool
   if (cached) profileCache.delete(cacheKey);
   try {
     const m = await getCardProfile({ apiUrl: ctx.apiUrl, botToken: ctx.botToken, signal });
-    // 能力清单是部署级事实(与 enabled 无关),探到就缓存供渲染裁剪。
-    capsCache.set(ctx.apiUrl, deriveCardCaps(m));
+    // 探到就缓存供渲染裁剪。按 bot 隔离,见 capsCacheKey。
+    capsCache.set(capsCacheKey(ctx), deriveCardCaps(m));
     // Profile 来自带 botToken 的请求，其中 enabled/templating 都是 Bot 级事实。
     profileCache.set(cacheKey, {
       manifest: m,
@@ -386,7 +401,7 @@ function renderEntryProgress(
   entry: CardEntry,
   state: CardProgressState,
 ): { card: Record<string, unknown>; plain: string } {
-  const caps = capsCache.get(entry.ctx.apiUrl);
+  const caps = capsCache.get(capsCacheKey(entry.ctx));
   return usesReasoningProcessContract(entry)
     ? renderReasoningProcessCard(state, caps)
     : renderProgressCard(state, caps);
@@ -935,7 +950,7 @@ export async function finalizeCardWithResponse(
     phase: "done",
     steps: entry.steps,
     elapsedMs: Date.now() - entry.startedAt,
-  }, responseText, capsCache.get(entry.ctx.apiUrl));
+  }, responseText, capsCache.get(capsCacheKey(entry.ctx)));
   if (!rendered) return false;
 
   // Freeze late hook/debounce activity while the terminal edit is in flight so


### PR DESCRIPTION
## Summary

- key the D12 render-caps cache by `[apiUrl, botToken]` instead of `apiUrl` alone
- add a regression test covering the exact order in which the pollution surfaces

## The defect

`capsCache` holds the render capabilities (`elements` / `inputs` / `actions` / `limits`) derived from the card profile manifest, and was keyed by `apiUrl` alone. The code stated the reason inline:

```ts
// 能力清单是部署级事实(与 enabled 无关),探到就缓存供渲染裁剪。
capsCache.set(ctx.apiUrl, deriveCardCaps(m));
```

That assumption is wrong. `/v1/bot/card/profile` is a bot-authenticated endpoint — calling it without a token returns `401 err.server.bot_api.auth_failed` — and it serves **that bot's** card configuration, falling back to a deployment default only when the bot has none set. So these fields are bot-scoped facts, exactly like `enabled` and `templating`, which already key by botToken.

## Why nothing misrenders today

Every bot currently lands on the same default configuration, so all of them derive identical caps and the overwrites are harmless. **This PR does not fix a production symptom.**

But the trigger is not a server-side migration — it is a single bot being configured differently (capability gating, plan quota). At that point two bots sharing a deployment clobber the same cache slot, and the one that probed first reads back the other's capability set on every later card, because its own profile cache is still warm and never re-probes:

```
1. bot A probes  → caps[apiUrl] = caps_A   ·  renders correctly
2. bot B probes  → caps[apiUrl] = caps_B   ·  renders correctly (it just overwrote A)
3. bot A sends again, profile cache still warm → no re-probe → reads caps_B   ← wrong
```

Step 3 is the common case rather than a corner: `PROFILE_CACHE_TTL_MS` is 60s, and a bot sends many cards in that window. The consequence is rendering against another bot's capability set — potentially emitting an element the server never advertised to this bot.

Multi-bot deployments are explicitly supported here (see `contextIdentity` and its cross-account fail-closed), so the path is reachable.

`profileCacheKey` already used `[apiUrl, botToken]`; this brings caps in line. The two functions are intentionally kept separate despite identical bodies — one is an authorization fact, the other a rendering capability.

## Scope check

The other profile consumers (`card-display-tool.ts`, `card-tool.ts`) probe the manifest fresh on every call and derive caps without caching, so they have no equivalent exposure. `card-progress.ts` is the only cache. Every other per-identity cache in the repo (`group-md`, `owner-registry`, `thread-binding-adapter`) is already partitioned by `accountId`.

## Verification

- `npm run type-check`
- `npm test -- --run` — 1788 passed, 6 skipped
- `npm run build`
- `npm run pack:check`
- the new test was verified in both directions: green with the fix, and red on the third assertion (`Received: "RichTextBlock"` where bot A must stay `TextBlock`) when the key is reverted to `apiUrl`

🤖 Generated with [Claude Code](https://claude.com/claude-code)