### PR TITLE
[已关闭] cards: cardToolDetail —— 加法档工具参数摘要

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Bot accounts are stored in `~/.openclaw/openclaw.json` under `channels.octo.acco
 
 Configuration fields per account:
 
-`cardProgress`, `reasoningCardTemplateMode`, `cardDisplay`, and `cardInteraction` may also be set directly under `channels.octo` as defaults for every account. An explicit per-account value overrides the corresponding top-level value.
+`cardProgress`, `reasoningCardTemplateMode`, `cardDisplay`, `cardInteraction`, and `cardToolDetail` may also be set directly under `channels.octo` as defaults for every account. An explicit per-account value overrides the corresponding top-level value.
 
 - `botToken` (required): Bot token. Either a User Bot token from BotFather (`bf_` prefix, full group + thread access) or an App Bot token from the Octo admin console (`app_` prefix, direct-message only — server-enforced).
 - `apiUrl` (required): Octo server REST API base URL (e.g. `https://your-server/api`). The default `http://localhost:8090/api` only works for a local Octo dev server with the standard `/api` mount.
@@ -79,6 +79,37 @@ Configuration fields per account:
   Four `experimental` behaviours are deliberate and worth knowing before you enable it. Template compatibility alone selects Model A, independent of reasoning visibility: a turn that never exposed any reasoning still renders the `ai.reasoning-process` card, with real tool rows under a generic placeholder thought line instead of captured reasoning text (local Model B rendering keeps its plain progress card in that case). Model A never synthesizes tool actions it did not observe, so a reasoning phase that has not yet run a tool is omitted from the frame — its thought text appears once that phase calls one, where Model B shows the phase immediately with a synthetic `think` row; a turn's last reasoning phase usually calls no tool before the model answers, so that closing segment usually never reaches the Model A card at all. Neither mode sends a progress card for a turn that calls no tools at all. Run control (stop/regenerate) is not a card action: the deployed template is expected to render no such controls, and this plugin only ACKs view-scoped `reasoning_stop` / `reasoning_retry` as a defensive no-op for cards already sitting in channels and for catalogs that still advertise them, so those buttons do not perform run control. Finally, if the initial Model A send receives a deterministic template-frame rejection and the advertised Model B profile is compatible, the plugin retries that first frame exactly once as Model B; an existing Model A message never switches wire modes.
 - `cardDisplay` (optional): Set `false` to hide and reject the `octo_send_display_card` tool for this account. Omitted or `true` follows the server card capability gate.
 - `cardInteraction` (optional): Set `false` to hide `octo_send_card` and prevent new interactive-card callback polling for this account. Omitted or `true` follows the server `octo/v2` capability gate.
+- `cardToolDetail` (optional, **opt-in**): Controls how much of each tool call appears on a progress card.
+
+  | value | `exec` tool step renders |
+  |---|---|
+  | omitted / `false` | program name only (`curl`), paths shortened, URLs reduced to the registrable domain |
+  | `true` | **structural summary** — program, subcommands, flag names, reduced URLs and paths; every assignment value and every unclassifiable token becomes `***` |
+
+  ```
+  curl -X POST -H 'Content-Type: application/json' https://api.example.com/v1/users
+    →  curl -X POST -H *** https://api.example.com/v1/users
+
+  deploy --token hunter2 ./go        →  deploy --token *** ./go
+  mount -o rw,passphrase=hunter2 /mnt →  mount -o *** /mnt
+  ```
+
+  **The summary is additive**: a token is rendered only if it can be positively classified as safe — a program name, a subcommand, a flag name, a path, or a URL that survives `new URL()` parsing. Everything else is `***`. This is the opposite of rendering the command and then removing what looks dangerous, and the difference is the *direction it fails*: a shape the classifier does not know becomes another `***` rather than a rendered credential. Assignment values are masked without looking at the variable name at all, so `FOO=hunter2` is covered even though nothing about the name suggests a secret. `curl -u user:pass` and `mysql -pswordfish` are covered for the same reason — the classifier does not need to recognise a password, only to fail to recognise it as safe.
+
+  Its residuals, enumerated — this list is the option's contract, so it is kept complete rather than short:
+
+  1. A credential that is itself an ordinary positional word (`deploy prod hunter2`) cannot be told apart from a subcommand.
+  2. A URL that parses is rendered with its host and path, so a **tunnel or presigned hostname whose randomness is the credential** still appears (`https://a1b2c3d4e5f6.ngrok-free.app/admin/reset`). Webhook paths are caught by the high-entropy check that also runs on the URL, but a short random subdomain is below its threshold. The default level strips subdomains and paths precisely for this, and `true` reopens it.
+  3. A credential-shaped flag masks **one** following word, which is what the shell means by `--password X` — so an unquoted multi-word secret keeps everything after its first token (`--passphrase correct horse battery staple` → `--passphrase *** horse battery staple`). Quoted, the whole value is one word and is masked.
+  4. Residual (1) is not limited to dictionary words: a positional token renders whenever it is ≤24 characters and below the high-entropy threshold, so `deploy prod Xk3Bq7Zp2Lm9Rt4Ns8Wc1Vy` renders too.
+  5. File paths are **expanded, not shortened** — `/home/alice/.ssh/id_rsa` renders in full. That is the stated point of the option, but it makes OS usernames and workspace layout group-visible.
+
+  The cost of keeping residual (1) that short is paid on single-dash flags: only `-x` and `-xy` are rendered, because `-pswordfish` and `-verbose` are the same shape and there is no way to tell a glued password from a long flag name. So `find . -name '*.ts'` renders as `find . *** ***`. `--long` flags are unaffected.
+
+  Two further costs. Any command carrying an unrelated `x:y@z` renders as its program name (`sed 's:a:b@c:g'` → `sed`), as does a query the reducer cannot cleanly terminate. And a *dotted* host DSN is rewritten rather than withheld, so `sed 's:a:b@c.io:g'` renders as `sed 'c.io:g'` — kept because the dotted form is where the genuinely useful DSN lives, but an operator cannot tell the command was altered.
+
+  One change reaches the **default** level and is listed here rather than left to be discovered: the `process` tool renders its `action` (from a closed whitelist) at every level. Before this option existed it rendered nothing at all, because `process` has no `command` field. Output is capped at 120 characters, and an input over 2000 characters falls back to the conservative summary.
+
 - `historyLimit` (optional): Group chat history message limit (default: 20)
 - `dispatchTimeoutMs` (optional): Per-inbound dispatch timeout in milliseconds — an infrastructure backstop that releases the per-group message queue if an upstream dispatch hangs. When unset, it is derived from OpenClaw's `agents.defaults.timeoutSeconds` (600 if unset) as `timeoutSeconds * 1000 + 60000`, so it always fires *after* the agent-run timeout: the agent terminates gracefully first, and this timeout only catches genuinely hung dispatches. Set explicitly only if you need to decouple it from the agent timeout.
 

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -94,6 +94,10 @@
             "type": "boolean",
             "description": "When omitted or true, follow the server octo/v2 card capability gate; false force-disables the octo_send_card tool and new interactive callback polling. Per-account values override the top-level value."
           },
