### PR TITLE
fix(cards): collapse the reasoning trace on every terminal state

### DIFF
--- a/src/reasoning-process.test.ts
+++ b/src/reasoning-process.test.ts
@@ -452,4 +452,36 @@ describe("reasoning process Adaptive Card", () => {
     expect(JSON.stringify(card)).not.toContain("ActionSet");
     expect(JSON.stringify(card)).not.toContain("Action.ToggleVisibility");
   });
+
+  /**
+   * A terminal card is collapsed by default, and the error block lives inside `trace_panel`. The
+   * reason therefore has to ride in an always-visible element or a failed run renders as a bare
+   * `Failed` badge with no cause — the regression `renderProgressCard` avoids by putting the reason
+   * in its header. Asserted against the body elements outside `trace_panel`, i.e. what the reader
+   * sees before clicking anything.
+   */
+  it("keeps the failure reason visible on a collapsed error card", () => {
+    const { card } = renderReasoningProcessCard(
+      state({ phase: "error", errorText: "provider timeout" }),
+      caps,
+    );
+    const body = card.body as Array<Record<string, unknown>>;
+    const withoutTrace = JSON.stringify(body.filter((item) => item.id !== "trace_panel"));
+
+    expect(body.find((item) => item.id === "trace_panel")).toMatchObject({ isVisible: false });
+    expect(withoutTrace).toContain("provider timeout");
+    // The collapsed summary is the default presentation of the outcome, so it must not badge a
+    // failure with the success glyph.
+    expect(withoutTrace).toContain("⚠");
+    expect(withoutTrace).not.toContain("✓");
+  });
+
+  it("labels an expired wait distinctly from an interrupted run", () => {
+    const { card } = renderReasoningProcessCard(state({ phase: "expired" }), caps);
+    const body = card.body as Array<Record<string, unknown>>;
+    const withoutTrace = JSON.stringify(body.filter((item) => item.id !== "trace_panel"));
+
+    expect(withoutTrace).toContain("Wait timed out");
+    expect(withoutTrace).not.toContain("Interrupted");
+  });
 });

--- a/src/reasoning-process.test.ts
+++ b/src/reasoning-process.test.ts
@@ -98,14 +98,24 @@ describe("ai.reasoning-process successor-compatible contract", () => {
       timerText: "6.0s · stopped at phase 1",
       collapsedSummary: "Kept 1 phase from before the stop",
     });
+    // 终态一律折叠(与 Model B 的 renderProgressCard 一致):失败卡默认收起,
+    // collapsedSummary 的 "open to see the steps so far" 才有意义 —— 展开时它永不显示。
     expect(buildReasoningProcessData(state({ phase: "error", errorText: "provider timeout" }))).toMatchObject({
       state: "error",
       statusLabel: "Failed",
       statusTone: "Attention",
-      traceExpanded: true,
-      traceCollapsed: false,
+      traceExpanded: false,
+      traceCollapsed: true,
+      collapsedSummary: "Interrupted · open to see the steps so far",
       errorTitle: "Generation failed",
       errorMessage: "provider timeout",
+    });
+    // expired 走同一条 error 契约状态,同样折叠。
+    expect(buildReasoningProcessData(state({ phase: "expired" }))).toMatchObject({
+      state: "error",
+      traceExpanded: false,
+      traceCollapsed: true,
+      errorMessage: "Timed out waiting for the background task.",
     });
   });
 