+          "cardToolDetail": {
+            "type": "boolean",
+            "description": "Opt-in. Omitted or false: progress-card tool steps render the program name only, with paths shortened and URLs reduced to their registrable domain. true: render an additive structural summary of each tool call \u2014 program name, subcommands, flag names, reduced URLs and full file paths \u2014 with every assignment value, and every token that cannot be positively classified as safe, replaced by ***. The summary is built by adding back what is recognised rather than by removing what looks dangerous, so a shape the classifier misses becomes another *** instead of a rendered credential. Residuals, enumerated: a positional token renders when it is at most 24 characters and not high-entropy, so a credential used as a bare argument (deploy prod hunter2) reads as a subcommand; a URL that parses renders with host and path, so a tunnel or presigned hostname whose randomness is the credential still appears; a credential-shaped flag masks one following word, so an unquoted multi-word secret keeps everything after its first token; and file paths are expanded rather than shortened, exposing home directories and workspace layout. Keeping that list short costs single-dash flags: only -x and -xy render, since a glued password and a long flag name are the same shape. Progress cards are visible to every member of a group. The process tool renders its action at every level. Per-account values override the top-level value."
+          },
           "accounts": {
             "type": "object",
             "additionalProperties": {
@@ -167,6 +171,10 @@
                 "cardInteraction": {
                   "type": "boolean",
                   "description": "When omitted or true, follow the server octo/v2 card capability gate; false force-disables the octo_send_card tool and new interactive callback polling. Per-account values override the top-level value."
+                },
+                "cardToolDetail": {
+                  "type": "boolean",
+                  "description": "Opt-in. Omitted or false: progress-card tool steps render the program name only, with paths shortened and URLs reduced to their registrable domain. true: render an additive structural summary of each tool call \u2014 program name, subcommands, flag names, reduced URLs and full file paths \u2014 with every assignment value, and every token that cannot be positively classified as safe, replaced by ***. The summary is built by adding back what is recognised rather than by removing what looks dangerous, so a shape the classifier misses becomes another *** instead of a rendered credential. Residuals, enumerated: a positional token renders when it is at most 24 characters and not high-entropy, so a credential used as a bare argument (deploy prod hunter2) reads as a subcommand; a URL that parses renders with host and path, so a tunnel or presigned hostname whose randomness is the credential still appears; a credential-shaped flag masks one following word, so an unquoted multi-word secret keeps everything after its first token; and file paths are expanded rather than shortened, exposing home directories and workspace layout. Keeping that list short costs single-dash flags: only -x and -xy render, since a glued password and a long flag name are the same shape. Progress cards are visible to every member of a group. The process tool renders its action at every level. Per-account values override the top-level value."
                 },
                 "onBehalfOf": {
                   "type": "string",

--- a/src/accounts.ts
+++ b/src/accounts.ts
@@ -24,6 +24,7 @@ export type ResolvedOctoAccount = {
     reasoningCardTemplateMode?: ReasoningCardTemplateMode;
     cardDisplay?: boolean;  // false disables the display-card tool for this account
     cardInteraction?: boolean;  // false disables interactive authoring and callback polling
+    cardToolDetail?: boolean;  // opt-in: true = additive structural summary of each tool call
     onBehalfOf?: string;  // Persona clone: grantor uid
     secretsFileRoot?: string;  // Jail root for write-secret file writes
     dispatchTimeoutMs?: number;  // Explicit dispatch-timeout override; unset = derive from agents.defaults.timeoutSeconds (issue #113)
@@ -116,6 +117,7 @@ export function resolveOctoAccount(params: {
       reasoningCardTemplateMode: accountConfig.reasoningCardTemplateMode ?? channel.reasoningCardTemplateMode,
       cardDisplay: accountConfig.cardDisplay ?? channel.cardDisplay,
       cardInteraction: accountConfig.cardInteraction ?? channel.cardInteraction,
+      cardToolDetail: accountConfig.cardToolDetail ?? channel.cardToolDetail,
       onBehalfOf: accountConfig.onBehalfOf ?? channel.onBehalfOf,
       secretsFileRoot: accountConfig.secretsFileRoot ?? channel.secretsFileRoot,
       dispatchTimeoutMs: accountConfig.dispatchTimeoutMs ?? channel.dispatchTimeoutMs,

--- a/src/card-progress.test.ts
+++ b/src/card-progress.test.ts
@@ -1599,6 +1599,73 @@ describe("card-progress 状态机 + hook + 节流", () => {
     });
   });
 
+  describe("cardToolDetail 开关", () => {
+    // sessionKey 必须每次调用都不同 —— 只按开关值命名时,同一档位调两次会复用已 finalize 的
+    // 卡片状态,第二次拿到空串,看起来像脱敏把整串隐藏了。
+    let detailCallSeq = 0;
+    async function firstStepText(cardToolDetail: boolean | undefined, command: string) {
+      const { fn, calls } = mockFetch();
+      global.fetch = fn as unknown as typeof fetch;
+      const { handlers } = makeApi();
+      const sessionKey = `detail-${String(cardToolDetail)}-${++detailCallSeq}`;
+      setCardContext(sessionKey, {
+        apiUrl: "https://detail.test",
+        botToken: "bf",
+        channelId: "g1",
+        channelType: ChannelType.Group,
+        ...(cardToolDetail === undefined ? {} : { cardToolDetail }),
+      });
+      handlers.before_tool_call({ toolName: "exec", toolCallId: "t1", params: { command } }, { sessionKey });
+      await vi.advanceTimersByTimeAsync(900);
+      handlers.after_tool_call({ toolName: "exec", toolCallId: "t1", durationMs: 10 }, { sessionKey });
+      await finalizeCard(sessionKey, { success: true });
+      const edit = calls.filter((c) => c.url.includes("/message/edit")).pop();
+      const env = JSON.parse(edit!.body!.content_edit as string);
+      return progressDetailItems(env.card).map(elementText)[0] ?? "";
+    }
+
+    it("未配置时默认只渲染程序名(opt-in)", async () => {
+      // 群卡对全员可见,完整命令里的内联凭据不是关键词守卫能抓的形状,所以升级不得静默放开。
+      const text = await firstStepText(undefined, "npm test -- --coverage");
+      expect(text).toContain("npm");
+      expect(text).not.toContain("--coverage");
+    });
+
+    it("显式 false 同样只渲染程序名", async () => {
+      const text = await firstStepText(false, "npm test -- --coverage");
+      expect(text).toContain("npm");
+      expect(text).not.toContain("--coverage");
+    });
+
+    it("显式 true 渲染加法摘要:可正面归类的 token 保留", async () => {
+      const text = await firstStepText(true, "npm test -- --coverage");
+      expect(text).toContain("npm test -- --coverage"); // 全是可正面归类的 token
+    });
+
+    it("显式 true:认不出的操作数抹成 ***", async () => {
+      // 注意用不含凭据关键词的 flag 名:卡片层还有第二道 isSensitive(card-blocks 的
+      // sanitize),`--token` 这类名字会让**整个 block** 被丢弃,拿到空串。方向是过度隐藏,
+      // 但意味着 summarizeToolParams 层的验证结果到卡片层还会再收紧一次。
+      const text = await firstStepText(true, "deploy --flag alice:hunter2 ./go");
+      expect(text).toContain("--flag");      // flag 名是结构,保留
+      expect(text).not.toContain("hunter2"); // 认不出的操作数抹掉
+    });
+
+    it("显式 true:已知残留 —— 密文就是个普通位置参数时仍会渲染", async () => {
+      // 两条可枚举残留之一(另一条是值粘在单横线 flag 上,`mysql -pRealPw123`)。
+      // 与子命令无法区分,靠 SECRET_RE / 形状守卫兜底,兜不住就是残留。钉在这里是为了让它
+      // 可见、可数 —— README 有同样的说明。
+      const text = await firstStepText(true, "deploy --flag hunter2 ./go");
+      expect(text).toContain("hunter2");
+    });
+
+    it("非法值 fail-closed 到只渲染程序名", async () => {
+      const text = await firstStepText("yes" as unknown as boolean, "npm test -- --coverage");
+      expect(text).toContain("npm");
+      expect(text).not.toContain("--coverage");
+    });
+  });
+
   it("OBO 场景跳过(不发任何请求)", async () => {
     const { fn, calls } = mockFetch();
     global.fetch = fn as unknown as typeof fetch;
@@ -2519,7 +2586,9 @@ describe("card-progress 状态机 + hook + 节流", () => {
     global.fetch = fn as unknown as typeof fetch;
     const { handlers } = makeApi();
 
-    setCardContext("tc", { apiUrl: "https://tc.test", botToken: "bf", channelId: "g1", channelType: ChannelType.Group });
+    // cardToolDetail 显式开启:本用例靠摘要里的参数(`sleep 1` / `sleep 2`)区分并发的 A/B 步骤。
+    // 开关默认 opt-in,不开则两步都渲染成 `sleep`,判别力就没了。
+    setCardContext("tc", { apiUrl: "https://tc.test", botToken: "bf", channelId: "g1", channelType: ChannelType.Group, cardToolDetail: true });
     // 两个并发 exec:A、B 都 running
     handlers.before_tool_call({ toolName: "exec", toolCallId: "A", params: { command: "sleep 1" } }, { sessionKey: "tc" });
     handlers.before_tool_call({ toolName: "exec", toolCallId: "B", params: { command: "sleep 2" } }, { sessionKey: "tc" });
@@ -2532,8 +2601,9 @@ describe("card-progress 状态机 + hook + 节流", () => {
     expect(edit).toBeTruthy();
     const env = JSON.parse(edit!.body!.content_edit as string);
     const texts = progressDetailItems(env.card).map(elementText);
-    expect(texts[0]).toBe("⌨️ exec: sleep · 50ms"); // A 已完成
-    expect(texts[1]).toBe("⏳ exec: sleep");          // B 仍 running
+    // 放开档的摘要带上参数,A/B 在断言里可区分 —— 串行错标会立刻暴露成 "sleep 2 · 50ms"。
+    expect(texts[0]).toBe("⌨️ exec: sleep 1 · 50ms"); // A 已完成
+    expect(texts[1]).toBe("⏳ exec: sleep 2");          // B 仍 running
   });
 
   it("P2-b(重复投递): toolCallId 命中失败不回退按名匹配,不误标并发步骤", async () => {
@@ -2541,7 +2611,9 @@ describe("card-progress 状态机 + hook + 节流", () => {
     global.fetch = fn as unknown as typeof fetch;
     const { handlers } = makeApi();
 
-    setCardContext("dup", { apiUrl: "https://dup.test", botToken: "bf", channelId: "g1", channelType: ChannelType.Group });
+    // cardToolDetail 显式开启:本用例靠摘要里的参数(`sleep 1` / `sleep 2`)区分并发的 A/B 步骤。
+    // 开关默认 opt-in,不开则两步都渲染成 `sleep`,判别力就没了。
+    setCardContext("dup", { apiUrl: "https://dup.test", botToken: "bf", channelId: "g1", channelType: ChannelType.Group, cardToolDetail: true });
     handlers.before_tool_call({ toolName: "exec", toolCallId: "A", params: { command: "sleep 1" } }, { sessionKey: "dup" });
     handlers.before_tool_call({ toolName: "exec", toolCallId: "B", params: { command: "sleep 2" } }, { sessionKey: "dup" });
     handlers.after_tool_call({ toolName: "exec", toolCallId: "A", durationMs: 50 }, { sessionKey: "dup" }); // A → done
@@ -2553,8 +2625,8 @@ describe("card-progress 状态机 + hook + 节流", () => {
     const edit = calls.filter((c) => c.url.includes("/message/edit")).pop();
     const env = JSON.parse(edit!.body!.content_edit as string);
     const texts = progressDetailItems(env.card).map(elementText);
-    expect(texts[0]).toBe("⌨️ exec: sleep · 50ms"); // A done(只被标一次)
-    expect(texts[1]).toBe("⏳ exec: sleep");          // B 仍 running,未被重复事件误标
+    expect(texts[0]).toBe("⌨️ exec: sleep 1 · 50ms"); // A done(只被标一次)
+    expect(texts[1]).toBe("⏳ exec: sleep 2");          // B 仍 running,未被重复事件误标
   });
 
   it("J1: finalize await 期间下一 run setCardContext,不误删新 run 的 entry", async () => {

--- a/src/card-progress.ts
+++ b/src/card-progress.ts
@@ -26,7 +26,7 @@ import {
   type CardTemplateRef,
 } from "./api-fetch.js";
 import { deriveCardCaps } from "./card-caps.js";
-import { renderProgressCard, renderProgressResponseCard, summarizeToolParams, SUBAGENT_WAIT_STEP_TOOL, type CardStep, type CardProgressState, type CardCaps } from "./card-render.js";
+import { renderProgressCard, renderProgressResponseCard, summarizeToolParams, SUBAGENT_WAIT_STEP_TOOL, type CardStep, type CardProgressState, type CardCaps, type SummaryDetail } from "./card-render.js";
 import {
   buildReasoningProcessId,
   buildReasoningProcessWireData,
@@ -40,6 +40,11 @@ import { getKnownGroupIds } from "./group-md.js";
 import type { ReasoningCardTemplateMode } from "./config-schema.js";
 
 /** dispatch 侧登记的发送上下文。 */
+/** 配置值 → 摘要档位。**fail-closed**:只认字面 `true`,其余一律 off。 */
+function toSummaryDetail(v: boolean | undefined): SummaryDetail {
+  return v === true ? "additive" : "off";
+}
+
 export interface CardContext {
   apiUrl: string;
   botToken: string;
@@ -49,6 +54,12 @@ export interface CardContext {
   cardProgress?: boolean;
   /** Explicit Registry migration gate. Defaults to experimental with Model B fallback. */
   reasoningCardTemplateMode?: ReasoningCardTemplateMode;
+  /**
+   * **opt-in**:只有显式 `true` 才渲染工具调用的结构化摘要。unset/false → 只渲染程序名(旧行为)。
+   * 进度卡对群内全员可见,而完整命令里的 `curl -u user:pass` / webhook path / 隧道主机名都不是
+   * 关键词守卫能抓的形状 —— 升级不应静默改变暴露面,必须由部署方主动打开。
+   */
+  cardToolDetail?: boolean;
   /** persona-clone 身份;存在则跳过卡片(服务端拒 type-17 OBO)。 */
   onBehalfOf?: string;
   /** OpenClaw reasoning visibility resolved for this turn/session. */
@@ -1312,7 +1323,12 @@ export function registerCardProgress(api: OpenClawPluginApi): void {
     entry.steps.push({
       tool: e.toolName,
       status: "running",
-      summary: summarizeToolParams(e.toolName, e.params),
+      // 默认 opt-in。群卡对全员可见,升级不应静默改变暴露面,必须由部署方主动打开。
+      // fail-closed:只有**字面 true** 才放开,任何其它值(undefined、false、配置里写错的字符串)
+      // 一律 off。
+      summary: summarizeToolParams(e.toolName, e.params, {
+        detail: toSummaryDetail(entry.ctx.cardToolDetail),
+      }),
       ...(e.toolCallId ? { toolCallId: e.toolCallId } : {}),
     });
     scheduleFlush(sk!, entry);

--- a/src/card-render.test.ts
+++ b/src/card-render.test.ts
@@ -154,6 +154,163 @@ describe("summarizeToolParams", () => {
     // 合法程序名/路径不受影响。
     expect(summarizeToolParams("exec", { command: "/usr/bin/python3 x.py" })).toBe("/usr/bin/python3");
   });
+  it("process 渲染受控的 action 枚举(其 schema 无 command,shell 策略永远取不到)", () => {
+    expect(summarizeToolParams("process", { action: "poll", sessionId: "s1" })).toBe("poll");
+    expect(summarizeToolParams("process", { action: "send-keys", literal: "secret-passphrase" })).toBe("send-keys");
+    // 白名单外的值一律不渲染:action 是模型可控字段,不能当自由文本 sink。
+    expect(summarizeToolParams("process", { action: "AKIAIOSFODNN7EXAMPLE" })).toBe("");
+    expect(summarizeToolParams("process", { action: "" })).toBe("");
+    expect(summarizeToolParams("process", { sessionId: "s1" })).toBe("");
+  });
+
+  describe("additive 档(cardToolDetail: true)", () => {
+    const A = { detail: "additive" as const };
+
+    it("只渲染能正面归类为安全的 token,其余一律 ***", () => {
+      // 判据是「加回认得出的」而不是「减掉危险的」:漏掉一个形状 = 多打一个 `***`,不是一次泄漏。
+      expect(summarizeToolParams("exec", { command: "npm test -- --coverage" }, A))
+        .toBe("npm test -- --coverage");
+      expect(summarizeToolParams("exec", { command: "go build -o bin/api ./cmd/api" }, A))
+        .toBe("go build -o bin/api ./cmd/api");
+      expect(summarizeToolParams("exec", { command: "git commit -m 'fix: handle empty payload'" }, A))
+        .toBe("git commit -m ***"); // 引号里的字面值认不出 → 抹掉
+      expect(summarizeToolParams("exec", { command: "curl -X POST -H 'Content-Type: application/json' https://api.example.com/v1/users" }, A))
+        .toBe("curl -X POST -H *** https://api.example.com/v1/users");
+      expect(summarizeToolParams("exec", { command: "deploy aB3dE7gH1jK4mN8pQ2rS5tU9vW6xY0zA1bC2dE3f" }, A))
+        .toBe("deploy ***"); // 高熵裸词
+    });
+
+    it("赋值不看名字,一律抹值 —— 所以没有「名字没暗示就漏」这条残留", () => {
+      // 靠变量名猜「像不像凭据」的做法,复数/序数/`+=`/索引形式会逐个漏;
+      // 加法档不猜,`NAME=` 就抹。
+      for (const [cmd, want] of [
+        ["FOO=hunter2 ./deploy", "FOO=*** ./deploy"],
+        ["DEPLOY_KEYS=hunter2 ./release", "DEPLOY_KEYS=*** ./release"],
+        ["ADMIN_PW=hunter2 ./release", "ADMIN_PW=*** ./release"],
+        ["DEPLOY_KEY+=hunter2 ./go", "DEPLOY_KEY+=*** ./go"],
+        ["DEPLOY_KEY[0]=hunter2 ./go", "DEPLOY_KEY[0]=*** ./go"],
+        ["GOOS=linux go build ./cmd/api", "GOOS=*** go build ./cmd/api"],
+      ] as const) {
+        expect(summarizeToolParams("exec", { command: cmd }, A)).toBe(want);
+      }
+    });
+
+    it("靠形状表逐条排查时漏掉过的那些写法,加法档一条都不渲染", () => {
+      for (const cmd of [
+        "DEPLOY_KEY=(hunter2 backup2) ./release",
+        "TOKEN=<(printf hunter2) ./go",
+        "ftp user~name:hunter2@ftpserver",
+        "curl [::1]/reset?code=hunter2",
+        "DEPLOY_KEY=$'hunter2' ./deploy",
+        "curl 'localhost/search?filter={\"a\":1}&code=hunter2'",
+        // 下面两条是「渲染字面命令再减掉危险形状」那条路**按设计关不掉**的,加法档顺手关了 ——
+        // 因为它不需要认出这是密码,只需要认不出它是安全的。
+        "curl -u alice:hunter2 https://api.example.com/v1",
+        "mysql -pRealPw123 appdb",
+      ]) {
+        expect(summarizeToolParams("exec", { command: cmd }, A)).not.toContain("hunter2");
+        expect(summarizeToolParams("exec", { command: cmd }, A)).not.toContain("RealPw123");
+      }
+    });
+
+    it("已知残留:密文本身是一个普通位置参数时仍会渲染", () => {
+      // 与子命令无法区分。钉在这里是为了让残留**可见、可数**。
+      //
+      // 注意此前这里写着「值粘在单横线 flag 上的那条已被 SHORT_FLAG_RE 挡下」——那是错的:
+      // 当时唯一的样例 `mysql -pRealPw123` 恰好落在形状约束**拒绝**的一侧(有大写和数字),
+      // 而 `-pswordfish` 这类全小写的粘连值当时是被放行的。用接受侧的单个样本去支撑覆盖性
+      // 断言不成立。现在单横线 flag 只接受 ≤2 字符,那条形状已封,代价见 README。
+      expect(summarizeToolParams("exec", { command: "deploy prod hunter2" }, A))
+        .toBe("deploy prod hunter2");
+    });
+
+    it("凭据形状的 flag 名会把下一个词抹掉,且 flag 名本身不触发整串隐藏", () => {
+      expect(summarizeToolParams("exec", { command: "deploy --token hunter2 ./go" }, A))
+        .toBe("deploy --token *** ./go");
+      expect(summarizeToolParams("exec", { command: "login --password hunter2" }, A))
+        .toBe("login --password ***");
+    });
+
+    it("单横线 flag 只认 ≤2 字符:粘连值与长 flag 形状相同,无法区分", () => {
+      // 曾经接受「3–12 位纯小写」,于是 `-pswordfish` 被正面归类成 flag 名渲染出去 ——
+      // 一条明文口令被当作 flag 名正面归类、渲染了出去。
+      expect(summarizeToolParams("exec", { command: "mysql -pswordfish mydb" }, A))
+        .toBe("mysql *** mydb");
+      expect(summarizeToolParams("exec", { command: "mysql --password hunter2 -phunterlove mydb" }, A))
+        .toBe("mysql --password *** *** mydb");
+      // 形状表:大小写/数字/长度都不能改变结论,单个样本支撑不了覆盖性断言。
+      for (const glued of ["-pswordfish", "-pRealPw123", "-phunterlove", "-sletmein", "-pverylongsecretvalue"]) {
+        expect(summarizeToolParams("exec", { command: `mysql ${glued} db` }, A)).toBe("mysql *** db");
+      }
+      // 代价:长形式单横线 flag 也变成 ***。`--long` 不受影响。
+      expect(summarizeToolParams("exec", { command: "find . -name x.ts" }, A)).toBe("find . *** x.ts");
+      expect(summarizeToolParams("exec", { command: "ls -la /tmp" }, A)).toBe("ls -la /tmp");
+    });
+
+    it("URL 解析得动 ≠ 安全:webhook path 的随机段仍要过形状检测", () => {
+      // `new URL()` 认得 Slack webhook,但 path 里的随机串**本身就是凭据**。url 策略一直有
+      // 这道检测(generic=true),shell 策略此前没有,于是同一个 URL 经 fetch 降级、经 exec 整条渲染。
+      expect(summarizeToolParams("exec", { command: "curl -X POST https://hooks.slack.com/services/T024BE7LD/B2S5TQ1PL/aBcDeFgHiJkLmNoPqR" }, A))
+        .toBe("curl -X POST ***");
+      // 普通 URL 不受影响。
+      expect(summarizeToolParams("exec", { command: "curl https://api.example.com/v1/users" }, A))
+        .toBe("curl https://api.example.com/v1/users");
+    });
+
+    it("程序名位置与操作数位置用同一组检查", () => {
+      // expectProgram 在每个控制算子之后重新置位,所以这个分支在命令中段也可达;
+      // 当时它既没有长度上限也没有高熵检测,是一条绕过路径。
+      expect(summarizeToolParams("exec", { command: "sh -c x ; AbCdEf0123456789AbCdEf0123456789AbCdEf01" }, A))
+        .toBe("sh -c x ; ***");
+    });
+
+    it("值粘进 flag 名里时,整个 token 抹掉;尾段本身是关键词的仍照常渲染", () => {
+      // `--tokenhunter2` 会被下游关键词守卫整串隐藏,`--token-hunter2` 却渲染 —— 差一个连字符,
+      // 因为加法档的守卫豁免会把 flag 名整个从探针里删掉。操作者无从推断,所以在分类层面堵。
+      expect(summarizeToolParams("exec", { command: "deploy --token-hunter2 run" }, A))
+        .toBe("deploy *** ***");
+      expect(summarizeToolParams("exec", { command: "cli --passphrase-correct run" }, A))
+        .toBe("cli *** ***");
+      // 关键词之后仍是关键词的是正常 flag 名,不能误伤。
+      for (const f of ["--refresh-token", "--api-key", "--client-secret", "--private-key",
+        "--access-key", "--session-cookie", "--otp-secret"]) {
+        expect(summarizeToolParams("exec", { command: `cli ${f} v run` }, A)).toBe(`cli ${f} *** run`);
+      }
+    });
+
+    it("数组下标的内容也必须分类过才能渲染", () => {
+      // 下标是任意文本,不是结构。值抹对了不代表 token 安全。
+      expect(summarizeToolParams("exec", { command: "arr[p@sswOrd]=1 ./go" }, A)).toBe("arr=*** ./go");
+      expect(summarizeToolParams("exec", { command: "arr[0]=1 ./go" }, A)).toBe("arr[0]=*** ./go");
+      expect(summarizeToolParams("exec", { command: "A+=1 ./go" }, A)).toBe("A+=*** ./go");
+    });
+
+    it("凭据 flag 名表与赋值名表同源 —— 遍历关键词,不抽样", () => {
+      // 原本是手写的第二张表,比赋值名表窄 14 个词。抽样测试测不出这种缺口,所以这里**遍历**。
+      const keywords = ["token","secret","password","passwd","pwd","passphrase","credential",
+        "creds","key","privkey","apikey","accesskey","apitoken","auth","bearer","session",
+        "sessionid","sid","cookie","jwt","otp","salt","signature","pat","pass","refresh"];
+      for (const k of keywords) {
+        expect(summarizeToolParams("exec", { command: `cli --${k} hunter2 run` }, A))
+          .toBe(`cli --${k} *** run`);
+      }
+      // 命令行的连字符拼法与环境变量的下划线拼法是同一个词。
+      for (const f of ["--private-key", "--api-key", "--client-secret", "--access-key"]) {
+        expect(summarizeToolParams("exec", { command: `cli ${f} hunter2 run` }, A))
+          .toBe(`cli ${f} *** run`);
+      }
+      // 不能误伤普通 flag。
+      expect(summarizeToolParams("exec", { command: "cli --verbose run" }, A)).toBe("cli --verbose run");
+      expect(summarizeToolParams("exec", { command: "git commit -m x" }, A)).toBe("git commit -m x");
+    });
+
+    it("分词器出错不会泄漏 —— 分错的 token 归不了类,结果是 ***", () => {
+      // 未闭合引号:整段被当成一个词,归不了类 → ***。
+      expect(summarizeToolParams("exec", { command: "gpg -d 'alpha hunter2" }, A))
+        .toBe("gpg -d ***");
+    });
+  });
+
   it("query/shell 策略也降级内嵌 URL(与 url/error 路径对称,单一 choke point)", () => {
     // query 里的 webhook URL:路径段短、无关键词 → isSensitive 抓不到,靠 URL 降级。
     expect(summarizeToolParams("web_search", { query: "https://hooks.slack.com/services/T00/B00/abcdEFGH1234abcdEFGH1234" })).toBe(

--- a/src/card-render.ts
+++ b/src/card-render.ts
@@ -112,6 +112,14 @@ export function resolveToolMeta(tool: string): { icon: string; label: string } {
 }
 
 const SUMMARY_MAX = 64;
+/** 放开档渲染的 token 更多,给更宽的余量(与 ERROR_MAX 对齐),但仍必须有硬上限。 */
+const SUMMARY_DETAILED_MAX = 120;
+/**
+ * 放开档接受的**输入**长度上限(区别于上面的渲染上限)。超过则退回保守摘要,不进分词与分类。
+ * 取 2000 是因为渲染上限只有 120,更长的输入本来也只剩截断,而真实命令(压缩 JSON body、
+ * base64 块)实测都在这个量级以下。
+ */
+const DETAILED_INPUT_MAX = 2000;
 /**
  * 进入 URL 归约管线前的**无条件**输入长度上限。
  *
@@ -217,10 +225,22 @@ function registrableDomain(host: string): string {
  * 工具 → 摘要提取策略(allowlist)。未列出的工具(含 MCP、未知工具)一律**不显示摘要**,
  * 杜绝把任意参数直渲到群卡片的泄露面。
  */
-type SummaryStrategy = "path" | "shell" | "url" | "query";
+type SummaryStrategy = "path" | "shell" | "url" | "query" | "enum";
+/**
+ * 工具参数摘要的档位。
+ *
+ * - `off`      程序名 / 短路径 / 注册域。默认。
+ * - `additive` 只渲染能正面归类为安全的 token,其余 `***`。漏掉一个形状 = 多打一个 `***`,
+ *              残留是**可枚举的两条**(见 summarizeShellAdditive)。
+ *
+ * 刻意**没有**「渲染整条命令、再减掉认出来的危险形状」这一档:那条路径上漏掉一个形状就是一次
+ * 明文泄漏,残留无界 —— 评审无法收敛到「已覆盖」这个结论上。见 summarizeShellAdditive 的说明。
+ */
+export type SummaryDetail = "off" | "additive";
 const SUMMARY_STRATEGY: Record<string, SummaryStrategy> = {
   read: "path", write: "path", edit: "path", apply_patch: "path", ls: "path", find: "path", glob: "path",
-  exec: "shell", bash: "shell", shell: "shell", process: "shell",
+  exec: "shell", bash: "shell", shell: "shell",
+  process: "enum",
   fetch: "url",
   web_search: "query", search: "query", grep: "query",
 };
@@ -262,6 +282,18 @@ function firstString(p: Record<string, unknown>, keys: string[]): string {
  */
 const SHELL_BREAK = "\\s'\"(;|&`<>)";
 
+
+/**
+ * 凭据形状的变量名。关键词必须落在**下划线分段边界**上(`(?:^|_)…(?:_|$)`),而不是子串匹配 ——
+ * 否则 `StrictHostKeyChecking` 里的 `Key` 会命中,把 `ssh -o StrictHostKeyChecking=no` 的值抹掉,
+ * 而那恰恰是运维最需要看见的安全选项。同理 `AUTHOR` 不因含 `AUTH` 而被抹。
+ * 无下划线的连写形式(`APIKEY`)单独列出。
+ */
+const CREDENTIAL_KEYWORDS =
+  "token|secret|password|passwd|pwd|passphrase|credentials?|creds?|key|privkey|apikey|accesskey"
+  + "|apitoken|auth|bearer|session|sessionid|sid|cookie|jwt|otp|salt|signature|pat|pass|refresh";
+
+
 const PROGRAM_TOKEN_RE = /^[A-Za-z0-9_./@:+-]+$/;
 const ASSIGNMENT_TOKEN_RE = /^[A-Za-z_][A-Za-z0-9_]*=/;
 
@@ -292,6 +324,188 @@ const ASSIGNMENT_VALUE_RE = new RegExp(
  */
 function foldAssignmentValues(cmd: string): string {
   return cmd.replace(ASSIGNMENT_VALUE_RE, (_m, lead: string, name: string) => `${lead}${name}=_`);
+}
+
+/* ── 加法 shell 摘要(cardToolDetail: true)────────────────────────────────────────────────
+ *
+ * 这一档**只渲染能正面归类为安全的 token,其余一律 `***`**。它与「渲染整条命令、再把认出来的
+ * 危险形状减掉」的减法思路是相反的判据,而判据的方向决定了失败模式:
+ *
+ *   减法:漏掉一个形状 = **一次明文泄漏**,残留无界
+ *   加法:漏掉一个形状 = **多打一个 `***`**,残留由接受规则界定
+ *
+ * 这不是风格取舍。这个模块此前每一个凭据泄漏类都出在减法路径上;而 `path` / `url` / `enum`
+ * 三个策略一次都没出过,因为它们本来就是加法的(`new URL()` 解析、封闭 enum、与路径同源的
+ * 形状)—— 保证是结构性的,不是靠把危险形状列全。
+ *
+ * 由此,评审要问的问题也换了:不再是「有没有哪个输入能让密文活下来」(搜索空间 = 整个 shell
+ * 语法,无界),而是「有没有哪个 token 被**正面分类进安全类别**却含密文」(搜索空间 = 下面这
+ * 几条接受规则,可枚举)。分词器写错也不会泄漏 —— 分错的 token 归不了类,结果就是 `***`。
+ *
+ * 已知残留(可枚举,README 里逐条写明):
+ *  1. 值粘在单横线 flag 上且形似长 flag(`mysql -pRealPw123`)—— 与 `-verbose` 无法区分。
+ *  2. 密文本身就是一个普通位置参数(`deploy prod hunter2`)—— 与子命令无法区分。
+ * 两条都靠 SECRET_RE / 形状守卫兜底,兜不住就是残留。
+ */
+
+/** 尊重引号与反斜杠的分词。分错只会让 token 归不了类 → `***`,所以这里不需要完美。 */
+function splitShellWords(cmd: string): string[] {
+  const words: string[] = [];
+  let cur = "";
+  let quote: string | null = null;
+  let started = false; // 空引号 `''` 也是一个词
+  for (let i = 0; i < cmd.length; i++) {
+    const c = cmd[i]!;
+    if (quote) {
+      if (c === "\\" && quote === '"') cur += c + (cmd[++i] ?? "");
+      else if (c === quote) quote = null;
+      else cur += c;
+      continue;
+    }
+    if (c === "'" || c === '"') { quote = c; started = true; continue; }
+    if (c === "\\") { cur += cmd[++i] ?? ""; started = true; continue; }
+    if (/\s/.test(c)) { if (cur || started) words.push(cur); cur = ""; started = false; continue; }
+    cur += c;
+  }
+  if (cur || started) words.push(cur);
+  return words;
+}
+
+const MASK = "***";
+/** 控制算子原样保留:它们是结构,不是值,而且决定了下一个词是程序名。 */
+const SHELL_OPERATORS = new Set(["&&", "||", "|", ";", "&", "|&"]);
+/**
+ * `--`(end-of-options)是结构记号,不是值 —— 但它**排在 maskNext 之后**:`cli --token -- x`
+ * 里 `--` 就是 `--token` 收到的那个值,按 shell 语义该抹。结构性只在它不占值位时成立。
+ */
+const END_OF_FLAGS = "--";
+/** 简单标识符:子命令、目标名、镜像 tag 之外的裸词。不含 `=` `:` `@` 等承载凭据的分隔符。 */
+const PLAIN_WORD_RE = /^[A-Za-z0-9][A-Za-z0-9._+-]*$/;
+/** `.` / `..`:当前目录与上级目录,`find . …` 里最常见的操作数。不含任何值。 */
+const CWD_WORD_RE = /^\.{1,2}$/;
+/**
+ * 相对或绝对路径。与 path 策略同源的形状,七轮零泄漏。
+ * 前瞻要求**至少含一个 `/`**:否则这条会吞掉所有裸词,绕过下面裸词分支的长度与高熵检查。
+ */
+const PATH_WORD_RE = /^(?=.*\/)\.{0,2}\/?[A-Za-z0-9._-]*(?:\/[A-Za-z0-9._-]*)*$/;
+/** `--long` / `--long=value`(值仍抹掉)。 */
+const LONG_FLAG_RE = /^--[A-Za-z0-9][A-Za-z0-9-]*$/;
+const FLAG_WITH_VALUE_RE = /^(--?[A-Za-z0-9][A-Za-z0-9-]*)=/;
+/**
+ * 单横线 flag,**只接受 ≤2 字符**。
+ *
+ * 曾经也接受「3–12 位纯小写」,理由是要保住 `-verbose` / `-name` 这类长形式。那是错的:
+ * `-pswordfish`、`-phunterlove`、`-sletmein` 与它们**在形状上完全一致**,于是明文口令被正面
+ * 归类成 flag 名渲染出去 —— 实测 `mysql --password hunter2 -phunterlove mydb` 在加法档渲染
+ * `-phunterlove`,一条明文口令被当作 flag 名渲染了出去。
+ *
+ * 加法模型的规则是「归类不了就抹」,`-xxx` 归类不了。代价是 `-name` / `-jar` / `-xzf` 也变成
+ * `***`(`--long` 不受影响,双横线后不存在粘连值)。这是加法档为「残留可枚举」付的价钱。
+ */
+const SHORT_FLAG_RE = /^-[A-Za-z0-9]{1,2}$/;
+/** 名字像凭据的 flag → 下一个词一定抹掉(`--token X`、`-p X`)。复用赋值名的关键词表。 */
+/**
+ * additive 输出里「已抹掉的值 + 紧邻的名字」。用于把它们排除出敏感串守卫的检测。
+ *
+ * 只匹配以 `***` 收尾的片段,前面可选一个赋值名或 flag 名。加法输出里 `***` 一定是我们自己
+ * 打的(输入里的字面 `***` 也只会被归类成一个普通词,不会造出 `NAME=***` 这种结构),所以
+ * 这里删掉的永远是名字与占位符,不会是任何被渲染的值。
+ */
+const ADDITIVE_MASKED_RE =
+  /(?:[A-Za-z_][A-Za-z0-9_]*(?:\+|\[[^\]]*\])?=|--?[A-Za-z0-9][A-Za-z0-9-]*[= ])?\*\*\*/g;
+
+/**
+ * 名字像凭据的 flag → 下一个词一定抹掉(`--token X`、`-p X`)。
+ *
+ * **必须与 SECRET_ASSIGNMENT_NAME_RE 同源。** 这里原本是手写的第二张表,比赋值名表窄了 14 个
+ * 关键词(`privkey`/`jwt`/`otp`/`signature`/`cookie`/`sid`/`salt`/`pat`/`refresh`/`session`/
+ * `bearer`/`accesskey`/`apitoken`/`sessionid`),于是 `cli --private-key hunter2` 在加法档明文
+ * 渲染,而 `--accesskey` 只是**碰巧**被 SECRET_RE 兜住 —— 两个都藏不藏,操作者无从推断。
+ *
+ * 这是这条 PR 反复出现的同一个形状:**本该互为镜像的第二张表,和第一张不同步**(兜底 vs 归约、
+ * flag 表 vs 赋值名表、长度上限 vs 它保护的递归)。派生而不是重抄,这一类才算封住。
+ * 分段符取 `[-_]`:命令行写 `--private-key`,环境变量写 `PRIVATE_KEY`,是同一个词。
+ */
+const CREDENTIAL_FLAG_RE = new RegExp(
+  `^-{1,2}(?:[A-Za-z0-9]+[-_])*(?:${CREDENTIAL_KEYWORDS})(?:[-_][A-Za-z0-9]+)*$`,
+  "i",
+);
+
+/**
+ * 凭据关键词之后挂着**非关键词**尾段的 flag(`--token-hunter2`)。这种 token 要整个抹掉。
+ * 尾段本身是关键词的(`--refresh-token`、`--api-key`)是正常 flag 名,照常渲染。
+ *
+ * `--api-key` / `--client-secret` / `--private-key` 的关键词落在**末尾**,前缀段是限定词,是
+ * 正常 flag 名;而 `--token-hunter2` 的尾段没有任何理由存在 —— 值粘进 flag 名里正是这个形状。
+ * 光靠下游关键词守卫兜不住:additive 的豁免会把 flag 名整个从探针里删掉,于是 `--tokenhunter2`
+ * 被整串隐藏,`--token-hunter2` 却渲染出来,两者差一个连字符,操作者无从推断。
+ */
+const CREDENTIAL_FLAG_CLEAN_RE = new RegExp(
+  `^-{1,2}(?:[A-Za-z0-9]+[-_])*(?:${CREDENTIAL_KEYWORDS})(?:[-_](?:${CREDENTIAL_KEYWORDS}))*$`,
+  "i",
+);
+
+/** 凭据 flag,但关键词之后挂着**不是关键词**的尾段。`--refresh-token` 的尾段是关键词,正常。 */
+const credentialFlagCarriesValue = (w: string): boolean =>
+  CREDENTIAL_FLAG_RE.test(w) && !CREDENTIAL_FLAG_CLEAN_RE.test(w);
+
+/**
+ * 加法 shell 摘要:程序名 + 子命令 + flag 名 + 归约后的 URL + 路径;其余一律 `***`。
+ * 赋值**不看名字**,一律抹值 —— 加法模型下没有「这个名字像不像凭据」的判断,所以也没有
+ * 「变量名没有凭据暗示就漏」(`FOO=hunter2`)这条残留 —— 加法路径上它不存在。
+ */
+function summarizeShellAdditive(p: Record<string, unknown>): string {
+  const cmd = firstString(p, ["command", "cmd"]).trim();
+  if (!cmd) return "";
+  const out: string[] = [];
+  let expectProgram = true; // 串首,以及每个控制算子之后
+  let maskNext = false;     // 上一个词是凭据形状的 flag
+  for (const w of splitShellWords(cmd)) {
+    if (SHELL_OPERATORS.has(w)) { out.push(w); expectProgram = true; maskNext = false; continue; }
+    if (maskNext) { out.push(MASK); maskNext = false; continue; }
+    if (w === END_OF_FLAGS) { out.push(w); continue; }
+    // 赋值:`NAME=`、`NAME+=`、`NAME[i]=` 都算。值一律不渲染。
+    // 下标内容(`arr[…]`)在加法档同样必须**分类过**才能渲染 —— 它是任意文本,不是结构。
+    // 只放行简单标识符/数字下标,其余连下标一起抹掉。
+    const assign = /^([A-Za-z_][A-Za-z0-9_]*)(\+|\[([^\]]*)\])?=/.exec(w);
+    if (assign) {
+      const [, name, suffix, subscript] = assign;
+      const safeSuffix = !suffix || suffix === "+"
+        || (subscript !== undefined && /^[A-Za-z0-9_]*$/.test(subscript) && subscript.length <= 24);
+      out.push(safeSuffix ? `${name}${suffix ?? ""}=${MASK}` : `${name}=${MASK}`);
+      continue;
+    }
+    if (expectProgram) {
+      // 与下面的操作数分支用**同一组**检查。`expectProgram` 在每个控制算子之后重新置位,
+      // 所以这个分支在命令中段也可达(`sh -c x ; <高熵串>`),少一组检查就是一条绕过路径。
+      expectProgram = false;
+      const safe = (PLAIN_WORD_RE.test(w) && w.length <= 24) || PATH_WORD_RE.test(w) || CWD_WORD_RE.test(w);
+      out.push(safe && !hasGenericSecretShape(w) ? w : MASK);
+      continue;
+    }
+    // URL:解析得动才渲染,并且**必须再过一次高熵形状检测** —— webhook path
+    // (`/services/T../B../XXXX`)与隧道/预签名子域的随机串**本身就是凭据**,它们能通过
+    // `new URL()`,所以"解析成功"不等于"安全"。url 策略一直是这么做的(generic=true),
+    // shell 策略此前没有,于是同一个 Slack webhook 经 fetch 会被降级、经 exec 却整条渲染。
+    if (w.includes("://")) {
+      const u = detailedUrl(w);
+      out.push(u && !hasGenericSecretShape(u) ? u : MASK);
+      continue;
+    }
+    const withValue = FLAG_WITH_VALUE_RE.exec(w);
+    if (withValue) { out.push(`${withValue[1]}=${MASK}`); continue; }
+    if (LONG_FLAG_RE.test(w) || SHORT_FLAG_RE.test(w)) {
+      if (credentialFlagCarriesValue(w)) { out.push(MASK); maskNext = true; continue; }
+      out.push(w);
+      maskNext = CREDENTIAL_FLAG_RE.test(w);
+      continue;
+    }
+    if (CWD_WORD_RE.test(w)) { out.push(w); continue; }
+    if (PATH_WORD_RE.test(w) && !hasGenericSecretShape(w)) { out.push(w); continue; }
+    if (PLAIN_WORD_RE.test(w) && w.length <= 24 && !hasGenericSecretShape(w)) { out.push(w); continue; }
+    out.push(MASK);
+  }
+  return out.join(" ");
 }
 
 /**
@@ -325,6 +539,26 @@ function summarizeShell(p: Record<string, unknown>): string {
  * 场景**主机名本身即密钥**(ngrok 随机子域、预签名 bucket 名)—— 这些随机串不含关键词、躲过
  * SECRET_RE。故只暴露注册域(eTLD+1)。解析失败返回 null(原串可能含 token,调用方丢弃)。
  */
+
+/**
+ * process 的 action 白名单。action 是模型可控字段(上游 processSchema 把它声明为裸
+ * `Type.String()`,枚举只写在 description 里),所以只认枚举值。
+ *
+ * 出处:`node_modules/openclaw/dist/bash-tools.schemas-*.js` 的 processSchema。上游新增 action
+ * 时这里不会报错,只会静默渲染空串 —— 升级后需比对。
+ *
+ * 注意这条**不受 cardToolDetail 控制**:改动前 process 走 shell 策略而 processSchema 没有
+ * command 字段,恒取空串,所以两种模式下渲染 action 都不是暴露面的放大,而是修一个恒空的 bug。
+ */
+const PROCESS_ACTIONS: ReadonlySet<string> = new Set([
+  "list", "poll", "log", "write", "send-keys", "submit", "paste", "kill", "clear", "remove",
+]);
+function summarizeEnum(p: Record<string, unknown>): string {
+  const action = firstString(p, ["action"]).trim();
+  return PROCESS_ACTIONS.has(action) ? action : "";
+}
+
+
 function originDomain(rawUrl: string): string | null {
   try {
     const u = new URL(rawUrl);
@@ -461,78 +695,169 @@ const RESIDUAL_QUERY_RE =
   /(?=[A-Za-z0-9._-]*[A-Za-z])[A-Za-z0-9._-]+(?::\d+)?(?:\/[^\s?]*)?\?[^\s]*=/;
 
 /** 把文本里内嵌的 URI 就地降级为 scheme://注册域(解析失败则整段抹除)。 */
-export function reduceUrlsInText(s: string): string {
+/**
+ * 放开档的 URL 归约:保留 scheme + **完整主机名(含子域)** + path,丢掉 query/fragment。
+ *
+ * 相对 originDomain 放开的是子域与路径 —— 这正是「隧道/预签名场景主机名即密钥」那条防护
+ * 覆盖的面,由 cardToolDetail 显式承担。**userinfo 与 query 仍然永不渲染**:前者是明文口令,
+ * 后者是裸 token 最常见的位置,二者都不影响「看清访问了哪个接口」这个诉求。
+ */
+function detailedUrl(rawUrl: string): string | null {
+  try {
+    const u = new URL(rawUrl);
+    // u.host 不含 userinfo。纯主机 URL 的 pathname 是 "/",直接拼会给卡片留个多余的尾斜杠
+    // (`redis-cli -u redis:6379/`),看着像被截断过。
+    return `${u.protocol}//${u.host}${u.pathname === "/" ? "" : u.pathname}`;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * 把文本里内嵌的 URI 就地归约(解析失败则整段抹除)。
+ * detailed=false → scheme://注册域;detailed=true → scheme://完整主机/path(仍剥 userinfo/query)。
+ */
+export function reduceUrlsInText(s: string, detailed = false): string {
+  const reduce = detailed ? detailedUrl : originDomain;
   // 1. 任意 `scheme://…`,不止 http(s):DB/AMQP/ssh DSN(postgres://user:pass@host 等)也常
   //    出现在 query/shell/错误文本里,userinfo 即明文密码。要求 `://` 故不误伤 Windows 盘符(C:/)。
-  let out = s.replace(/[a-z][a-z0-9+.-]*:\/\/[^\s]+/gi, (m) => originDomain(m) ?? "");
-  // 2. 协议相对 `//host/path`:补 https 后降级(secret 可能在 path)。
+  let out = s.replace(/[a-z][a-z0-9+.-]*:\/\/[^\s]+/gi, (m) => reduce(m) ?? "");
+  // 2. 协议相对 `//host/path`:补 https 后归约(secret 可能在 path)。
   out = out.replace(PROTOCOL_RELATIVE_RE, (_m, p1: string) => {
     const url = _m.slice(p1.length); // 去掉前导分隔符
-    return p1 + (originDomain(`https:${url}`) ?? "");
+    return p1 + (reduce(`https:${url}`) ?? "");
   });
-  // 3. 无 scheme 的 userinfo DSN(`user:pass@host…`):只留注册域,丢 userinfo/path。
+  // 3. 无 scheme 的 userinfo DSN(`user:pass@host…`):丢 userinfo。detailed 保留主机/path。
   out = out.replace(SCHEMELESS_USERINFO_RE, (m) => {
-    const host = m.slice(m.lastIndexOf("@") + 1).split(/[/:]/)[0];
-    return originDomain(`https://${host}`) ?? "";
+    const rest = m.slice(m.lastIndexOf("@") + 1); // host[:port][/path] 或 host:/path
+    if (!detailed) return originDomain(`https://${rest.split(/[/:]/)[0]}`) ?? "";
+    // `host:/path`(rsync/scp 远端路径)不能过 new URL():空端口会被吃掉,`backup:/data`
+    // 变成 `backup/data`,语义就错了。userinfo 已经落在 rest 之外,保留主机与路径、只丢 query。
+    if (/^[^/:]+:\//.test(rest)) return rest.replace(/\?.*$/, "");
+    return detailedUrl(`https://${rest}`)?.replace(/^https:\/\//, "") ?? "";
   });
-  // 4. 任意无 scheme 的 `host.tld/path`:保留注册域,统一抹掉可能承载凭据的 path。
-  out = out.replace(SCHEMELESS_HOST_PATH_RE, (_m, prefix: string, hostAndPath: string) => (
-    prefix + (originDomain(`https://${hostAndPath}`) ?? "")
-  ));
+  // 4. 任意无 scheme 的 `host.tld/path`:非 detailed 统一抹掉可能承载凭据的 path。
+  out = out.replace(SCHEMELESS_HOST_PATH_RE, (_m, prefix: string, hostAndPath: string) => {
+    const reduced = reduce(`https://${hostAndPath}`);
+    if (!reduced) return prefix;
+    return prefix + (detailed ? reduced.replace(/^https:\/\//, "") : reduced);
+  });
   // 5. 单标签主机的 `host/path?query`:上面几趟都要求主机带点,漏掉这一类,query 原样留下。
   //
-  // 这一趟落在 reduceUrlsInText 里,所以它的另外几个调用方(display card 文本、action label、
-  // reasoning 文本、card-author、card-display-tool)一并生效。代价要说全,别只说样式:
-  // card-blocks.ts 的 noReducibleUrl 会因为更多串算作"可归约"而退到单个 TextBlock(丢富文本
-  // 样式);而 card-action-status.ts 的 neutralizeEcho 跑在**用户提交的输入值**上、结果会被冻结
-  // 到状态卡里 —— `docs/parser?mode=fast` → `docs/parser`,卡片记下的就不再是用户提交的原文。
-  // 这是内容保真的代价,不是样式的代价。见 README 的 scope note。
+  // 这一趟**有意不按 detailed 分流**,与 1–4 趟不同。「query 永不渲染」是全局不变量,而
+  // reduceUrlsInText 的另外几个调用方(display card 文本、action label、reasoning 文本、
+  // card-author、card-display-tool)同样群可见 —— 只在进度卡里补上,等于把另一半留着。
+  // 见 README 的 scope note。
   out = out.replace(SCHEMELESS_QUERY_RE, "$1$2");
   return out;
 }
 
-/** url 策略:取 url 参数并降级为注册域。 */
-function summarizeUrl(p: Record<string, unknown>): string {
+/** url 策略:取 url 参数并归约(detailed 保留子域与路径)。 */
+function summarizeUrl(p: Record<string, unknown>, detailed: boolean): string {
   const raw = firstString(p, ["url"]);
   if (!raw) return "";
-  return originDomain(raw) ?? "";
+  return (detailed ? detailedUrl(raw) : originDomain(raw)) ?? "";
 }
 
 /**
  * 从工具参数提取一句人可读摘要 —— 按工具 allowlist 策略取值,未知/MCP 工具不显示,
  * 命中敏感串则整串隐藏,最后折叠空白并截断。群卡片对全员可见,安全优先于信息量。
  */
-export function summarizeToolParams(toolName: string | undefined, params: unknown): string {
+/**
+ * 放开档判定长度上限用的**原始输入**长度。刻意不复用 extractSummary —— 上限的全部意义就是
+ * 不让超长输入进入解析/递归,先解析再量长度等于没设上限。
+ */
+function rawCommandLength(strategy: SummaryStrategy, p: Record<string, unknown>): number {
+  switch (strategy) {
+    case "shell": return firstString(p, ["command", "cmd"]).length;
+    case "path": return firstString(p, ["path", "file_path", "file"]).length;
+    case "url": return firstString(p, ["url"]).length;
+    case "query": return firstString(p, ["query", "pattern"]).length;
+    case "enum": return 0;
+  }
+}
+
+export function summarizeToolParams(
+  toolName: string | undefined,
+  params: unknown,
+  opts: { detail?: SummaryDetail } = {},
+): string {
   if (!toolName || !params || typeof params !== "object") return "";
   const strategy = SUMMARY_STRATEGY[toolName];
   if (!strategy) return ""; // MCP / 未知工具:不渲染任意参数
   const p = params as Record<string, unknown>;
-  let v: string;
+  let detail = opts.detail ?? "off";
+  // 放开档的长度上限在 extractSummary **之前**判定,量的是**原始输入**。放到 sanitizeSummary
+  // 里(晚一个调用帧)等于没设:分词与分类都发生在上游。这条与 SUMMARY_INPUT_MAX 阶段不同、
+  // 目的也不同 —— 那条无条件截断、挡的是归约管线的正则回溯,两条都要留。
+  if (detail !== "off" && rawCommandLength(strategy, p) > DETAILED_INPUT_MAX) detail = "off";
+  const cleaned = sanitizeSummary(extractSummary(strategy, p, detail), strategy, detail);
+  if (cleaned || detail === "off") return cleaned;
+  // 放开后的内容更容易命中关键词/前缀,而脱敏是 fail-safe 整串隐藏 —— 直接返回空会让放开的
+  // 模式比保守模式**信息更少**。退回保守摘要,保证信息量单调不减。
+  return sanitizeSummary(extractSummary(strategy, p, "off"), strategy, "off");
+}
+
+/**
+ * 按策略取原始摘要值。
+ *
+ * 只有 `shell` 需要单独的加法摘要 —— 其余三个策略本来就是加法的(`new URL()` 解析、封闭
+ * enum、与路径同源的形状),放开档只是让它们少丢一点结构,判据不变。
+ */
+function extractSummary(
+  strategy: SummaryStrategy,
+  p: Record<string, unknown>,
+  detail: SummaryDetail,
+): string {
+  const open = detail !== "off";
   switch (strategy) {
-    case "path": v = shortenPath(firstString(p, ["path", "file_path", "file"])); break;
-    case "shell": v = summarizeShell(p); break;
-    case "url": v = summarizeUrl(p); break;
-    case "query": v = firstString(p, ["query", "pattern"]); break;
+    case "path": {
+      const raw = firstString(p, ["path", "file_path", "file"]);
+      return open ? raw : shortenPath(raw);
+    }
+    case "shell": return open ? summarizeShellAdditive(p) : summarizeShell(p);
+    case "enum": return summarizeEnum(p);
+    case "url": return summarizeUrl(p, open);
+    case "query": return firstString(p, ["query", "pattern"]);
   }
+}
+
+/** 摘要清洗管线:折叠空白 → URL 降级 → 敏感串守卫 → 截断。命中守卫返回空串(fail-safe)。 */
+function sanitizeSummary(v: string, strategy: SummaryStrategy, detail: SummaryDetail): string {
   if (!v) return "";
+  const open = detail !== "off";
   let s = v.replace(/\s+/g, " ").trim();
-  // 无条件先截断,再进归约管线 —— 见 SUMMARY_INPUT_MAX。不按策略分流:二次回溯在 query 策略
-  // (原样返回 pattern)、path 策略、shell 策略上都实测可达。
+  // 无条件截断仍在这里(与放开档无关,见 SUMMARY_INPUT_MAX)。渲染上限只有 120/64,截断掉的
+  // 部分本来也不会被渲染,所以守卫仍然跑在"会被渲染的那段"的完整形态上。
   if (s.length > SUMMARY_INPUT_MAX) s = s.slice(0, SUMMARY_INPUT_MAX);
-  // 单一 choke point:所有策略统一把内嵌 URL 降级为 scheme://注册域。避免逐 sink 加降级时
-  // 漏掉某个策略(query 的 pattern、shell 的 URL-as-program 都会原样渲染 webhook/userinfo/内网主机)。
-  s = reduceUrlsInText(s).replace(/\s+/g, " ").trim();
-  // 归约管线处理不掉的 userinfo 形状 → 整串不渲染。必须放在归约**之后**:能确定是 DSN 的形状
-  // 此时已被剥掉 userinfo,不会在这里误伤。
+  // 单一 choke point:所有策略统一归约内嵌 URL。避免逐 sink 加处理时漏掉某个策略(query 的
+  // pattern、shell 的 URL-as-program 都会原样渲染 webhook/userinfo/内网主机)。detailed 只放开
+  // 子域与路径,userinfo/query 在任何模式下都不渲染。
+  s = reduceUrlsInText(s, open).replace(/\s+/g, " ").trim();
+  // 归约管线处理不掉的 userinfo 形状 → 整串不渲染(放开档会退回保守摘要)。必须放在归约
+  // **之后**:能确定是 DSN 的形状此时已被剥掉 userinfo,不会误伤。
   if (RESIDUAL_USERINFO_RE.test(s)) return "";
   if (RESIDUAL_QUERY_RE.test(s)) return "";
   // query/url 是「裸 token」易出没处 → 额外套用通用高熵/长 hex 检测;path/shell 只走关键词
   // + 明确前缀,避免把 git SHA / docker digest / 缓存哈希等正常路径误伤成空。
+  //
+  // 放开档**不**一并打开 generic。实测代价远不止误伤哈希 ——
+  // `/root/.openclaw/workspace/octo-server/modules/bot_api/send.go` 这种普通路径就会命中,
+  // path 策略在放开档等于失效(退回 `…/bot_api/send.go`)。而它要补的洞(`FOO=hunter2` 这类
+  // 名字没有暗示的赋值)在加法路径上根本不存在:加法不看变量名,所有赋值一律抹值。
   const generic = strategy === "query" || strategy === "url";
-  if (!s || isSensitive(s, generic)) return "";
-  return s.length > SUMMARY_MAX ? s.slice(0, SUMMARY_MAX) + "…" : s;
+  // 已抹掉的值及其紧邻的名字(`TOKEN=***`、`--token ***`)不参与守卫检测:值早就是 `***` 了,
+  // 再让**名字**命中 SECRET_RE 只会把整条命令误伤成空、退回程序名 —— 加法档几乎每条带凭据
+  // flag 的命令都会退化成只剩程序名,恰恰丢掉这一档想给的信息。
+  //
+  // 这条豁免之所以安全,理由是加法特有的、不可照搬到任何减法路径:加法输出里的值**按构造**
+  // 已经是 `***`,所以删掉「`***` 及其紧邻的名字」不可能放出任何被渲染的值,能被删掉的只有
+  // 我们已经正面归类为安全的 token。渲染字面值的路径没有这个性质。
+  const probe = open && strategy === "shell" ? s.replace(ADDITIVE_MASKED_RE, " ") : s;
+  if (!s || isSensitive(probe, generic)) return "";
+  const max = open ? SUMMARY_DETAILED_MAX : SUMMARY_MAX;
+  return s.length > max ? s.slice(0, max) + "…" : s;
 }
-
 /** ms → 友好耗时(<1s 用 ms,否则 x.xs)。 */
 export function fmtDuration(ms?: number): string {
   if (typeof ms !== "number") return "";

--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -34,6 +34,7 @@ export interface OctoAccountConfig {
   reasoningCardTemplateMode?: ReasoningCardTemplateMode;  // off=Model B, shadow=discover only, experimental=Model A when compatible
   cardDisplay?: boolean;  // false force-disables the display-card tool; true/unset follows server capabilities
   cardInteraction?: boolean;  // false force-disables interactive cards; true/unset follows server capabilities
+  cardToolDetail?: boolean;  // opt-in: true = additive structural summary (unclassifiable tokens masked); false/unset = program name only
   onBehalfOf?: string;  // Persona clone: grantor uid — bot acts on behalf of this human
   secretsFileRoot?: string;  // Jail root for write-secret: secret files may only be written under this path. When unset, defaults to the agent's workspace (agents.list[].workspace matched to the agent, else agents.defaults.workspace); if neither resolves, write-secret fails closed (no process.cwd() fallback).
   dispatchTimeoutMs?: number;  // Explicit per-inbound dispatch timeout override (ms). Unset = derived from agents.defaults.timeoutSeconds + 60s buffer (issue #113).
@@ -57,6 +58,7 @@ export interface OctoConfig {
   reasoningCardTemplateMode?: ReasoningCardTemplateMode;  // Top-level Registry migration mode for reasoning cards
   cardDisplay?: boolean;  // Top-level default for the display-card tool
   cardInteraction?: boolean;  // Top-level default for interactive cards
+  cardToolDetail?: boolean;  // Top-level default for tool-step summary detail (opt-in; unset = off)
   onBehalfOf?: string;  // Persona clone: grantor uid — bot acts on behalf of this human
   secretsFileRoot?: string;  // Jail root for write-secret (see OctoAccountConfig)
   dispatchTimeoutMs?: number;  // Explicit per-inbound dispatch timeout override (ms); see OctoAccountConfig
@@ -101,6 +103,9 @@ export const CARD_DISPLAY_DESCRIPTION =
 
 export const CARD_INTERACTION_DESCRIPTION =
   "When omitted or true, follow the server octo/v2 card capability gate; false force-disables the octo_send_card tool and new interactive callback polling. Per-account values override the top-level value.";
+
+export const CARD_TOOL_DETAIL_DESCRIPTION =
+  "Opt-in. Omitted or false: progress-card tool steps render the program name only, with paths shortened and URLs reduced to their registrable domain. true: render an additive structural summary of each tool call \u2014 program name, subcommands, flag names, reduced URLs and full file paths \u2014 with every assignment value, and every token that cannot be positively classified as safe, replaced by ***. The summary is built by adding back what is recognised rather than by removing what looks dangerous, so a shape the classifier misses becomes another *** instead of a rendered credential. Residuals, enumerated: a positional token renders when it is at most 24 characters and not high-entropy, so a credential used as a bare argument (deploy prod hunter2) reads as a subcommand; a URL that parses renders with host and path, so a tunnel or presigned hostname whose randomness is the credential still appears; a credential-shaped flag masks one following word, so an unquoted multi-word secret keeps everything after its first token; and file paths are expanded rather than shortened, exposing home directories and workspace layout. Keeping that list short costs single-dash flags: only -x and -xy render, since a glued password and a long flag name are the same shape. Progress cards are visible to every member of a group. The process tool renders its action at every level. Per-account values override the top-level value.";
 
 export const EVENT_WAIT_SECONDS_DESCRIPTION =
   "Seconds to let the server hold an empty /v1/bot/events queue open (its `wait` parameter), so a card action reaches the bot as soon as it happens instead of on the next poll tick. Omitted or 0 keeps plain short polling at pollIntervalMs; a non-zero value below 5 is raised to 5, because shorter holds issue more requests than the short polling they replace. Requires a server that supports the long poll; older servers ignore the field and answer immediately, which is safe but gives no benefit. The client request timeout is derived from this value, and the server clamps it to 30s. Per-account values override the top-level value.";
@@ -150,6 +155,7 @@ export const OctoConfigJsonSchema = {
       reasoningCardTemplateMode: REASONING_CARD_TEMPLATE_MODE_SCHEMA,
       cardDisplay: { type: "boolean", description: CARD_DISPLAY_DESCRIPTION },
       cardInteraction: { type: "boolean", description: CARD_INTERACTION_DESCRIPTION },
+      cardToolDetail: { type: "boolean", description: CARD_TOOL_DETAIL_DESCRIPTION },
       onBehalfOf: { type: "string" },
       secretsFileRoot: { type: "string", description: SECRETS_FILE_ROOT_DESCRIPTION },
       dispatchTimeoutMs: { type: "number", minimum: 1000, description: DISPATCH_TIMEOUT_MS_DESCRIPTION },
@@ -176,6 +182,7 @@ export const OctoConfigJsonSchema = {
             reasoningCardTemplateMode: REASONING_CARD_TEMPLATE_MODE_SCHEMA,
             cardDisplay: { type: "boolean", description: CARD_DISPLAY_DESCRIPTION },
             cardInteraction: { type: "boolean", description: CARD_INTERACTION_DESCRIPTION },
+            cardToolDetail: { type: "boolean", description: CARD_TOOL_DETAIL_DESCRIPTION },
             onBehalfOf: { type: "string" },
             secretsFileRoot: { type: "string", description: SECRETS_FILE_ROOT_DESCRIPTION },
             dispatchTimeoutMs: { type: "number", minimum: 1000, description: DISPATCH_TIMEOUT_MS_DESCRIPTION },


### PR DESCRIPTION
**已关闭,不合并。** 分支 `octo/card-tool-detail` 保留(head `d700ea0`),内容随时可取。

关闭的原因不是这个特性不成立,而是**它挂靠的地基已经不存在了**。

## 为什么重做而不是 rebase

`d700ea0` 写在 `octo/card-render-default-fixes` 的**第 1 轮中间态** `d153e74` 上。那条分支后来又走了五轮,最终以 #203 squash 进 `main`(`58639fb`),而这五轮把它依赖的地基整个换掉了:移除了它引用的兜底、改了 `reduceUrlsInText` 的签名、加了「界丢掉的那一段用调用方自己的谓词检查」这套接线。

实测 `git rebase --onto main d153e74`:**`src/card-render.ts` 4 处冲突**,而且不是机械冲突 —— 它引入的六个符号在新 `main` 里**一个都不存在**:

| 符号 | `d700ea0` | 新 `main` |
|---|---|---|
| `detailedUrl` | 5 处 | 0 |
| `SUMMARY_DETAILED_MAX` | 2 处 | 0 |
| `RESIDUAL_USERINFO_RE` | 5 处 | 0 |
| `SCHEMELESS_QUERY_RE` | 4 处 | 0 |
| `RESIDUAL_QUERY_RE` | 3 处 | 0 |
| `ADDITIVE_MASKED_RE` | 2 处 | 0 |

前两个是本特性自己的,没问题。**后四个是在 #203 / #205 的评审里被否决或移除掉的东西** —— 硬解这 4 处冲突,等于把它们悄悄搬回 `main`:

- **`RESIDUAL_USERINFO_RE`** 在 #203 第 2 轮出现过,随后被整个摘掉:三次方回溯(冒号密集参数 5877 ms)+ 终止符旁路(8 个 DSN 形状漏 7 个)。
- **`SCHEMELESS_QUERY_RE` / `RESIDUAL_QUERY_RE`**(query 剥离)在本 PR 的评审里实测是二次方 —— 100k 输入 24.7 秒,`http://` + 120k 从 4 ms 变 21.5 秒,且默认档可达。抽成 #205 重写后是**三次方**(3902 字符 9707 ms),#205 已因此关闭。
- **`ADDITIVE_MASKED_RE` 豁免**按现在的写法会把 `token` 这个关键词从守卫探针里删掉,于是 `cli --token=abc -p hunter2` 渲染出 `hunter2`。这与 #203 第 6 轮的 P0 是同一个失败模式:**删掉守卫正在读的证据**。

## 还有 7 条未处理的评审意见

与 rebase 无关、关于分类器本身的:`-p X` 空格形式漏、`--flag=` 名字未分类、数组下标未分类、百分号编码绕过 `hasGenericSecretShape`、`--long` 无长度/熵界、detailed `path` 策略无形状检查、以及上面那条豁免。评审给出的方向不是逐条打补丁,而是**把分类器抽成一个显式的 accept-list 函数,所有 token(名字、下标、flag、操作数、路径段、URL 组件)都强制走它,残留清单由那个函数的测试生成**。那是重做。

## 后续怎么走

要继续做 `cardToolDetail` 的话,从新 `main` 起干净分支重写:

- **直接取用**:`detailedUrl`、`SUMMARY_DETAILED_MAX`、配置管线(四处 schema、per-account 覆盖 top-level、fail-closed 解析 —— 这部分评审确认完整且有测试)。
- **不带**:`RESIDUAL_USERINFO_RE`、query 剥离两条正则。
- **收窄后再用**:`ADDITIVE_MASKED_RE` 豁免,只删字面 `***`,不删紧邻的名字。
- **重做**:分类器主体。

另外,本 PR 里把 `process` 策略从 `"shell"` 改成 `"enum"` 是一条**默认档的真 bug 修复**(改之前 `process` 摘要恒返回空串),与 `cardToolDetail` 无关,会单独随默认档那批提交。