--- a/src/reasoning-process.ts
+++ b/src/reasoning-process.ts
@@ -326,7 +326,14 @@ function buildReasoningProcessDataWithPhases(
   const toolCount = state.steps.filter((step) =>
     step.tool !== "__thinking__" && step.tool !== SUBAGENT_WAIT_STEP_TOOL).length;
   const active = mapped === "reasoning" || mapped === "answering";
-  const errorMessage = sanitizeErrorText(state.errorText) ||
+  // The failure reason must ride in an always-visible field. The error block lives inside the
+  // collapsible trace, and for Model A the server template owns the layout — so hiding the trace
+  // by default would bury the reason on both renderers unless the header carries it. This mirrors
+  // renderProgressCard's header (`⚠️ Interrupted: <detail>` / `⏱️ Wait timed out`), including its
+  // ERROR_MAX cap, which sanitizeErrorText already applies.
+  const failureDetail = sanitizeErrorText(state.errorText);
+  const failureLabel = state.phase === "expired" ? "Wait timed out" : "Interrupted";
+  const errorMessage = failureDetail ||
     (state.phase === "expired"
       ? "Timed out waiting for the background task."
       : "Reasoning was interrupted. Completed steps were preserved.");
@@ -346,7 +353,7 @@ function buildReasoningProcessDataWithPhases(
     timerText: mapped === "reasoning" ? "Reasoning…"
       : mapped === "answering" ? "Writing the answer…"
         : mapped === "stopped" ? `${elapsed} · stopped at phase ${phases.length}`
-          : mapped === "error" ? "Interrupted"
+          : mapped === "error" ? (failureDetail ? `${failureLabel} · ${failureDetail}` : failureLabel)
             : `${elapsed} · ${phaseCount(phases.length)} · ${toolCallCount(toolCount)}`,
     // Every terminal state collapses (done/stopped/error/expired), matching renderProgressCard:
     // a settled card is a summary, and collapsedSummary tells the reader to open it for the steps.
@@ -355,7 +362,7 @@ function buildReasoningProcessDataWithPhases(
     traceCollapsed: !active,
     collapsedSummary: mapped === "answering" ? "Reasoning complete · answer in progress"
       : mapped === "stopped" ? `Kept ${phaseCount(phases.length)} from before the stop`
-        : mapped === "error" ? "Interrupted · open to see the steps so far"
+        : mapped === "error" ? `${failureLabel} · open to see the steps so far`
           : mapped === "completed" ? `${elapsed} · trace collapsed`
             : "Reasoning in progress · open to follow along",
     phases,
@@ -437,6 +444,14 @@ function plainText(data: ReasoningProcessData): string {
   return lines.join("\n") || PROGRESS_CARD_PLACEHOLDER;
 }
 
+/**
+ * Glyph for the collapsed summary line. A terminal card is collapsed by default, so this glyph is
+ * the default presentation of the outcome — a hardcoded `✓` would badge a failed run as successful.
+ */
+function collapsedGlyph(state: ReasoningProcessState): string {
+  return state === "completed" ? "✓" : state === "error" || state === "stopped" ? "⚠" : "◌";
+}
+
 /** Render the local toggle-only variant of the shared Registry data shape. */
 export function renderReasoningProcessCard(
   state: CardProgressState,
@@ -504,7 +519,7 @@ export function renderReasoningProcessCard(
       id: "collapsed_panel",
       isVisible: canToggle ? data.traceCollapsed : false,
       spacing: "Medium",
-      items: [textBlock(`✓  ${data.collapsedSummary}`, { size: "Small", isSubtle: true, spacing: "None" })],
+      items: [textBlock(`${collapsedGlyph(data.state)}  ${data.collapsedSummary}`, { size: "Small", isSubtle: true, spacing: "None" })],
     },
   ];
   if (canToggle) {

--- a/src/reasoning-process.ts
+++ b/src/reasoning-process.ts
@@ -348,8 +348,11 @@ function buildReasoningProcessDataWithPhases(
         : mapped === "stopped" ? `${elapsed} · stopped at phase ${phases.length}`
           : mapped === "error" ? "Interrupted"
             : `${elapsed} · ${phaseCount(phases.length)} · ${toolCallCount(toolCount)}`,
-    traceExpanded: active || mapped === "error",
-    traceCollapsed: !active && mapped !== "error",
+    // Every terminal state collapses (done/stopped/error/expired), matching renderProgressCard:
+    // a settled card is a summary, and collapsedSummary tells the reader to open it for the steps.
+    // Only a running turn stays expanded.
+    traceExpanded: active,
+    traceCollapsed: !active,
     collapsedSummary: mapped === "answering" ? "Reasoning complete · answer in progress"
       : mapped === "stopped" ? `Kept ${phaseCount(phases.length)} from before the stop`
         : mapped === "error" ? "Interrupted · open to see the steps so far"


### PR DESCRIPTION
## Summary

- collapse the reasoning trace on **every** terminal state, not just the successful ones
- keep the failure **reason** visible when it collapses, by folding it into the header field

## The inconsistency

The Registry card (Model A) kept the trace expanded on `error`, while `renderProgressCard` collapses every terminal state — its `isTerminal` check folds in `error` and `expired`. Which renderer serves a turn depends on template negotiation, so the *same deployment* showed a failed card expanded or collapsed depending on what the Bot catalog advertised.

```diff
-    traceExpanded: active || mapped === "error",
-    traceCollapsed: !active && mapped !== "error",
+    traceExpanded: active,
+    traceCollapsed: !active,
```

## Collapsing alone would have buried the reason

Matching only the boolean is not parity, and the first revision of this PR got that wrong. The error block lives *inside* `trace_panel`, so hiding the trace hid the cause with it — the always-visible header carried only `✦ Reasoning`, a constant `Interrupted`, and the `Failed` badge.

`renderProgressCard` does the opposite of what that produces: it collapses the **steps** and keeps the **reason**, because its header *is* the reason and is built outside the collapsible container (`⚠️ Interrupted: provider timeout`, `⏱️ Wait timed out`). Collapsing both would have made the two renderers agree on the flag and disagree on what the user sees.

So the reason now rides in `timerText`:

```ts
mapped === "error" ? (failureDetail ? `${failureLabel} · ${failureDetail}` : failureLabel)
```

**Why `timerText` and not a layout change.** For Model A the server template owns the layout — hoisting the error block out of the local container would fix the local renderer and leave the template card exactly as broken. `timerText` is data both renderers consume, so it is the only layer that fixes both. The bound is `sanitizeErrorText`'s existing `ERROR_MAX`, the same one `renderProgressCard` applies to its own header.

`expired` gets its own label rather than the generic one. It is reached from the paused-card TTL timer, where no dispatch is running and no accompanying text message is sent — the card is the only signal the user gets.

## The collapsed summary no longer badges failures as successful

`collapsed_panel` hardcoded `✓`. That was reachable before only by manually collapsing a failed card; with terminal states collapsed by default it becomes the *default* presentation, so every failure and every stop opened as `✓ Interrupted …` under an `Attention`-coloured `Failed` badge. The glyph is now derived from state (`⚠` for `error`/`stopped`).

## Scope

- Running states (`reasoning`, `answering`) stay expanded — unchanged.
- A deployment that does not advertise the trace-toggle capability still renders the trace visible — unchanged.
- No wire-contract change: `traceExpanded` / `traceCollapsed` / `timerText` all already exist in the producer data shape.

## Correction to an earlier claim

The first revision of this description argued that `collapsedSummary` was *unreachable* while `traceExpanded` was true. That is wrong: `reasoning_toggle` passes `targetElements` as bare strings, which per the Adaptive Cards spec **inverts** each element's visibility, so one click on an expanded error card already revealed it. The copy was reachable before — it just was not the default. Defaulting terminal states to collapsed stands on its own (it matches `renderProgressCard`), but that reachability argument was not evidence for it, and focusing on the summary copy is what made the buried-reason regression easy to miss.

## Verification

- `npm run type-check` — clean
- `npm test` — 1809 passed, 7 skipped
- reverse-verified all three production changes: reverting the two collapse lines turns the boolean assertion red; reverting the `timerText` fold turns both new render tests red; reverting the glyph derivation turns one red

🤖 Generated with [Claude Code](https://claude.com/claude-code)
