### PR TITLE
feat(cards): use server-driven per-bot card policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Bot accounts are stored in `~/.openclaw/openclaw.json` under `channels.octo.acco
 
 Configuration fields per account:
 
-`cardProgress`, `reasoningCardTemplateMode`, `cardDisplay`, and `cardInteraction` may also be set directly under `channels.octo` as defaults for every account. An explicit per-account value overrides the corresponding top-level value.
+Card policy is configured per Bot on the Octo server, not in `openclaw.json`. The plugin reads the effective `card_enabled`, `display_enabled`, `interaction_enabled`, `reasoning_enabled`, and `reasoning_template_ref` values from `GET /v1/bot/card/profile`. Legacy local fields (`cardProgress`, `reasoningCardTemplateMode`, `cardDisplay`, and `cardInteraction`) are ignored.
 
 - `botToken` (required): Bot token. Either a User Bot token from BotFather (`bf_` prefix, full group + thread access) or an App Bot token from the Octo admin console (`app_` prefix, direct-message only — server-enforced).
 - `apiUrl` (required): Octo server REST API base URL (e.g. `https://your-server/api`). The default `http://localhost:8090/api` only works for a local Octo dev server with the standard `/api` mount.
@@ -73,32 +73,10 @@ Configuration fields per account:
 - `requireMention` (optional): Only respond when @mentioned in groups
 - `pollIntervalMs` (optional): Short-poll interval for `card_action` callbacks after this account sends an interactive card (default `2000`, minimum `500`).
 - `eventWaitSeconds` (optional): Seconds to let the server hold an empty `/v1/bot/events` queue open, so a card action reaches the bot as soon as it is clicked instead of on the next poll tick (default `0` = plain short polling at `pollIntervalMs`; a non-zero value is clamped to 5–30 — below 5 a hold issues more requests than the short polling it replaces, and 30 matches the server's own clamp). Requires a server that supports the long poll; older servers answer immediately and the poller falls back to `pollIntervalMs` pacing, so setting it is safe but gives no benefit. Lower it if a reverse proxy in front of the server has an idle timeout below ~40s, since the client request timeout is derived as `eventWaitSeconds + 10s`.
-- `cardProgress` (optional): Set `false` to force-disable automatic progress cards for this account. Omitted or `true` follows the server card capability gate.
-- `reasoningCardTemplateMode` (optional): Registry migration mode for automatic reasoning cards. `experimental` (default) sends Model A when the server advertises exactly one compatible `ai.reasoning-process` template and uses that manifest version unchanged, without a local version allowlist. Compatibility includes exactly one copy of every required view/state, rejects unknown Submit actions, and accepts either no controls or the deployed view-scoped controls (`reasoning_stop` on active, `reasoning_retry` on error, none on result). Zero or multiple compatible entries fall back to Model B because catalog order is not a preference signal. `off` keeps local Model B rendering; `shadow` validates Registry discovery but still sends Model B. This does not affect `octo_send_display_card` or `octo_send_card`. Separately, when OpenClaw reasoning visibility is enabled (`on` or `stream`), sanitized and length-bounded reasoning text is included in progress cards and is visible to channel members. Note that this changes the local Model B card too: whenever Model B is the one rendering — `off`, `shadow`, or `experimental` with no single compatible template — a turn that actually captured reasoning text uses the reasoning layout instead of the plain progress card.
-
-  Four `experimental` behaviours are deliberate and worth knowing before you enable it. Template compatibility alone selects Model A, independent of reasoning visibility: a turn that never exposed any reasoning still renders the `ai.reasoning-process` card, with real tool rows under a generic placeholder thought line instead of captured reasoning text (local Model B rendering keeps its plain progress card in that case). Model A never synthesizes tool actions it did not observe, so a reasoning phase that has not yet run a tool is omitted from the frame — its thought text appears once that phase calls one, where Model B shows the phase immediately with a synthetic `think` row; a turn's last reasoning phase usually calls no tool before the model answers, so that closing segment usually never reaches the Model A card at all. Neither mode sends a progress card for a turn that calls no tools at all. Run control (stop/regenerate) is not a card action: the deployed template is expected to render no such controls, and this plugin only ACKs view-scoped `reasoning_stop` / `reasoning_retry` as a defensive no-op for cards already sitting in channels and for catalogs that still advertise them, so those buttons do not perform run control. Finally, if the initial Model A send receives a deterministic template-frame rejection and the advertised Model B profile is compatible, the plugin retries that first frame exactly once as Model B; an existing Model A message never switches wire modes.
-- `cardDisplay` (optional): Set `false` to hide and reject the `octo_send_display_card` tool for this account. Omitted or `true` follows the server card capability gate.
-- `cardInteraction` (optional): Set `false` to hide `octo_send_card` and prevent new interactive-card callback polling for this account. Omitted or `true` follows the server `octo/v2` capability gate.
 - `historyLimit` (optional): Group chat history message limit (default: 20)
 - `dispatchTimeoutMs` (optional): Per-inbound dispatch timeout in milliseconds — an infrastructure backstop that releases the per-group message queue if an upstream dispatch hangs. When unset, it is derived from OpenClaw's `agents.defaults.timeoutSeconds` (600 if unset) as `timeoutSeconds * 1000 + 60000`, so it always fires *after* the agent-run timeout: the agent terminates gracefully first, and this timeout only catches genuinely hung dispatches. Set explicitly only if you need to decouple it from the agent timeout.
 
-For example, to suppress intermediate progress frames while keeping final display cards available:
-
-```json
-{
-  "channels": {
-    "octo": {
-      "accounts": {
-        "my_bot": {
-          "cardProgress": false,
-          "cardDisplay": true,
-          "cardInteraction": true
-        }
-      }
-    }
-  }
-}
-```
+Automatic reasoning progress uses only the exact Registry template ref selected by the server and advertised in the same profile response. If reasoning is disabled, the ref is missing/incompatible, or the profile cannot be read, no progress card is sent; the plugin never falls back to the old locally rendered Model B. Profile results are cached privately per Bot and invalidated immediately by the server's `bot_setting_updated` event.
 
 ## Agent tools
 

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -76,24 +76,6 @@
           "historyPromptTemplate": {
             "type": "string"
           },
-          "cardProgress": {
-            "type": "boolean",
-            "description": "When omitted or true, follow the server card capability gate; false force-disables automatic progress cards. Per-account values override the top-level value."
-          },
-          "reasoningCardTemplateMode": {
-            "type": "string",
-            "enum": ["off", "shadow", "experimental"],
-            "default": "experimental",
-            "description": "Registry migration mode for automatic reasoning progress cards. off keeps local Model B rendering, shadow validates discovery while still sending Model B, and experimental sends Model A when exactly one compatible Bot-catalog template is advertised, using its manifest version unchanged; zero or multiple compatible entries fall back to Model B because catalog order is not a preference signal. A rejected experimental first frame retries once as Model B only for a deterministic card-invalid response; timeouts, conflicts, and transient/server errors do not trigger that fallback. Defaults to experimental; per-account values override the top-level value."
-          },
-          "cardDisplay": {
-            "type": "boolean",
-            "description": "When omitted or true, follow the server card capability gate; false force-disables the octo_send_display_card tool. Per-account values override the top-level value."
-          },
-          "cardInteraction": {
-            "type": "boolean",
-            "description": "When omitted or true, follow the server octo/v2 card capability gate; false force-disables the octo_send_card tool and new interactive callback polling. Per-account values override the top-level value."
-          },
           "accounts": {
             "type": "object",
             "additionalProperties": {
@@ -149,24 +131,6 @@
                 },
                 "historyPromptTemplate": {
                   "type": "string"
-                },
-                "cardProgress": {
-                  "type": "boolean",
-                  "description": "When omitted or true, follow the server card capability gate; false force-disables automatic progress cards. Per-account values override the top-level value."
-                },
-                "reasoningCardTemplateMode": {
-                  "type": "string",
-                  "enum": ["off", "shadow", "experimental"],
-                  "default": "experimental",
-                  "description": "Registry migration mode for automatic reasoning progress cards. off keeps local Model B rendering, shadow validates discovery while still sending Model B, and experimental sends Model A when exactly one compatible Bot-catalog template is advertised, using its manifest version unchanged; zero or multiple compatible entries fall back to Model B because catalog order is not a preference signal. A rejected experimental first frame retries once as Model B only for a deterministic card-invalid response; timeouts, conflicts, and transient/server errors do not trigger that fallback. Defaults to experimental; per-account values override the top-level value."
-                },
-                "cardDisplay": {
-                  "type": "boolean",
-                  "description": "When omitted or true, follow the server card capability gate; false force-disables the octo_send_display_card tool. Per-account values override the top-level value."
-                },
-                "cardInteraction": {
-                  "type": "boolean",
-                  "description": "When omitted or true, follow the server octo/v2 card capability gate; false force-disables the octo_send_card tool and new interactive callback polling. Per-account values override the top-level value."
                 },
                 "onBehalfOf": {
                   "type": "string",

--- a/src/__tests__/accounts.test.ts
+++ b/src/__tests__/accounts.test.ts
@@ -27,8 +27,8 @@ function buildCfg(accounts: Record<string, unknown>): unknown {
 }
 
 describe("resolveOctoAccount", () => {
-  describe("card feature switch inheritance", () => {
-    it("inherits top-level card switches when the account omits them", () => {
+  describe("server-owned card policy", () => {
+    it("does not copy legacy local card switches into the resolved account", () => {
       const cfg = {
         channels: {
           octo: {
@@ -44,61 +44,9 @@ describe("resolveOctoAccount", () => {
 
       const account = resolveOctoAccount({ cfg: cfg as never, accountId: MIXED_CASE_ID });
 
-      expect(account.config.cardProgress).toBe(false);
-      expect(account.config.cardDisplay).toBe(false);
-      expect(account.config.cardInteraction).toBe(false);
-    });
-
-    it("allows an account true to override a top-level false", () => {
-      const cfg = {
-        channels: {
-          octo: {
-            cardProgress: false,
-            cardDisplay: false,
-            cardInteraction: false,
-            accounts: {
-              [MIXED_CASE_ID]: {
-                botToken: "bf_cards_enable",
-                cardProgress: true,
-                cardDisplay: true,
-                cardInteraction: true,
-              },
-            },
-          },
-        },
-      };
-
-      const account = resolveOctoAccount({ cfg: cfg as never, accountId: MIXED_CASE_ID });
-
-      expect(account.config.cardProgress).toBe(true);
-      expect(account.config.cardDisplay).toBe(true);
-      expect(account.config.cardInteraction).toBe(true);
-    });
-
-    it("allows an account false to override a top-level true", () => {
-      const cfg = {
-        channels: {
-          octo: {
-            cardProgress: true,
-            cardDisplay: true,
-            cardInteraction: true,
-            accounts: {
-              [MIXED_CASE_ID]: {
-                botToken: "bf_cards_disable",
-                cardProgress: false,
-                cardDisplay: false,
-                cardInteraction: false,
-              },
-            },
-          },
-        },
-      };
-
-      const account = resolveOctoAccount({ cfg: cfg as never, accountId: MIXED_CASE_ID });
-
-      expect(account.config.cardProgress).toBe(false);
-      expect(account.config.cardDisplay).toBe(false);
-      expect(account.config.cardInteraction).toBe(false);
+      expect(account.config).not.toHaveProperty("cardProgress");
+      expect(account.config).not.toHaveProperty("cardDisplay");
+      expect(account.config).not.toHaveProperty("cardInteraction");
     });
   });
 

--- a/src/accounts.test.ts
+++ b/src/accounts.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "vitest";
 import { resolveOctoAccount } from "./accounts.js";
 
-describe("resolveOctoAccount reasoning card template mode", () => {
-  it("uses the account override before the channel default", () => {
+describe("resolveOctoAccount server-owned card policy", () => {
+  it("ignores legacy local card policy fields", () => {
     const cfg = {
       channels: {
         octo: {
@@ -16,9 +16,9 @@ describe("resolveOctoAccount reasoning card template mode", () => {
       },
     };
 
-    expect(resolveOctoAccount({ cfg: cfg as never, accountId: "a1" }).config.reasoningCardTemplateMode)
-      .toBe("experimental");
-    expect(resolveOctoAccount({ cfg: cfg as never, accountId: "a2" }).config.reasoningCardTemplateMode)
-      .toBe("shadow");
+    expect(resolveOctoAccount({ cfg: cfg as never, accountId: "a1" }).config)
+      .not.toHaveProperty("reasoningCardTemplateMode");
+    expect(resolveOctoAccount({ cfg: cfg as never, accountId: "a2" }).config)
+      .not.toHaveProperty("reasoningCardTemplateMode");
   });
 });

--- a/src/accounts.ts
+++ b/src/accounts.ts
@@ -1,6 +1,6 @@
 import type { OpenClawConfig } from "openclaw/plugin-sdk";
 import { DEFAULT_ACCOUNT_ID } from "./sdk-compat.js";
-import type { OctoConfig, ReasoningCardTemplateMode } from "./config-schema.js";
+import type { OctoConfig } from "./config-schema.js";
 import { getChannelConfig } from "./constants.js";
 
 export type ResolvedOctoAccount = {
@@ -20,10 +20,6 @@ export type ResolvedOctoAccount = {
     requireMention?: boolean;
     historyLimit?: number;  // 群聊历史消息条数限制
     historyPromptTemplate?: string;  // Template for group history context injection
-    cardProgress?: boolean;  // false disables automatic progress cards for this account
-    reasoningCardTemplateMode?: ReasoningCardTemplateMode;
-    cardDisplay?: boolean;  // false disables the display-card tool for this account
-    cardInteraction?: boolean;  // false disables interactive authoring and callback polling
     onBehalfOf?: string;  // Persona clone: grantor uid
     secretsFileRoot?: string;  // Jail root for write-secret file writes
     dispatchTimeoutMs?: number;  // Explicit dispatch-timeout override; unset = derive from agents.defaults.timeoutSeconds (issue #113)
@@ -112,10 +108,6 @@ export function resolveOctoAccount(params: {
       requireMention: accountConfig.requireMention ?? channel.requireMention,
       historyLimit: accountConfig.historyLimit ?? channel.historyLimit ?? 20,
       historyPromptTemplate: accountConfig.historyPromptTemplate ?? channel.historyPromptTemplate,
-      cardProgress: accountConfig.cardProgress ?? channel.cardProgress,
-      reasoningCardTemplateMode: accountConfig.reasoningCardTemplateMode ?? channel.reasoningCardTemplateMode,
-      cardDisplay: accountConfig.cardDisplay ?? channel.cardDisplay,
-      cardInteraction: accountConfig.cardInteraction ?? channel.cardInteraction,
       onBehalfOf: accountConfig.onBehalfOf ?? channel.onBehalfOf,
       secretsFileRoot: accountConfig.secretsFileRoot ?? channel.secretsFileRoot,
       dispatchTimeoutMs: accountConfig.dispatchTimeoutMs ?? channel.dispatchTimeoutMs,

--- a/src/api-fetch.test.ts
+++ b/src/api-fetch.test.ts
@@ -2301,6 +2301,27 @@ describe("getCardProfile server-driven config", () => {
       reasoning_enabled: false,
       reasoning_template_ref: { id: "ai.reasoning-process", version: "0.3.0" },
     },
+    {
+      card_enabled: false,
+      display_enabled: true,
+      interaction_enabled: false,
+      reasoning_enabled: false,
+      reasoning_template_ref: null,
+    },
+    {
+      card_enabled: false,
+      display_enabled: false,
+      interaction_enabled: true,
+      reasoning_enabled: false,
+      reasoning_template_ref: null,
+    },
+    {
+      card_enabled: false,
+      display_enabled: false,
+      interaction_enabled: false,
+      reasoning_enabled: true,
+      reasoning_template_ref: { id: "ai.reasoning-process", version: "0.3.0" },
+    },
   ])("fails closed on a missing, malformed, or internally inconsistent config: %j", async (config) => {
     global.fetch = vi.fn().mockResolvedValue(Response.json({
       enabled: true,

--- a/src/api-fetch.test.ts
+++ b/src/api-fetch.test.ts
@@ -2241,3 +2241,84 @@ describe("eventsPollTimeoutMs", () => {
     expect(eventsPollTimeoutMs(30) - 30_000).toBeGreaterThanOrEqual(5_000);
   });
 });
+
+describe("getCardProfile server-driven config", () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it("parses the effective per-bot card config without changing existing capability fields", async () => {
+    global.fetch = vi.fn().mockResolvedValue(Response.json({
+      enabled: true,
+      card_version: "1.5",
+      profiles: ["octo/v1", "octo/v2"],
+      elements: ["TextBlock"],
+      config: {
+        card_enabled: true,
+        display_enabled: true,
+        interaction_enabled: false,
+        reasoning_enabled: true,
+        reasoning_template_ref: { id: "ai.reasoning-process", version: "0.3.0" },
+      },
+    })) as typeof fetch;
+
+    const { getCardProfile } = await import("./api-fetch.js");
+    const profile = await getCardProfile({ apiUrl: "https://api.test", botToken: "bot-a" });
+
+    expect(profile).toMatchObject({
+      available: true,
+      enabled: true,
+      card_version: "1.5",
+      profiles: ["octo/v1", "octo/v2"],
+      elements: ["TextBlock"],
+      config: {
+        card_enabled: true,
+        display_enabled: true,
+        interaction_enabled: false,
+        reasoning_enabled: true,
+        reasoning_template_ref: { id: "ai.reasoning-process", version: "0.3.0" },
+      },
+    });
+  });
+
+  it.each([
+    null,
+    {},
+    {
+      card_enabled: true,
+      display_enabled: true,
+      interaction_enabled: true,
+      reasoning_enabled: true,
+      reasoning_template_ref: null,
+    },
+    {
+      card_enabled: true,
+      display_enabled: true,
+      interaction_enabled: true,
+      reasoning_enabled: false,
+      reasoning_template_ref: { id: "ai.reasoning-process", version: "0.3.0" },
+    },
+  ])("fails closed on a missing, malformed, or internally inconsistent config: %j", async (config) => {
+    global.fetch = vi.fn().mockResolvedValue(Response.json({
+      enabled: true,
+      profiles: ["octo/v1", "octo/v2"],
+      config,
+    })) as typeof fetch;
+
+    const { getCardProfile } = await import("./api-fetch.js");
+    const profile = await getCardProfile({ apiUrl: "https://api.test", botToken: "bot-a" });
+
+    expect(profile.config).toBeUndefined();
+  });
+
+  it("propagates a profile 500 instead of caching it as a disabled policy", async () => {
+    global.fetch = vi.fn().mockResolvedValue(new Response("internal", { status: 500 })) as typeof fetch;
+
+    const { getCardProfile } = await import("./api-fetch.js");
+    await expect(getCardProfile({ apiUrl: "https://api.test", botToken: "bot-a" }))
+      .rejects.toThrow(/card\/profile failed \(500\)/);
+  });
+});

--- a/src/api-fetch.ts
+++ b/src/api-fetch.ts
@@ -505,6 +505,15 @@ export interface CardTemplateRef {
   version: string;
 }
 
+/** Effective per-bot card policy returned by GET /v1/bot/card/profile. */
+export interface BotCardConfig {
+  card_enabled: boolean;
+  display_enabled: boolean;
+  interaction_enabled: boolean;
+  reasoning_enabled: boolean;
+  reasoning_template_ref: CardTemplateRef | null;
+}
+
 export interface CardTemplateViewCapability {
   name: string;
   states: string[];
@@ -693,12 +702,11 @@ export async function editTemplateCardMessage(params: {
  */
 export interface CardProfileManifest {
   /**
-   * D12 manifest 端点是否**已部署并响应**（非 404）。
-   * `false` 表示端点尚未上线（PR-D 未落地）—— 调用方应回退到 adapter 侧 config
-   * 显式开关决定是否发卡,**不可**把它等同于「服务端明确关闭」。
+   * D12 manifest 端点是否**已部署并响应**（非 404）。`false` 时所有卡片能力 fail
+   * closed；插件不再使用本地开关或本地推理卡模板兜底。
    */
   available: boolean;
-  /** 卡片消息是否启用（OCTO_CARD_MESSAGE_ENABLED）。禁用时 server 仍返 200 + manifest。 */
+  /** 兼容保留的 manifest 总闸；实际发送使用 `config` 中服务端已 AND 的有效值。 */
   enabled: boolean;
   /** 支持的 profile 列表，如 `["octo/v1"]`（P2 增 `"octo/v2"`）。 */
   profiles?: string[];
@@ -721,6 +729,8 @@ export interface CardProfileManifest {
   limits?: Record<string, unknown>;
   /** Optional Registry template-ref/v1 capability and explicit Bot catalog. */
   templating?: CardTemplatingCapability;
+  /** Effective per-bot policy. Each feature flag already includes the server's global gate. */
+  config?: BotCardConfig;
 }
 
 function stringArray(value: unknown): string[] {
@@ -756,14 +766,51 @@ function parseTemplatingCapability(value: unknown): CardTemplatingCapability | u
   };
 }
 
+function parseCardTemplateRef(value: unknown): CardTemplateRef | null | undefined {
+  if (value === null) return null;
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const ref = value as Record<string, unknown>;
+  if (Object.keys(ref).length !== 2 ||
+      typeof ref.id !== "string" || !ref.id || ref.id.trim() !== ref.id ||
+      typeof ref.version !== "string" || !ref.version || ref.version.trim() !== ref.version) {
+    return undefined;
+  }
+  return { id: ref.id, version: ref.version };
+}
+
+function parseBotCardConfig(value: unknown): BotCardConfig | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const config = value as Record<string, unknown>;
+  if (typeof config.card_enabled !== "boolean" ||
+      typeof config.display_enabled !== "boolean" ||
+      typeof config.interaction_enabled !== "boolean" ||
+      typeof config.reasoning_enabled !== "boolean") {
+    return undefined;
+  }
+  const reasoningRef = parseCardTemplateRef(config.reasoning_template_ref);
+  // The server guarantees this invariant. Reject a malformed response rather than guessing a
+  // policy locally: a permissive normalization could re-enable a card the Bot owner disabled.
+  if (reasoningRef === undefined ||
+      (config.reasoning_enabled && reasoningRef === null) ||
+      (!config.reasoning_enabled && reasoningRef !== null)) {
+    return undefined;
+  }
+  return {
+    card_enabled: config.card_enabled,
+    display_enabled: config.display_enabled,
+    interaction_enabled: config.interaction_enabled,
+    reasoning_enabled: config.reasoning_enabled,
+    reasoning_template_ref: reasoningRef,
+  };
+}
+
 /**
  * GET /v1/bot/card/profile — D12 能力发现。发卡前 feature-detect，避免用发送试探
  * （一个 400 无法区分「disabled」与「invalid」）。
  *
- * 返回 `available` 区分两种「不发」语义（避免 gate 死锁）:
- *   - 端点未部署（404）→ `{ available:false }`：调用方回退 adapter config 显式开关，
- *     **不可**当作服务端明确关闭（octo-server PR-D 上线前 R2 未落地即此情形）。
- *   - 端点已部署但 `enabled:false` → `{ available:true, enabled:false }`：服务端明确关，不发。
+ * 返回 `available` 区分端点未部署与已部署；两者都由调用方 fail closed：
+ *   - 端点未部署（404）→ `{ available:false }`。
+ *   - 端点已部署但缺失/非法 `config` → `{ available:true }` 且无 `config`。
  * 传输 / 5xx 抛错，交由调用方重试节奏处理。
  */
 export async function getCardProfile(params: {
@@ -777,8 +824,7 @@ export async function getCardProfile(params: {
     headers: { Authorization: `Bearer ${params.botToken}` },
     signal: params.signal ?? AbortSignal.timeout(DEFAULT_TIMEOUT_MS),
   });
-  // 端点尚未部署（PR-D 未落地）→ available:false，调用方回退 config 显式开关，
-  // 不可当作「服务端明确关闭」硬降级不发。
+  // 端点尚未部署时 fail closed；不使用本地开关猜测服务端 Bot 策略。
   if (resp.status === 404) return { available: false, enabled: false };
   if (!resp.ok) {
     const text = await resp.text().catch(() => "");
@@ -788,6 +834,7 @@ export async function getCardProfile(params: {
   const raw = (await resp.json().catch(() => null)) as Record<string, unknown> | null;
   if (!raw || typeof raw !== "object") return { available: true, enabled: false };
   const templating = parseTemplatingCapability(raw.templating);
+  const config = parseBotCardConfig(raw.config);
   return {
     available: true,
     // 兼容布尔与 1/0 序列化(与本仓 GroupMember.robot / getMentionPref 的 flag 惯例一致)。
@@ -799,6 +846,7 @@ export async function getCardProfile(params: {
     ...(Array.isArray(raw.actions) ? { actions: (raw.actions as unknown[]).filter((e): e is string => typeof e === "string") } : {}),
     ...(raw.limits && typeof raw.limits === "object" ? { limits: raw.limits as Record<string, unknown> } : {}),
     ...(templating ? { templating } : {}),
+    ...(config ? { config } : {}),
   };
 }
 

--- a/src/api-fetch.ts
+++ b/src/api-fetch.ts
@@ -787,6 +787,10 @@ function parseBotCardConfig(value: unknown): BotCardConfig | undefined {
       typeof config.reasoning_enabled !== "boolean") {
     return undefined;
   }
+  if (!config.card_enabled &&
+      (config.display_enabled || config.interaction_enabled || config.reasoning_enabled)) {
+    return undefined;
+  }
   const reasoningRef = parseCardTemplateRef(config.reasoning_template_ref);
   // The server guarantees this invariant. Reject a malformed response rather than guessing a
   // policy locally: a permissive normalization could re-enable a card the Bot owner disabled.

--- a/src/card-adaptation.test.ts
+++ b/src/card-adaptation.test.ts
@@ -338,7 +338,7 @@ describe("getCardProfile (D12 feature-detect)", () => {
     });
   });
 
-  it("404(端点未部署)→ available:false(调用方回退 config)", async () => {
+  it("404(端点未部署)→ available:false（调用方 fail closed）", async () => {
     global.fetch = vi.fn().mockResolvedValue({
       ok: false,
       status: 404,

--- a/src/card-display-tool.test.ts
+++ b/src/card-display-tool.test.ts
@@ -56,6 +56,13 @@ function setupOk(): void {
     profiles: ["octo/v1"],
     card_version: "1.5",
     elements: ["TextBlock", "RichTextBlock", "Container", "FactSet"],
+    config: {
+      card_enabled: true,
+      display_enabled: true,
+      interaction_enabled: true,
+      reasoning_enabled: false,
+      reasoning_template_ref: null,
+    },
   } as never);
   vi.mocked(sendCardMessage).mockResolvedValue({ message_id: "m1" } as never);
 }
@@ -101,7 +108,7 @@ describe("createDisplayCardTool 骨架", () => {
     } as DisplayToolParams)).toEqual([]);
   });
 
-  it("已知当前账号 cardDisplay:false 时 discovery 不注册工具", () => {
+  it("本地 cardDisplay:false 已弃用，discovery 不再读取它", () => {
     vi.mocked(resolveOctoAccount).mockReturnValue({
       accountId: "default",
       enabled: true,
@@ -120,10 +127,10 @@ describe("createDisplayCardTool 骨架", () => {
       agentAccountId: "default",
       deliveryContext: CURRENT_DELIVERY,
       messageChannel: "octo",
-    } as DisplayToolParams)).toEqual([]);
+    } as DisplayToolParams)).toHaveLength(1);
   });
 
-  it("无当前账号上下文但只有一个配置账号时也按 cardDisplay:false 隐藏工具", () => {
+  it("无当前账号上下文时也不读取本地 cardDisplay:false", () => {
     vi.mocked(resolveOctoAccount).mockReturnValue({
       accountId: "only-account",
       enabled: true,
@@ -138,10 +145,10 @@ describe("createDisplayCardTool 骨架", () => {
     } as never);
     vi.mocked(listOctoAccountIds).mockReturnValue(["only-account"]);
 
-    expect(createDisplayCardTool({ cfg: mockCfg } as DisplayToolParams)).toEqual([]);
+    expect(createDisplayCardTool({ cfg: mockCfg } as DisplayToolParams)).toHaveLength(1);
   });
 
-  it("多账号且 discovery 无法确定当前账号时,全部 cardDisplay:false 则隐藏工具", () => {
+  it("多账号 discovery 不再聚合本地 cardDisplay 值", () => {
     vi.mocked(listOctoAccountIds).mockReturnValue(["account-a", "account-b"]);
     vi.mocked(resolveOctoAccount).mockImplementation(({ accountId }: { accountId?: string }) => ({
       accountId: accountId ?? "default",
@@ -156,7 +163,7 @@ describe("createDisplayCardTool 骨架", () => {
       },
     }) as never);
 
-    expect(createDisplayCardTool({ cfg: mockCfg } as DisplayToolParams)).toEqual([]);
+    expect(createDisplayCardTool({ cfg: mockCfg } as DisplayToolParams)).toHaveLength(1);
   });
 
   it("多账号且 discovery 无法确定当前账号时,任一账号允许展示卡则保留工具", () => {
@@ -251,7 +258,7 @@ describe("execute:发展示卡", () => {
     expect(res.content[0].text).toContain("m1"); // 返回 message_id
   });
 
-  it("execute 再检查热更新后的 cardDisplay:false,不探测 manifest 也不发送", async () => {
+  it("execute 忽略本地 cardDisplay:false，仍以服务端配置为准", async () => {
     const tool = getTool();
     vi.mocked(resolveOctoAccount).mockReturnValue({
       accountId: "default",
@@ -265,14 +272,36 @@ describe("execute:发展示卡", () => {
         cardDisplay: false,
       },
     } as never);
-    vi.mocked(getCardProfile).mockClear();
-
     const res = await tool.execute("display-disabled-after-discovery", {
+      blocks: [{ type: "text", text: "server policy allows this" }],
+    });
+
+    expect(res.details).toMatchObject({ message_id: "m1" });
+    expect(getCardProfile).toHaveBeenCalledTimes(1);
+    expect(sendCardMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it("服务端 display_enabled=false 时拒绝发送展示卡", async () => {
+    vi.mocked(getCardProfile).mockResolvedValue({
+      available: true,
+      enabled: true,
+      profiles: ["octo/v1"],
+      card_version: "1.5",
+      elements: ["TextBlock"],
+      config: {
+        card_enabled: true,
+        display_enabled: false,
+        interaction_enabled: true,
+        reasoning_enabled: false,
+        reasoning_template_ref: null,
+      },
+    } as never);
+
+    const res = await getTool().execute("server-display-disabled", {
       blocks: [{ type: "text", text: "must use plain text" }],
     });
 
     expect(res.content[0].text).toMatch(/disabled|plain text/i);
-    expect(getCardProfile).not.toHaveBeenCalled();
     expect(sendCardMessage).not.toHaveBeenCalled();
   });
 

--- a/src/card-display-tool.test.ts
+++ b/src/card-display-tool.test.ts
@@ -11,8 +11,11 @@ vi.mock("./accounts.js", () => ({
 
 vi.mock("./api-fetch.js", () => ({
   sendCardMessage: vi.fn(),
-  getCardProfile: vi.fn(),
   generateClientMsgNo: vi.fn(),
+}));
+vi.mock("./card-profile-cache.js", () => ({
+  getBotCardProfile: vi.fn(),
+  peekBotCardProfile: vi.fn(),
 }));
 
 import { createDisplayCardTool } from "./card-display-tool.js";
@@ -20,7 +23,8 @@ import {
   listOctoAccountIds,
   resolveOctoAccount,
 } from "./accounts.js";
-import { sendCardMessage, getCardProfile } from "./api-fetch.js";
+import { sendCardMessage } from "./api-fetch.js";
+import { getBotCardProfile, peekBotCardProfile } from "./card-profile-cache.js";
 import { generateClientMsgNo } from "./api-fetch.js";
 import { cardMaxDepth, cardPayloadBytes, countCardNodes } from "./card-limits.js";
 
@@ -50,7 +54,8 @@ function setupOk(): void {
       heartbeatIntervalMs: 30000,
     },
   } as never);
-  vi.mocked(getCardProfile).mockResolvedValue({
+  vi.mocked(peekBotCardProfile).mockReturnValue(undefined);
+  vi.mocked(getBotCardProfile).mockResolvedValue({
     available: true,
     enabled: true,
     profiles: ["octo/v1"],
@@ -184,6 +189,41 @@ describe("createDisplayCardTool 骨架", () => {
     expect(createDisplayCardTool({ cfg: mockCfg } as DisplayToolParams)).toHaveLength(1);
   });
 
+  it("cached display_enabled 只隐藏匹配 Bot 的展示卡工具", () => {
+    vi.mocked(listOctoAccountIds).mockReturnValue(["account-a", "account-b"]);
+    vi.mocked(resolveOctoAccount).mockImplementation(({ accountId }: { accountId?: string }) => ({
+      accountId: accountId ?? "account-a",
+      enabled: true,
+      configured: true,
+      config: {
+        botToken: `tok-${accountId}`,
+        apiUrl: "https://api.test",
+        pollIntervalMs: 2000,
+        heartbeatIntervalMs: 30000,
+      },
+    }) as never);
+    vi.mocked(peekBotCardProfile).mockImplementation(({ botToken }) => ({
+      available: true,
+      enabled: true,
+      config: {
+        card_enabled: true,
+        display_enabled: botToken !== "tok-account-a",
+        interaction_enabled: true,
+        reasoning_enabled: false,
+        reasoning_template_ref: null,
+      },
+    }));
+
+    expect(createDisplayCardTool({
+      cfg: mockCfg,
+      deliveryContext: { ...CURRENT_DELIVERY, accountId: "account-a" },
+    } as DisplayToolParams)).toEqual([]);
+    expect(createDisplayCardTool({
+      cfg: mockCfg,
+      deliveryContext: { ...CURRENT_DELIVERY, accountId: "account-b" },
+    } as DisplayToolParams)).toHaveLength(1);
+  });
+
   it("tool 元数据:name=octo_send_display_card,description 涵盖『展示型』『不回流』", () => {
     const t = getTool();
     expect(t.name).toBe("octo_send_display_card");
@@ -277,12 +317,12 @@ describe("execute:发展示卡", () => {
     });
 
     expect(res.details).toMatchObject({ message_id: "m1" });
-    expect(getCardProfile).toHaveBeenCalledTimes(1);
+    expect(getBotCardProfile).toHaveBeenCalledTimes(1);
     expect(sendCardMessage).toHaveBeenCalledTimes(1);
   });
 
   it("服务端 display_enabled=false 时拒绝发送展示卡", async () => {
-    vi.mocked(getCardProfile).mockResolvedValue({
+    vi.mocked(getBotCardProfile).mockResolvedValue({
       available: true,
       enabled: true,
       profiles: ["octo/v1"],
@@ -344,7 +384,7 @@ describe("execute:发展示卡", () => {
   });
 
   it("gate available:false + env 未开 → 拒绝(agent 由错误退回文本)", async () => {
-    vi.mocked(getCardProfile).mockResolvedValue({ available: false, enabled: false } as never);
+    vi.mocked(getBotCardProfile).mockResolvedValue({ available: false, enabled: false } as never);
     delete process.env.OCTO_CARD_MESSAGE_ENABLED;
     const t = getTool();
     const res = await t.execute("c3", { channelId: "group:g1", title: "T", blocks: [{ type: "text", text: "a" }] });
@@ -352,22 +392,32 @@ describe("execute:发展示卡", () => {
     expect(res.content[0].text.toLowerCase()).toMatch(/error|not (available|enabled)|unavailable/);
   });
 
-  it("gate available:false + 显式 env opt-in → 按 legacy baseline 发送", async () => {
-    vi.mocked(getCardProfile).mockResolvedValue({ available: false, enabled: false } as never);
+  it("gate available:false 即使有旧 env opt-in 也 fail closed", async () => {
+    vi.mocked(getBotCardProfile).mockResolvedValue({ available: false, enabled: false } as never);
     process.env.OCTO_CARD_MESSAGE_ENABLED = "1";
     try {
       const res = await getTool().execute("legacy-opt-in", {
         blocks: [{ type: "text", text: "legacy deployment" }],
       });
-      expect(sendCardMessage).toHaveBeenCalledTimes(1);
-      expect(res.content[0].text).toContain("sent display card");
+      expect(sendCardMessage).not.toHaveBeenCalled();
+      expect(res.content[0].text).toMatch(/disabled|policy/i);
     } finally {
       delete process.env.OCTO_CARD_MESSAGE_ENABLED;
     }
   });
 
   it("gate enabled:false → 拒绝", async () => {
-    vi.mocked(getCardProfile).mockResolvedValue({ available: true, enabled: false } as never);
+    vi.mocked(getBotCardProfile).mockResolvedValue({
+      available: true,
+      enabled: false,
+      config: {
+        card_enabled: false,
+        display_enabled: false,
+        interaction_enabled: false,
+        reasoning_enabled: false,
+        reasoning_template_ref: null,
+      },
+    } as never);
     const t = getTool();
     const res = await t.execute("c4", { channelId: "group:g1", title: "T", blocks: [{ type: "text", text: "a" }] });
     expect(sendCardMessage).not.toHaveBeenCalled();
@@ -375,11 +425,18 @@ describe("execute:发展示卡", () => {
   });
 
   it("profile 不含 octo/v1 → 拒绝(避免 400)", async () => {
-    vi.mocked(getCardProfile).mockResolvedValue({
+    vi.mocked(getBotCardProfile).mockResolvedValue({
       available: true,
       enabled: true,
       profiles: ["octo/v2"],
       card_version: "1.5",
+      config: {
+        card_enabled: true,
+        display_enabled: true,
+        interaction_enabled: true,
+        reasoning_enabled: false,
+        reasoning_template_ref: null,
+      },
     } as never);
     const t = getTool();
     const res = await t.execute("c5", { channelId: "group:g1", title: "T", blocks: [{ type: "text", text: "a" }] });
@@ -388,11 +445,18 @@ describe("execute:发展示卡", () => {
   });
 
   it("card_version 不兼容 → fail closed", async () => {
-    vi.mocked(getCardProfile).mockResolvedValue({
+    vi.mocked(getBotCardProfile).mockResolvedValue({
       available: true,
       enabled: true,
       profiles: ["octo/v1"],
       card_version: "1.4",
+      config: {
+        card_enabled: true,
+        display_enabled: true,
+        interaction_enabled: true,
+        reasoning_enabled: false,
+        reasoning_template_ref: null,
+      },
     } as never);
     const res = await getTool().execute("bad-version", {
       blocks: [{ type: "text", text: "must not send" }],
@@ -466,7 +530,7 @@ describe("execute:发展示卡", () => {
   });
 
   it("profile probe 与 send 的非 Error 异常都转成稳定工具错误", async () => {
-    vi.mocked(getCardProfile).mockRejectedValue("profile unavailable");
+    vi.mocked(getBotCardProfile).mockRejectedValue("profile unavailable");
     const probe = await getTool().execute("probe-failure", { blocks: [{ type: "text", text: "x" }] });
     expect(probe.content[0].text).toContain("profile unavailable");
 
@@ -477,12 +541,19 @@ describe("execute:发展示卡", () => {
   });
 
   it("能力协商生效:advertise 不含 FactSet → 卡里 FactSet 被降级(不 400,不拒绝)", async () => {
-    vi.mocked(getCardProfile).mockResolvedValue({
+    vi.mocked(getBotCardProfile).mockResolvedValue({
       available: true,
       enabled: true,
       profiles: ["octo/v1"],
       card_version: "1.5",
       elements: ["TextBlock"], // 无 FactSet
+      config: {
+        card_enabled: true,
+        display_enabled: true,
+        interaction_enabled: true,
+        reasoning_enabled: false,
+        reasoning_template_ref: null,
+      },
     } as never);
     const t = getTool();
     await t.execute("c6", { channelId: "group:g1", blocks: [
@@ -497,12 +568,19 @@ describe("execute:发展示卡", () => {
   });
 
   it("manifest 明确 elements=[] → 无安全 fallback,拒绝发送", async () => {
-    vi.mocked(getCardProfile).mockResolvedValue({
+    vi.mocked(getBotCardProfile).mockResolvedValue({
       available: true,
       enabled: true,
       profiles: ["octo/v1"],
       card_version: "1.5",
       elements: [],
+      config: {
+        card_enabled: true,
+        display_enabled: true,
+        interaction_enabled: true,
+        reasoning_enabled: false,
+        reasoning_template_ref: null,
+      },
     } as never);
     const res = await getTool().execute("empty-elements", {
       blocks: [{ type: "text", text: "cannot render" }],
@@ -512,13 +590,20 @@ describe("execute:发展示卡", () => {
   });
 
   it("manifest hard limits 贯穿到最终 sendCardMessage 信封", async () => {
-    vi.mocked(getCardProfile).mockResolvedValue({
+    vi.mocked(getBotCardProfile).mockResolvedValue({
       available: true,
       enabled: true,
       profiles: ["octo/v1"],
       card_version: "1.5",
       elements: ["TextBlock", "RichTextBlock", "Container", "Table"],
       limits: { max_nodes: 8, max_depth: 3, max_payload_bytes: 420 },
+      config: {
+        card_enabled: true,
+        display_enabled: true,
+        interaction_enabled: true,
+        reasoning_enabled: false,
+        reasoning_template_ref: null,
+      },
     } as never);
     await getTool().execute("limited", {
       blocks: [{

--- a/src/card-display-tool.ts
+++ b/src/card-display-tool.ts
@@ -24,7 +24,8 @@ import type { OpenClawPluginToolContext } from "openclaw/plugin-sdk/plugin-entry
 import { listOctoAccountIds, resolveOctoAccount } from "./accounts.js";
 import { appendFile, mkdir } from "node:fs/promises";
 import path from "node:path";
-import { sendCardMessage, getCardProfile, generateClientMsgNo, type CardProfileManifest } from "./api-fetch.js";
+import { sendCardMessage, generateClientMsgNo, type CardProfileManifest } from "./api-fetch.js";
+import { getBotCardProfile, peekBotCardProfile } from "./card-profile-cache.js";
 import { buildDisplayCard, validateDisplayBlocks } from "./card-blocks.js";
 import { deriveCardCaps } from "./card-caps.js";
 import { isSensitive, reduceUrlsInText } from "./card-render.js";
@@ -32,6 +33,7 @@ import { resolveOutboundOctoTarget } from "./actions.js";
 import type { CardCaps } from "./card-render.js";
 import { ChannelType, CARD_PROFILE, CARD_VERSION } from "./types.js";
 import { CHANNEL_ID, DISPLAY_CARD_TOOL_NAME } from "./constants.js";
+import { requestCardEventPolling } from "./events-poll.js";
 
 /** 展示卡发送超时(postJson 无默认超时,防挂起的 POST 拖死 tool 调用)。 */
 const SEND_TIMEOUT_MS = 15_000;
@@ -82,6 +84,7 @@ function manifestForDebug(m: CardProfileManifest): Record<string, unknown> {
     elements: m.elements,
     actions: m.actions,
     limits: m.limits,
+    config: m.config,
   };
 }
 
@@ -99,17 +102,13 @@ async function recordDisplayCardRequest(entry: Record<string, unknown>): Promise
 }
 
 /**
- * gate 校验:manifest 明确 disabled / profile 不含 octo/v1 / card_version 不匹配 → 拒绝。
- * `available:false`(端点未部署)时回退 env `OCTO_CARD_MESSAGE_ENABLED === "1"` —— 与 hook
- * 进度卡的 gate 语义对齐,单一权威。
+ * gate 校验：服务端 Bot 策略未明确允许 / profile 不含 octo/v1 / card_version 不匹配
+ * 均拒绝；不读取本地配置兜底。
  */
 function gateReason(m: CardProfileManifest): string | null {
-  if (!m.available) {
-    return process.env.OCTO_CARD_MESSAGE_ENABLED === "1"
-      ? null
-      : "card manifest endpoint not available and OCTO_CARD_MESSAGE_ENABLED is not set";
+  if (!m.available || m.config?.display_enabled !== true) {
+    return "display cards are disabled by the server Bot policy";
   }
-  if (!m.enabled) return "card sending is disabled on this deployment (manifest.enabled=false)";
   if (Array.isArray(m.profiles) && m.profiles.length > 0 && !m.profiles.includes(CARD_PROFILE)) {
     return `profile ${CARD_PROFILE} not advertised by server (got: ${m.profiles.join(",")})`;
   }
@@ -153,18 +152,23 @@ export function createDisplayCardTool(params: Params): Array<{
       .map((id) => resolveOctoAccount({ cfg, accountId: id }))
       .filter((acct) => acct.enabled && acct.configured && !!acct.config.botToken);
     if (configuredAccounts.length === 0) return [];
-    // Best-effort discovery filtering: when the runtime identifies the current
-    // account, do not offer a tool that account explicitly disabled. Execution
-    // checks again because config may hot-reload after tool discovery. When a
-    // multi-account discovery has no current account, hide only if every usable
-    // account disables the tool; a mixed set must keep it available.
+    // Discovery is synchronous. Hide only on a cached authoritative server decision; an unknown
+    // profile stays visible so execute can perform the authoritative async read.
     const discoveryAccountId = deliveryContext?.accountId
       ?? agentAccountId
       ?? (ids.length === 1 ? ids[0] : undefined);
     if (discoveryAccountId) {
       const discoveryAccount = resolveOctoAccount({ cfg, accountId: discoveryAccountId });
-      if (discoveryAccount.config.cardDisplay === false) return [];
-    } else if (configuredAccounts.every((account) => account.config.cardDisplay === false)) {
+      if (discoveryAccount.config.botToken &&
+          peekBotCardProfile({
+            apiUrl: discoveryAccount.config.apiUrl,
+            botToken: discoveryAccount.config.botToken,
+          })?.config?.display_enabled === false) return [];
+    } else if (configuredAccounts.every((account) =>
+      !!account.config.botToken && peekBotCardProfile({
+        apiUrl: account.config.apiUrl,
+        botToken: account.config.botToken,
+      })?.config?.display_enabled === false)) {
       return [];
     }
   } catch {
@@ -265,9 +269,6 @@ export function createDisplayCardTool(params: Params): Array<{
         if (!acct.enabled || !acct.configured || !acct.config.botToken) {
           return err("Octo account is not fully configured");
         }
-        if (acct.config.cardDisplay === false) {
-          return err("display cards are disabled for this Octo account. Send your reply as a plain text message instead.");
-        }
         const apiUrl = acct.config.apiUrl;
         const botToken = acct.config.botToken;
         if (!apiUrl) return err("apiUrl not configured");
@@ -275,7 +276,8 @@ export function createDisplayCardTool(params: Params): Array<{
         // D12 能力探测(gate + caps)。
         let manifest: CardProfileManifest;
         try {
-          manifest = await getCardProfile({ apiUrl, botToken });
+          requestCardEventPolling(acct.accountId);
+          manifest = await getBotCardProfile({ apiUrl, botToken });
         } catch (e) {
           return err(`card profile probe failed: ${e instanceof Error ? e.message : String(e)}`);
         }

--- a/src/card-profile-cache.test.ts
+++ b/src/card-profile-cache.test.ts
@@ -84,4 +84,35 @@ describe("bot card profile cache", () => {
     await expect(getBotCardProfile(bot)).resolves.toEqual(profile(true));
     expect(getCardProfile).toHaveBeenCalledTimes(2);
   });
+
+  it("deduplicates concurrent reads for the same Bot", async () => {
+    let resolveRead!: (value: CardProfileManifest) => void;
+    vi.mocked(getCardProfile).mockReturnValue(new Promise((resolve) => { resolveRead = resolve; }));
+    const bot = { apiUrl: "https://api.test", botToken: "bot-a" };
+
+    const first = getBotCardProfile(bot);
+    const second = getBotCardProfile(bot);
+    expect(getCardProfile).toHaveBeenCalledTimes(1);
+
+    resolveRead(profile(true));
+    await expect(Promise.all([first, second])).resolves.toEqual([profile(true), profile(true)]);
+  });
+
+  it("does not let a pre-invalidation response refill the cache", async () => {
+    let resolveStale!: (value: CardProfileManifest) => void;
+    vi.mocked(getCardProfile)
+      .mockReturnValueOnce(new Promise((resolve) => { resolveStale = resolve; }))
+      .mockResolvedValueOnce(profile(true));
+    const bot = { apiUrl: "https://api.test", botToken: "bot-a" };
+
+    const staleRead = getBotCardProfile(bot);
+    invalidateBotCardProfile(bot);
+    resolveStale(profile(false));
+    await expect(staleRead).resolves.toEqual(profile(false));
+    expect(peekBotCardProfile(bot)).toBeUndefined();
+
+    await expect(getBotCardProfile(bot)).resolves.toEqual(profile(true));
+    expect(peekBotCardProfile(bot)?.config?.display_enabled).toBe(true);
+    expect(getCardProfile).toHaveBeenCalledTimes(2);
+  });
 });

--- a/src/card-profile-cache.test.ts
+++ b/src/card-profile-cache.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./api-fetch.js", () => ({
+  getCardProfile: vi.fn(),
+}));
+
+import { getCardProfile, type CardProfileManifest } from "./api-fetch.js";
+import {
+  _resetBotCardProfileCacheForTests,
+  getBotCardProfile,
+  invalidateBotCardProfile,
+  peekBotCardProfile,
+} from "./card-profile-cache.js";
+
+function profile(displayEnabled: boolean): CardProfileManifest {
+  return {
+    available: true,
+    enabled: true,
+    profiles: ["octo/v1", "octo/v2"],
+    card_version: "1.5",
+    config: {
+      card_enabled: true,
+      display_enabled: displayEnabled,
+      interaction_enabled: true,
+      reasoning_enabled: true,
+      reasoning_template_ref: { id: "ai.reasoning-process", version: "0.3.0" },
+    },
+  };
+}
+
+describe("bot card profile cache", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    _resetBotCardProfileCacheForTests();
+  });
+
+  afterEach(() => {
+    _resetBotCardProfileCacheForTests();
+  });
+
+  it("is private to apiUrl + botToken and supports synchronous discovery peeks", async () => {
+    vi.mocked(getCardProfile)
+      .mockResolvedValueOnce(profile(false))
+      .mockResolvedValueOnce(profile(true));
+
+    const botA = { apiUrl: "https://api.test", botToken: "bot-a" };
+    const botB = { apiUrl: "https://api.test", botToken: "bot-b" };
+    expect(peekBotCardProfile(botA)).toBeUndefined();
+
+    await getBotCardProfile(botA);
+    await getBotCardProfile(botB);
+
+    expect(peekBotCardProfile(botA)?.config?.display_enabled).toBe(false);
+    expect(peekBotCardProfile(botB)?.config?.display_enabled).toBe(true);
+    expect(getCardProfile).toHaveBeenCalledTimes(2);
+  });
+
+  it("invalidates only the matching bot and refetches it on the next authoritative read", async () => {
+    vi.mocked(getCardProfile)
+      .mockResolvedValueOnce(profile(false))
+      .mockResolvedValueOnce(profile(true))
+      .mockResolvedValueOnce(profile(true));
+    const botA = { apiUrl: "https://api.test", botToken: "bot-a" };
+    const botB = { apiUrl: "https://api.test", botToken: "bot-b" };
+    await getBotCardProfile(botA);
+    await getBotCardProfile(botB);
+
+    invalidateBotCardProfile(botA);
+
+    expect(peekBotCardProfile(botA)).toBeUndefined();
+    expect(peekBotCardProfile(botB)?.config?.display_enabled).toBe(true);
+    expect((await getBotCardProfile(botA)).config?.display_enabled).toBe(true);
+    expect(getCardProfile).toHaveBeenCalledTimes(3);
+  });
+
+  it("does not cache profile read failures as a disabled result", async () => {
+    vi.mocked(getCardProfile)
+      .mockRejectedValueOnce(new Error("profile unavailable"))
+      .mockResolvedValueOnce(profile(true));
+    const bot = { apiUrl: "https://api.test", botToken: "bot-a" };
+
+    await expect(getBotCardProfile(bot)).rejects.toThrow("profile unavailable");
+    expect(peekBotCardProfile(bot)).toBeUndefined();
+    await expect(getBotCardProfile(bot)).resolves.toEqual(profile(true));
+    expect(getCardProfile).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/card-profile-cache.test.ts
+++ b/src/card-profile-cache.test.ts
@@ -98,7 +98,7 @@ describe("bot card profile cache", () => {
     await expect(Promise.all([first, second])).resolves.toEqual([profile(true), profile(true)]);
   });
 
-  it("does not let a pre-invalidation response refill the cache", async () => {
+  it("discards a pre-invalidation response and refreshes before resolving the waiting caller", async () => {
     let resolveStale!: (value: CardProfileManifest) => void;
     vi.mocked(getCardProfile)
       .mockReturnValueOnce(new Promise((resolve) => { resolveStale = resolve; }))
@@ -108,10 +108,7 @@ describe("bot card profile cache", () => {
     const staleRead = getBotCardProfile(bot);
     invalidateBotCardProfile(bot);
     resolveStale(profile(false));
-    await expect(staleRead).resolves.toEqual(profile(false));
-    expect(peekBotCardProfile(bot)).toBeUndefined();
-
-    await expect(getBotCardProfile(bot)).resolves.toEqual(profile(true));
+    await expect(staleRead).resolves.toEqual(profile(true));
     expect(peekBotCardProfile(bot)?.config?.display_enabled).toBe(true);
     expect(getCardProfile).toHaveBeenCalledTimes(2);
   });

--- a/src/card-profile-cache.ts
+++ b/src/card-profile-cache.ts
@@ -1,0 +1,92 @@
+import { getCardProfile, type CardProfileManifest } from "./api-fetch.js";
+
+export interface BotCardProfileKey {
+  apiUrl: string;
+  botToken: string;
+}
+
+interface CachedProfile {
+  manifest: CardProfileManifest;
+  expiresAt: number;
+}
+
+interface BotCardProfileCacheState {
+  cache: Map<string, CachedProfile>;
+  inFlight: Map<string, Promise<CardProfileManifest>>;
+  generations: Map<string, number>;
+}
+
+const CACHE_TTL_MS = 60_000;
+const STATE_KEY = Symbol.for("openclaw.octo.bot-card-profile-cache.v1");
+
+function getState(): BotCardProfileCacheState {
+  const root = process as unknown as Record<PropertyKey, unknown>;
+  const existing = root[STATE_KEY] as BotCardProfileCacheState | undefined;
+  if (existing) return existing;
+  const created: BotCardProfileCacheState = {
+    cache: new Map(),
+    inFlight: new Map(),
+    generations: new Map(),
+  };
+  root[STATE_KEY] = created;
+  return created;
+}
+
+const state = getState();
+
+function cacheKey(params: BotCardProfileKey): string {
+  return JSON.stringify([params.apiUrl.replace(/\/+$/, ""), params.botToken]);
+}
+
+function currentGeneration(key: string): number {
+  return state.generations.get(key) ?? 0;
+}
+
+/** Synchronous best-effort read for tool discovery. Unknown/expired means "do not hide". */
+export function peekBotCardProfile(params: BotCardProfileKey): CardProfileManifest | undefined {
+  const key = cacheKey(params);
+  const cached = state.cache.get(key);
+  if (!cached) return undefined;
+  if (cached.expiresAt <= Date.now()) {
+    state.cache.delete(key);
+    return undefined;
+  }
+  return cached.manifest;
+}
+
+/** Authoritative async read for execution paths, deduplicated and cached per Bot credential. */
+export async function getBotCardProfile(params: BotCardProfileKey): Promise<CardProfileManifest> {
+  const cached = peekBotCardProfile(params);
+  if (cached) return cached;
+  const key = cacheKey(params);
+  const pending = state.inFlight.get(key);
+  if (pending) return pending;
+
+  const generation = currentGeneration(key);
+  const work = getCardProfile(params).then((manifest) => {
+    // A bot_setting_updated event may race this request. Never let the older response refill a
+    // cache that the event already invalidated.
+    if (currentGeneration(key) === generation) {
+      state.cache.set(key, { manifest, expiresAt: Date.now() + CACHE_TTL_MS });
+    }
+    return manifest;
+  }).finally(() => {
+    if (state.inFlight.get(key) === work) state.inFlight.delete(key);
+  });
+  state.inFlight.set(key, work);
+  return work;
+}
+
+/** Invalidate exactly one Bot; other tokens on the same deployment remain isolated. */
+export function invalidateBotCardProfile(params: BotCardProfileKey): void {
+  const key = cacheKey(params);
+  state.cache.delete(key);
+  state.inFlight.delete(key);
+  state.generations.set(key, currentGeneration(key) + 1);
+}
+
+export function _resetBotCardProfileCacheForTests(): void {
+  state.cache.clear();
+  state.inFlight.clear();
+  state.generations.clear();
+}

--- a/src/card-profile-cache.ts
+++ b/src/card-profile-cache.ts
@@ -64,11 +64,12 @@ export async function getBotCardProfile(params: BotCardProfileKey): Promise<Card
 
   const generation = currentGeneration(key);
   const work = getCardProfile(params).then((manifest) => {
-    // A bot_setting_updated event may race this request. Never let the older response refill a
-    // cache that the event already invalidated.
-    if (currentGeneration(key) === generation) {
-      state.cache.set(key, { manifest, expiresAt: Date.now() + CACHE_TTL_MS });
+    // A bot_setting_updated event may race this request. The stale response must not reach the
+    // waiting sender either: join (or start) the current generation's read before resolving.
+    if (currentGeneration(key) !== generation) {
+      return getBotCardProfile(params);
     }
+    state.cache.set(key, { manifest, expiresAt: Date.now() + CACHE_TTL_MS });
     return manifest;
   }).finally(() => {
     if (state.inFlight.get(key) === work) state.inFlight.delete(key);

--- a/src/card-progress.test.ts
+++ b/src/card-progress.test.ts
@@ -364,6 +364,41 @@ describe("server-driven Registry reasoning progress", () => {
     });
   });
 
+  it("releases finalize at the progress timeout while the shared profile read continues", async () => {
+    let resolveProfile!: (response: Response) => void;
+    const profileGate = new Promise<Response>((resolve) => { resolveProfile = resolve; });
+    global.fetch = vi.fn().mockImplementation(async (url: string) => {
+      if (url.includes("/card/profile")) return profileGate;
+      throw new Error(`unexpected request: ${url}`);
+    }) as typeof fetch;
+    const handlers = makeApi();
+    setCardContext("profile-timeout", context());
+    const hookContext = { sessionKey: "profile-timeout", runId: "run-1" };
+    handlers.before_agent_run?.({}, hookContext);
+    handlers.before_tool_call?.({ toolName: "read", toolCallId: "tool-1" }, hookContext);
+
+    vi.advanceTimersByTime(900);
+    for (let index = 0; index < 10 && vi.mocked(global.fetch).mock.calls.length === 0; index++) {
+      await Promise.resolve();
+    }
+    expect(vi.mocked(global.fetch)).toHaveBeenCalledOnce();
+
+    let finalized = false;
+    const finalizing = finalizeCard("profile-timeout", { success: true }).then(() => {
+      finalized = true;
+    });
+    await vi.advanceTimersByTimeAsync(10_100);
+    await Promise.resolve();
+
+    expect(finalized).toBe(true);
+    expect(vi.mocked(global.fetch).mock.calls.some(([url]) => String(url).includes("/sendMessage")))
+      .toBe(false);
+
+    resolveProfile(Response.json(profile()));
+    await finalizing;
+    for (let index = 0; index < 5; index++) await Promise.resolve();
+  });
+
   it("fails closed when the same sessionKey is replaced by a different Bot identity", async () => {
     const wire = mockFetch();
     global.fetch = wire.fetch as typeof fetch;

--- a/src/card-progress.test.ts
+++ b/src/card-progress.test.ts
@@ -349,8 +349,7 @@ describe("server-driven Registry reasoning progress", () => {
     handlers.before_tool_call?.({ toolName: "read", toolCallId: "tool-1" }, hookContext);
 
     vi.advanceTimersByTime(900);
-    for (let index = 0; index < 10 && !sendStarted; index++) await Promise.resolve();
-    expect(sendStarted).toBe(true);
+    await vi.waitFor(() => expect(sendStarted).toBe(true));
     const finalized = finalizeCard("send-race", { success: true });
     resolveSend();
     await finalized;
@@ -364,7 +363,8 @@ describe("server-driven Registry reasoning progress", () => {
     });
   });
 
-  it("releases finalize at the progress timeout while the shared profile read continues", async () => {
+  it("releases the old finalize when a replacement aborts its shared profile wait", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
     let resolveProfile!: (response: Response) => void;
     const profileGate = new Promise<Response>((resolve) => { resolveProfile = resolve; });
     global.fetch = vi.fn().mockImplementation(async (url: string) => {
@@ -387,16 +387,23 @@ describe("server-driven Registry reasoning progress", () => {
     const finalizing = finalizeCard("profile-timeout", { success: true }).then(() => {
       finalized = true;
     });
-    await vi.advanceTimersByTimeAsync(10_100);
-    await Promise.resolve();
-
-    expect(finalized).toBe(true);
+    setCardContext("profile-timeout", context());
+    await vi.waitFor(() => expect(finalized).toBe(true));
     expect(vi.mocked(global.fetch).mock.calls.some(([url]) => String(url).includes("/sendMessage")))
       .toBe(false);
 
     resolveProfile(Response.json(profile()));
     await finalizing;
     for (let index = 0; index < 5; index++) await Promise.resolve();
+
+    const replacementContext = { sessionKey: "profile-timeout", runId: "run-2" };
+    handlers.before_agent_run?.({}, replacementContext);
+    handlers.before_tool_call?.({ toolName: "read", toolCallId: "tool-2" }, replacementContext);
+    await vi.advanceTimersByTimeAsync(900);
+    expect(vi.mocked(global.fetch).mock.calls.filter(([url]) => String(url).includes("/card/profile")))
+      .toHaveLength(1);
+    expect(vi.mocked(global.fetch).mock.calls.filter(([url]) => String(url).includes("/sendMessage")))
+      .toHaveLength(1);
   });
 
   it("fails closed when the same sessionKey is replaced by a different Bot identity", async () => {

--- a/src/card-progress.test.ts
+++ b/src/card-progress.test.ts
@@ -1,69 +1,36 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ChannelType } from "./types.js";
-import { registerGroupAccount, _testGetGroupAccountMap } from "./group-md.js";
-import { OCTO_CARD_LAYOUTS } from "./card-render.js";
 import {
-  setCardContext,
-  finalizeCard,
-  finalizeCardWithResponse,
-  clearCard,
-  registerCardProgress,
-  bindCardRun,
-  markCardAnswering,
-  createCardReasoningRecorder,
-  recordCardReasoning,
   _resetCardProgressForTests,
+  bindCardRun,
+  clearCard,
+  finalizeCard,
+  markCardAnswering,
+  recordCardReasoning,
+  registerCardProgress,
+  setCardContext,
 } from "./card-progress.js";
+import { DISPLAY_CARD_TOOL_NAME } from "./constants.js";
 
-type AgentEvent = {
-  runId: string;
-  sessionKey?: string;
-  stream: string;
-  data: Record<string, unknown>;
-};
+type Hook = (event: Record<string, unknown>, ctx: { sessionKey: string; runId?: string }) => unknown;
 
-/** 收集 registerCardProgress 注册的 hook 与 lifecycle handler。 */
-function makeApi(opts: {
-  lifecycle?: boolean;
-  register?: typeof registerCardProgress;
-} = {}): {
-  handlers: Record<string, (e: unknown, c: unknown) => unknown>;
-  emitLifecycle: (event: AgentEvent) => Promise<void>;
-  emitAgentEvent: (event: AgentEvent) => Promise<void>;
-} {
-  const handlers: Record<string, (e: unknown, c: unknown) => unknown> = {};
-  const agentEventHandlers = new Map<string, (event: AgentEvent) => void | Promise<void>>();
-  const api: Record<string, unknown> = {
-    on: (name: string, fn: (e: unknown, c: unknown) => unknown) => { handlers[name] = fn; },
-  };
-  if (opts.lifecycle !== false) {
-    api.agent = {
-      events: {
-        registerAgentEventSubscription: (subscription: {
-          id: string;
-          streams?: string[];
-          handle: (event: AgentEvent) => void | Promise<void>;
-        }) => {
-          for (const stream of subscription.streams ?? []) {
-            agentEventHandlers.set(stream, subscription.handle);
-          }
-        },
-      },
-    };
-  }
-  (opts.register ?? registerCardProgress)(api as never);
+function makeApi(): Record<string, Hook> {
+  const handlers: Record<string, Hook> = {};
+  registerCardProgress({
+    on: (name: string, handler: Hook) => { handlers[name] = handler; },
+  } as never);
+  return handlers;
+}
+
+function template(version: string) {
   return {
-    handlers,
-    emitLifecycle: async (event) => {
-      const handler = agentEventHandlers.get("lifecycle");
-      expect(handler).toBeTypeOf("function");
-      await handler!(event);
-    },
-    emitAgentEvent: async (event) => {
-      const handler = agentEventHandlers.get(event.stream);
-      expect(handler).toBeTypeOf("function");
-      await handler!(event);
-    },
+    id: "ai.reasoning-process",
+    version,
+    views: [
+      { name: "active", states: ["reasoning", "answering"], wire_profile: "octo/v2", submit_actions: ["reasoning_stop"] },
+      { name: "error", states: ["error"], wire_profile: "octo/v2", submit_actions: ["reasoning_retry"] },
+      { name: "result", states: ["completed", "stopped"], wire_profile: "octo/v1", submit_actions: [] },
+    ],
   };
 }
 
@@ -81,27 +48,13 @@ function completionPrompt(childSessionKey: string): string {
   ].join("\n");
 }
 
-/** mock fetch,按 url 分派 getCardProfile / sendMessage / message-edit,记录请求。 */
-function mockFetch(opts: { enabled?: boolean; sendId?: string; profile?: Record<string, unknown> } = {}) {
-  const calls: Array<{ url: string; body: Record<string, unknown> | undefined }> = [];
-  const fn = vi.fn().mockImplementation(async (url: string, init?: { body?: string }) => {
-    calls.push({ url: String(url), body: init?.body ? JSON.parse(init.body) : undefined });
-    if (String(url).includes("/v1/bot/card/profile")) {
-      return {
-        ok: true,
-        status: 200,
-        json: async () => opts.profile ?? ({ enabled: opts.enabled ?? true, profiles: ["octo/v1"] }),
-      };
-    }
-    if (String(url).includes("/v1/bot/sendMessage")) {
-      return { ok: true, status: 200, text: async () => JSON.stringify({ message_id: opts.sendId ?? "card1" }) };
-    }
-    return { ok: true, status: 200, text: async () => "" }; // message/edit
-  });
-  return { fn, calls };
-}
-
-function registryProfile(version = "0.2.0"): Record<string, unknown> {
+function profile(opts: {
+  reasoningEnabled?: boolean;
+  configuredVersion?: string | null;
+  catalogVersions?: string[];
+} = {}): Record<string, unknown> {
+  const reasoningEnabled = opts.reasoningEnabled ?? true;
+  const configuredVersion = opts.configuredVersion === undefined ? "0.3.0" : opts.configuredVersion;
   return {
     enabled: true,
     profiles: ["octo/v1", "octo/v2"],
@@ -109,3736 +62,393 @@ function registryProfile(version = "0.2.0"): Record<string, unknown> {
       card_enabled: true,
       display_enabled: true,
       interaction_enabled: true,
-      reasoning_enabled: true,
-      reasoning_template_ref: { id: "ai.reasoning-process", version },
+      reasoning_enabled: reasoningEnabled,
+      reasoning_template_ref: reasoningEnabled && configuredVersion !== null
+        ? { id: "ai.reasoning-process", version: configuredVersion }
+        : null,
     },
     templating: {
       supported: true,
       wire: "template-ref/v1",
-      templates: [{
-        id: "ai.reasoning-process",
-        version,
-        views: [
-          { name: "active", states: ["reasoning", "answering"], wire_profile: "octo/v2", submit_actions: ["reasoning_stop"] },
-          { name: "error", states: ["error"], wire_profile: "octo/v2", submit_actions: ["reasoning_retry"] },
-          { name: "result", states: ["completed", "stopped"], wire_profile: "octo/v1", submit_actions: [] },
-        ],
-      }],
+      templates: (opts.catalogVersions ?? ["0.3.0"]).map(template),
     },
   };
 }
 
-function elementText(e: Record<string, unknown>): string {
-  if (typeof e.text === "string") return e.text;
-  if (Array.isArray(e.inlines)) return e.inlines.map((i) => (i as { text?: string }).text ?? "").join("");
-  if (Array.isArray(e.items)) return e.items.map((item) => elementText(item as Record<string, unknown>)).join("\n");
-  if (Array.isArray(e.columns)) {
-    return e.columns
-      .flatMap((c) => ((c as { items?: unknown[] }).items ?? []) as Record<string, unknown>[])
-      .map(elementText)
-      .join("\n");
-  }
-  return "";
+type Call = { url: string; body?: Record<string, unknown>; signal?: AbortSignal };
+
+function mockFetch(opts: {
+  profile?: Record<string, unknown>;
+  profileResponses?: Array<Record<string, unknown> | Error>;
+  sendResponses?: Array<{ status: number; body?: string; messageId?: string }>;
+  editResponses?: number[];
+} = {}): { fetch: ReturnType<typeof vi.fn>; calls: Call[] } {
+  const calls: Call[] = [];
+  let profileIndex = 0;
+  let sendIndex = 0;
+  let editIndex = 0;
+  const fetch = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
+    const call: Call = {
+      url: String(url),
+      ...(init?.body ? { body: JSON.parse(String(init.body)) as Record<string, unknown> } : {}),
+      ...(init?.signal ? { signal: init.signal } : {}),
+    };
+    calls.push(call);
+    if (call.url.includes("/card/profile")) {
+      const response = opts.profileResponses?.[profileIndex++] ?? opts.profile ?? profile();
+      if (response instanceof Error) {
+        return new Response(response.message, { status: 500 });
+      }
+      return Response.json(response);
+    }
+    if (call.url.includes("/sendMessage")) {
+      const response = opts.sendResponses?.[sendIndex++] ?? { status: 200, messageId: "card-1" };
+      return new Response(
+        response.body ?? JSON.stringify({ message_id: response.messageId ?? "card-1" }),
+        { status: response.status, statusText: response.status >= 400 ? "Rejected" : "OK" },
+      );
+    }
+    const status = opts.editResponses?.[editIndex++] ?? 200;
+    return new Response(status >= 400 ? "temporary" : "", {
+      status,
+      statusText: status >= 400 ? "Rejected" : "OK",
+    });
+  });
+  return { fetch, calls };
 }
 
-function progressHeaderText(card: { body: Array<Record<string, unknown>> }): string {
-  return elementText(card.body[0]);
+function context(overrides: Record<string, unknown> = {}) {
+  return {
+    apiUrl: "https://api.test",
+    botToken: "bot-a",
+    channelId: "group-1",
+    channelType: ChannelType.Group,
+    ...overrides,
+  } as never;
 }
 
-function progressDetailItems(card: { body: Array<Record<string, unknown>> }): Array<Record<string, unknown>> {
-  return ((card.body[1] as { items?: Array<Record<string, unknown>> })?.items ?? []);
+async function triggerFirstFrame(
+  handlers: Record<string, Hook>,
+  sessionKey: string,
+  runId = "run-1",
+): Promise<void> {
+  const hookContext = { sessionKey, runId };
+  handlers.before_agent_run?.({}, hookContext);
+  handlers.model_call_started?.({ callId: "model-1" }, hookContext);
+  handlers.before_tool_call?.({ toolName: "read", toolCallId: "tool-1" }, hookContext);
+  await vi.advanceTimersByTimeAsync(900);
 }
 
-function progressCardText(card: { body: Array<Record<string, unknown>> }): string {
-  return card.body.map(elementText).join("\n");
-}
-
-/** 可控 promise:用于把某个请求悬在 in-flight 状态。 */
-function makeDeferred(): { promise: Promise<void>; resolve: () => void } {
-  let resolve!: () => void;
-  const promise = new Promise<void>((r) => { resolve = r; });
-  return { promise, resolve };
-}
-
-describe("card-progress 状态机 + hook + 节流", () => {
+describe("server-driven Registry reasoning progress", () => {
   const originalFetch = global.fetch;
+
   beforeEach(() => {
     vi.useFakeTimers();
     _resetCardProgressForTests();
   });
+
   afterEach(() => {
+    _resetCardProgressForTests();
     vi.useRealTimers();
-    global.fetch = originalFetch;
     vi.restoreAllMocks();
+    global.fetch = originalFetch;
   });
 
-  it("bundled channel 与 agent runtime 分别加载模块时共享进度状态", async () => {
-    const { fn, calls } = mockFetch();
-    global.fetch = fn as unknown as typeof fetch;
-    const channelInstance = await import("./card-progress.js");
-    channelInstance.setCardContext("dual-loader", {
-      apiUrl: "https://dual-loader.test",
-      botToken: "bf",
-      channelId: "g",
-      channelType: ChannelType.Group,
-    });
+  it("sends the configured Registry ref, then edits answering and terminal states with monotonic card_seq", async () => {
+    const wire = mockFetch();
+    global.fetch = wire.fetch as typeof fetch;
+    const handlers = makeApi();
+    setCardContext("lifecycle", context());
 
-    // OpenClaw 会分别加载 bundled channel 与 embedded agent runtime。真实 host 中它们可处于
-    // 不同 global realm，但仍属于同一 Node 进程。删除 realm 槽位并重置模块缓存来模拟该边界；
-    // 进度状态必须锚定 process，而不能只锚定 globalThis。
-    const realmRoot = globalThis as unknown as Record<PropertyKey, unknown>;
-    delete realmRoot[Symbol.for("openclaw.octo.card-progress-state.v1")];
-    vi.resetModules();
-    const agentRuntimeInstance = await import("./card-progress.js");
-    const { handlers } = makeApi({ register: agentRuntimeInstance.registerCardProgress });
-
-    try {
-      const hookCtx = { sessionKey: "dual-loader", runId: "run-1" };
-      handlers.before_agent_run({}, hookCtx);
-      handlers.before_tool_call({ toolName: "read", toolCallId: "tool-1" }, hookCtx);
-      await vi.advanceTimersByTimeAsync(900);
-
-      expect(calls.some((call) => call.url.includes("/sendMessage"))).toBe(true);
-    } finally {
-      channelInstance._resetCardProgressForTests();
-      agentRuntimeInstance._resetCardProgressForTests();
-    }
-  });
-
-  it("首个 tool 事件懒发占位卡(gate+send),after_tool_call 触发 edit", async () => {
-    const { fn, calls } = mockFetch();
-    global.fetch = fn as unknown as typeof fetch;
-    const { handlers } = makeApi();
-
-    setCardContext("s1", { apiUrl: "https://a1.test", botToken: "bf", channelId: "g1", channelType: ChannelType.Group });
-    handlers.before_tool_call({ toolName: "read" }, { sessionKey: "s1" });
-    await vi.advanceTimersByTimeAsync(900);
-
-    expect(calls.some((c) => c.url.includes("/card/profile"))).toBe(true);
-    const send = calls.find((c) => c.url.includes("/sendMessage"));
-    expect(send).toBeTruthy();
-    expect((send!.body!.payload as { type: number }).type).toBe(17);
-
-    handlers.after_tool_call({ toolName: "read", durationMs: 30 }, { sessionKey: "s1" });
-    await vi.advanceTimersByTimeAsync(900);
-    const edit = calls.find((c) => c.url.includes("/message/edit"));
-    expect(edit).toBeTruthy();
-    const editEnv = JSON.parse(edit!.body!.content_edit as string);
-    expect(editEnv.type).toBe(17);
-    expect(editEnv.transient).toBe(true); // 进度中间帧不进修订历史(D10)
-  });
-
-  it("experimental 模式用 manifest 版本发送 Registry 推理卡并以递增 seq 更新状态", async () => {
-    const profile = {
-      enabled: true,
-      profiles: ["octo/v1", "octo/v2"],
-      card_version: "1.5",
-      elements: ["TextBlock", "Container", "ColumnSet", "ActionSet"],
-      actions: ["Action.ToggleVisibility"],
-      templating: {
-        supported: true,
-        wire: "template-ref/v1",
-        templates: [{
-          id: "ai.reasoning-process",
-          version: "0.2.0",
-          views: [
-            { name: "active", states: ["reasoning", "answering"], wire_profile: "octo/v2", submit_actions: ["reasoning_stop"] },
-            { name: "error", states: ["error"], wire_profile: "octo/v2", submit_actions: ["reasoning_retry"] },
-            { name: "result", states: ["completed", "stopped"], wire_profile: "octo/v1", submit_actions: [] },
-          ],
-        }],
-      },
-    };
-    const { fn, calls } = mockFetch({ profile, sendId: "registry-card" });
-    global.fetch = fn as unknown as typeof fetch;
-    const { handlers } = makeApi();
-    const hookCtx = { sessionKey: "registry-progress", runId: "run-1" };
-
-    setCardContext("registry-progress", {
-      apiUrl: "https://registry-progress.test",
-      botToken: "bf",
-      channelId: "g",
-      channelType: ChannelType.Group,
-      reasoningVisibility: "stream",
-      reasoningCardTemplateMode: "experimental",
-    });
-    handlers.before_agent_run({}, hookCtx);
-    handlers.model_call_started({ callId: "call-1" }, hookCtx);
-    recordCardReasoning("registry-progress", "先核对输入。", { snapshot: true });
-    handlers.before_tool_call({ toolName: "read", toolCallId: "tool-1", params: { path: "README.md" } }, hookCtx);
-    handlers.after_tool_call({ toolName: "read", toolCallId: "tool-1", result: {} }, hookCtx);
-    await vi.advanceTimersByTimeAsync(900);
-
-    const send = calls.find((call) => call.url.includes("/sendMessage"));
-    const sendPayload = send?.body?.payload as Record<string, unknown>;
-    expect(sendPayload).toMatchObject({
+    await triggerFirstFrame(handlers, "lifecycle");
+    const sent = wire.calls.find((call) => call.url.includes("/sendMessage"))?.body?.payload;
+    expect(sent).toMatchObject({
       type: 17,
-      template_ref: { id: "ai.reasoning-process", version: "0.2.0" },
+      template_ref: { id: "ai.reasoning-process", version: "0.3.0" },
       state: "reasoning",
-      data: { state: "reasoning", reasoningId: "registry-progress:run-1" },
     });
-    expect(sendPayload).not.toHaveProperty("card");
+    expect(sent).not.toHaveProperty("card");
 
-    calls.length = 0;
-    markCardAnswering("registry-progress");
+    markCardAnswering("lifecycle");
     await vi.advanceTimersByTimeAsync(900);
-    const answering = calls.find((call) => call.url.includes("/message/edit"))?.body;
-    expect(answering).toMatchObject({
-      template_ref: { id: "ai.reasoning-process", version: "0.2.0" },
-      state: "answering",
-      card_seq: 1,
-      transient: true,
+    await finalizeCard("lifecycle", { success: true });
+    const edits = wire.calls.filter((call) => call.url.includes("/message/edit")).map((call) => call.body!);
+    expect(edits.map((body) => [body.state, body.card_seq])).toEqual([
+      ["answering", 1],
+      ["completed", 2],
+    ]);
+    expect(edits[0]).toHaveProperty("transient", true);
+    expect(edits[1]).not.toHaveProperty("transient");
+    expect(edits.every((body) => !Object.hasOwn(body, "content_edit"))).toBe(true);
+  });
+
+  it("selects the exact configured ref from a multi-version catalog", async () => {
+    const wire = mockFetch({
+      profile: profile({ configuredVersion: "0.3.0", catalogVersions: ["0.2.0", "0.3.0"] }),
     });
-    expect(answering).not.toHaveProperty("content_edit");
+    global.fetch = wire.fetch as typeof fetch;
+    const handlers = makeApi();
+    setCardContext("exact-ref", context());
+    await triggerFirstFrame(handlers, "exact-ref");
 
-    calls.length = 0;
-    await finalizeCard("registry-progress", { success: true });
-    const completed = calls.find((call) => call.url.includes("/message/edit"))?.body;
-    expect(completed).toMatchObject({ state: "completed", card_seq: 2 });
-    expect(completed).not.toHaveProperty("transient");
-    expect(completed).not.toHaveProperty("content_edit");
+    expect(wire.calls.find((call) => call.url.includes("/sendMessage"))?.body?.payload)
+      .toHaveProperty("template_ref.version", "0.3.0");
   });
 
-  it("同 apiUrl 的不同 bot 各自使用自己的 Registry catalog", async () => {
-    const calls: Array<{ url: string; body?: Record<string, unknown>; token?: string }> = [];
-    global.fetch = vi.fn().mockImplementation(async (
-      url: string,
-      init?: { body?: string; headers?: HeadersInit },
-    ) => {
-      const token = new Headers(init?.headers).get("Authorization")?.replace(/^Bearer /, "");
-      calls.push({
-        url: String(url),
-        ...(init?.body ? { body: JSON.parse(init.body) as Record<string, unknown> } : {}),
-        ...(token ? { token } : {}),
-      });
-      if (String(url).includes("/card/profile")) {
-        return {
-          ok: true,
-          status: 200,
-          json: async () => registryProfile(token === "bot-a" ? "0.1.0" : "0.2.0"),
-        };
-      }
-      if (String(url).includes("/sendMessage")) {
-        return { ok: true, status: 200, text: async () => JSON.stringify({ message_id: `card-${token}` }) };
-      }
-      return { ok: true, status: 200, text: async () => "" };
-    }) as unknown as typeof fetch;
-    const { handlers } = makeApi();
+  it("does not send when reasoning is disabled", async () => {
+    const wire = mockFetch({ profile: profile({ reasoningEnabled: false }) });
+    global.fetch = wire.fetch as typeof fetch;
+    const handlers = makeApi();
+    setCardContext("disabled", context());
+    await triggerFirstFrame(handlers, "disabled");
 
-    for (const [sessionKey, botToken] of [["bot-a-session", "bot-a"], ["bot-b-session", "bot-b"]]) {
-      setCardContext(sessionKey, {
-        apiUrl: "https://shared-registry.test",
-        botToken,
-        channelId: `channel-${botToken}`,
-        channelType: ChannelType.Group,
-        reasoningCardTemplateMode: "experimental",
-      });
-      handlers.model_call_started({ callId: `call-${botToken}` }, { sessionKey });
-      handlers.before_tool_call(
-        { toolName: "read", toolCallId: `tool-${botToken}` },
-        { sessionKey },
-      );
-      await vi.advanceTimersByTimeAsync(900);
-    }
-
-    expect(calls.filter((call) => call.url.includes("/card/profile")).map((call) => call.token))
-      .toEqual(["bot-a", "bot-b"]);
-    expect(calls.filter((call) => call.url.includes("/sendMessage")).map((call) =>
-      ((call.body?.payload as { template_ref?: { version?: string } }).template_ref?.version)))
-      .toEqual(["0.1.0", "0.2.0"]);
+    expect(wire.calls.some((call) => call.url.includes("/card/profile"))).toBe(true);
+    expect(wire.calls.some((call) => call.url.includes("/sendMessage"))).toBe(false);
   });
 
-  it("reasoningId 在 512 字符边界保留原值，513 字符使用稳定摘要", async () => {
-    const { fn, calls } = mockFetch({ profile: registryProfile(), sendId: "reasoning-id-card" });
-    global.fetch = fn as unknown as typeof fetch;
-    const { handlers } = makeApi();
+  it.each([
+    profile({ configuredVersion: null }),
+    profile({ configuredVersion: "9.9.9" }),
+  ])("fails closed when the configured ref is missing or absent from the catalog", async (serverProfile) => {
+    const wire = mockFetch({ profile: serverProfile });
+    global.fetch = wire.fetch as typeof fetch;
+    const handlers = makeApi();
+    setCardContext("invalid-ref", context());
+    await triggerFirstFrame(handlers, "invalid-ref");
 
-    const sendReasoningId = async (sessionKey: string, runId: string): Promise<string> => {
-      setCardContext(sessionKey, {
-        apiUrl: "https://reasoning-id.test",
-        botToken: "bf",
-        channelId: "g",
-        channelType: ChannelType.Group,
-        reasoningCardTemplateMode: "experimental",
-      });
-      const hookCtx = { sessionKey, runId };
-      handlers.before_agent_run({}, hookCtx);
-      handlers.model_call_started({ callId: `call-${runId}` }, hookCtx);
-      handlers.before_tool_call({ toolName: "read", toolCallId: `tool-${runId}` }, hookCtx);
-      await vi.advanceTimersByTimeAsync(900);
-      const payload = calls.filter((call) => call.url.includes("/sendMessage")).at(-1)?.body?.payload as {
-        data?: { reasoningId?: string };
-      };
-      clearCard(sessionKey);
-      return payload.data?.reasoningId ?? "";
-    };
-
-    const runId = "r";
-    const session512 = "x".repeat(510);
-    const raw512 = `${session512}:${runId}`;
-    expect([...raw512]).toHaveLength(512);
-    expect(await sendReasoningId(session512, runId)).toBe(raw512);
-
-    const session513 = "x".repeat(511);
-    const raw513 = `${session513}:${runId}`;
-    expect([...raw513]).toHaveLength(513);
-    const hashed = await sendReasoningId(session513, runId);
-    expect(hashed).toMatch(/^octo-reasoning:sha256:[a-f0-9]{64}$/);
-    expect([...hashed]).toHaveLength(86);
-    expect(await sendReasoningId(session513, runId)).toBe(hashed);
-    expect(await sendReasoningId("y".repeat(511), runId)).not.toBe(hashed);
+    expect(wire.calls.some((call) => call.url.includes("/sendMessage"))).toBe(false);
   });
 
-  it("兼容 Registry 模板不受 Model B card_version/elements gate 限制", async () => {
-    const { fn, calls } = mockFetch({
-      profile: {
-        ...registryProfile("0.3.0"),
-        card_version: "9.9",
-        elements: [],
-      },
-      sendId: "registry-without-model-b",
-    });
-    global.fetch = fn as unknown as typeof fetch;
-    const { handlers } = makeApi();
-    setCardContext("registry-without-model-b", {
-      apiUrl: "https://registry-without-model-b.test",
-      botToken: "bf",
-      channelId: "g",
-      channelType: ChannelType.Group,
-      reasoningCardTemplateMode: "experimental",
-    });
-    handlers.model_call_started({ callId: "call-1" }, { sessionKey: "registry-without-model-b" });
-    handlers.before_tool_call(
-      { toolName: "read", toolCallId: "tool-1" },
-      { sessionKey: "registry-without-model-b" },
-    );
-    await vi.advanceTimersByTimeAsync(900);
-
-    const payload = calls.find((call) => call.url.includes("/sendMessage"))?.body?.payload as
-      Record<string, unknown> | undefined;
-    expect(payload).toHaveProperty("template_ref.version", "0.3.0");
-    expect(payload).not.toHaveProperty("card");
-  });
-
-  it("空白 Registry 版本不固定 Model A，而是安全回退 Model B", async () => {
-    const { fn, calls } = mockFetch({ profile: registryProfile("   ") });
-    global.fetch = fn as unknown as typeof fetch;
-    const { handlers } = makeApi();
-    setCardContext("blank-registry-version", {
-      apiUrl: "https://blank-registry-version.test",
-      botToken: "bf",
-      channelId: "g",
-      channelType: ChannelType.Group,
-      reasoningCardTemplateMode: "experimental",
-    });
-    handlers.before_tool_call(
-      { toolName: "read", toolCallId: "tool-1" },
-      { sessionKey: "blank-registry-version" },
-    );
-    await vi.advanceTimersByTimeAsync(900);
-
-    const payload = calls.find((call) => call.url.includes("/sendMessage"))?.body?.payload as
-      Record<string, unknown> | undefined;
-    expect(payload).toHaveProperty("card");
-    expect(payload).not.toHaveProperty("template_ref");
-  });
-
-  it("未配置 reasoningCardTemplateMode 时默认选择兼容的 Registry 模板", async () => {
-    const { fn, calls } = mockFetch({
-      profile: {
-        ...registryProfile(),
-        card_version: "9.9",
-        elements: [],
-      },
-      sendId: "registry-default-experimental",
-    });
-    global.fetch = fn as unknown as typeof fetch;
-    const { handlers } = makeApi();
-    setCardContext("registry-default-experimental", {
-      apiUrl: "https://registry-default-experimental.test",
-      botToken: "bf",
-      channelId: "g",
-      channelType: ChannelType.Group,
-    });
-    handlers.model_call_started(
-      { callId: "call-1" },
-      { sessionKey: "registry-default-experimental" },
-    );
-    handlers.before_tool_call(
-      { toolName: "read", toolCallId: "tool-1" },
-      { sessionKey: "registry-default-experimental" },
-    );
-    await vi.advanceTimersByTimeAsync(900);
-
-    const payload = calls.find((call) => call.url.includes("/sendMessage"))?.body?.payload as
-      Record<string, unknown> | undefined;
-    expect(payload).toHaveProperty("template_ref.version", "0.2.0");
-    expect(payload).not.toHaveProperty("card");
-  });
-
-  it("服务端 reasoning_enabled=false 时不发送任何推理进度卡", async () => {
-    const profile = registryProfile("0.3.0");
-    profile.config = {
-      card_enabled: true,
-      display_enabled: true,
-      interaction_enabled: true,
-      reasoning_enabled: false,
-      reasoning_template_ref: null,
-    };
-    const { fn, calls } = mockFetch({ profile });
-    global.fetch = fn as unknown as typeof fetch;
-    const { handlers } = makeApi();
-    const hookCtx = { sessionKey: "server-reasoning-disabled", runId: "run-1" };
-
-    setCardContext(hookCtx.sessionKey, {
-      apiUrl: "https://server-reasoning-disabled.test",
-      botToken: "bot-a",
-      channelId: "g",
-      channelType: ChannelType.Group,
-      reasoningVisibility: "stream",
-    });
-    handlers.before_agent_run({}, hookCtx);
-    handlers.model_call_started({ callId: "call-1" }, hookCtx);
-    recordCardReasoning(hookCtx.sessionKey, "先核对服务端配置。", { snapshot: true });
-    handlers.before_tool_call({ toolName: "read", toolCallId: "tool-1" }, hookCtx);
-    await vi.advanceTimersByTimeAsync(900);
-
-    expect(calls.some((call) => call.url.includes("/card/profile"))).toBe(true);
-    expect(calls.some((call) => call.url.includes("/sendMessage"))).toBe(false);
-  });
-
-  it("reasoning ref 缺失或不在 catalog 时 fail closed，不发送 Model B", async () => {
-    for (const profile of [
-      {
-        ...registryProfile("0.3.0"),
-        config: {
-          card_enabled: true,
-          display_enabled: true,
-          interaction_enabled: true,
-          reasoning_enabled: true,
-          reasoning_template_ref: null,
-        },
-      },
-      {
-        ...registryProfile("0.3.0"),
-        config: {
-          card_enabled: true,
-          display_enabled: true,
-          interaction_enabled: true,
-          reasoning_enabled: true,
-          reasoning_template_ref: { id: "ai.reasoning-process", version: "9.9.9" },
-        },
-      },
-    ]) {
-      _resetCardProgressForTests();
-      const { fn, calls } = mockFetch({ profile });
-      global.fetch = fn as unknown as typeof fetch;
-      const { handlers } = makeApi();
-      const sessionKey = `invalid-server-ref-${String((profile.config as { reasoning_template_ref: unknown }).reasoning_template_ref)}`;
-      setCardContext(sessionKey, {
-        apiUrl: `https://${sessionKey}.test`,
-        botToken: "bot-a",
-        channelId: "g",
-        channelType: ChannelType.Group,
-      });
-      handlers.before_tool_call({ toolName: "read", toolCallId: "tool-1" }, { sessionKey });
-      await vi.advanceTimersByTimeAsync(900);
-
-      expect(calls.some((call) => call.url.includes("/sendMessage"))).toBe(false);
-    }
-  });
-
-  it("忽略本地 cardProgress/reasoningCardTemplateMode，按服务端有效配置发送 Registry 模板", async () => {
-    const { fn, calls } = mockFetch({ profile: registryProfile("0.3.0") });
-    global.fetch = fn as unknown as typeof fetch;
-    const { handlers } = makeApi();
-    const hookCtx = { sessionKey: "server-policy-over-local", runId: "run-1" };
-
-    setCardContext(hookCtx.sessionKey, {
-      apiUrl: "https://server-policy-over-local.test",
-      botToken: "bot-a",
-      channelId: "g",
-      channelType: ChannelType.Group,
+  it("ignores deprecated local cardProgress and reasoningCardTemplateMode values", async () => {
+    const wire = mockFetch();
+    global.fetch = wire.fetch as typeof fetch;
+    const handlers = makeApi();
+    setCardContext("local-flags", context({
       cardProgress: false,
       reasoningCardTemplateMode: "off",
-      reasoningVisibility: "stream",
-    });
-    handlers.before_agent_run({}, hookCtx);
-    handlers.model_call_started({ callId: "call-1" }, hookCtx);
-    recordCardReasoning(hookCtx.sessionKey, "服务端配置是唯一策略来源。", { snapshot: true });
-    handlers.before_tool_call({ toolName: "read", toolCallId: "tool-1" }, hookCtx);
-    await vi.advanceTimersByTimeAsync(900);
+    }));
+    await triggerFirstFrame(handlers, "local-flags");
 
-    const sends = calls.filter((call) => call.url.includes("/sendMessage"));
+    const sends = wire.calls.filter((call) => call.url.includes("/sendMessage"));
     expect(sends).toHaveLength(1);
     expect(sends[0]?.body?.payload).toHaveProperty("template_ref.version", "0.3.0");
     expect(sends[0]?.body?.payload).not.toHaveProperty("card");
   });
 
-  it("shadow 模式只验证 manifest，仍发送 Model B 完整卡", async () => {
-    const { fn, calls } = mockFetch({
-      profile: {
-        enabled: true,
-        profiles: ["octo/v1", "octo/v2"],
-        templating: {
-          supported: true,
-          wire: "template-ref/v1",
-          templates: [{
-            id: "ai.reasoning-process",
-            version: "0.2.0",
-            views: [
-              { name: "active", states: ["reasoning", "answering"], wire_profile: "octo/v2", submit_actions: ["reasoning_stop"] },
-              { name: "error", states: ["error"], wire_profile: "octo/v2", submit_actions: ["reasoning_retry"] },
-              { name: "result", states: ["completed", "stopped"], wire_profile: "octo/v1", submit_actions: [] },
-            ],
-          }],
-        },
-      },
+  it("never retries a rejected Registry first frame as raw Model B", async () => {
+    const wire = mockFetch({
+      sendResponses: [{ status: 400, body: '{"code":"card_invalid"}' }],
     });
-    global.fetch = fn as unknown as typeof fetch;
-    const { handlers } = makeApi();
-    setCardContext("shadow-progress", {
-      apiUrl: "https://shadow-progress.test",
-      botToken: "bf",
-      channelId: "g",
-      channelType: ChannelType.Group,
-      reasoningCardTemplateMode: "shadow",
-    });
-    handlers.model_call_started({ callId: "call-1" }, { sessionKey: "shadow-progress" });
-    handlers.before_tool_call({ toolName: "read", toolCallId: "tool-1" }, { sessionKey: "shadow-progress" });
-    await vi.advanceTimersByTimeAsync(900);
+    global.fetch = wire.fetch as typeof fetch;
+    const handlers = makeApi();
+    setCardContext("no-model-b", context());
+    await triggerFirstFrame(handlers, "no-model-b");
 
-    const payload = calls.find((call) => call.url.includes("/sendMessage"))?.body?.payload as Record<string, unknown>;
-    expect(payload).toHaveProperty("card");
-    expect(payload).not.toHaveProperty("template_ref");
+    const sends = wire.calls.filter((call) => call.url.includes("/sendMessage"));
+    expect(sends).toHaveLength(1);
+    expect(sends[0]?.body?.payload).toHaveProperty("template_ref");
+    expect(sends[0]?.body?.payload).not.toHaveProperty("card");
   });
 
-  it("Model A 卡禁止用 raw content_edit 合并最终回答", async () => {
-    const { fn, calls } = mockFetch({
-      profile: {
-        enabled: true,
-        profiles: ["octo/v1", "octo/v2"],
-        templating: {
-          supported: true,
-          wire: "template-ref/v1",
-          templates: [{
-            id: "ai.reasoning-process",
-            version: "0.2.0",
-            views: [
-              { name: "active", states: ["reasoning", "answering"], wire_profile: "octo/v2", submit_actions: ["reasoning_stop"] },
-              { name: "error", states: ["error"], wire_profile: "octo/v2", submit_actions: ["reasoning_retry"] },
-              { name: "result", states: ["completed", "stopped"], wire_profile: "octo/v1", submit_actions: [] },
-            ],
-          }],
-        },
-      },
-    });
-    global.fetch = fn as unknown as typeof fetch;
-    const { handlers } = makeApi();
-    setCardContext("registry-no-raw", {
-      apiUrl: "https://registry-no-raw.test",
-      botToken: "bf",
-      channelId: "g",
-      channelType: ChannelType.Group,
-      reasoningCardTemplateMode: "experimental",
-    });
-    handlers.model_call_started({ callId: "call-1" }, { sessionKey: "registry-no-raw" });
-    handlers.before_tool_call({ toolName: "read", toolCallId: "tool-1" }, { sessionKey: "registry-no-raw" });
-    await vi.advanceTimersByTimeAsync(900);
-    calls.length = 0;
+  it("does not cache a profile 500 and retries on the next tool event", async () => {
+    const wire = mockFetch({ profileResponses: [new Error("down"), profile()] });
+    global.fetch = wire.fetch as typeof fetch;
+    const handlers = makeApi();
+    setCardContext("profile-retry", context());
+    await triggerFirstFrame(handlers, "profile-retry");
+    expect(wire.calls.filter((call) => call.url.includes("/card/profile"))).toHaveLength(1);
+    expect(wire.calls.some((call) => call.url.includes("/sendMessage"))).toBe(false);
 
-    expect(await finalizeCardWithResponse("registry-no-raw", "最终回答")).toBe(false);
-    expect(calls).toEqual([]);
+    handlers.after_tool_call?.({ toolName: "read", toolCallId: "tool-1" }, { sessionKey: "profile-retry", runId: "run-1" });
+    await vi.advanceTimersByTimeAsync(900);
+    expect(wire.calls.filter((call) => call.url.includes("/card/profile"))).toHaveLength(2);
+    expect(wire.calls.filter((call) => call.url.includes("/sendMessage"))).toHaveLength(1);
   });
 
-  it("Model A edit 的 5xx 重试复用完全相同的 body 和 card_seq", async () => {
-    const calls: Array<{ url: string; body: Record<string, unknown> | undefined }> = [];
-    let editAttempts = 0;
-    global.fetch = vi.fn().mockImplementation(async (url: string, init?: { body?: string }) => {
-      calls.push({ url: String(url), body: init?.body ? JSON.parse(init.body) : undefined });
-      if (String(url).includes("/card/profile")) {
-        return {
-          ok: true,
-          status: 200,
-          json: async () => ({
-            enabled: true,
-            profiles: ["octo/v1", "octo/v2"],
-            templating: {
-              supported: true,
-              wire: "template-ref/v1",
-              templates: [{
-                id: "ai.reasoning-process",
-                version: "0.2.0",
-                views: [
-                  { name: "active", states: ["reasoning", "answering"], wire_profile: "octo/v2", submit_actions: ["reasoning_stop"] },
-                  { name: "error", states: ["error"], wire_profile: "octo/v2", submit_actions: ["reasoning_retry"] },
-                  { name: "result", states: ["completed", "stopped"], wire_profile: "octo/v1", submit_actions: [] },
-                ],
-              }],
-            },
-          }),
-        };
-      }
-      if (String(url).includes("/sendMessage")) {
-        return { ok: true, status: 200, text: async () => JSON.stringify({ message_id: "retry-card" }) };
-      }
-      editAttempts += 1;
-      return editAttempts === 1
-        ? { ok: false, status: 503, statusText: "down", text: async () => "temporary" }
-        : { ok: true, status: 200, text: async () => "" };
-    }) as unknown as typeof fetch;
-    const { handlers } = makeApi();
-    setCardContext("registry-retry", {
-      apiUrl: "https://registry-retry.test",
-      botToken: "bf",
-      channelId: "g",
-      channelType: ChannelType.Group,
-      reasoningCardTemplateMode: "experimental",
-    });
-    handlers.model_call_started({ callId: "call-1" }, { sessionKey: "registry-retry" });
-    handlers.before_tool_call({ toolName: "read", toolCallId: "tool-1" }, { sessionKey: "registry-retry" });
-    await vi.advanceTimersByTimeAsync(900);
-    calls.length = 0;
+  it("retries a transient Registry edit with an identical body and card_seq", async () => {
+    const wire = mockFetch({ editResponses: [503, 200] });
+    global.fetch = wire.fetch as typeof fetch;
+    const handlers = makeApi();
+    setCardContext("edit-retry", context());
+    await triggerFirstFrame(handlers, "edit-retry");
 
-    markCardAnswering("registry-retry");
+    markCardAnswering("edit-retry");
     await vi.advanceTimersByTimeAsync(2_000);
-
-    const edits = calls.filter((call) => call.url.includes("/message/edit"));
+    const edits = wire.calls.filter((call) => call.url.includes("/message/edit"));
     expect(edits).toHaveLength(2);
     expect(edits[0]?.body).toEqual(edits[1]?.body);
     expect(edits[0]?.body?.card_seq).toBe(1);
   });
 
-  it("并发 Model A 编辑按 card_seq 顺序提交且不会触发 stale CAS", async () => {
-    const calls: Array<{ url: string; body: Record<string, unknown> | undefined }> = [];
-    const appliedSeqs: number[] = [];
-    const staleSeqs: number[] = [];
-    const firstEditReached = makeDeferred();
-    const releaseFirstEdit = makeDeferred();
-    let editCount = 0;
-    let highestApplied = 0;
-    global.fetch = vi.fn().mockImplementation(async (url: string, init?: { body?: string }) => {
-      const body = init?.body ? JSON.parse(init.body) as Record<string, unknown> : undefined;
-      calls.push({ url: String(url), body });
-      if (String(url).includes("/card/profile")) {
-        return { ok: true, status: 200, json: async () => registryProfile() };
-      }
-      if (String(url).includes("/sendMessage")) {
-        return { ok: true, status: 200, text: async () => JSON.stringify({ message_id: "seq-card" }) };
-      }
-      if (String(url).includes("/message/edit")) {
-        editCount += 1;
-        if (editCount === 1) {
-          firstEditReached.resolve();
-          await releaseFirstEdit.promise;
-        }
-        const cardSeq = Number(body?.card_seq);
-        if (cardSeq <= highestApplied) {
-          staleSeqs.push(cardSeq);
-          return { ok: false, status: 409, statusText: "Conflict", text: async () => "stale card_seq" };
-        }
-        highestApplied = cardSeq;
-        appliedSeqs.push(cardSeq);
-      }
-      return { ok: true, status: 200, text: async () => "" };
-    }) as unknown as typeof fetch;
+  it("keeps editing an already-sent card to terminal state without rereading policy", async () => {
+    const wire = mockFetch();
+    global.fetch = wire.fetch as typeof fetch;
+    const handlers = makeApi();
+    setCardContext("terminal-after-off", context());
+    await triggerFirstFrame(handlers, "terminal-after-off");
 
-    const { handlers, emitLifecycle } = makeApi();
-    const hookCtx = { sessionKey: "registry-seq-race", runId: "run-1" };
-    setCardContext(hookCtx.sessionKey, {
-      apiUrl: "https://registry-seq-race.test",
-      botToken: "bf",
-      channelId: "g",
-      channelType: ChannelType.Group,
-      reasoningCardTemplateMode: "experimental",
-    });
-    handlers.before_agent_run({}, hookCtx);
-    handlers.before_tool_call({ toolName: "read", toolCallId: "read-1" }, hookCtx);
-    await vi.advanceTimersByTimeAsync(900);
-
-    handlers.before_tool_call({ toolName: "sessions_yield", toolCallId: "yield-1" }, hookCtx);
-    handlers.after_tool_call({ toolName: "sessions_yield", toolCallId: "yield-1" }, hookCtx);
-    const terminalEdit = emitLifecycle({
-      runId: hookCtx.runId,
-      sessionKey: hookCtx.sessionKey,
-      stream: "lifecycle",
-      data: { phase: "error", error: "continuation failed" },
-    });
-    await firstEditReached.promise;
-
-    handlers.model_call_started({ callId: "late-call" }, hookCtx);
-    await vi.advanceTimersByTimeAsync(900);
-
-    const editsBeforeRelease = calls.filter((call) => call.url.includes("/message/edit"));
-    releaseFirstEdit.resolve();
-    await terminalEdit;
-    await vi.runAllTicks();
-
-    expect(editsBeforeRelease).toHaveLength(1);
-    expect(staleSeqs).toEqual([]);
-    expect(appliedSeqs[0]).toBe(1);
-    expect(appliedSeqs).toEqual([...appliedSeqs].sort((a, b) => a - b));
+    await finalizeCard("terminal-after-off", { success: true });
+    expect(wire.calls.filter((call) => call.url.includes("/card/profile"))).toHaveLength(1);
+    expect(wire.calls.find((call) => call.url.includes("/message/edit"))?.body)
+      .toMatchObject({ state: "completed", card_seq: 1 });
   });
 
-  it("Registry 首帧被确定性拒绝时也绝不回退本地 Model B", async () => {
-    const calls: Array<{ url: string; body: Record<string, unknown> | undefined }> = [];
-    global.fetch = vi.fn().mockImplementation(async (url: string, init?: { body?: string }) => {
-      const target = String(url);
-      const body = init?.body ? JSON.parse(init.body) as Record<string, unknown> : undefined;
-      calls.push({ url: target, body });
-      if (target.includes("/card/profile")) {
-        return { ok: true, status: 200, json: async () => registryProfile("0.3.0") };
-      }
-      if (target.includes("/sendMessage")) {
-        const payload = body?.payload as Record<string, unknown> | undefined;
-        if (payload?.template_ref) {
-          return {
-            ok: false,
-            status: 400,
-            statusText: "Bad Request",
-            text: async () => '{"code":"card_invalid"}',
-          };
-        }
-        return { ok: true, status: 200, text: async () => JSON.stringify({ message_id: "must-not-send-model-b" }) };
-      }
-      return { ok: true, status: 200, text: async () => "" };
-    }) as unknown as typeof fetch;
-
-    const { handlers } = makeApi();
-    const sessionKey = "registry-first-send-fallback";
-    setCardContext(sessionKey, {
-      apiUrl: "https://registry-first-send-fallback.test",
-      botToken: "bf",
-      channelId: "g",
-      channelType: ChannelType.Group,
-      reasoningCardTemplateMode: "experimental",
-    });
-    handlers.before_tool_call({ toolName: "read", toolCallId: "tool-1" }, { sessionKey });
-    await vi.advanceTimersByTimeAsync(900);
-
-    const sends = calls.filter((call) => call.url.includes("/sendMessage"));
-    expect(sends).toHaveLength(1);
-    expect(sends[0]?.body?.payload).toHaveProperty("template_ref.version", "0.3.0");
-    expect(sends.some((send) => Object.hasOwn(send.body?.payload ?? {}, "card"))).toBe(false);
-
-    markCardAnswering(sessionKey);
-    await vi.advanceTimersByTimeAsync(900);
-    expect(calls.some((call) => call.url.includes("/message/edit"))).toBe(false);
+  it("skips OBO contexts before any profile or send request", async () => {
+    const wire = mockFetch();
+    global.fetch = wire.fetch as typeof fetch;
+    const handlers = makeApi();
+    setCardContext("obo", context({ onBehalfOf: "grantor" }));
+    await triggerFirstFrame(handlers, "obo");
+    expect(wire.calls).toEqual([]);
   });
 
-  it.each([
-    {
-      label: "transport 408",
-      status: 408,
-      statusText: "Request Timeout",
-      body: "request timed out",
-    },
-    {
-      label: "semantic 409 conflict",
-      status: 400,
-      statusText: "Bad Request",
-      body: JSON.stringify({
-        error: {
-          code: "err.server.bot_api.card_seq_conflict",
-          http_status: 409,
-        },
-      }),
-    },
-    {
-      label: "card_disabled",
-      status: 400,
-      statusText: "Bad Request",
-      body: JSON.stringify({
-        error: {
-          code: "err.server.bot_api.card_disabled",
-          http_status: 400,
-        },
-      }),
-    },
-  ])("Model A 首帧遇 $label 时不二次发送 Model B", async ({ status, statusText, body }) => {
-    const sends: Record<string, unknown>[] = [];
-    global.fetch = vi.fn().mockImplementation(async (url: string, init?: { body?: string }) => {
-      const target = String(url);
-      if (target.includes("/card/profile")) {
-        return { ok: true, status: 200, json: async () => registryProfile("0.3.0") };
-      }
-      if (target.includes("/sendMessage")) {
-        sends.push(JSON.parse(init?.body ?? "{}") as Record<string, unknown>);
-        return { ok: false, status, statusText, text: async () => body };
-      }
-      return { ok: true, status: 200, text: async () => "" };
-    }) as unknown as typeof fetch;
-
-    const { handlers } = makeApi();
-    const sessionKey = `registry-no-unsafe-fallback-${status}-${statusText}`;
-    setCardContext(sessionKey, {
-      apiUrl: `https://${sessionKey}.test`,
-      botToken: "bf",
-      channelId: "g",
-      channelType: ChannelType.Group,
-      reasoningCardTemplateMode: "experimental",
-    });
-    handlers.before_tool_call({ toolName: "read", toolCallId: "tool-1" }, { sessionKey });
-    await vi.advanceTimersByTimeAsync(900);
-
-    handlers.after_tool_call({ toolName: "read", toolCallId: "tool-1", result: {} }, { sessionKey });
-    await vi.advanceTimersByTimeAsync(900);
-
-    expect(sends).toHaveLength(1);
-    expect(sends[0]?.payload).toHaveProperty("template_ref.version", "0.3.0");
-    expect(sends[0]?.payload).not.toHaveProperty("card");
-  });
-
-  it("Model A 首帧的 transport 400 包裹 semantic 503 时保留 Model A 供后续事件重试", async () => {
-    const sends: Record<string, unknown>[] = [];
-    global.fetch = vi.fn().mockImplementation(async (url: string, init?: { body?: string }) => {
-      const target = String(url);
-      if (target.includes("/card/profile")) {
-        return { ok: true, status: 200, json: async () => registryProfile("0.3.0") };
-      }
-      if (target.includes("/sendMessage")) {
-        const request = JSON.parse(init?.body ?? "{}") as Record<string, unknown>;
-        sends.push(request);
-        if (sends.length === 1) {
-          return {
-            ok: false,
-            status: 400,
-            statusText: "Bad Request",
-            text: async () => JSON.stringify({
-              error: {
-                code: "err.shared.internal",
-                http_status: 503,
-              },
-            }),
-          };
-        }
-        return { ok: true, status: 200, text: async () => JSON.stringify({ message_id: "retry-card" }) };
-      }
-      return { ok: true, status: 200, text: async () => "" };
-    }) as unknown as typeof fetch;
-
-    const { handlers } = makeApi();
-    const sessionKey = "registry-semantic-503-retry";
-    setCardContext(sessionKey, {
-      apiUrl: "https://registry-semantic-503-retry.test",
-      botToken: "bf",
-      channelId: "g",
-      channelType: ChannelType.Group,
-      reasoningCardTemplateMode: "experimental",
-    });
-    handlers.before_tool_call({ toolName: "read", toolCallId: "tool-1" }, { sessionKey });
-    await vi.advanceTimersByTimeAsync(900);
-
-    expect(sends).toHaveLength(1);
-    expect(sends[0]?.payload).toHaveProperty("template_ref.version", "0.3.0");
-
-    handlers.after_tool_call({ toolName: "read", toolCallId: "tool-1", result: {} }, { sessionKey });
-    await vi.advanceTimersByTimeAsync(900);
-
-    expect(sends).toHaveLength(2);
-    expect(sends[1]?.payload).toHaveProperty("template_ref.version", "0.3.0");
-    expect(sends[1]?.payload).not.toHaveProperty("card");
-  });
-
-  it("Model A 首帧被拒绝但 Model B capability 不兼容时不盲目回退", async () => {
-    const sends: Record<string, unknown>[] = [];
-    global.fetch = vi.fn().mockImplementation(async (url: string, init?: { body?: string }) => {
-      const target = String(url);
-      if (target.includes("/card/profile")) {
-        return {
-          ok: true,
-          status: 200,
-          json: async () => ({
-            ...registryProfile("0.3.0"),
-            profiles: ["octo/v2"],
-            card_version: "9.9",
-            elements: [],
-          }),
-        };
-      }
-      if (target.includes("/sendMessage")) {
-        sends.push(JSON.parse(init?.body ?? "{}") as Record<string, unknown>);
-        return { ok: false, status: 400, statusText: "Bad Request", text: async () => "card_invalid" };
-      }
-      return { ok: true, status: 200, text: async () => "" };
-    }) as unknown as typeof fetch;
-
-    const { handlers } = makeApi();
-    const sessionKey = "registry-no-model-b-fallback";
-    setCardContext(sessionKey, {
-      apiUrl: "https://registry-no-model-b-fallback.test",
-      botToken: "bf",
-      channelId: "g",
-      channelType: ChannelType.Group,
-      reasoningCardTemplateMode: "experimental",
-    });
-    handlers.before_tool_call({ toolName: "read", toolCallId: "tool-1" }, { sessionKey });
-    await vi.advanceTimersByTimeAsync(900);
-
-    expect(sends).toHaveLength(1);
-    expect(sends[0]?.payload).toHaveProperty("template_ref.version", "0.3.0");
-  });
-
-  it.each([429, 503])("Model A 首帧 %i 后下个事件仍可重试", async (failureStatus) => {
-    const calls: string[] = [];
-    let sendAttempts = 0;
-    global.fetch = vi.fn().mockImplementation(async (url: string) => {
-      calls.push(String(url));
-      if (String(url).includes("/card/profile")) {
-        return { ok: true, status: 200, json: async () => registryProfile() };
-      }
-      if (String(url).includes("/sendMessage")) {
-        sendAttempts += 1;
-        if (sendAttempts === 1) {
-          return {
-            ok: false,
-            status: failureStatus,
-            statusText: "temporary",
-            text: async () => "temporary",
-          };
-        }
-        return { ok: true, status: 200, text: async () => JSON.stringify({ message_id: "retry-card" }) };
-      }
-      return { ok: true, status: 200, text: async () => "" };
-    }) as unknown as typeof fetch;
-    const { handlers } = makeApi();
-    const sessionKey = `registry-send-retry-${failureStatus}`;
-    setCardContext(sessionKey, {
-      apiUrl: `https://registry-send-retry-${failureStatus}.test`,
-      botToken: "bf",
-      channelId: "g",
-      channelType: ChannelType.Group,
-      reasoningCardTemplateMode: "experimental",
-    });
-    handlers.model_call_started({ callId: "call-1" }, { sessionKey });
-    handlers.before_tool_call({ toolName: "read", toolCallId: "tool-1" }, { sessionKey });
-    await vi.advanceTimersByTimeAsync(900);
-
-    handlers.after_tool_call({ toolName: "read", toolCallId: "tool-1", result: {} }, { sessionKey });
-    await vi.advanceTimersByTimeAsync(900);
-
-    expect(calls.filter((url) => url.includes("/sendMessage"))).toHaveLength(2);
-  });
-
-  it("Model A stopped 状态始终是非 transient 终态", async () => {
-    const { fn, calls } = mockFetch({ profile: registryProfile(), sendId: "stopped-card" });
-    global.fetch = fn as unknown as typeof fetch;
-    const { handlers } = makeApi();
-    const hookCtx = { sessionKey: "registry-stopped", runId: "run-1" };
-    setCardContext("registry-stopped", {
-      apiUrl: "https://registry-stopped.test",
-      botToken: "bf",
-      channelId: "g",
-      channelType: ChannelType.Group,
-      reasoningCardTemplateMode: "experimental",
-    });
-    handlers.before_agent_run({}, hookCtx);
-    handlers.model_call_started({ callId: "call-1" }, hookCtx);
-    handlers.before_tool_call({ toolName: "read", toolCallId: "tool-1" }, hookCtx);
-    handlers.after_tool_call({ toolName: "read", toolCallId: "tool-1", result: {} }, hookCtx);
-    await vi.advanceTimersByTimeAsync(900);
-    calls.length = 0;
-
-    handlers.model_call_ended({
-      callId: "call-1",
-      durationMs: 10,
-      outcome: "error",
-      failureKind: "aborted",
-    }, hookCtx);
-    await vi.advanceTimersByTimeAsync(900);
-
-    const edit = calls.find((call) => call.url.includes("/message/edit"))?.body;
-    expect(edit).toMatchObject({ state: "stopped", card_seq: 1 });
-    expect(edit).not.toHaveProperty("transient");
-  });
-
-  it("Model A 状态转换遇 5xx 后卡片仍可更新(瞬时抖动不终结)", async () => {
-    // markCardPaused 在 entry 仍是活动卡时走 flush;editTrackedCardState 的失败路径要经
-    // finalizeCard 的 retainForContinuation 分支才可达。让那一次 paused 编辑吃 503,再放行
-    // registry,断言 TTL 过期帧仍然发得出去 —— 若失败被当成终态,pausedCards 里的 entry 会被
-    // skip 挡住每一条回收路径,卡片永久停在中途帧。
-    const states: string[] = [];
-    let failStatus: number | undefined;
-    global.fetch = vi.fn().mockImplementation(async (url: string, init?: { body?: string }) => {
-      const target = String(url);
-      if (target.includes("/card/profile")) return { ok: true, status: 200, json: async () => registryProfile() };
-      if (target.includes("/sendMessage")) {
-        return { ok: true, status: 200, text: async () => JSON.stringify({ message_id: "transient-card" }) };
-      }
-      if (target.includes("/message/edit")) {
-        states.push(String((JSON.parse(init?.body ?? "{}") as { state?: string }).state));
-        if (failStatus !== undefined) {
-          return { ok: false, status: failStatus, statusText: "unavailable", text: async () => "unavailable" };
-        }
-      }
-      return { ok: true, status: 200, text: async () => "" };
-    }) as unknown as typeof fetch;
-
-    const { handlers } = makeApi();
-    const hookCtx = { sessionKey: "registry-transient", runId: "run-1" };
-    setCardContext(hookCtx.sessionKey, {
-      apiUrl: "https://registry-transient.test",
-      botToken: "bf",
-      channelId: "g",
-      channelType: ChannelType.Group,
-      reasoningCardTemplateMode: "experimental",
-    });
-    handlers.before_agent_run({}, hookCtx);
-    handlers.before_tool_call({ toolName: "read", toolCallId: "tool-1" }, hookCtx);
-    await vi.advanceTimersByTimeAsync(900);
-    handlers.before_tool_call({ toolName: "sessions_yield", toolCallId: "yield-1" }, hookCtx);
-    handlers.after_tool_call({ toolName: "sessions_yield", toolCallId: "yield-1" }, hookCtx);
-    await vi.advanceTimersByTimeAsync(900);
-
-    failStatus = 503;
-    // 不能直接 await:重试延迟是 fake timer,await 住就没人推进它们,最后落地的会是
-    // AbortSignal.timeout(EDIT_TIMEOUT_MS) 的真实超时而不是这里要测的 5xx。
-    const finalized = finalizeCard(hookCtx.sessionKey, { success: true });
-    await vi.advanceTimersByTimeAsync(2_000);
-    await finalized;
-    expect(states).toContain("reasoning");
-    failStatus = undefined;
-
-    // PAUSED_CARD_TTL_MS = 1h;expired 经 contractState 映射成 error。
-    await vi.advanceTimersByTimeAsync(3_700_000);
-    await vi.advanceTimersByTimeAsync(2_000);
-
-    expect(states).toContain("error");
-  });
-
-  it("Model A 状态转换遇确定性 4xx 仍然终结卡片(收窄的另一半)", async () => {
-    // 与上一条对称:4xx 会重复必然失败的请求,所以仍按终态处理 —— 过期帧不再发出。
-    const states: string[] = [];
-    let failStatus: number | undefined;
-    global.fetch = vi.fn().mockImplementation(async (url: string, init?: { body?: string }) => {
-      const target = String(url);
-      if (target.includes("/card/profile")) return { ok: true, status: 200, json: async () => registryProfile() };
-      if (target.includes("/sendMessage")) {
-        return { ok: true, status: 200, text: async () => JSON.stringify({ message_id: "deterministic-card" }) };
-      }
-      if (target.includes("/message/edit")) {
-        states.push(String((JSON.parse(init?.body ?? "{}") as { state?: string }).state));
-        if (failStatus !== undefined) {
-          return { ok: false, status: failStatus, statusText: "bad frame", text: async () => "bad frame" };
-        }
-      }
-      return { ok: true, status: 200, text: async () => "" };
-    }) as unknown as typeof fetch;
-
-    const { handlers } = makeApi();
-    const hookCtx = { sessionKey: "registry-deterministic", runId: "run-1" };
-    setCardContext(hookCtx.sessionKey, {
-      apiUrl: "https://registry-deterministic.test",
-      botToken: "bf",
-      channelId: "g",
-      channelType: ChannelType.Group,
-      reasoningCardTemplateMode: "experimental",
-    });
-    handlers.before_agent_run({}, hookCtx);
-    handlers.before_tool_call({ toolName: "read", toolCallId: "tool-1" }, hookCtx);
-    await vi.advanceTimersByTimeAsync(900);
-    handlers.before_tool_call({ toolName: "sessions_yield", toolCallId: "yield-1" }, hookCtx);
-    handlers.after_tool_call({ toolName: "sessions_yield", toolCallId: "yield-1" }, hookCtx);
-    await vi.advanceTimersByTimeAsync(900);
-
-    failStatus = 400;
-    const finalized = finalizeCard(hookCtx.sessionKey, { success: true });
-    await vi.advanceTimersByTimeAsync(2_000);
-    await finalized;
-    failStatus = undefined;
-    const afterTransition = states.length;
-
-    await vi.advanceTimersByTimeAsync(3_700_000);
-    await vi.advanceTimersByTimeAsync(2_000);
-
-    expect(states).toHaveLength(afterTransition);
-  });
-
-  it("Model A 队列前序失败不吞掉排在其后的终态帧", async () => {
-    // 可达条件:findPausedFlowEntry 也看 cards,所以 sessions_yield 之后 entry 仍是活动卡时
-    // lifecycle error 会对它跑 finishPausedCard 的状态编辑。finalizeCard 只 await flushPromise、
-    // 不 await stateEditPromise,于是它的直接 editEntryProgress 排在那次状态编辑后面 —— 前序被
-    // 拒绝时,终态帧必须照发,而不是连带失败。
-    const states: string[] = [];
-    const stateEditReached = makeDeferred();
-    const releaseStateEdit = makeDeferred();
-    let stateEditSeen = 0;
-    global.fetch = vi.fn().mockImplementation(async (url: string, init?: { body?: string }) => {
-      const target = String(url);
-      if (target.includes("/card/profile")) return { ok: true, status: 200, json: async () => registryProfile() };
-      if (target.includes("/sendMessage")) {
-        return { ok: true, status: 200, text: async () => JSON.stringify({ message_id: "queue-card" }) };
-      }
-      if (target.includes("/message/edit")) {
-        const body = JSON.parse(init?.body ?? "{}") as { state?: string };
-        states.push(String(body.state));
-        // finishPausedCard 发的那一帧,按 state 而不是 card_seq 认 —— 序号会随中间帧漂移。
-        if (body.state === "error") {
-          if (++stateEditSeen === 1) {
-            stateEditReached.resolve();
-            await releaseStateEdit.promise;
-          }
-          return { ok: false, status: 503, statusText: "unavailable", text: async () => "unavailable" };
-        }
-      }
-      return { ok: true, status: 200, text: async () => "" };
-    }) as unknown as typeof fetch;
-
-    const { handlers, emitLifecycle } = makeApi();
-    const hookCtx = { sessionKey: "registry-queue", runId: "run-1" };
-    setCardContext(hookCtx.sessionKey, {
-      apiUrl: "https://registry-queue.test",
-      botToken: "bf",
-      channelId: "g",
-      channelType: ChannelType.Group,
-      reasoningCardTemplateMode: "experimental",
-    });
-    handlers.before_agent_run({}, hookCtx);
-    handlers.before_tool_call({ toolName: "read", toolCallId: "tool-1" }, hookCtx);
-    await vi.advanceTimersByTimeAsync(900);
-    handlers.before_tool_call({ toolName: "sessions_yield", toolCallId: "yield-1" }, hookCtx);
-    handlers.after_tool_call({ toolName: "sessions_yield", toolCallId: "yield-1" }, hookCtx);
-    await vi.advanceTimersByTimeAsync(900);
-
-    const terminal = emitLifecycle({
-      runId: hookCtx.runId,
-      sessionKey: hookCtx.sessionKey,
-      stream: "lifecycle",
-      data: { phase: "error", error: "boom" },
-    });
-    await stateEditReached.promise;
-    const finalize = finalizeCard(hookCtx.sessionKey, { success: true });
-    releaseStateEdit.resolve();
-    // 同上:重试延迟是 fake timer,直接 await 会让真实的 EDIT_TIMEOUT_MS 抢先落地。
-    await vi.advanceTimersByTimeAsync(2_000);
-    await Promise.allSettled([terminal, finalize]);
-    await vi.advanceTimersByTimeAsync(3_000);
-
-    // 终态帧必须发出,且排在失败的状态编辑之后。
-    expect(states).toContain("error");
-    expect(states).toContain("completed");
-    expect(states.indexOf("completed")).toBeGreaterThan(states.indexOf("error"));
-  });
-
-  it("Model A error 状态始终是非 transient 终态", async () => {
-    const { fn, calls } = mockFetch({ profile: registryProfile(), sendId: "error-card" });
-    global.fetch = fn as unknown as typeof fetch;
-    const { handlers } = makeApi();
-    const hookCtx = { sessionKey: "registry-error", runId: "run-1" };
-    setCardContext("registry-error", {
-      apiUrl: "https://registry-error.test",
-      botToken: "bf",
-      channelId: "g",
-      channelType: ChannelType.Group,
-      reasoningCardTemplateMode: "experimental",
-    });
-    handlers.before_agent_run({}, hookCtx);
-    handlers.model_call_started({ callId: "call-1" }, hookCtx);
-    handlers.before_tool_call({ toolName: "read", toolCallId: "tool-1" }, hookCtx);
-    handlers.after_tool_call({ toolName: "read", toolCallId: "tool-1", result: {} }, hookCtx);
-    await vi.advanceTimersByTimeAsync(900);
-    calls.length = 0;
-
-    await finalizeCard("registry-error", { success: false, errorText: "provider timeout" });
-
-    const edit = calls.find((call) => call.url.includes("/message/edit"))?.body;
-    expect(edit).toMatchObject({ state: "error", card_seq: 1 });
-    expect(edit).not.toHaveProperty("transient");
-  });
-
-  it("reasoning 关闭时 experimental 仍选 Model A,phases 用占位思考且不含任何捕获文本", async () => {
-    // 已文档化行为(README `reasoningCardTemplateMode`):Model A 的选择只取决于模板兼容性,
-    // 与 reasoning 可见性无关。可见性关闭的一轮不会有任何 thought 被捕获,卡片用
-    // FALLBACK_THOUGHT 承载真实工具行 —— 这里把它锁成显式期望,而不是隐式副产品。
-    const { fn, calls } = mockFetch({ profile: registryProfile(), sendId: "no-reasoning-card" });
-    global.fetch = fn as unknown as typeof fetch;
-    const { handlers } = makeApi();
-    const hookCtx = { sessionKey: "registry-reasoning-off", runId: "run-1" };
-    setCardContext("registry-reasoning-off", {
-      apiUrl: "https://registry-reasoning-off.test",
-      botToken: "bf",
-      channelId: "g",
-      channelType: ChannelType.Group,
-      reasoningVisibility: "off",
-      reasoningCardTemplateMode: "experimental",
-    });
-    handlers.before_agent_run({}, hookCtx);
-    handlers.model_call_started({ callId: "call-1" }, hookCtx);
-    // host 照常投递无 runId 的持久化 hook；该车道已 fail-close，不得落到卡上。
-    handlers.before_message_write?.({
-      sessionKey: "registry-reasoning-off",
-      message: { role: "assistant", content: [{ type: "thinking", thinking: "MUST STAY HIDDEN" }] },
-    }, {});
-    handlers.before_tool_call({ toolName: "read", toolCallId: "tool-1", params: { path: "README.md" } }, hookCtx);
-    handlers.after_tool_call({ toolName: "read", toolCallId: "tool-1", result: {} }, hookCtx);
-    await vi.advanceTimersByTimeAsync(900);
-
-    const payload = calls.find((call) => call.url.includes("/sendMessage"))?.body?.payload as {
-      template_ref?: Record<string, unknown>;
-      data?: { phases?: Array<{ thought: string; actions: unknown[] }> };
-    };
-    expect(payload?.template_ref).toMatchObject({ id: "ai.reasoning-process" });
-    const phases = payload?.data?.phases ?? [];
-    expect(phases.length).toBeGreaterThan(0);
-    expect(phases.every((phase) => phase.thought === "Thinking through…")).toBe(true);
-    expect(phases.some((phase) => phase.actions.length > 0)).toBe(true);
-    expect(JSON.stringify(payload?.data)).not.toContain("MUST STAY HIDDEN");
-  });
-
-  it("Model A paused 帧是持久帧(可能挂 1h,不能进 transient)", async () => {
-    // contractState 把 paused 映射成 reasoning,但 markCardPaused 明确不要 transient:
-    // yielded 卡最长可挂 PAUSED_CARD_TTL_MS(1h),必须进修订历史,与 Model B 语义一致。
-    const { fn, calls } = mockFetch({ profile: registryProfile(), sendId: "paused-card" });
-    global.fetch = fn as unknown as typeof fetch;
-    const { handlers } = makeApi();
-    const hookCtx = { sessionKey: "registry-paused", runId: "run-1" };
-    setCardContext("registry-paused", {
-      apiUrl: "https://registry-paused.test",
-      botToken: "bf",
-      channelId: "g",
-      channelType: ChannelType.Group,
-      reasoningVisibility: "stream",
-      reasoningCardTemplateMode: "experimental",
-    });
-    handlers.before_agent_run({}, hookCtx);
-    handlers.model_call_started({ callId: "call-1" }, hookCtx);
-    recordCardReasoning("registry-paused", "先派一个子任务。", { snapshot: true });
-    handlers.before_tool_call({ toolName: "read", toolCallId: "tool-1" }, hookCtx);
-    handlers.after_tool_call({ toolName: "read", toolCallId: "tool-1", result: {} }, hookCtx);
-    await vi.advanceTimersByTimeAsync(900);
-    calls.length = 0;
-
-    handlers.before_tool_call({ toolName: "sessions_yield", toolCallId: "yield-1" }, hookCtx);
-    handlers.after_tool_call({ toolName: "sessions_yield", toolCallId: "yield-1", result: {} }, hookCtx);
-    await vi.advanceTimersByTimeAsync(900);
-    // dispatch 收尾:卡片移入 pausedCards 等 continuation,这一帧就是可能挂 1h 的那帧。
-    await finalizeCard("registry-paused", { success: true });
-
-    const paused = calls.filter((call) => call.url.includes("/message/edit")).at(-1)?.body;
-    expect(paused).toMatchObject({ state: "reasoning" });
-    expect(paused).not.toHaveProperty("transient");
-  });
-
-  it("manifest 短 TTL 到期后新消息可发现刚部署的 Registry 能力", async () => {
-    const calls: Array<{ url: string; body: Record<string, unknown> | undefined }> = [];
-    let profileCalls = 0;
-    global.fetch = vi.fn().mockImplementation(async (url: string, init?: { body?: string }) => {
-      calls.push({ url: String(url), body: init?.body ? JSON.parse(init.body) : undefined });
-      if (String(url).includes("/card/profile")) {
-        profileCalls += 1;
-        return {
-          ok: true,
-          status: 200,
-          json: async () => profileCalls === 1
-            ? { enabled: true, profiles: ["octo/v1"] }
-            : registryProfile(),
-        };
-      }
-      if (String(url).includes("/sendMessage")) {
-        return { ok: true, status: 200, text: async () => JSON.stringify({ message_id: `m-${profileCalls}` }) };
-      }
-      return { ok: true, status: 200, text: async () => "" };
-    }) as unknown as typeof fetch;
-    const { handlers } = makeApi();
-    const context = {
-      apiUrl: "https://registry-rollout.test",
-      botToken: "bf",
-      channelId: "g",
-      channelType: ChannelType.Group,
-      reasoningCardTemplateMode: "experimental" as const,
-    };
-
-    setCardContext("before-rollout", context);
-    handlers.model_call_started({ callId: "call-1" }, { sessionKey: "before-rollout" });
-    handlers.before_tool_call({ toolName: "read", toolCallId: "tool-1" }, { sessionKey: "before-rollout" });
-    await vi.advanceTimersByTimeAsync(900);
-    expect((calls.find((call) => call.url.includes("/sendMessage"))?.body?.payload as Record<string, unknown>))
-      .toHaveProperty("card");
-    clearCard("before-rollout");
-    calls.length = 0;
-
-    await vi.advanceTimersByTimeAsync(60_001);
-    setCardContext("after-rollout", context);
-    handlers.model_call_started({ callId: "call-2" }, { sessionKey: "after-rollout" });
-    handlers.before_tool_call({ toolName: "read", toolCallId: "tool-2" }, { sessionKey: "after-rollout" });
-    await vi.advanceTimersByTimeAsync(900);
-
-    expect(profileCalls).toBe(2);
-    expect((calls.find((call) => call.url.includes("/sendMessage"))?.body?.payload as Record<string, unknown>))
-      .toHaveProperty("template_ref.version", "0.2.0");
-  });
-
-  it("Model A reasoningId 在 paused continuation 跨 run 后保持不变", async () => {
-    const { fn, calls } = mockFetch({ profile: registryProfile(), sendId: "continuation-card" });
-    global.fetch = fn as unknown as typeof fetch;
-    const { handlers } = makeApi();
-    const sessionKey = "registry-continuation";
-    const childSessionKey = "agent:main:subagent:registry-child";
-    setCardContext(sessionKey, {
-      apiUrl: "https://registry-continuation.test",
-      botToken: "bf",
-      channelId: "g",
-      channelType: ChannelType.Group,
-      reasoningCardTemplateMode: "experimental",
-    });
-    handlers.before_agent_run({}, { sessionKey, runId: "run-original" });
-    handlers.model_call_started({ callId: "call-1" }, { sessionKey, runId: "run-original" });
-    handlers.before_tool_call(
-      { toolName: "sessions_spawn", toolCallId: "spawn-1" },
-      { sessionKey, runId: "run-original" },
+  it("pins the owning run and ignores a late hook from another run", async () => {
+    const wire = mockFetch();
+    global.fetch = wire.fetch as typeof fetch;
+    const handlers = makeApi();
+    setCardContext("run-owner", context());
+    bindCardRun("run-owner", "run-new");
+    handlers.before_tool_call?.(
+      { toolName: "exec", toolCallId: "old-tool" },
+      { sessionKey: "run-owner", runId: "run-old" },
     );
-    handlers.after_tool_call({
+    handlers.before_tool_call?.(
+      { toolName: "read", toolCallId: "new-tool" },
+      { sessionKey: "run-owner", runId: "run-new" },
+    );
+    await vi.advanceTimersByTimeAsync(900);
+
+    const data = wire.calls.find((call) => call.url.includes("/sendMessage"))?.body?.payload as {
+      data?: { phases?: Array<{ actions?: Array<{ tool?: string }> }> };
+    };
+    const tools = data.data?.phases?.flatMap((phase) => phase.actions ?? []).map((action) => action.tool);
+    expect(tools).toContain("read");
+    expect(tools).not.toContain("exec");
+    clearCard("run-owner");
+  });
+
+  it("waits for an in-flight first send before committing the terminal frame", async () => {
+    let resolveSend!: () => void;
+    const sendGate = new Promise<void>((resolve) => { resolveSend = resolve; });
+    let sendStarted = false;
+    global.fetch = vi.fn().mockImplementation(async (url: string) => {
+      if (url.includes("/card/profile")) {
+        return { ok: true, status: 200, json: async () => profile() };
+      }
+      if (url.includes("/sendMessage")) {
+        sendStarted = true;
+        await sendGate;
+        return { ok: true, status: 200, text: async () => JSON.stringify({ message_id: "card-race" }) };
+      }
+      return { ok: true, status: 200, text: async () => "" };
+    }) as typeof fetch;
+    const handlers = makeApi();
+    setCardContext("send-race", context());
+    const hookContext = { sessionKey: "send-race", runId: "run-1" };
+    handlers.before_agent_run?.({}, hookContext);
+    handlers.before_tool_call?.({ toolName: "read", toolCallId: "tool-1" }, hookContext);
+
+    vi.advanceTimersByTime(900);
+    for (let index = 0; index < 10 && !sendStarted; index++) await Promise.resolve();
+    expect(sendStarted).toBe(true);
+    const finalized = finalizeCard("send-race", { success: true });
+    resolveSend();
+    await finalized;
+
+    const calls = vi.mocked(global.fetch).mock.calls;
+    const editInit = calls.find(([url]) => String(url).includes("/message/edit"))?.[1] as RequestInit;
+    expect(JSON.parse(String(editInit.body))).toMatchObject({
+      message_id: "card-race",
+      state: "completed",
+      card_seq: 1,
+    });
+  });
+
+  it("fails closed when the same sessionKey is replaced by a different Bot identity", async () => {
+    const wire = mockFetch();
+    global.fetch = wire.fetch as typeof fetch;
+    const handlers = makeApi();
+    setCardContext("identity-collision", context({ botToken: "bot-a" }));
+    setCardContext("identity-collision", context({ botToken: "bot-b" }));
+
+    await triggerFirstFrame(handlers, "identity-collision");
+    expect(wire.calls).toEqual([]);
+  });
+
+  it("keeps one Registry card across yield and a trusted continuation", async () => {
+    const wire = mockFetch();
+    global.fetch = wire.fetch as typeof fetch;
+    const handlers = makeApi();
+    setCardContext("continuation", context());
+    await triggerFirstFrame(handlers, "continuation", "run-1");
+    const firstContext = { sessionKey: "continuation", runId: "run-1" };
+
+    handlers.before_tool_call?.({ toolName: "sessions_spawn", toolCallId: "spawn-1" }, firstContext);
+    handlers.after_tool_call?.({
       toolName: "sessions_spawn",
       toolCallId: "spawn-1",
-      result: { details: { status: "accepted", childSessionKey } },
-    }, { sessionKey, runId: "run-original" });
-    handlers.before_tool_call(
-      { toolName: "sessions_yield", toolCallId: "yield-1" },
-      { sessionKey, runId: "run-original" },
+      result: { status: "accepted", childSessionKey: "child-1" },
+    }, firstContext);
+    handlers.before_tool_call?.({ toolName: "sessions_yield", toolCallId: "yield-1" }, firstContext);
+    handlers.after_tool_call?.({ toolName: "sessions_yield", toolCallId: "yield-1" }, firstContext);
+    await vi.advanceTimersByTimeAsync(900);
+    await finalizeCard("continuation", { success: false });
+
+    setCardContext("continuation", context());
+    const secondContext = { sessionKey: "continuation", runId: "run-2" };
+    handlers.before_agent_run?.({ prompt: completionPrompt("child-1") }, secondContext);
+    await handlers.agent_end?.({ runId: "run-2", success: true }, secondContext);
+
+    const edits = wire.calls
+      .filter((call) => call.url.includes("/message/edit"))
+      .map((call) => call.body!);
+    expect(edits.at(-1)).toMatchObject({ state: "completed" });
+    expect(edits.map((body) => body.card_seq)).toEqual(
+      edits.map((_body, index) => index + 1),
     );
-    handlers.after_tool_call(
-      { toolName: "sessions_yield", toolCallId: "yield-1", result: {} },
-      { sessionKey, runId: "run-original" },
-    );
-    await vi.advanceTimersByTimeAsync(900);
-    const firstData = (calls.find((call) => call.url.includes("/sendMessage"))?.body?.payload as {
-      data?: { reasoningId?: string };
-    }).data;
-    expect(firstData?.reasoningId).toBe(`${sessionKey}:run-original`);
-
-    await finalizeCard(sessionKey, { success: false });
-    calls.length = 0;
-    handlers.before_agent_run(
-      { prompt: completionPrompt(childSessionKey), messages: [] },
-      { sessionKey, runId: "run-continuation" },
-    );
-    await vi.runAllTicks();
-
-    const continuationData = calls.find((call) => call.url.includes("/message/edit"))?.body?.data as {
-      reasoningId?: string;
-    };
-    expect(continuationData?.reasoningId).toBe(firstData?.reasoningId);
-  });
-
-  /**
-   * agent 用 `message` 工具把答复直接投递给用户、turn 结束又没有 final text 时,
-   * dispatch 的 `replySucceeded` 保持 false —— 但这一轮其实成功了(OpenClaw core 的
-   * resolveAttemptTrajectoryTerminal 同样把 messaging 投递算作交付证据)。卡片不能
-   * 因此谎报「⚠️ Interrupted」。归属校验 fail-closed:只认发往本卡频道的成功 send。
-   */
-  describe("message 工具投递证据", () => {
-    async function runMessageToolTurn(opts: {
-      sessionKey: string;
-      channelId: string;
-      channelType: ChannelType;
-      params: Record<string, unknown>;
-      toolError?: string;
-      toolName?: string;
-    }) {
-      const { fn, calls } = mockFetch();
-      global.fetch = fn as unknown as typeof fetch;
-      const { handlers } = makeApi();
-      const hookCtx = { sessionKey: opts.sessionKey, runId: "run-msg" };
-      setCardContext(opts.sessionKey, {
-        apiUrl: "https://msg-tool.test",
-        botToken: "bf",
-        channelId: opts.channelId,
-        channelType: opts.channelType,
-      });
-      handlers.before_agent_run({}, hookCtx);
-      const toolName = opts.toolName ?? "message";
-      handlers.before_tool_call({ toolName, toolCallId: "msg-1", params: opts.params }, hookCtx);
-      await vi.advanceTimersByTimeAsync(900);
-      handlers.after_tool_call({
-        toolName,
-        toolCallId: "msg-1",
-        durationMs: 20,
-        ...(opts.toolError ? { error: opts.toolError } : { result: {} }),
-      }, hookCtx);
-      calls.length = 0;
-
-      // The dispatcher never saw a deliverable final text for this turn.
-      await finalizeCard(opts.sessionKey, { success: false });
-
-      const edit = calls.find((call) => call.url.includes("/message/edit"));
-      expect(edit).toBeTruthy();
-      return progressHeaderText(JSON.parse(edit!.body!.content_edit as string).card);
-    }
-
-    it("成功投递到本卡频道时收成完成态,而不是已中断", async () => {
-      const header = await runMessageToolTurn({
-        sessionKey: "msg-deliver-dm",
-        channelId: "u1",
-        channelType: ChannelType.DM,
-        params: { action: "send", target: "user:u1", message: "答复正文" },
-      });
-      expect(header).toContain("✅ Done");
-      expect(header).not.toContain("Interrupted");
-    });
-
-    it("群卡认同 group: 前缀的成功投递", async () => {
-      const header = await runMessageToolTurn({
-        sessionKey: "msg-deliver-group",
-        channelId: "g1",
-        channelType: ChannelType.Group,
-        params: { action: "send", target: "group:g1", message: "答复正文" },
-      });
-      expect(header).toContain("✅ Done");
-    });
-
-    it("投递到别的频道不算本卡交付", async () => {
-      const header = await runMessageToolTurn({
-        sessionKey: "msg-other-channel",
-        channelId: "g1",
-        channelType: ChannelType.Group,
-        params: { action: "send", target: "group:g-other", message: "发给别人的通知" },
-      });
-      expect(header).toContain("Interrupted");
-    });
-
-    it("群卡不认发往子区的投递(发送路径也会落到子区)", async () => {
-      const header = await runMessageToolTurn({
-        sessionKey: "msg-thread-vs-parent",
-        channelId: "g1",
-        channelType: ChannelType.Group,
-        params: { action: "send", target: "group:g1____t1", message: "发到子区" },
-      });
-      expect(header).toContain("Interrupted");
-    });
-
-    /**
-     * 归一化必须和真实发送路径一致(resolveOutboundTarget),否则发送**确实落到本卡频道**的
-     * target 会被判为「不是本轮答复」,本 PR 要修的 Failed 卡在这些形态下原样存活。
-     */
-    it("认同堆叠前缀 octo:user: 的投递", async () => {
-      const header = await runMessageToolTurn({
-        sessionKey: "msg-stacked-user",
-        channelId: "u1",
-        channelType: ChannelType.DM,
-        params: { action: "send", target: "octo:user:u1", message: "答复正文" },
-      });
-      expect(header).toContain("✅ Done");
-    });
-
-    it("认同带内联 @uid 后缀的群投递", async () => {
-      const header = await runMessageToolTurn({
-        sessionKey: "msg-mention-suffix",
-        channelId: "g1",
-        channelType: ChannelType.Group,
-        params: { action: "send", target: "group:g1@u2", message: "答复正文" },
-      });
-      expect(header).toContain("✅ Done");
-    });
-
-    it("线程卡认同 bare-parent 投递(发送路径会自动重路由到本线程,issue #98)", async () => {
-      const header = await runMessageToolTurn({
-        sessionKey: "msg-thread-reroute",
-        channelId: "g1____t1",
-        channelType: ChannelType.CommunityTopic,
-        params: { action: "send", target: "group:g1", message: "答复正文" },
-      });
-      expect(header).toContain("✅ Done");
-    });
-
-    it("scope=parent 时不认 bare-parent(发送路径发往父群,不是本线程)", async () => {
-      const header = await runMessageToolTurn({
-        sessionKey: "msg-thread-scope-parent",
-        channelId: "g1____t1",
-        channelType: ChannelType.CommunityTopic,
-        params: { action: "send", target: "group:g1", scope: "parent", message: "发到父群" },
-      });
-      expect(header).toContain("Interrupted");
-    });
-
-    it("裸 id 在 knownGroupIds 命中时认同群投递,未命中则不认", async () => {
-      // 发送路径把裸 id 交给 knownGroupIds 分类,evidence 检查共用同一套输入。
-      registerGroupAccount("gk1", "acct-known", "agent-known");
-      try {
-        expect(await runMessageToolTurn({
-          sessionKey: "msg-bare-known",
-          channelId: "gk1",
-          channelType: ChannelType.Group,
-          params: { action: "send", target: "gk1", message: "答复正文" },
-        })).toContain("✅ Done");
-      } finally {
-        _testGetGroupAccountMap().delete("agent-known:gk1");
-      }
-      // 未注册的裸 id 会被解析成 DM,群卡不认。
-      expect(await runMessageToolTurn({
-        sessionKey: "msg-bare-unknown",
-        channelId: "gk2",
-        channelType: ChannelType.Group,
-        params: { action: "send", target: "gk2", message: "答复正文" },
-      })).toContain("Interrupted");
-    });
-
-    /**
-     * scope:"parent" 在发送路径里**最先**生效:group-like target 被折叠到父群、ambient
-     * threadId 被清掉,随后跳过 in-thread 重路由。归属判定必须先做同样的折叠再比较,否则
-     * 两个方向都会错 —— 子区卡把发往父群的投递记成自己的,父群卡又不认真正发给它的投递。
-     */
-    it("scope=parent + 显式子区 target:子区卡不得认领(实际发往父群)", async () => {
-      const header = await runMessageToolTurn({
-        sessionKey: "msg-scope-parent-thread",
-        channelId: "g1____t1",
-        channelType: ChannelType.CommunityTopic,
-        params: { action: "send", target: "group:g1____t1", scope: "parent", message: "发到父群" },
-      });
-      expect(header).toContain("Interrupted");
-    });
-
-    it("scope=parent + 显式子区 target:父群卡应认领(实际就发给它)", async () => {
-      const header = await runMessageToolTurn({
-        sessionKey: "msg-scope-parent-group",
-        channelId: "g1",
-        channelType: ChannelType.Group,
-        params: { action: "send", target: "group:g1____t1", scope: "parent", message: "答复正文" },
-      });
-      expect(header).toContain("✅ Done");
-    });
-
-    it("认同 threadId 参数合成出的子区目标", async () => {
-      const header = await runMessageToolTurn({
-        sessionKey: "msg-threadid-merge",
-        channelId: "g1____t1",
-        channelType: ChannelType.CommunityTopic,
-        params: { action: "send", target: "group:g1", threadId: "t1", message: "答复正文" },
-      });
-      expect(header).toContain("✅ Done");
-    });
-
-    it("投递失败不算交付", async () => {
-      const header = await runMessageToolTurn({
-        sessionKey: "msg-send-failed",
-        channelId: "u1",
-        channelType: ChannelType.DM,
-        params: { action: "send", target: "user:u1", message: "答复正文" },
-        toolError: "Octo API /v1/bot/sendMessage failed (400)",
-      });
-      expect(header).toContain("Interrupted");
-    });
-
-    it("非 send 动作不算交付", async () => {
-      const header = await runMessageToolTurn({
-        sessionKey: "msg-read-action",
-        channelId: "u1",
-        channelType: ChannelType.DM,
-        params: { action: "read", target: "user:u1" },
-      });
-      expect(header).toContain("Interrupted");
-    });
-
-    it("同名的其它工具不算交付", async () => {
-      const header = await runMessageToolTurn({
-        sessionKey: "msg-not-message-tool",
-        channelId: "u1",
-        channelType: ChannelType.DM,
-        toolName: "read",
-        params: { action: "send", target: "user:u1" },
-      });
-      expect(header).toContain("Interrupted");
-    });
-
-    it("旧 host 缺 toolCallId 时不认投递证据(无法归因,fail-closed)", async () => {
-      const { fn, calls } = mockFetch();
-      global.fetch = fn as unknown as typeof fetch;
-      const { handlers } = makeApi();
-      const hookCtx = { sessionKey: "msg-no-tool-call-id", runId: "run-msg" };
-      setCardContext("msg-no-tool-call-id", {
-        apiUrl: "https://msg-tool.test",
-        botToken: "bf",
-        channelId: "u1",
-        channelType: ChannelType.DM,
-      });
-      handlers.before_agent_run({}, hookCtx);
-      // 发往本卡频道的调用(最终会失败)。
-      handlers.before_tool_call(
-        { toolName: "message", params: { action: "send", target: "user:u1" } },
-        hookCtx,
-      );
-      // 发往别处的通知(会成功)。两次调用都没有 toolCallId,彼此不可区分。
-      handlers.before_tool_call(
-        { toolName: "message", params: { action: "send", target: "user:other" } },
-        hookCtx,
-      );
-      await vi.advanceTimersByTimeAsync(900);
-      handlers.after_tool_call({ toolName: "message", result: {} }, hookCtx); // 别处那次成功
-      calls.length = 0;
-
-      await finalizeCard("msg-no-tool-call-id", { success: false });
-
-      const edit = calls.find((call) => call.url.includes("/message/edit"));
-      const header = progressHeaderText(JSON.parse(edit!.body!.content_edit as string).card);
-      // 成功的那次并非发往本卡,不能被当成本轮答复。
-      expect(header).toContain("Interrupted");
-    });
-
-    it("显式失败(errorText)优先于工具投递证据", async () => {
-      const { fn, calls } = mockFetch();
-      global.fetch = fn as unknown as typeof fetch;
-      const { handlers } = makeApi();
-      const hookCtx = { sessionKey: "msg-explicit-error", runId: "run-msg" };
-      setCardContext("msg-explicit-error", {
-        apiUrl: "https://msg-tool.test",
-        botToken: "bf",
-        channelId: "u1",
-        channelType: ChannelType.DM,
-      });
-      handlers.before_agent_run({}, hookCtx);
-      handlers.before_tool_call(
-        { toolName: "message", toolCallId: "msg-1", params: { action: "send", target: "user:u1" } },
-        hookCtx,
-      );
-      await vi.advanceTimersByTimeAsync(900);
-      handlers.after_tool_call({ toolName: "message", toolCallId: "msg-1", result: {} }, hookCtx);
-      calls.length = 0;
-
-      await finalizeCard("msg-explicit-error", { success: false, errorText: "provider timeout" });
-
-      const edit = calls.find((call) => call.url.includes("/message/edit"));
-      const header = progressHeaderText(JSON.parse(edit!.body!.content_edit as string).card);
-      expect(header).toContain("Interrupted");
-      expect(header).toContain("provider timeout");
-    });
-  });
-
-  it("OBO 场景跳过(不发任何请求)", async () => {
-    const { fn, calls } = mockFetch();
-    global.fetch = fn as unknown as typeof fetch;
-    const { handlers } = makeApi();
-    setCardContext("s2", { apiUrl: "https://a2.test", botToken: "y", channelId: "g", channelType: ChannelType.Group, onBehalfOf: "grantor" });
-    handlers.before_tool_call({ toolName: "read" }, { sessionKey: "s2" });
-    await vi.advanceTimersByTimeAsync(900);
-    expect(calls.length).toBe(0);
-  });
-
-  it("cardProgress:false 在 session 入口直接跳过,不探测 manifest 也不发送", async () => {
-    const { fn, calls } = mockFetch();
-    global.fetch = fn as unknown as typeof fetch;
-    const { handlers } = makeApi();
-
-    setCardContext("progress-disabled", {
-      apiUrl: "https://shared-card-gate.test",
-      botToken: "disabled-account",
-      channelId: "g-disabled",
-      channelType: ChannelType.Group,
-      cardProgress: false,
-    });
-    handlers.before_tool_call({ toolName: "read" }, { sessionKey: "progress-disabled" });
-    await vi.advanceTimersByTimeAsync(900);
-
-    expect(calls).toEqual([]);
-  });
-
-  it("账号级关闭不污染同 apiUrl 的共享 gate cache", async () => {
-    const { fn, calls } = mockFetch();
-    global.fetch = fn as unknown as typeof fetch;
-    const { handlers } = makeApi();
-
-    setCardContext("progress-disabled-account", {
-      apiUrl: "https://shared-card-gate.test",
-      botToken: "disabled-account",
-      channelId: "g-disabled",
-      channelType: ChannelType.Group,
-      cardProgress: false,
-    });
-    handlers.before_tool_call({ toolName: "read" }, { sessionKey: "progress-disabled-account" });
-    await vi.advanceTimersByTimeAsync(900);
-
-    setCardContext("progress-enabled-account", {
-      apiUrl: "https://shared-card-gate.test",
-      botToken: "enabled-account",
-      channelId: "g-enabled",
-      channelType: ChannelType.Group,
-      cardProgress: true,
-    });
-    handlers.before_tool_call({ toolName: "read" }, { sessionKey: "progress-enabled-account" });
-    await vi.advanceTimersByTimeAsync(900);
-
-    expect(calls.filter((call) => call.url.includes("/card/profile"))).toHaveLength(1);
-    expect(calls.filter((call) => call.url.includes("/sendMessage"))).toHaveLength(1);
-  });
-
-  it("cardProgress:true 仍不能绕过不兼容 card_version", async () => {
-    const calls: Array<{ url: string }> = [];
-    global.fetch = vi.fn().mockImplementation(async (url: string) => {
-      calls.push({ url: String(url) });
-      if (String(url).includes("/card/profile")) {
-        return {
-          ok: true,
-          status: 200,
-          json: async () => ({
-            enabled: true,
-            profiles: ["octo/v1"],
-            card_version: "1.6",
-            elements: ["TextBlock"],
-          }),
-        };
-      }
-      return { ok: true, status: 200, text: async () => JSON.stringify({ message_id: "must-not-send" }) };
-    }) as unknown as typeof fetch;
-    const { handlers } = makeApi();
-
-    setCardContext("progress-incompatible", {
-      apiUrl: "https://incompatible-card-version.test",
-      botToken: "enabled-account",
-      channelId: "g-enabled",
-      channelType: ChannelType.Group,
-      cardProgress: true,
-    });
-    handlers.before_tool_call({ toolName: "read" }, { sessionKey: "progress-incompatible" });
-    await vi.advanceTimersByTimeAsync(900);
-
-    expect(calls.some((call) => call.url.includes("/card/profile"))).toBe(true);
-    expect(calls.some((call) => call.url.includes("/sendMessage"))).toBe(false);
-  });
-
-  it("未登记 session 的事件 no-op(天然过滤非 octo run)", async () => {
-    const { fn, calls } = mockFetch();
-    global.fetch = fn as unknown as typeof fetch;
-    const { handlers } = makeApi();
-    handlers.before_tool_call({ toolName: "read" }, { sessionKey: "unknown" });
-    await vi.advanceTimersByTimeAsync(900);
-    expect(calls.length).toBe(0);
-  });
-
-  it("D12 gate disabled → 不发卡", async () => {
-    const { fn, calls } = mockFetch({ enabled: false });
-    global.fetch = fn as unknown as typeof fetch;
-    const { handlers } = makeApi();
-    setCardContext("s3", { apiUrl: "https://a3.test", botToken: "y", channelId: "g", channelType: ChannelType.Group });
-    handlers.before_tool_call({ toolName: "read" }, { sessionKey: "s3" });
-    await vi.advanceTimersByTimeAsync(900);
-    expect(calls.some((c) => c.url.includes("/sendMessage"))).toBe(false);
-  });
-
-  it("D12 明确 elements=[] 时不回退 baseline,不发送无法渲染的卡", async () => {
-    const calls: Array<{ url: string }> = [];
-    global.fetch = vi.fn().mockImplementation(async (url: string) => {
-      calls.push({ url: String(url) });
-      if (String(url).includes("/card/profile")) {
-        return { ok: true, status: 200, json: async () => ({ enabled: true, profiles: ["octo/v1"], elements: [] }) };
-      }
-      return { ok: true, status: 200, text: async () => JSON.stringify({ message_id: "should-not-send" }) };
-    }) as unknown as typeof fetch;
-    const { handlers } = makeApi();
-    setCardContext("empty-elements", { apiUrl: "https://empty.test", botToken: "bf", channelId: "g", channelType: ChannelType.Group });
-    handlers.before_tool_call({ toolName: "read" }, { sessionKey: "empty-elements" });
-    await vi.advanceTimersByTimeAsync(900);
-    expect(calls.some((c) => c.url.includes("/sendMessage"))).toBe(false);
-  });
-
-  it("finalizeCard 发终态帧(已有占位卡)", async () => {
-    const { fn, calls } = mockFetch();
-    global.fetch = fn as unknown as typeof fetch;
-    const { handlers } = makeApi();
-    setCardContext("s4", { apiUrl: "https://a4.test", botToken: "bf", channelId: "g1", channelType: ChannelType.Group });
-    handlers.before_tool_call({ toolName: "read" }, { sessionKey: "s4" });
-    await vi.advanceTimersByTimeAsync(900);
-    calls.length = 0;
-
-    await finalizeCard("s4", { success: true });
-    const edit = calls.find((c) => c.url.includes("/message/edit"));
-    expect(edit).toBeTruthy();
-    const env = JSON.parse(edit!.body!.content_edit as string);
-    expect(progressHeaderText(env.card)).toContain("✅ Done");
-    expect(env.transient).toBeUndefined(); // 终态帧进修订历史(不带 transient)
-  });
-
-  it("sessions_yield 成功后显示等待任务结果,而不是已中断", async () => {
-    const { fn, calls } = mockFetch();
-    global.fetch = fn as unknown as typeof fetch;
-    const { handlers } = makeApi();
-    setCardContext("yield-fallback", {
-      apiUrl: "https://yield.test",
-      botToken: "bf",
-      channelId: "g1",
-      channelType: ChannelType.Group,
-    });
-    handlers.before_agent_run({}, { sessionKey: "yield-fallback", runId: "run-a" });
-    handlers.before_tool_call(
-      { toolName: "sessions_yield", toolCallId: "yield-1" },
-      { sessionKey: "yield-fallback", runId: "run-a" },
-    );
-    await vi.advanceTimersByTimeAsync(900);
-    handlers.after_tool_call(
-      { toolName: "sessions_yield", toolCallId: "yield-1", durationMs: 20 },
-      { sessionKey: "yield-fallback", runId: "run-a" },
-    );
-    calls.length = 0;
-
-    await finalizeCard("yield-fallback", { success: false });
-
-    const edit = calls.find((call) => call.url.includes("/message/edit"));
-    expect(edit).toBeTruthy();
-    const env = JSON.parse(edit!.body!.content_edit as string);
-    expect(progressHeaderText(env.card)).toContain("⏸️ Waiting for results");
-    expect(progressHeaderText(env.card)).not.toContain("Interrupted");
-  });
-
-  it("yielded lifecycle 后保留原卡,后续 run 开始时整理、结束时完成", async () => {
-    const { fn, calls } = mockFetch();
-    global.fetch = fn as unknown as typeof fetch;
-    const { handlers, emitLifecycle } = makeApi();
-    setCardContext("yield-lifecycle", {
-      apiUrl: "https://yield-lifecycle.test",
-      botToken: "bf",
-      channelId: "g1",
-      channelType: ChannelType.Group,
-    });
-    handlers.before_agent_run({}, { sessionKey: "yield-lifecycle", runId: "run-a" });
-    handlers.before_tool_call(
-      { toolName: "sessions_spawn", toolCallId: "spawn-1" },
-      { sessionKey: "yield-lifecycle", runId: "run-a" },
-    );
-    handlers.after_tool_call(
-      {
-        toolName: "sessions_spawn",
-        toolCallId: "spawn-1",
-        durationMs: 30,
-        result: {
-          content: [{ type: "text", text: '{"status":"accepted","childSessionKey":"agent:main:subagent:child-1","runId":"child-run-1"}' }],
-        },
-      },
-      { sessionKey: "yield-lifecycle", runId: "run-a" },
-    );
-    await vi.advanceTimersByTimeAsync(900);
-    calls.length = 0;
-
-    await emitLifecycle({
-      runId: "run-a",
-      sessionKey: "yield-lifecycle",
-      stream: "lifecycle",
-      data: { phase: "end", yielded: true, livenessState: "paused" },
-    });
-    await finalizeCard("yield-lifecycle", { success: false });
-    const pausedEdit = calls.find((call) => {
-      if (!call.url.includes("/message/edit")) return false;
-      const env = JSON.parse(call.body!.content_edit as string);
-      return progressHeaderText(env.card).includes("⏸️ Waiting for results");
-    });
-    expect(pausedEdit).toBeTruthy();
-    expect(progressCardText(JSON.parse(pausedEdit!.body!.content_edit as string).card))
-      .toContain("⏳ Waiting for subtask");
-
-    await vi.advanceTimersByTimeAsync(65_000);
-
-    calls.length = 0;
-    await emitLifecycle({
-      runId: "run-b",
-      sessionKey: "yield-lifecycle",
-      stream: "lifecycle",
-      data: { phase: "start" },
-    });
-    handlers.before_agent_run(
-      { prompt: completionPrompt("agent:main:subagent:child-1"), messages: [] },
-      { sessionKey: "yield-lifecycle", runId: "run-b" },
-    );
-    await vi.runAllTicks();
-    const resumingEdit = calls.find((call) => {
-      if (!call.url.includes("/message/edit")) return false;
-      const env = JSON.parse(call.body!.content_edit as string);
-      return progressHeaderText(env.card).includes("🤖 Preparing results");
-    });
-    expect(resumingEdit).toBeTruthy();
-    expect(progressCardText(JSON.parse(resumingEdit!.body!.content_edit as string).card))
-      .toContain("⏸️ Waiting for subtask · 1m 5s");
-
-    calls.length = 0;
-    await emitLifecycle({
-      runId: "run-b",
-      sessionKey: "yield-lifecycle",
-      stream: "lifecycle",
-      data: { phase: "end" },
-    });
-    const completed = calls.find((call) => call.url.includes("/message/edit"));
-    expect(completed).toBeTruthy();
-    const completedEnv = JSON.parse(completed!.body!.content_edit as string);
-    expect(progressHeaderText(completedEnv.card)).toContain("✅ Done");
-  });
-
-  it("无关用户 run 不得劫持 paused 卡,真正 completion run 仍可继续更新", async () => {
-    const { fn, calls } = mockFetch();
-    global.fetch = fn as unknown as typeof fetch;
-    const { handlers, emitLifecycle } = makeApi();
-    const childSessionKey = "agent:main:subagent:child-unrelated";
-    const target = {
-      apiUrl: "https://yield-unrelated.test",
-      botToken: "bf",
-      channelId: "g1",
-      channelType: ChannelType.Group,
-    };
-
-    setCardContext("yield-unrelated", target);
-    handlers.before_agent_run({}, { sessionKey: "yield-unrelated", runId: "run-a" });
-    handlers.before_tool_call(
-      { toolName: "sessions_spawn", toolCallId: "spawn-1" },
-      { sessionKey: "yield-unrelated", runId: "run-a" },
-    );
-    handlers.after_tool_call(
-      {
-        toolName: "sessions_spawn",
-        toolCallId: "spawn-1",
-        result: { details: { status: "accepted", childSessionKey, runId: "child-run" } },
-      },
-      { sessionKey: "yield-unrelated", runId: "run-a" },
-    );
-    handlers.before_tool_call(
-      { toolName: "sessions_yield", toolCallId: "yield-1" },
-      { sessionKey: "yield-unrelated", runId: "run-a" },
-    );
-    handlers.after_tool_call(
-      { toolName: "sessions_yield", toolCallId: "yield-1" },
-      { sessionKey: "yield-unrelated", runId: "run-a" },
-    );
-    await vi.advanceTimersByTimeAsync(900);
-    await finalizeCard("yield-unrelated", { success: false });
-
-    calls.length = 0;
-    setCardContext("yield-unrelated", target);
-    await emitLifecycle({
-      runId: "run-user",
-      sessionKey: "yield-unrelated",
-      stream: "lifecycle",
-      data: { phase: "start" },
-    });
-    handlers.before_agent_run(
-      { prompt: "用户在等待期间发来的普通追问", messages: [] },
-      { sessionKey: "yield-unrelated", runId: "run-user" },
-    );
-    await emitLifecycle({
-      runId: "run-user",
-      sessionKey: "yield-unrelated",
-      stream: "lifecycle",
-      data: { phase: "end" },
-    });
-    expect(calls.some((call) => call.url.includes("/message/edit"))).toBe(false);
-
-    await emitLifecycle({
-      runId: "run-continuation",
-      sessionKey: "yield-unrelated",
-      stream: "lifecycle",
-      data: { phase: "start" },
-    });
-    handlers.before_agent_run(
-      { prompt: completionPrompt(childSessionKey), messages: [] },
-      { sessionKey: "yield-unrelated", runId: "run-continuation" },
-    );
-    await vi.runAllTicks();
-    expect(calls.some((call) => {
-      if (!call.url.includes("/message/edit")) return false;
-      const env = JSON.parse(call.body!.content_edit as string);
-      return progressHeaderText(env.card).includes("🤖 Preparing results");
-    })).toBe(true);
-
-    calls.length = 0;
-    await emitLifecycle({
-      runId: "run-continuation",
-      sessionKey: "yield-unrelated",
-      stream: "lifecycle",
-      data: { phase: "end" },
-    });
-    const finalEdit = calls.find((call) => call.url.includes("/message/edit"));
-    expect(finalEdit).toBeTruthy();
-    expect(progressHeaderText(JSON.parse(finalEdit!.body!.content_edit as string).card)).toContain("✅ Done");
-  });
-
-  it("乱序 start/end 编辑必须串行,最终不能被迟到的 resuming 覆盖", async () => {
-    const calls: Array<{ url: string; body: Record<string, unknown> | undefined }> = [];
-    const appliedHeaders: string[] = [];
-    const resumingReached = makeDeferred();
-    const releaseResuming = makeDeferred();
-    global.fetch = vi.fn().mockImplementation(async (url: string, init?: { body?: string }) => {
-      const body = init?.body ? JSON.parse(init.body) : undefined;
-      calls.push({ url: String(url), body });
-      if (String(url).includes("/card/profile")) {
-        return { ok: true, status: 200, json: async () => ({ enabled: true, profiles: ["octo/v1"] }) };
-      }
-      if (String(url).includes("/sendMessage")) {
-        return { ok: true, status: 200, text: async () => JSON.stringify({ message_id: "race-card" }) };
-      }
-      if (String(url).includes("/message/edit")) {
-        const env = JSON.parse(body.content_edit as string);
-        const header = progressHeaderText(env.card);
-        if (header.includes("Preparing result")) {
-          resumingReached.resolve();
-          await releaseResuming.promise;
-        }
-        appliedHeaders.push(header);
-      }
-      return { ok: true, status: 200, text: async () => "" };
-    }) as unknown as typeof fetch;
-
-    const { handlers, emitLifecycle } = makeApi();
-    const childSessionKey = "agent:main:subagent:child-race";
-    setCardContext("yield-race", {
-      apiUrl: "https://yield-race.test",
-      botToken: "bf",
-      channelId: "g1",
-      channelType: ChannelType.Group,
-    });
-    handlers.before_agent_run({}, { sessionKey: "yield-race", runId: "run-a" });
-    handlers.before_tool_call({ toolName: "sessions_spawn", toolCallId: "spawn-1" }, { sessionKey: "yield-race", runId: "run-a" });
-    handlers.after_tool_call(
-      { toolName: "sessions_spawn", toolCallId: "spawn-1", result: { details: { status: "accepted", childSessionKey, runId: "child-run" } } },
-      { sessionKey: "yield-race", runId: "run-a" },
-    );
-    handlers.before_tool_call({ toolName: "sessions_yield", toolCallId: "yield-1" }, { sessionKey: "yield-race", runId: "run-a" });
-    handlers.after_tool_call({ toolName: "sessions_yield", toolCallId: "yield-1" }, { sessionKey: "yield-race", runId: "run-a" });
-    await vi.advanceTimersByTimeAsync(900);
-    await finalizeCard("yield-race", { success: false });
-    calls.length = 0;
-
-    const startEvent = emitLifecycle({
-      runId: "run-b",
-      sessionKey: "yield-race",
-      stream: "lifecycle",
-      data: { phase: "start" },
-    });
-    handlers.before_agent_run(
-      { prompt: completionPrompt(childSessionKey), messages: [] },
-      { sessionKey: "yield-race", runId: "run-b" },
-    );
-    await resumingReached.promise;
-    const endEvent = emitLifecycle({
-      runId: "run-b",
-      sessionKey: "yield-race",
-      stream: "lifecycle",
-      data: { phase: "end" },
-    });
-    await vi.runAllTicks();
-    releaseResuming.resolve();
-    await Promise.all([startEvent, endEvent]);
-
-    expect(appliedHeaders.length).toBeGreaterThanOrEqual(2);
-    expect(appliedHeaders.at(-1)).toContain("✅ Done");
-  });
-
-  it("旧 host 无 lifecycle API 时仍可由受信 completion prompt + agent_end 完成卡片", async () => {
-    const { fn, calls } = mockFetch();
-    global.fetch = fn as unknown as typeof fetch;
-    const { handlers } = makeApi({ lifecycle: false });
-    const childSessionKey = "agent:main:subagent:child-legacy";
-    setCardContext("yield-legacy", {
-      apiUrl: "https://yield-legacy.test",
-      botToken: "bf",
-      channelId: "g1",
-      channelType: ChannelType.Group,
-    });
-    handlers.before_agent_run({}, { sessionKey: "yield-legacy", runId: "run-a" });
-    handlers.before_tool_call({ toolName: "sessions_spawn", toolCallId: "spawn-1" }, { sessionKey: "yield-legacy", runId: "run-a" });
-    handlers.after_tool_call(
-      { toolName: "sessions_spawn", toolCallId: "spawn-1", result: { details: { status: "accepted", childSessionKey, runId: "child-run" } } },
-      { sessionKey: "yield-legacy", runId: "run-a" },
-    );
-    handlers.before_tool_call({ toolName: "sessions_yield", toolCallId: "yield-1" }, { sessionKey: "yield-legacy", runId: "run-a" });
-    handlers.after_tool_call({ toolName: "sessions_yield", toolCallId: "yield-1" }, { sessionKey: "yield-legacy", runId: "run-a" });
-    await vi.advanceTimersByTimeAsync(900);
-    await finalizeCard("yield-legacy", { success: false });
-    calls.length = 0;
-
-    handlers.before_agent_run(
-      { prompt: completionPrompt(childSessionKey), messages: [] },
-      { sessionKey: "yield-legacy", runId: "run-b" },
-    );
-    await vi.runAllTicks();
-    await handlers.agent_end(
-      { runId: "run-b", messages: [], success: true },
-      { sessionKey: "yield-legacy", runId: "run-b" },
-    );
-
-    const edits = calls.filter((call) => call.url.includes("/message/edit"));
-    const lastEnv = JSON.parse(edits.at(-1)!.body!.content_edit as string);
-    expect(progressHeaderText(lastEnv.card)).toContain("✅ Done");
-  });
-
-  it("无 continuation 的 paused 卡到期后显示等待超时并释放追踪", async () => {
-    const { fn, calls } = mockFetch();
-    global.fetch = fn as unknown as typeof fetch;
-    const { handlers } = makeApi({ lifecycle: false });
-    setCardContext("yield-expire", {
-      apiUrl: "https://yield-expire.test",
-      botToken: "bf",
-      channelId: "g1",
-      channelType: ChannelType.Group,
-    });
-    handlers.before_agent_run({}, { sessionKey: "yield-expire", runId: "run-a" });
-    handlers.before_tool_call({ toolName: "sessions_yield", toolCallId: "yield-1" }, { sessionKey: "yield-expire", runId: "run-a" });
-    handlers.after_tool_call({ toolName: "sessions_yield", toolCallId: "yield-1" }, { sessionKey: "yield-expire", runId: "run-a" });
-    await vi.advanceTimersByTimeAsync(900);
-    await finalizeCard("yield-expire", { success: false });
-    calls.length = 0;
-
-    await vi.advanceTimersByTimeAsync(3_600_100);
-
-    const edit = calls.find((call) => call.url.includes("/message/edit"));
-    expect(edit).toBeTruthy();
-    const env = JSON.parse(edit!.body!.content_edit as string);
-    expect(progressHeaderText(env.card)).toContain("⏱️ Wait timed out");
-  });
-
-  it("yield 后 continuation 只产出 final text 时,兜底把孤儿 paused 卡收到已完成", async () => {
-    const { fn, calls } = mockFetch();
-    global.fetch = fn as unknown as typeof fetch;
-    const { handlers } = makeApi({ lifecycle: false });
-    const ctx = {
-      apiUrl: "https://yield-bare.test",
-      botToken: "bf",
-      channelId: "g1",
-      channelType: ChannelType.Group,
-    };
-    // run-a:真实工具发出占位卡,随后 bare sessions_yield(无 spawn)→ paused
-    setCardContext("yield-bare", ctx);
-    handlers.before_agent_run({}, { sessionKey: "yield-bare", runId: "run-a" });
-    handlers.before_tool_call({ toolName: "run_command", toolCallId: "cmd-1" }, { sessionKey: "yield-bare", runId: "run-a" });
-    handlers.after_tool_call({ toolName: "run_command", toolCallId: "cmd-1", durationMs: 10 }, { sessionKey: "yield-bare", runId: "run-a" });
-    handlers.before_tool_call({ toolName: "sessions_yield", toolCallId: "yield-1" }, { sessionKey: "yield-bare", runId: "run-a" });
-    handlers.after_tool_call({ toolName: "sessions_yield", toolCallId: "yield-1", durationMs: 5 }, { sessionKey: "yield-bare", runId: "run-a" });
-    await vi.advanceTimersByTimeAsync(900);
-    await finalizeCard("yield-bare", { success: false });
-    calls.length = 0;
-
-    // 同一 run resume 后的 continuation:新 dispatch 重置 context(空 entry、无 messageId),
-    // before_agent_run 用原 runId 重新绑定(resumed run 保留 runId),只产出 final text。
-    setCardContext("yield-bare", ctx);
-    handlers.before_agent_run({ prompt: "继续:这是最终战报,没有 completion event", messages: [] }, { sessionKey: "yield-bare", runId: "run-a" });
-    await finalizeCard("yield-bare", { success: true });
-
-    const doneEdit = calls.find((call) => {
-      if (!call.url.includes("/message/edit")) return false;
-      const env = JSON.parse(call.body!.content_edit as string);
-      return progressHeaderText(env.card).includes("✅ Done");
-    });
-    expect(doneEdit).toBeTruthy();
-
-    // 孤儿卡已释放:TTL 到期后不再有 edit(不会把成功任务误标为「等待超时」)
-    calls.length = 0;
-    await vi.advanceTimersByTimeAsync(3_600_100);
-    expect(calls.some((call) => call.url.includes("/message/edit"))).toBe(false);
-  });
-
-  it("continuation 失败时兜底把孤儿 paused 卡收到已中断", async () => {
-    const { fn, calls } = mockFetch();
-    global.fetch = fn as unknown as typeof fetch;
-    const { handlers } = makeApi({ lifecycle: false });
-    const ctx = {
-      apiUrl: "https://yield-bare-err.test",
-      botToken: "bf",
-      channelId: "g1",
-      channelType: ChannelType.Group,
-    };
-    setCardContext("yield-bare-err", ctx);
-    handlers.before_agent_run({}, { sessionKey: "yield-bare-err", runId: "run-a" });
-    handlers.before_tool_call({ toolName: "run_command", toolCallId: "cmd-1" }, { sessionKey: "yield-bare-err", runId: "run-a" });
-    handlers.after_tool_call({ toolName: "run_command", toolCallId: "cmd-1", durationMs: 10 }, { sessionKey: "yield-bare-err", runId: "run-a" });
-    handlers.before_tool_call({ toolName: "sessions_yield", toolCallId: "yield-1" }, { sessionKey: "yield-bare-err", runId: "run-a" });
-    handlers.after_tool_call({ toolName: "sessions_yield", toolCallId: "yield-1", durationMs: 5 }, { sessionKey: "yield-bare-err", runId: "run-a" });
-    await vi.advanceTimersByTimeAsync(900);
-    await finalizeCard("yield-bare-err", { success: false });
-    calls.length = 0;
-
-    setCardContext("yield-bare-err", ctx);
-    handlers.before_agent_run({ prompt: "继续", messages: [] }, { sessionKey: "yield-bare-err", runId: "run-a" });
-    await finalizeCard("yield-bare-err", { success: false, errorText: "boom" });
-
-    const errEdit = calls.find((call) => {
-      if (!call.url.includes("/message/edit")) return false;
-      const env = JSON.parse(call.body!.content_edit as string);
-      return progressHeaderText(env.card).includes("⚠️ Interrupted");
-    });
-    expect(errEdit).toBeTruthy();
-  });
-
-  /**
-   * 投递证据属于产生它的那个 run。CardEntry 会跨 run 存活(finalizeCard 把它停进
-   * pausedCards),若证据不清除,孤儿收尾就会拿上一个 run 的投递去洗白本轮的失败 ——
-   * 用户刚收到道歉消息,卡片却显示 ✅ Done。
-   */
-  it("前一 run 的工具投递不得洗白 continuation 的失败", async () => {
-    const { fn, calls } = mockFetch();
-    global.fetch = fn as unknown as typeof fetch;
-    const { handlers } = makeApi({ lifecycle: false });
-    const ctx = {
-      apiUrl: "https://leak-guard.test",
-      botToken: "bf",
-      channelId: "u1",
-      channelType: ChannelType.DM,
-    };
-    setCardContext("leak-guard", ctx);
-    handlers.before_agent_run({}, { sessionKey: "leak-guard", runId: "run-a" });
-    // run A 通过 message 工具向本卡频道投递 → 本 run 有交付证据
-    handlers.before_tool_call(
-      { toolName: "message", toolCallId: "msg-1", params: { action: "send", target: "user:u1" } },
-      { sessionKey: "leak-guard", runId: "run-a" },
-    );
-    handlers.after_tool_call(
-      { toolName: "message", toolCallId: "msg-1", result: {} },
-      { sessionKey: "leak-guard", runId: "run-a" },
-    );
-    handlers.before_tool_call({ toolName: "sessions_yield", toolCallId: "y-1" }, { sessionKey: "leak-guard", runId: "run-a" });
-    handlers.after_tool_call({ toolName: "sessions_yield", toolCallId: "y-1", durationMs: 5 }, { sessionKey: "leak-guard", runId: "run-a" });
-    await vi.advanceTimersByTimeAsync(900);
-    await finalizeCard("leak-guard", { success: true });
-    calls.length = 0;
-
-    // continuation:同 runId 恢复,自己没有任何工具调用、也没有任何投递。
-    setCardContext("leak-guard", ctx);
-    handlers.before_agent_run({ prompt: "继续", messages: [] }, { sessionKey: "leak-guard", runId: "run-a" });
-    // 生产形态:inbound.ts 只传 success,不传 errorText。
-    await finalizeCard("leak-guard", { success: false });
-
-    const edit = calls.filter((c) => c.url.includes("/message/edit")).pop();
-    expect(edit).toBeTruthy();
-    const header = progressHeaderText(JSON.parse(edit!.body!.content_edit as string).card);
-    expect(header).toContain("Interrupted");
-    expect(header).not.toContain("Done");
-  });
-
-  it("bare yield 等待期间无关 run 收尾不得接管原 paused 卡,真正 resume 才收尾", async () => {
-    const { fn, calls } = mockFetch();
-    global.fetch = fn as unknown as typeof fetch;
-    const { handlers } = makeApi({ lifecycle: false });
-    const ctx = {
-      apiUrl: "https://yield-bare-intervene.test",
-      botToken: "bf",
-      channelId: "g1",
-      channelType: ChannelType.Group,
-    };
-    // run-a:真实工具发卡 → bare sessions_yield → paused(pausedFromRunId=run-a)
-    setCardContext("yield-bare-intervene", ctx);
-    handlers.before_agent_run({}, { sessionKey: "yield-bare-intervene", runId: "run-a" });
-    handlers.before_tool_call({ toolName: "run_command", toolCallId: "cmd-1" }, { sessionKey: "yield-bare-intervene", runId: "run-a" });
-    handlers.after_tool_call({ toolName: "run_command", toolCallId: "cmd-1", durationMs: 10 }, { sessionKey: "yield-bare-intervene", runId: "run-a" });
-    handlers.before_tool_call({ toolName: "sessions_yield", toolCallId: "yield-1" }, { sessionKey: "yield-bare-intervene", runId: "run-a" });
-    handlers.after_tool_call({ toolName: "sessions_yield", toolCallId: "yield-1", durationMs: 5 }, { sessionKey: "yield-bare-intervene", runId: "run-a" });
-    await vi.advanceTimersByTimeAsync(900);
-    await finalizeCard("yield-bare-intervene", { success: false });
-    calls.length = 0;
-
-    // 等待期间到达的**无关** run(不同 runId)只产出 final text 并收尾 ——
-    // 缺乏 run 归属,绝不能把原 paused 任务误标 done 并移除。
-    setCardContext("yield-bare-intervene", ctx);
-    handlers.before_agent_run({ prompt: "等待期间的无关用户消息", messages: [] }, { sessionKey: "yield-bare-intervene", runId: "run-unrelated" });
-    await finalizeCard("yield-bare-intervene", { success: true });
-    expect(calls.some((call) => call.url.includes("/message/edit"))).toBe(false);
-
-    // 真正的 resume(原 run 保留 runId)收尾时,才把 paused 卡收到终态
-    calls.length = 0;
-    setCardContext("yield-bare-intervene", ctx);
-    handlers.before_agent_run({ prompt: "真正 resume 后的最终战报", messages: [] }, { sessionKey: "yield-bare-intervene", runId: "run-a" });
-    await finalizeCard("yield-bare-intervene", { success: true });
-    const doneEdit = calls.find((call) => {
-      if (!call.url.includes("/message/edit")) return false;
-      const env = JSON.parse(call.body!.content_edit as string);
-      return progressHeaderText(env.card).includes("✅ Done");
-    });
-    expect(doneEdit).toBeTruthy();
-  });
-
-  it("兜底不得劫持仍在等子任务的 subagent-yield paused 卡", async () => {
-    const { fn, calls } = mockFetch();
-    global.fetch = fn as unknown as typeof fetch;
-    const { handlers } = makeApi({ lifecycle: false });
-    const childSessionKey = "agent:main:subagent:child-guard";
-    const ctx = {
-      apiUrl: "https://yield-guard.test",
-      botToken: "bf",
-      channelId: "g1",
-      channelType: ChannelType.Group,
-    };
-    setCardContext("yield-guard", ctx);
-    handlers.before_agent_run({}, { sessionKey: "yield-guard", runId: "run-a" });
-    handlers.before_tool_call({ toolName: "sessions_spawn", toolCallId: "spawn-1" }, { sessionKey: "yield-guard", runId: "run-a" });
-    handlers.after_tool_call(
-      { toolName: "sessions_spawn", toolCallId: "spawn-1", result: { details: { status: "accepted", childSessionKey, runId: "child-run" } } },
-      { sessionKey: "yield-guard", runId: "run-a" },
-    );
-    handlers.before_tool_call({ toolName: "sessions_yield", toolCallId: "yield-1" }, { sessionKey: "yield-guard", runId: "run-a" });
-    handlers.after_tool_call({ toolName: "sessions_yield", toolCallId: "yield-1" }, { sessionKey: "yield-guard", runId: "run-a" });
-    await vi.advanceTimersByTimeAsync(900);
-    await finalizeCard("yield-guard", { success: false });
-    calls.length = 0;
-
-    // 等待期间无关 run 只产出 final text 并收尾 —— 不得把仍在等子任务的卡关掉
-    setCardContext("yield-guard", ctx);
-    handlers.before_agent_run({ prompt: "等待期间的无关消息", messages: [] }, { sessionKey: "yield-guard", runId: "run-user" });
-    await finalizeCard("yield-guard", { success: true });
-    expect(calls.some((call) => call.url.includes("/message/edit"))).toBe(false);
-
-    // 真正的 completion run 回来仍能把卡收到已完成
-    calls.length = 0;
-    handlers.before_agent_run({ prompt: completionPrompt(childSessionKey), messages: [] }, { sessionKey: "yield-guard", runId: "run-b" });
-    await vi.runAllTicks();
-    await handlers.agent_end({ runId: "run-b", messages: [], success: true }, { sessionKey: "yield-guard", runId: "run-b" });
-    const doneEdit = calls.find((call) => {
-      if (!call.url.includes("/message/edit")) return false;
-      const env = JSON.parse(call.body!.content_edit as string);
-      return progressHeaderText(env.card).includes("✅ Done");
-    });
-    expect(doneEdit).toBeTruthy();
-  });
-
-  it("paused 窗口的跨身份同 sessionKey 碰撞必须 fail-closed", async () => {
-    const { fn, calls } = mockFetch();
-    global.fetch = fn as unknown as typeof fetch;
-    const { handlers, emitLifecycle } = makeApi();
-    const childSessionKey = "agent:main:subagent:child-collision";
-    setCardContext("yield-collision", {
-      apiUrl: "https://yield-collision.test",
-      botToken: "bot-a",
-      channelId: "group-a",
-      channelType: ChannelType.Group,
-    });
-    handlers.before_agent_run({}, { sessionKey: "yield-collision", runId: "run-a" });
-    handlers.before_tool_call({ toolName: "sessions_spawn", toolCallId: "spawn-1" }, { sessionKey: "yield-collision", runId: "run-a" });
-    handlers.after_tool_call(
-      { toolName: "sessions_spawn", toolCallId: "spawn-1", result: { details: { status: "accepted", childSessionKey, runId: "child-run" } } },
-      { sessionKey: "yield-collision", runId: "run-a" },
-    );
-    handlers.before_tool_call({ toolName: "sessions_yield", toolCallId: "yield-1" }, { sessionKey: "yield-collision", runId: "run-a" });
-    handlers.after_tool_call({ toolName: "sessions_yield", toolCallId: "yield-1" }, { sessionKey: "yield-collision", runId: "run-a" });
-    await vi.advanceTimersByTimeAsync(900);
-    await finalizeCard("yield-collision", { success: false });
-    calls.length = 0;
-
-    setCardContext("yield-collision", {
-      apiUrl: "https://yield-collision.test",
-      botToken: "bot-b",
-      channelId: "group-b",
-      channelType: ChannelType.Group,
-    });
-    await emitLifecycle({
-      runId: "run-b",
-      sessionKey: "yield-collision",
-      stream: "lifecycle",
-      data: { phase: "start" },
-    });
-    handlers.before_agent_run(
-      { prompt: completionPrompt(childSessionKey), messages: [] },
-      { sessionKey: "yield-collision", runId: "run-b" },
-    );
-    await emitLifecycle({
-      runId: "run-b",
-      sessionKey: "yield-collision",
-      stream: "lifecycle",
-      data: { phase: "end" },
-    });
-
-    expect(calls.some((call) => call.url.includes("/message/edit"))).toBe(false);
-  });
-
-  it("失败的 sessions_yield 不进入等待状态", async () => {
-    const { fn, calls } = mockFetch();
-    global.fetch = fn as unknown as typeof fetch;
-    const { handlers } = makeApi();
-    setCardContext("yield-error", {
-      apiUrl: "https://yield-error.test",
-      botToken: "bf",
-      channelId: "g1",
-      channelType: ChannelType.Group,
-    });
-    handlers.before_agent_run({}, { sessionKey: "yield-error", runId: "run-a" });
-    handlers.before_tool_call(
-      { toolName: "sessions_yield", toolCallId: "yield-1" },
-      { sessionKey: "yield-error", runId: "run-a" },
-    );
-    await vi.advanceTimersByTimeAsync(900);
-    handlers.after_tool_call(
-      { toolName: "sessions_yield", toolCallId: "yield-1", error: "yield failed" },
-      { sessionKey: "yield-error", runId: "run-a" },
-    );
-    calls.length = 0;
-
-    await finalizeCard("yield-error", { success: false });
-
-    const edit = calls.find((call) => call.url.includes("/message/edit"));
-    expect(edit).toBeTruthy();
-    const env = JSON.parse(edit!.body!.content_edit as string);
-    expect(progressHeaderText(env.card)).toContain("Interrupted");
-    expect(progressHeaderText(env.card)).not.toContain("Waiting for results");
-  });
-
-  it("finalizeCard 未发过占位卡 → 仅清理不发", async () => {
-    const { fn, calls } = mockFetch();
-    global.fetch = fn as unknown as typeof fetch;
-    makeApi();
-    setCardContext("s5", { apiUrl: "https://a5.test", botToken: "y", channelId: "g", channelType: ChannelType.Group });
-    await finalizeCard("s5", { success: true });
-    expect(calls.length).toBe(0);
-  });
-
-  it("finalizeCardWithResponse edits the existing progress message into one terminal response", async () => {
-    const { fn, calls } = mockFetch();
-    global.fetch = fn as unknown as typeof fetch;
-    const { handlers } = makeApi();
-    setCardContext("merged-final", {
-      apiUrl: "https://merge.test",
-      botToken: "bf",
-      channelId: "g1",
-      channelType: ChannelType.Group,
-    });
-    handlers.before_tool_call({ toolName: "read" }, { sessionKey: "merged-final" });
-    await vi.advanceTimersByTimeAsync(900);
-    calls.length = 0;
-
-    const merged = await finalizeCardWithResponse(
-      "merged-final",
-      "结论\n\n渠道 B 的下降主要来自权益认知不足。",
-    );
-
-    expect(merged).toBe(true);
-    const edits = calls.filter((call) => call.url.includes("/message/edit"));
-    expect(edits).toHaveLength(1);
-    const env = JSON.parse(edits[0].body!.content_edit as string);
-    expect(env.transient).toBeUndefined();
-    expect(progressCardText(env.card)).toContain("渠道 B 的下降主要来自权益认知不足");
-    calls.length = 0;
-    await finalizeCard("merged-final", { success: true });
-    expect(calls).toHaveLength(0);
-  });
-
-  it("finalizeCardWithResponse returns false when no progress message was sent", async () => {
-    const { fn, calls } = mockFetch();
-    global.fetch = fn as unknown as typeof fetch;
-    setCardContext("plain-final", {
-      apiUrl: "https://merge.test",
-      botToken: "bf",
-      channelId: "g1",
-      channelType: ChannelType.Group,
-    });
-
-    expect(await finalizeCardWithResponse("plain-final", "普通回答")).toBe(false);
-    expect(calls).toHaveLength(0);
-  });
-
-  it("P1: finalize 等待 in-flight 首帧 send,终态帧不丢失", async () => {
-    const calls: Array<{ url: string; body: Record<string, unknown> | undefined }> = [];
-    const sendGate = makeDeferred(); // 悬住首帧 send
-    const sendReached = makeDeferred(); // 通知 send 已进入
-    const fn = vi.fn().mockImplementation(async (url: string, init?: { body?: string }) => {
-      calls.push({ url: String(url), body: init?.body ? JSON.parse(init.body) : undefined });
-      if (String(url).includes("/card/profile")) {
-        return { ok: true, status: 200, json: async () => ({ enabled: true }) };
-      }
-      if (String(url).includes("/sendMessage")) {
-        sendReached.resolve();
-        await sendGate.promise; // 保持 send in-flight
-        return { ok: true, status: 200, text: async () => JSON.stringify({ message_id: "card1" }) };
-      }
-      return { ok: true, status: 200, text: async () => "" };
-    });
-    global.fetch = fn as unknown as typeof fetch;
-    const { handlers } = makeApi();
-
-    setCardContext("p1", { apiUrl: "https://p1.test", botToken: "bf", channelId: "g1", channelType: ChannelType.Group });
-    handlers.before_tool_call({ toolName: "read" }, { sessionKey: "p1" });
-    await vi.advanceTimersByTimeAsync(900); // flush 启动:gate 过,send 悬在 sendGate
-    await sendReached.promise;
-
-    // send 仍 in-flight(messageId 未就绪)时收尾 —— 旧实现会跳过终态帧。
-    const finalizing = finalizeCard("p1", { success: true });
-    sendGate.resolve(); // 放行 send 完成
-    await finalizing;
-
-    const edit = calls.find((c) => c.url.includes("/message/edit"));
-    expect(edit).toBeTruthy();
-    const env = JSON.parse(edit!.body!.content_edit as string);
-    expect(progressHeaderText(env.card)).toContain("✅ Done");
-    expect(env.transient).toBeUndefined(); // 终态帧进修订历史
-  });
-
-  it("P1(重叠 flush): 首帧 send 在途时第二个 debounce 到期,finalize 仍等真实 send", async () => {
-    const calls: Array<{ url: string; body: Record<string, unknown> | undefined }> = [];
-    const sendGate = makeDeferred();
-    const sendReached = makeDeferred();
-    let sendCount = 0;
-    const fn = vi.fn().mockImplementation(async (url: string, init?: { body?: string }) => {
-      calls.push({ url: String(url), body: init?.body ? JSON.parse(init.body) : undefined });
-      if (String(url).includes("/card/profile")) {
-        return { ok: true, status: 200, json: async () => ({ enabled: true }) };
-      }
-      if (String(url).includes("/sendMessage")) {
-        sendCount++;
-        sendReached.resolve();
-        await sendGate.promise; // 首帧 send 一直悬着
-        return { ok: true, status: 200, text: async () => JSON.stringify({ message_id: "card1" }) };
-      }
-      return { ok: true, status: 200, text: async () => "" };
-    });
-    global.fetch = fn as unknown as typeof fetch;
-    const { handlers } = makeApi();
-
-    setCardContext("p1b", { apiUrl: "https://p1b.test", botToken: "bf", channelId: "g1", channelType: ChannelType.Group });
-    handlers.before_tool_call({ toolName: "read", toolCallId: "A" }, { sessionKey: "p1b" });
-    await vi.advanceTimersByTimeAsync(900); // 首帧 flush 启动,send 悬在 sendGate
-    await sendReached.promise;
-
-    // 首帧 send 仍在途,再来一个事件 → 第二个 debounce 窗口到期(旧实现会用空转 flush 覆盖 flushPromise)
-    handlers.after_tool_call({ toolName: "read", toolCallId: "A", durationMs: 20 }, { sessionKey: "p1b" });
-    await vi.advanceTimersByTimeAsync(900);
-
-    const finalizing = finalizeCard("p1b", { success: true });
-    sendGate.resolve();
-    await finalizing;
-
-    expect(sendCount).toBe(1); // 只发一次首帧(无重复 send)
-    const edit = calls.find((c) => c.url.includes("/message/edit"));
-    expect(edit).toBeTruthy(); // 终态帧未丢
-    const env = JSON.parse(edit!.body!.content_edit as string);
-    expect(progressHeaderText(env.card)).toContain("✅ Done");
-  });
-
-  it("P2-a: gate 5xx 不缓存,下次 flush 重探成功仍能发卡", async () => {
-    const calls: Array<{ url: string }> = [];
-    let profileCall = 0;
-    const fn = vi.fn().mockImplementation(async (url: string) => {
-      calls.push({ url: String(url) });
-      if (String(url).includes("/card/profile")) {
-        profileCall++;
-        if (profileCall === 1) return { ok: false, status: 500, text: async () => "boom" };
-        return { ok: true, status: 200, json: async () => ({ enabled: true }) };
-      }
-      if (String(url).includes("/sendMessage")) {
-        return { ok: true, status: 200, text: async () => JSON.stringify({ message_id: "card1" }) };
-      }
-      return { ok: true, status: 200, text: async () => "" };
-    });
-    global.fetch = fn as unknown as typeof fetch;
-    const { handlers } = makeApi();
-
-    setCardContext("ga", { apiUrl: "https://ga.test", botToken: "bf", channelId: "g1", channelType: ChannelType.Group });
-    handlers.before_tool_call({ toolName: "read" }, { sessionKey: "ga" });
-    await vi.advanceTimersByTimeAsync(900); // 首次 gate 抛错 → 不缓存、不发卡
-    expect(calls.some((c) => c.url.includes("/sendMessage"))).toBe(false);
-
-    handlers.before_tool_call({ toolName: "read" }, { sessionKey: "ga" });
-    await vi.advanceTimersByTimeAsync(900); // 重探 gate → enabled → 发卡
-    expect(profileCall).toBe(2); // 未命中缓存,确实重探了
-    expect(calls.some((c) => c.url.includes("/sendMessage"))).toBe(true);
-  });
-
-  it("P2-b: 并发同名工具按 toolCallId 精确回填(不串到最后一个)", async () => {
-    const { fn, calls } = mockFetch();
-    global.fetch = fn as unknown as typeof fetch;
-    const { handlers } = makeApi();
-
-    setCardContext("tc", { apiUrl: "https://tc.test", botToken: "bf", channelId: "g1", channelType: ChannelType.Group });
-    // 两个并发 exec:A、B 都 running
-    handlers.before_tool_call({ toolName: "exec", toolCallId: "A", params: { command: "sleep 1" } }, { sessionKey: "tc" });
-    handlers.before_tool_call({ toolName: "exec", toolCallId: "B", params: { command: "sleep 2" } }, { sessionKey: "tc" });
-    // 先完成的是 A(不是最后 push 的 B)—— 旧逻辑会错标 B。
-    handlers.after_tool_call({ toolName: "exec", toolCallId: "A", durationMs: 50 }, { sessionKey: "tc" });
-    await vi.advanceTimersByTimeAsync(900);
-    await finalizeCard("tc", { success: true });
-
-    const edit = calls.filter((c) => c.url.includes("/message/edit")).pop();
-    expect(edit).toBeTruthy();
-    const env = JSON.parse(edit!.body!.content_edit as string);
-    const texts = progressDetailItems(env.card).map(elementText);
-    expect(texts[0]).toBe("⌨️ exec: sleep · 50ms"); // A 已完成
-    expect(texts[1]).toBe("⏳ exec: sleep");          // B 仍 running
-  });
-
-  it("P2-b(重复投递): toolCallId 命中失败不回退按名匹配,不误标并发步骤", async () => {
-    const { fn, calls } = mockFetch();
-    global.fetch = fn as unknown as typeof fetch;
-    const { handlers } = makeApi();
-
-    setCardContext("dup", { apiUrl: "https://dup.test", botToken: "bf", channelId: "g1", channelType: ChannelType.Group });
-    handlers.before_tool_call({ toolName: "exec", toolCallId: "A", params: { command: "sleep 1" } }, { sessionKey: "dup" });
-    handlers.before_tool_call({ toolName: "exec", toolCallId: "B", params: { command: "sleep 2" } }, { sessionKey: "dup" });
-    handlers.after_tool_call({ toolName: "exec", toolCallId: "A", durationMs: 50 }, { sessionKey: "dup" }); // A → done
-    // 同一 after 事件重复投递(at-least-once):A 已非 running,旧逻辑会回退把 B 误标 done。
-    handlers.after_tool_call({ toolName: "exec", toolCallId: "A", durationMs: 50 }, { sessionKey: "dup" });
-    await vi.advanceTimersByTimeAsync(900);
-    await finalizeCard("dup", { success: true });
-
-    const edit = calls.filter((c) => c.url.includes("/message/edit")).pop();
-    const env = JSON.parse(edit!.body!.content_edit as string);
-    const texts = progressDetailItems(env.card).map(elementText);
-    expect(texts[0]).toBe("⌨️ exec: sleep · 50ms"); // A done(只被标一次)
-    expect(texts[1]).toBe("⏳ exec: sleep");          // B 仍 running,未被重复事件误标
-  });
-
-  it("J1: finalize await 期间下一 run setCardContext,不误删新 run 的 entry", async () => {
-    const calls: Array<{ url: string; body: Record<string, unknown> | undefined }> = [];
-    const sendGate = makeDeferred();
-    const sendReached = makeDeferred();
-    let sendId = 0;
-    const fn = vi.fn().mockImplementation(async (url: string, init?: { body?: string }) => {
-      calls.push({ url: String(url), body: init?.body ? JSON.parse(init.body) : undefined });
-      if (String(url).includes("/card/profile")) {
-        return { ok: true, status: 200, json: async () => ({ enabled: true }) };
-      }
-      if (String(url).includes("/sendMessage")) {
-        sendId++;
-        if (sendId === 1) { sendReached.resolve(); await sendGate.promise; } // run1 首帧悬住
-        return { ok: true, status: 200, text: async () => JSON.stringify({ message_id: `card${sendId}` }) };
-      }
-      return { ok: true, status: 200, text: async () => "" };
-    });
-    global.fetch = fn as unknown as typeof fetch;
-    const { handlers } = makeApi();
-    const ctx = { apiUrl: "https://j1.test", botToken: "bf", channelId: "g1", channelType: ChannelType.Group };
-
-    setCardContext("S", ctx);
-    handlers.before_tool_call({ toolName: "read" }, { sessionKey: "S" });
-    await vi.advanceTimersByTimeAsync(900); // run1 flush 首帧 send 悬在 sendGate
-    await sendReached.promise;
-
-    const finalizing = finalizeCard("S", { success: true }); // 捕获 entry1,await 其 flushPromise
-    setCardContext("S", ctx);                                // 队列推进:同身份 run2 覆盖 Map
-    sendGate.resolve();                                       // 放行 run1 首帧完成 → finalize 恢复
-    await finalizing;
-
-    // run2 entry 未被误删:它的 before_tool_call 能发出自己的卡(否则无 entry → no-op)。
-    handlers.before_tool_call({ toolName: "read" }, { sessionKey: "S" });
-    await vi.advanceTimersByTimeAsync(900);
-    const sends = calls.filter((c) => c.url.includes("/sendMessage"));
-    expect(sends.length).toBe(2); // run1 card1 + run2 card2;若误删则仅 1
-  });
-
-  it("J2: 同 sessionKey 不同身份并发 → fail closed,两边都不发", async () => {
-    const { fn, calls } = mockFetch();
-    global.fetch = fn as unknown as typeof fetch;
-    const { handlers } = makeApi();
-
-    // 两个不同账号(不同频道)共享同一 sessionKey —— hook 侧无法区分。
-    setCardContext("X", { apiUrl: "https://a.test", botToken: "tA", channelId: "chA", channelType: ChannelType.Group });
-    setCardContext("X", { apiUrl: "https://a.test", botToken: "tB", channelId: "chB", channelType: ChannelType.Group });
-    handlers.before_tool_call({ toolName: "read" }, { sessionKey: "X" });
-    await vi.advanceTimersByTimeAsync(900);
-    expect(calls.length).toBe(0); // 碰撞 → 两边 skip,绝不发到任一频道
-  });
-
-  it("J2: 同 sessionKey 同身份(同账号下一 run)不算碰撞,正常发卡", async () => {
-    const { fn, calls } = mockFetch();
-    global.fetch = fn as unknown as typeof fetch;
-    const { handlers } = makeApi();
-    const ctx = { apiUrl: "https://same.test", botToken: "bf", channelId: "g1", channelType: ChannelType.Group };
-
-    setCardContext("Y", ctx);
-    setCardContext("Y", ctx); // 同身份重登记(如上一 run 尚未 finalize)→ 不 fail closed
-    handlers.before_tool_call({ toolName: "read" }, { sessionKey: "Y" });
-    await vi.advanceTimersByTimeAsync(900);
-    expect(calls.some((c) => c.url.includes("/sendMessage"))).toBe(true);
-  });
-
-  it("J2: 同 apiUrl+同频道但不同 botToken(两个账号同群回复)也 fail closed", async () => {
-    const { fn, calls } = mockFetch();
-    global.fetch = fn as unknown as typeof fetch;
-    const { handlers } = makeApi();
-
-    const base = { apiUrl: "https://a.test", channelId: "g1", channelType: ChannelType.Group };
-    setCardContext("Z", { ...base, botToken: "tokA" });
-    setCardContext("Z", { ...base, botToken: "tokB" }); // 仅 token 不同 → 仍视为跨身份碰撞
-    handlers.before_tool_call({ toolName: "read" }, { sessionKey: "Z" });
-    await vi.advanceTimersByTimeAsync(900);
-    expect(calls.length).toBe(0); // fail closed,两边都不发
-  });
-
-  it("影响项#2: 首帧 send 持续 4xx → fail-closed,不再重试", async () => {
-    const calls: string[] = [];
-    const fn = vi.fn().mockImplementation(async (url: string) => {
-      calls.push(String(url));
-      if (String(url).includes("/card/profile")) return { ok: true, status: 200, json: async () => ({ enabled: true }) };
-      if (String(url).includes("/sendMessage")) return { ok: false, status: 403, text: async () => "forbidden" };
-      return { ok: true, status: 200, text: async () => "" };
-    });
-    global.fetch = fn as unknown as typeof fetch;
-    const { handlers } = makeApi();
-
-    setCardContext("e4", { apiUrl: "https://e4.test", botToken: "bf", channelId: "g1", channelType: ChannelType.Group });
-    handlers.before_tool_call({ toolName: "read" }, { sessionKey: "e4" });
-    await vi.advanceTimersByTimeAsync(900); // 首帧 send → 403 抛错
-    const sends1 = calls.filter((c) => c.includes("/sendMessage")).length;
-    handlers.after_tool_call({ toolName: "read", durationMs: 5 }, { sessionKey: "e4" });
-    await vi.advanceTimersByTimeAsync(900); // 未 skip 则会再试一次
-    const sends2 = calls.filter((c) => c.includes("/sendMessage")).length;
-    expect(sends1).toBe(1);
-    expect(sends2).toBe(1); // 4xx → skip,没有第二次 send
-  });
-
-  it("影响项#2: 首帧 send 429/5xx 仍可重试(不 fail-closed)", async () => {
-    const calls: string[] = [];
-    let sendN = 0;
-    const fn = vi.fn().mockImplementation(async (url: string) => {
-      calls.push(String(url));
-      if (String(url).includes("/card/profile")) return { ok: true, status: 200, json: async () => ({ enabled: true }) };
-      if (String(url).includes("/sendMessage")) {
-        sendN++;
-        if (sendN === 1) return { ok: false, status: 429, text: async () => "rate limited" };
-        return { ok: true, status: 200, text: async () => JSON.stringify({ message_id: "card1" }) };
-      }
-      return { ok: true, status: 200, text: async () => "" };
-    });
-    global.fetch = fn as unknown as typeof fetch;
-    const { handlers } = makeApi();
-
-    setCardContext("e5", { apiUrl: "https://e5.test", botToken: "bf", channelId: "g1", channelType: ChannelType.Group });
-    handlers.before_tool_call({ toolName: "read" }, { sessionKey: "e5" });
-    await vi.advanceTimersByTimeAsync(900); // 首帧 429 抛错 → 不 skip
-    handlers.after_tool_call({ toolName: "read", durationMs: 5 }, { sessionKey: "e5" });
-    await vi.advanceTimersByTimeAsync(900); // 重试成功
-    expect(calls.filter((c) => c.includes("/sendMessage")).length).toBe(2);
-  });
-
-  it("影响项#P2-4: gate 瞬时失败后无新事件不再每 tick 重探", async () => {
-    const calls: string[] = [];
-    const fn = vi.fn().mockImplementation(async (url: string) => {
-      calls.push(String(url));
-      if (String(url).includes("/card/profile")) return { ok: false, status: 503, text: async () => "down" };
-      return { ok: true, status: 200, text: async () => "" };
-    });
-    global.fetch = fn as unknown as typeof fetch;
-    const { handlers } = makeApi();
-
-    setCardContext("g0", { apiUrl: "https://g0.test", botToken: "bf", channelId: "g1", channelType: ChannelType.Group });
-    handlers.before_tool_call({ toolName: "read" }, { sessionKey: "g0" });
-    await vi.advanceTimersByTimeAsync(900); // 首次 probe → 503 → null
-    const p1 = calls.filter((c) => c.includes("/card/profile")).length;
-    await vi.advanceTimersByTimeAsync(4000); // 无新事件,推进多个 debounce 周期
-    const p2 = calls.filter((c) => c.includes("/card/profile")).length;
-    expect(p1).toBe(1);
-    expect(p2).toBe(1); // 不再自动重探,等下个工具事件
-  });
-
-  it("波C: manifest advertise RichTextBlock → 进度卡按富文本行渲染(缺省则 TextBlock 平铺)", async () => {
-    const calls: Array<{ url: string; body: Record<string, unknown> | undefined }> = [];
-    const fn = vi.fn().mockImplementation(async (url: string, init?: { body?: string }) => {
-      calls.push({ url: String(url), body: init?.body ? JSON.parse(init.body) : undefined });
-      if (String(url).includes("/card/profile")) {
-        return {
-          ok: true,
-          status: 200,
-          json: async () => ({
-            enabled: true,
-            profiles: ["octo/v1"],
-            // 真实 im-test 部署 advertise 的元素超集(P1-d 起进度卡优先 RichTextBlock 而非 ColumnSet:
-            // 解决服务端权威重算 plain 时 ColumnSet 图标/文本分行的问题)
-            elements: ["TextBlock", "RichTextBlock", "Container", "ColumnSet", "FactSet"],
-            limits: { max_nodes: 200 },
-          }),
-        };
-      }
-      if (String(url).includes("/sendMessage")) return { ok: true, status: 200, text: async () => JSON.stringify({ message_id: "card1" }) };
-      return { ok: true, status: 200, text: async () => "" };
-    });
-    global.fetch = fn as unknown as typeof fetch;
-    const { handlers } = makeApi();
-
-    setCardContext("wc", { apiUrl: "https://wc.test", botToken: "bf", channelId: "g1", channelType: ChannelType.Group });
-    handlers.before_tool_call({ toolName: "exec", params: { command: "ls" } }, { sessionKey: "wc" });
-    await vi.advanceTimersByTimeAsync(900);
-
-    const send = calls.find((c) => c.url.includes("/sendMessage"));
-    expect(send).toBeTruthy();
-    const card = (send!.body!.payload as {
-      card: { body: Array<{ type: string; items?: Array<{ type: string }> }> };
-    }).card;
-    expect(card.body[0].type).toBe("ColumnSet");
-    expect(card.body[1].type).toBe("Container"); // timeline_detail
-    expect(card.body[1].items?.[0]?.type).toBe("Container"); // timeline 步骤组
-    expect((card.body[1].items?.[0] as { items?: Array<{ type: string }> }).items?.[0]?.type).toBe("RichTextBlock"); // 组内仍是富文本行
-  });
-
-  it("波C: manifest advertise Action.ToggleVisibility → 终态 edit 折叠 thinking/tool 明细", async () => {
-    const calls: Array<{ url: string; body: Record<string, unknown> | undefined }> = [];
-    const fn = vi.fn().mockImplementation(async (url: string, init?: { body?: string }) => {
-      calls.push({ url: String(url), body: init?.body ? JSON.parse(init.body) : undefined });
-      if (String(url).includes("/card/profile")) {
-        return {
-          ok: true,
-          status: 200,
-          json: async () => ({
-            enabled: true,
-            profiles: ["octo/v1"],
-            elements: ["TextBlock", "RichTextBlock", "Container", "ColumnSet", "ActionSet"],
-            actions: ["Action.ToggleVisibility"],
-            limits: { max_nodes: 200 },
-          }),
-        };
-      }
-      if (String(url).includes("/sendMessage")) return { ok: true, status: 200, text: async () => JSON.stringify({ message_id: "card1" }) };
-      return { ok: true, status: 200, text: async () => "" };
-    });
-    global.fetch = fn as unknown as typeof fetch;
-    const { handlers } = makeApi();
-
-    setCardContext("wc-toggle", { apiUrl: "https://wc-toggle.test", botToken: "bf", channelId: "g1", channelType: ChannelType.Group });
-    handlers.model_call_started({}, { sessionKey: "wc-toggle" });
-    await vi.advanceTimersByTimeAsync(100);
-    handlers.before_tool_call({ toolName: "exec", toolCallId: "e1", params: { command: "find src" } }, { sessionKey: "wc-toggle" });
-    handlers.after_tool_call({ toolName: "exec", toolCallId: "e1", durationMs: 50 }, { sessionKey: "wc-toggle" });
-    await vi.advanceTimersByTimeAsync(900);
-
-    await finalizeCard("wc-toggle", { success: true });
-    const edit = calls.filter((c) => c.url.includes("/message/edit")).pop();
-    expect(edit).toBeTruthy();
-    const env = JSON.parse(edit!.body!.content_edit as string);
-    expect(env.card.metadata).toEqual({ octo_layout: OCTO_CARD_LAYOUTS.agentProgressV1 });
-    const body = env.card.body as Array<Record<string, unknown>>;
-    expect(body[0].type).toBe("ColumnSet");
-    const summaryHeader = body[0] as { columns: Array<{ width: string; items: Array<Record<string, unknown>> }> };
-    const headerBlock = summaryHeader.columns[0].items[0] as { type: string; inlines: Array<Record<string, unknown>> };
-    expect(headerBlock.type).toBe("RichTextBlock");
-    expect(headerBlock.inlines[0]).toMatchObject({ text: "✅ Done", weight: "Bolder" });
-    const summaryBlock = summaryHeader.columns[0].items[1] as { type: string; inlines: Array<Record<string, unknown>> };
-    expect(summaryBlock.inlines[0]).toMatchObject({ text: "Reasoning 1 · Tools 1", isSubtle: true });
-    const collapseBtn = summaryHeader.columns[1].items[0] as { id: string; isVisible: boolean; actions: Array<Record<string, unknown>> };
-    const expandBtn = summaryHeader.columns[1].items[1] as { id: string; isVisible: boolean; actions: Array<Record<string, unknown>> };
-    expect(collapseBtn.isVisible).toBe(false);
-    expect(expandBtn.isVisible).toBe(true);
-    expect(collapseBtn.actions[0]).toMatchObject({ type: "Action.ToggleVisibility", title: "Hide details" });
-    expect(expandBtn.actions[0]).toMatchObject({ type: "Action.ToggleVisibility", title: "Show details" });
-    expect((body[1] as { type: string; id: string; isVisible: boolean }).type).toBe("Container");
-    expect((body[1] as { id: string }).id).toBe("timeline_detail");
-    expect((body[1] as { isVisible: boolean }).isVisible).toBe(false);
-    expect(collapseBtn.actions[0].targetElements).toEqual([
-      { elementId: (body[1] as { id: string }).id, isVisible: false },
-      { elementId: collapseBtn.id, isVisible: false },
-      { elementId: expandBtn.id, isVisible: true },
-    ]);
-    expect(JSON.stringify(body[1])).toContain("exec");
-  });
-
-  it("P1-g: model_call_started 产 running thinking step,before_tool_call 结束它(标 done + durationMs)", async () => {
-    const { fn, calls } = mockFetch();
-    global.fetch = fn as unknown as typeof fetch;
-    const { handlers } = makeApi();
-    setCardContext("tk1", { apiUrl: "https://tk1.test", botToken: "bf", channelId: "g", channelType: ChannelType.Group });
-
-    // 起 thinking(agent 首次调 model 决定用哪个工具)
-    handlers.model_call_started({}, { sessionKey: "tk1" });
-    // 100ms 后开始调 tool —— thinking 结束
-    await vi.advanceTimersByTimeAsync(100);
-    handlers.before_tool_call({ toolName: "read", params: { path: "/a" }, toolCallId: "r1" }, { sessionKey: "tk1" });
-    handlers.after_tool_call({ toolName: "read", toolCallId: "r1", durationMs: 50 }, { sessionKey: "tk1" });
-    await vi.advanceTimersByTimeAsync(900);
-
-    const send = calls.find((c) => c.url.includes("/sendMessage"));
-    expect(send).toBeTruthy();
-    const card = (send!.body!.payload as { card: { body: Array<Record<string, unknown>> } }).card;
-    // 首帧应含:header + thinking(done) + read(running/done)
-    const joined = progressCardText(card);
-    expect(joined).toContain("💭 Reasoning"); // thinking step 出现
-    expect(joined).toContain("read");  // 后续 tool step 也在
-  });
-
-  it("captures reasoning snapshots and tool output summaries into the contract card", async () => {
-    const calls: Array<{ url: string; body: Record<string, unknown> | undefined }> = [];
-    const fn = vi.fn().mockImplementation(async (url: string, init?: { body?: string }) => {
-      calls.push({ url: String(url), body: init?.body ? JSON.parse(init.body) : undefined });
-      if (String(url).includes("/card/profile")) {
-        return {
-          ok: true,
-          status: 200,
-          json: async () => ({
-            enabled: true,
-            profiles: ["octo/v1"],
-            elements: ["TextBlock", "Container", "ColumnSet", "ActionSet"],
-            actions: ["Action.ToggleVisibility"],
-            limits: { max_nodes: 200 },
-          }),
-        };
-      }
-      if (String(url).includes("/sendMessage")) {
-        return { ok: true, status: 200, text: async () => JSON.stringify({ message_id: "reasoning-card" }) };
-      }
-      return { ok: true, status: 200, text: async () => "" };
-    });
-    global.fetch = fn as unknown as typeof fetch;
-    const { handlers } = makeApi();
-    const ctx = { sessionKey: "reasoning-capture", runId: "run-1" };
-
-    setCardContext("reasoning-capture", {
-      apiUrl: "https://reasoning.test",
-      botToken: "bf",
-      channelId: "g",
-      channelType: ChannelType.Group,
-      reasoningVisibility: "stream",
-    });
-    handlers.before_agent_run({}, ctx);
-    handlers.model_call_started({ callId: "call-1" }, ctx);
-    recordCardReasoning("reasoning-capture", "partial text", { snapshot: false });
-    recordCardReasoning("reasoning-capture", "先核对仓库，再执行测试。", { snapshot: true });
-    handlers.before_tool_call(
-      { toolName: "exec", toolCallId: "tool-1", params: { command: "npm test" } },
-      ctx,
-    );
-    handlers.after_tool_call({
-      toolName: "exec",
-      toolCallId: "tool-1",
-      durationMs: 50,
-      result: {
-        details: { exitCode: 0, status: "completed" },
-        content: [{ type: "text", text: "Authorization: Bearer should-not-render" }],
-      },
-    }, ctx);
-    await vi.advanceTimersByTimeAsync(900);
-
-    const send = calls.find((call) => call.url.includes("/sendMessage"));
-    expect(send).toBeTruthy();
-    const card = (send!.body!.payload as { card: { body: Array<Record<string, unknown>> } }).card;
-    const text = progressCardText(card);
-    expect(text).toContain("先核对仓库，再执行测试。");
-    expect(text).not.toContain("partial text");
-    expect(text).toContain("exec");
-    expect(text).toContain("npm");
-    expect(text).toContain("exit 0");
-    expect(text).not.toContain("should-not-render");
-  });
-
-  it("captures host thinking agent events as reasoning snapshots", async () => {
-    const { fn, calls } = mockFetch();
-    global.fetch = fn as unknown as typeof fetch;
-    const { handlers, emitAgentEvent } = makeApi();
-    const ctx = { sessionKey: "reasoning-agent-event", runId: "run-1" };
-
-    setCardContext("reasoning-agent-event", {
-      apiUrl: "https://reasoning-event.test",
-      botToken: "bf",
-      channelId: "g",
-      channelType: ChannelType.Group,
-      reasoningVisibility: "stream",
-    });
-    handlers.before_agent_run({}, ctx);
-    handlers.model_call_started({ callId: "call-1" }, ctx);
-    await emitAgentEvent({
-      runId: "run-1",
-      sessionKey: "reasoning-agent-event",
-      stream: "thinking",
-      data: {
-        text: "Inspect the tool input before running it.",
-        delta: "Inspect the tool input before running it.",
-      },
-    });
-    handlers.before_tool_call(
-      { toolName: "exec", toolCallId: "tool-1", params: { command: "printf ok" } },
-      ctx,
-    );
-    handlers.after_tool_call({
-      toolName: "exec",
-      toolCallId: "tool-1",
-      result: { details: { exitCode: 0 } },
-    }, ctx);
-    await vi.advanceTimersByTimeAsync(900);
-
-    const send = calls.find((call) => call.url.includes("/sendMessage"));
-    expect(send).toBeTruthy();
-    const card = (send!.body!.payload as { card: { body: Array<Record<string, unknown>> } }).card;
-    expect(progressCardText(card)).toContain("Inspect the tool input before running it.");
-    expect(progressCardText(card)).toContain("exec");
-    expect(progressCardText(card)).toContain("printf");
-    expect(progressCardText(card)).toContain("exit 0");
-  });
-
-  it("registers only run-aware reasoning capture lanes", async () => {
-    const { fn, calls } = mockFetch();
-    global.fetch = fn as unknown as typeof fetch;
-    const { handlers, emitAgentEvent } = makeApi();
-    const { handlers: legacyHandlers } = makeApi({ lifecycle: false });
-
-    expect(handlers.before_message_write).toBeUndefined();
-    expect(handlers.llm_output).toBeTypeOf("function");
-    expect(legacyHandlers.before_message_write).toBeUndefined();
-    expect(legacyHandlers.llm_output).toBeTypeOf("function");
-
-    setCardContext("reasoning-stale-message-write", {
-      apiUrl: "https://reasoning-stale-write.test",
-      botToken: "bf",
-      channelId: "g",
-      channelType: ChannelType.Group,
-      reasoningVisibility: "stream",
-    });
-    const oldCtx = { sessionKey: "reasoning-stale-message-write", runId: "run-old" };
-    handlers.before_agent_run({}, oldCtx);
-    handlers.model_call_started({ callId: "call-old" }, oldCtx);
-
-    setCardContext("reasoning-stale-message-write", {
-      apiUrl: "https://reasoning-stale-write.test",
-      botToken: "bf",
-      channelId: "g",
-      channelType: ChannelType.Group,
-      reasoningVisibility: "stream",
-    });
-    const currentCtx = { sessionKey: "reasoning-stale-message-write", runId: "run-current" };
-    handlers.before_agent_run({}, currentCtx);
-    handlers.model_call_started({ callId: "call-current" }, currentCtx);
-
-    handlers.model_call_ended({ callId: "call-old", outcome: "completed" }, oldCtx);
-    handlers.before_message_write?.({
-      sessionKey: "reasoning-stale-message-write",
-      message: {
-        role: "assistant",
-        content: [{ type: "thinking", thinking: "STALE PRIVATE REASONING" }],
-      },
-    }, {});
-    handlers.llm_output({
-      runId: "run-old",
-      lastAssistant: {
-        role: "assistant",
-        content: [{ type: "thinking", thinking: "STALE PRIVATE REASONING" }],
-      },
-    }, { sessionKey: "reasoning-stale-message-write", runId: "run-old" });
-    await emitAgentEvent({
-      runId: "run-old",
-      sessionKey: "reasoning-stale-message-write",
-      stream: "thinking",
-      data: { text: "STALE PRIVATE REASONING" },
-    });
-    handlers.model_call_ended({ callId: "call-current", outcome: "completed" }, currentCtx);
-    // 当前 run 的推理仅由带 runId 的车道(thinking 订阅 / llm_output)负责。
-    handlers.before_message_write?.({
-      sessionKey: "reasoning-stale-message-write",
-      message: {
-        role: "assistant",
-        content: [{ type: "thinking", thinking: "CURRENT VISIBLE REASONING" }],
-      },
-    }, {});
-    await emitAgentEvent({
-      runId: "run-current",
-      sessionKey: "reasoning-stale-message-write",
-      stream: "thinking",
-      data: { text: "CURRENT VISIBLE REASONING" },
-    });
-    handlers.before_tool_call({ toolName: "read", toolCallId: "tool-current" }, currentCtx);
-    handlers.after_tool_call({ toolName: "read", toolCallId: "tool-current" }, currentCtx);
-    await vi.advanceTimersByTimeAsync(900);
-
-    const send = calls.find((call) => call.url.includes("/sendMessage"));
-    expect(send).toBeTruthy();
-    const card = (send!.body!.payload as { card: { body: Array<Record<string, unknown>> } }).card;
-    expect(progressCardText(card)).not.toContain("STALE PRIVATE REASONING");
-    expect(progressCardText(card)).toContain("CURRENT VISIBLE REASONING");
-  });
-
-  it("model_call_ended 逆序到达时,被取代 run 的 reasoning-off 思考不得写入替换后的卡", async () => {
-    // P1-1:host 用 fire-and-forget 有界队列派发 model_call_ended(可丢弃),而
-    // before_message_write 在 appendMessage 里同步执行 —— 被取代的慢 run 的 token 完全
-    // 可能后到。此时 FIFO 队首属于**替换后**的 run,取队首会把 reasoning 关闭那轮的
-    // 私有思考按新一轮的可见性发到频道,并顶掉当前轮自己的写入。
-    const { fn, calls } = mockFetch();
-    global.fetch = fn as unknown as typeof fetch;
-    const { handlers } = makeApi();
-    const sessionKey = "reasoning-reversed-model-end";
-    const base = {
-      apiUrl: "https://reasoning-reversed.test",
-      botToken: "bf",
-      channelId: "g",
-      channelType: ChannelType.Group,
-    };
-
-    setCardContext(sessionKey, { ...base, reasoningVisibility: "off" });
-    const oldCtx = { sessionKey, runId: "run-old" };
-    handlers.before_agent_run({}, oldCtx);
-    handlers.model_call_started({ callId: "call-old" }, oldCtx);
-
-    setCardContext(sessionKey, { ...base, reasoningVisibility: "stream" });
-    const currentCtx = { sessionKey, runId: "run-current" };
-    handlers.before_agent_run({}, currentCtx);
-    handlers.model_call_started({ callId: "call-current" }, currentCtx);
-
-    // 逆序:替换后 run 的 model_call_ended 先落,被取代 run 的后落。
-    handlers.model_call_ended({ callId: "call-current", outcome: "completed" }, currentCtx);
-    handlers.model_call_ended({ callId: "call-old", outcome: "completed" }, oldCtx);
-
-    handlers.before_message_write?.({
-      sessionKey,
-      message: { role: "assistant", content: [{ type: "thinking", thinking: "STALE PRIVATE REASONING" }] },
-    }, {});
-    handlers.before_message_write?.({
-      sessionKey,
-      message: { role: "assistant", content: [{ type: "thinking", thinking: "ALSO UNATTRIBUTABLE" }] },
-    }, {});
-    handlers.before_tool_call({ toolName: "read", toolCallId: "tool-current" }, currentCtx);
-    handlers.after_tool_call({ toolName: "read", toolCallId: "tool-current", durationMs: 20 }, currentCtx);
-    await vi.advanceTimersByTimeAsync(900);
-
-    const send = calls.find((call) => call.url.includes("/sendMessage"));
-    expect(send).toBeTruthy();
-    const card = (send!.body!.payload as { card: { body: Array<Record<string, unknown>> } }).card;
-    const text = progressCardText(card);
-    expect(text).not.toContain("STALE PRIVATE REASONING");
-    expect(text).not.toContain("ALSO UNATTRIBUTABLE");
-    expect(text).toContain("📖 read · 20ms");
-  });
-
-  it("yielded reasoning-off run 无 token 的迟到写入不得借用新 run token 公开私有思考", async () => {
-    const { fn, calls } = mockFetch();
-    global.fetch = fn as unknown as typeof fetch;
-    const { handlers } = makeApi();
-    const sessionKey = "reasoning-yielded-tokenless-write";
-    const base = {
-      apiUrl: "https://reasoning-yielded-tokenless.test",
-      botToken: "bf",
-      channelId: "g",
-      channelType: ChannelType.Group,
-    };
-
-    setCardContext(sessionKey, { ...base, reasoningVisibility: "off" });
-    const oldCtx = { sessionKey, runId: "run-old" };
-    handlers.before_agent_run({}, oldCtx);
-    handlers.model_call_started({ callId: "call-old-1" }, oldCtx);
-    handlers.before_tool_call({ toolName: "read", toolCallId: "old-read" }, oldCtx);
-    handlers.after_tool_call({ toolName: "read", toolCallId: "old-read", durationMs: 10 }, oldCtx);
-    await vi.advanceTimersByTimeAsync(900);
-    expect(calls.some((call) => call.url.includes("/sendMessage"))).toBe(true);
-
-    handlers.before_tool_call({ toolName: "sessions_yield", toolCallId: "old-yield" }, oldCtx);
-    handlers.after_tool_call({
-      toolName: "sessions_yield",
-      toolCallId: "old-yield",
-      result: {},
-    }, oldCtx);
-    await vi.advanceTimersByTimeAsync(900);
-    await finalizeCard(sessionKey, { success: true });
-    calls.length = 0;
-
-    // Yield 后旧 generation 仍可继续跑 model call，但 cards 中已无它，因此
-    // model_call_ended 不会留下 token。
-    handlers.model_call_started({ callId: "call-old-2" }, oldCtx);
-    handlers.model_call_ended({ callId: "call-old-2", outcome: "completed" }, oldCtx);
-
-    setCardContext(sessionKey, { ...base, reasoningVisibility: "stream" });
-    const currentCtx = { sessionKey, runId: "run-current" };
-    handlers.before_agent_run({}, currentCtx);
-    handlers.model_call_started({ callId: "call-current" }, currentCtx);
-    handlers.model_call_ended({ callId: "call-current", outcome: "completed" }, currentCtx);
-
-    // 无 runId 的旧写入此时只看到新 run 的 token，绝不能将它当作归属依据。
-    handlers.before_message_write?.({
-      sessionKey,
-      message: {
-        role: "assistant",
-        content: [{ type: "thinking", thinking: "YIELDED PRIVATE REASONING" }],
-      },
-    }, {});
-    handlers.before_tool_call({ toolName: "read", toolCallId: "current-read" }, currentCtx);
-    handlers.after_tool_call({
-      toolName: "read",
-      toolCallId: "current-read",
-      durationMs: 20,
-    }, currentCtx);
-    await vi.advanceTimersByTimeAsync(900);
-
-    const send = calls.find((call) => call.url.includes("/sendMessage"));
-    expect(send).toBeTruthy();
-    const card = (send!.body!.payload as { card: { body: Array<Record<string, unknown>> } }).card;
-    expect(progressCardText(card)).not.toContain("YIELDED PRIVATE REASONING");
-  });
-
-  it("旧 run 丢失 model_call_ended 时的迟到写入不得借用新 run token 公开私有思考", async () => {
-    const { fn, calls } = mockFetch();
-    global.fetch = fn as unknown as typeof fetch;
-    const { handlers } = makeApi();
-    const sessionKey = "reasoning-dropped-token-write";
-    const base = {
-      apiUrl: "https://reasoning-dropped-token.test",
-      botToken: "bf",
-      channelId: "g",
-      channelType: ChannelType.Group,
-    };
-
-    setCardContext(sessionKey, { ...base, reasoningVisibility: "off" });
-    const oldCtx = { sessionKey, runId: "run-old" };
-    handlers.before_agent_run({}, oldCtx);
-    handlers.model_call_started({ callId: "call-old" }, oldCtx);
-    // 旧 run 的 model_call_ended 被 host 有界队列丢弃，所以它没有 token。
-
-    setCardContext(sessionKey, { ...base, reasoningVisibility: "stream" });
-    const currentCtx = { sessionKey, runId: "run-current" };
-    handlers.before_agent_run({}, currentCtx);
-    handlers.model_call_started({ callId: "call-current" }, currentCtx);
-    handlers.model_call_ended({ callId: "call-current", outcome: "completed" }, currentCtx);
-
-    handlers.before_message_write?.({
-      sessionKey,
-      message: {
-        role: "assistant",
-        content: [{ type: "thinking", thinking: "DROPPED TOKEN PRIVATE REASONING" }],
-      },
-    }, {});
-    handlers.before_tool_call({ toolName: "read", toolCallId: "current-read" }, currentCtx);
-    handlers.after_tool_call({
-      toolName: "read",
-      toolCallId: "current-read",
-      durationMs: 20,
-    }, currentCtx);
-    await vi.advanceTimersByTimeAsync(900);
-
-    const send = calls.find((call) => call.url.includes("/sendMessage"));
-    expect(send).toBeTruthy();
-    const card = (send!.body!.payload as { card: { body: Array<Record<string, unknown>> } }).card;
-    expect(progressCardText(card)).not.toContain("DROPPED TOKEN PRIVATE REASONING");
-  });
-
-  it("单 run 的多次 thinking agent event 仍可按 runId 捕获中间思考", async () => {
-    const { fn, calls } = mockFetch();
-    global.fetch = fn as unknown as typeof fetch;
-    const { handlers, emitAgentEvent } = makeApi();
-    const sessionKey = "reasoning-owned-model-write";
-    const ctx = { sessionKey, runId: "run-1" };
-
-    setCardContext(sessionKey, {
-      apiUrl: "https://reasoning-owned.test",
-      botToken: "bf",
-      channelId: "g",
-      channelType: ChannelType.Group,
-      reasoningVisibility: "stream",
-    });
-    handlers.before_agent_run({}, ctx);
-    handlers.model_call_started({ callId: "call-1" }, ctx);
-    handlers.model_call_ended({ callId: "call-1", outcome: "completed" }, ctx);
-    await emitAgentEvent({
-      runId: "run-1",
-      sessionKey,
-      stream: "thinking",
-      data: { text: "FIRST INTERMEDIATE BLOCK" },
-    });
-    handlers.before_tool_call({ toolName: "read", toolCallId: "tool-1" }, ctx);
-    handlers.after_tool_call({ toolName: "read", toolCallId: "tool-1", durationMs: 20 }, ctx);
-    handlers.model_call_started({ callId: "call-2" }, ctx);
-    handlers.model_call_ended({ callId: "call-2", outcome: "completed" }, ctx);
-    await emitAgentEvent({
-      runId: "run-1",
-      sessionKey,
-      stream: "thinking",
-      data: { text: "SECOND INTERMEDIATE BLOCK" },
-    });
-    await vi.advanceTimersByTimeAsync(900);
-
-    const send = calls.find((call) => call.url.includes("/sendMessage"));
-    expect(send).toBeTruthy();
-    const card = (send!.body!.payload as { card: { body: Array<Record<string, unknown>> } }).card;
-    const text = progressCardText(card);
-    expect(text).toContain("FIRST INTERMEDIATE BLOCK");
-    expect(text).toContain("SECOND INTERMEDIATE BLOCK");
-  });
-
-  it("createCardReasoningRecorder 丢弃 entry 被替换后的迟到回调", async () => {
-    const { fn, calls } = mockFetch();
-    global.fetch = fn as unknown as typeof fetch;
-    const { handlers } = makeApi();
-    const sessionKey = "reasoning-recorder-generation";
-    const cardCtx = {
-      apiUrl: "https://reasoning-recorder.test",
-      botToken: "bf",
-      channelId: "g",
-      channelType: ChannelType.Group,
-      reasoningVisibility: "stream" as const,
-    };
-
-    setCardContext(sessionKey, cardCtx);
-    // dispatch 侧在 setCardContext 之后立刻取 recorder,绑定的是当时那个 generation。
-    const staleRecorder = createCardReasoningRecorder(sessionKey);
-    const oldCtx = { sessionKey, runId: "run-old" };
-    handlers.before_agent_run({}, oldCtx);
-    handlers.model_call_started({ callId: "call-old" }, oldCtx);
-
-    // 同 sessionKey 的下一 run 替换 entry(cards.set 换对象 = generation fence)。
-    setCardContext(sessionKey, cardCtx);
-    const currentRecorder = createCardReasoningRecorder(sessionKey);
-    const currentCtx = { sessionKey, runId: "run-current" };
-    handlers.before_agent_run({}, currentCtx);
-    handlers.model_call_started({ callId: "call-current" }, currentCtx);
-
-    staleRecorder("STALE GENERATION REASONING", { snapshot: true });
-    currentRecorder("CURRENT GENERATION REASONING", { snapshot: true });
-    handlers.before_tool_call({ toolName: "read", toolCallId: "tool-current" }, currentCtx);
-    handlers.after_tool_call({ toolName: "read", toolCallId: "tool-current", durationMs: 20 }, currentCtx);
-    await vi.advanceTimersByTimeAsync(900);
-
-    const send = calls.find((call) => call.url.includes("/sendMessage"));
-    expect(send).toBeTruthy();
-    const card = (send!.body!.payload as { card: { body: Array<Record<string, unknown>> } }).card;
-    expect(progressCardText(card)).not.toContain("STALE GENERATION REASONING");
-    expect(progressCardText(card)).toContain("CURRENT GENERATION REASONING");
-  });
-
-  it("createCardReasoningRecorder 在 reasoning 关闭的 generation 上不记录任何文本", async () => {
-    const { fn, calls } = mockFetch();
-    global.fetch = fn as unknown as typeof fetch;
-    const { handlers } = makeApi();
-    const sessionKey = "reasoning-recorder-off";
-    const ctx = { sessionKey, runId: "run-1" };
-
-    setCardContext(sessionKey, {
-      apiUrl: "https://reasoning-recorder-off.test",
-      botToken: "bf",
-      channelId: "g",
-      channelType: ChannelType.Group,
-      reasoningVisibility: "off",
-    });
-    const recorder = createCardReasoningRecorder(sessionKey);
-    handlers.before_agent_run({}, ctx);
-    handlers.model_call_started({ callId: "call-1" }, ctx);
-    recorder("MUST STAY HIDDEN FROM RECORDER", { snapshot: true });
-    handlers.before_tool_call({ toolName: "read", toolCallId: "tool-1" }, ctx);
-    handlers.after_tool_call({ toolName: "read", toolCallId: "tool-1", durationMs: 20 }, ctx);
-    await vi.advanceTimersByTimeAsync(900);
-
-    const send = calls.find((call) => call.url.includes("/sendMessage"));
-    expect(send).toBeTruthy();
-    const card = (send!.body!.payload as { card: { body: Array<Record<string, unknown>> } }).card;
-    expect(progressCardText(card)).not.toContain("MUST STAY HIDDEN FROM RECORDER");
-    expect(progressCardText(card)).toContain("📖 read · 20ms");
-  });
-
-  it("recordCardReasoning sink 在 reasoning 关闭时拒绝直接写入", async () => {
-    const { fn, calls } = mockFetch({ profile: registryProfile() });
-    global.fetch = fn as unknown as typeof fetch;
-    const { handlers } = makeApi();
-    const sessionKey = "reasoning-sink-off";
-    const ctx = { sessionKey, runId: "run-1" };
-
-    setCardContext(sessionKey, {
-      apiUrl: "https://reasoning-sink-off.test",
-      botToken: "bf",
-      channelId: "g",
-      channelType: ChannelType.Group,
-      reasoningVisibility: "off",
-      reasoningCardTemplateMode: "experimental",
-    });
-    handlers.before_agent_run({}, ctx);
-    handlers.model_call_started({ callId: "call-1" }, ctx);
-    recordCardReasoning(sessionKey, "DIRECT SINK WRITE MUST STAY HIDDEN", { snapshot: true });
-    handlers.before_tool_call({ toolName: "read", toolCallId: "tool-1" }, ctx);
-    handlers.after_tool_call({ toolName: "read", toolCallId: "tool-1", durationMs: 20 }, ctx);
-    await vi.advanceTimersByTimeAsync(900);
-
-    const send = calls.find((call) => call.url.includes("/sendMessage"));
-    expect(send).toBeTruthy();
-    expect(JSON.stringify(send!.body!.payload)).not.toContain("DIRECT SINK WRITE MUST STAY HIDDEN");
-  });
-
-  it("keeps host thinking agent events hidden when reasoning visibility is off", async () => {
-    const { fn, calls } = mockFetch();
-    global.fetch = fn as unknown as typeof fetch;
-    const { handlers, emitAgentEvent } = makeApi();
-    const ctx = { sessionKey: "reasoning-agent-event-hidden", runId: "run-1" };
-
-    setCardContext("reasoning-agent-event-hidden", {
-      apiUrl: "https://reasoning-event-hidden.test",
-      botToken: "bf",
-      channelId: "g",
-      channelType: ChannelType.Group,
-      reasoningVisibility: "off",
-    });
-    handlers.before_agent_run({}, ctx);
-    handlers.model_call_started({ callId: "call-1" }, ctx);
-    await emitAgentEvent({
-      runId: "run-1",
-      sessionKey: "reasoning-agent-event-hidden",
-      stream: "thinking",
-      data: { text: "MUST STAY HIDDEN FROM THINKING EVENTS" },
-    });
-    handlers.before_tool_call({ toolName: "read", toolCallId: "tool-1" }, ctx);
-    handlers.after_tool_call({ toolName: "read", toolCallId: "tool-1", durationMs: 20 }, ctx);
-    await vi.advanceTimersByTimeAsync(900);
-
-    const send = calls.find((call) => call.url.includes("/sendMessage"));
-    expect(send).toBeTruthy();
-    const card = (send!.body!.payload as { card: { body: Array<Record<string, unknown>> } }).card;
-    expect(progressCardText(card)).not.toContain("MUST STAY HIDDEN");
-    expect(progressCardText(card)).not.toContain("Thinking through…");
-    expect(progressCardText(card)).toContain("Reasoning 1 · Tools 1");
-    expect(progressCardText(card)).toContain("📖 read · 20ms");
-  });
-
-  it("captures persisted thinking blocks only when reasoning visibility is enabled", async () => {
-    const { fn, calls } = mockFetch();
-    global.fetch = fn as unknown as typeof fetch;
-    const { handlers } = makeApi();
-    const ctx = { sessionKey: "reasoning-message-write", runId: "run-1" };
-
-    setCardContext("reasoning-message-write", {
-      apiUrl: "https://reasoning-write.test",
-      botToken: "bf",
-      channelId: "g",
-      channelType: ChannelType.Group,
-      reasoningVisibility: "stream",
-    });
-    handlers.before_agent_run({}, ctx);
-    handlers.model_call_started({ callId: "call-1" }, ctx);
-    handlers.llm_output({
-      runId: "run-1",
-      lastAssistant: {
-        role: "assistant",
-        content: [{
-          type: "thinking",
-          thinking: "Read the command input, then verify its exit status.",
-          thinkingSignature: "reasoning_content",
-        }],
-      },
-    }, ctx);
-    handlers.before_tool_call(
-      { toolName: "exec", toolCallId: "tool-1", params: { command: "printf ok" } },
-      ctx,
-    );
-    handlers.after_tool_call({
-      toolName: "exec",
-      toolCallId: "tool-1",
-      result: { details: { exitCode: 0 } },
-    }, ctx);
-    await vi.advanceTimersByTimeAsync(900);
-
-    const send = calls.find((call) => call.url.includes("/sendMessage"));
-    expect(send).toBeTruthy();
-    const card = (send!.body!.payload as { card: { body: Array<Record<string, unknown>> } }).card;
-    expect(progressCardText(card)).toContain("Read the command input, then verify its exit status.");
-  });
-
-  it("keeps persisted thinking blocks hidden when reasoning visibility is off", async () => {
-    const { fn, calls } = mockFetch();
-    global.fetch = fn as unknown as typeof fetch;
-    const { handlers } = makeApi();
-    const ctx = { sessionKey: "reasoning-hidden", runId: "run-1" };
-
-    setCardContext("reasoning-hidden", {
-      apiUrl: "https://reasoning-hidden.test",
-      botToken: "bf",
-      channelId: "g",
-      channelType: ChannelType.Group,
-      reasoningVisibility: "off",
-    });
-    handlers.before_agent_run({}, ctx);
-    handlers.model_call_started({ callId: "call-1" }, ctx);
-    handlers.llm_output({
-      runId: "run-1",
-      lastAssistant: {
-        role: "assistant",
-        content: [{ type: "thinking", thinking: "MUST STAY HIDDEN" }],
-      },
-    }, ctx);
-    handlers.before_tool_call({ toolName: "read", toolCallId: "tool-1" }, ctx);
-    await vi.advanceTimersByTimeAsync(900);
-
-    const send = calls.find((call) => call.url.includes("/sendMessage"));
-    expect(send).toBeTruthy();
-    const card = (send!.body!.payload as { card: { body: Array<Record<string, unknown>> } }).card;
-    expect(progressCardText(card)).not.toContain("MUST STAY HIDDEN");
-    expect(progressCardText(card)).not.toContain("Thinking through…");
-    expect(progressCardText(card)).toContain("Reasoning 1 · Tools 1");
-  });
-
-  it("uses model_call_ended duration and preserves aborted as stopped at finalize", async () => {
-    const { fn, calls } = mockFetch();
-    global.fetch = fn as unknown as typeof fetch;
-    const { handlers } = makeApi();
-    const ctx = { sessionKey: "reasoning-stopped", runId: "run-1" };
-
-    setCardContext("reasoning-stopped", {
-      apiUrl: "https://reasoning-stopped.test",
-      botToken: "bf",
-      channelId: "g",
-      channelType: ChannelType.Group,
-      reasoningVisibility: "stream",
-    });
-    handlers.before_agent_run({}, ctx);
-    handlers.model_call_started({ callId: "call-1" }, ctx);
-    recordCardReasoning("reasoning-stopped", "正在核对数据。", { snapshot: true });
-    handlers.before_tool_call({ toolName: "read", toolCallId: "tool-1" }, ctx);
-    handlers.after_tool_call({ toolName: "read", toolCallId: "tool-1", result: {} }, ctx);
-    await vi.advanceTimersByTimeAsync(900);
-    handlers.model_call_started({ callId: "call-2" }, ctx);
-    handlers.model_call_ended({
-      callId: "call-2",
-      durationMs: 1_200,
-      outcome: "error",
-      failureKind: "aborted",
-    }, ctx);
-    await finalizeCard("reasoning-stopped", { success: false });
-
-    const edit = calls.filter((call) => call.url.includes("/message/edit")).pop();
-    expect(edit).toBeTruthy();
-    const envelope = JSON.parse(edit!.body!.content_edit as string);
-    expect(progressCardText(envelope.card)).toContain("Stopped");
-    expect(progressCardText(envelope.card)).not.toContain("生成失败");
-    expect(JSON.stringify(envelope.card)).toContain("1.2s");
-  });
-
-  it("exposes answering as the first non-reasoning reply state", async () => {
-    const { fn, calls } = mockFetch();
-    global.fetch = fn as unknown as typeof fetch;
-    const { handlers } = makeApi();
-
-    setCardContext("reasoning-answering", {
-      apiUrl: "https://reasoning-answering.test",
-      botToken: "bf",
-      channelId: "g",
-      channelType: ChannelType.Group,
-      reasoningVisibility: "stream",
-    });
-    handlers.model_call_started({ callId: "call-1" }, { sessionKey: "reasoning-answering" });
-    recordCardReasoning("reasoning-answering", "正在核对输入。", { snapshot: true });
-    handlers.before_tool_call(
-      { toolName: "read", toolCallId: "tool-1" },
-      { sessionKey: "reasoning-answering" },
-    );
-    handlers.after_tool_call(
-      { toolName: "read", toolCallId: "tool-1", result: {} },
-      { sessionKey: "reasoning-answering" },
-    );
-    await vi.advanceTimersByTimeAsync(900);
-    calls.length = 0;
-
-    markCardAnswering("reasoning-answering");
-    await vi.advanceTimersByTimeAsync(900);
-
-    const edit = calls.find((call) => call.url.includes("/message/edit"));
-    expect(edit).toBeTruthy();
-    const envelope = JSON.parse(edit!.body!.content_edit as string);
-    expect(progressCardText(envelope.card)).toContain("Answering");
-    expect(progressCardText(envelope.card)).toContain("Writing the answer…");
-  });
-
-  it("P1-g: 多次 model_call_started 累积多步 thinking(同类合并压缩)", async () => {
-    const { fn, calls } = mockFetch();
-    global.fetch = fn as unknown as typeof fetch;
-    const { handlers } = makeApi();
-    setCardContext("tk2", { apiUrl: "https://tk2.test", botToken: "bf", channelId: "g", channelType: ChannelType.Group });
-
-    // agent 循环:thinking → tool → thinking → tool → thinking → tool
-    for (let i = 0; i < 3; i++) {
-      handlers.model_call_started({}, { sessionKey: "tk2" });
-      await vi.advanceTimersByTimeAsync(50);
-      const id = `t${i}`;
-      handlers.before_tool_call({ toolName: "read", params: { path: `/${i}` }, toolCallId: id }, { sessionKey: "tk2" });
-      handlers.after_tool_call({ toolName: id, toolCallId: id, durationMs: 30 }, { sessionKey: "tk2" });
-    }
-    await vi.advanceTimersByTimeAsync(900);
-    // 只验证:发送时的 payload 里出现了 thinking(至少一处)—— 合并/顺序具体断言在 render 层测
-    const send = calls.find((c) => c.url.includes("/sendMessage"));
-    expect(send).toBeTruthy();
-    const s = JSON.stringify((send!.body!.payload as { card: unknown }).card);
-    expect(s).toContain("💭");
-  });
-
-  it("P1-g: finalize 前的 running thinking 被收尾(不留 running 尾巴)", async () => {
-    const { fn, calls } = mockFetch();
-    global.fetch = fn as unknown as typeof fetch;
-    const { handlers } = makeApi();
-    setCardContext("tk3", { apiUrl: "https://tk3.test", botToken: "bf", channelId: "g", channelType: ChannelType.Group });
-
-    // thinking + 一个 tool,然后再一次 thinking(无后续 tool)→ finalize 收尾
-    handlers.model_call_started({}, { sessionKey: "tk3" });
-    handlers.before_tool_call({ toolName: "read", params: { path: "/a" }, toolCallId: "r1" }, { sessionKey: "tk3" });
-    handlers.after_tool_call({ toolName: "read", toolCallId: "r1", durationMs: 30 }, { sessionKey: "tk3" });
-    handlers.model_call_started({}, { sessionKey: "tk3" });
-    await vi.advanceTimersByTimeAsync(900); // 首帧发出
-    calls.length = 0;
-
-    await finalizeCard("tk3", { success: true });
-    const edit = calls.find((c) => c.url.includes("/message/edit"));
-    expect(edit).toBeTruthy();
-    const env = JSON.parse(edit!.body!.content_edit as string);
-    // 终态帧不应残留 running:⏳ 不该出现
-    const cardStr = JSON.stringify(env.card);
-    expect(cardStr).not.toContain("⏳");
-  });
-
-  it("P1-h: octo_send_display_card 不入进度卡 —— 纯 display-card turn 无占位卡、无终态帧", async () => {
-    const { fn, calls } = mockFetch();
-    global.fetch = fn as unknown as typeof fetch;
-    const { handlers } = makeApi();
-    setCardContext("dh1", { apiUrl: "https://dh1.test", botToken: "bf", channelId: "g", channelType: ChannelType.Group });
-    handlers.before_tool_call({ toolName: "octo_send_display_card", toolCallId: "d1" }, { sessionKey: "dh1" });
-    handlers.after_tool_call({ toolName: "octo_send_display_card", toolCallId: "d1", durationMs: 120 }, { sessionKey: "dh1" });
-    await vi.advanceTimersByTimeAsync(900);
-    // 从未 scheduleFlush → 连 gate 探测/发送都没有
-    expect(calls.some((c) => c.url.includes("/sendMessage"))).toBe(false);
-    expect(calls.some((c) => c.url.includes("/card/profile"))).toBe(false);
-    // finalize 因 !messageId 静默,不发终态帧
-    await finalizeCard("dh1", { success: true });
-    expect(calls.some((c) => c.url.includes("/message/edit"))).toBe(false);
-  });
-
-  it("P1-h: 混合 turn:display-card 不计步,真实工具照常显示进度(读取文件在,display-card 不在)", async () => {
-    const { fn, calls } = mockFetch();
-    global.fetch = fn as unknown as typeof fetch;
-    const { handlers } = makeApi();
-    setCardContext("dh2", { apiUrl: "https://dh2.test", botToken: "bf", channelId: "g", channelType: ChannelType.Group });
-    handlers.before_tool_call({ toolName: "octo_send_display_card", toolCallId: "d1" }, { sessionKey: "dh2" }); // 忽略
-    handlers.before_tool_call({ toolName: "read", params: { path: "/a" }, toolCallId: "r1" }, { sessionKey: "dh2" }); // 计入
-    await vi.advanceTimersByTimeAsync(900);
-    const send = calls.find((c) => c.url.includes("/sendMessage"));
-    expect(send).toBeTruthy();
-    const card = (send!.body!.payload as { card: { metadata?: unknown; body: Array<Record<string, unknown>> } }).card;
-    expect(card.metadata).toEqual({ octo_layout: OCTO_CARD_LAYOUTS.agentProgressV1 });
-    const joined = progressCardText(card);
-    expect(joined).toContain("read");
-    expect(joined).not.toContain("octo_send_display_card");
-  });
-
-  it("懒发契约:model_call_started 单独不发卡 —— 纯 display-card turn(含思考步)无占位卡、无中断终态", async () => {
-    // 回归:P1-g 的 model_call_started 曾无条件 scheduleFlush,击穿 P1-h 抑制 ——
-    // 纯 display-card turn 仍发占位卡并 finalize 成「⚠️ Interrupted」。
-    const { fn, calls } = mockFetch();
-    global.fetch = fn as unknown as typeof fetch;
-    const { handlers } = makeApi();
-    setCardContext("nf1", { apiUrl: "https://nf1.test", botToken: "bf", channelId: "g", channelType: ChannelType.Group });
-    handlers.model_call_started({}, { sessionKey: "nf1" });   // 思考步(真实事件序:先于 tool)
-    handlers.before_tool_call({ toolName: "octo_send_display_card", toolCallId: "d1" }, { sessionKey: "nf1" });
-    handlers.after_tool_call({ toolName: "octo_send_display_card", toolCallId: "d1", durationMs: 120 }, { sessionKey: "nf1" });
-    await vi.advanceTimersByTimeAsync(900);
-    expect(calls.some((c) => c.url.includes("/sendMessage"))).toBe(false);
-    expect(calls.some((c) => c.url.includes("/card/profile"))).toBe(false);
-    await finalizeCard("nf1", { success: false });
-    expect(calls.some((c) => c.url.includes("/message/edit"))).toBe(false); // 无 messageId → 无中断帧
-  });
-
-  it("懒发契约:纯思考(无任何工具)turn 不发进度卡", async () => {
-    const { fn, calls } = mockFetch();
-    global.fetch = fn as unknown as typeof fetch;
-    const { handlers } = makeApi();
-    setCardContext("nf2", { apiUrl: "https://nf2.test", botToken: "bf", channelId: "g", channelType: ChannelType.Group });
-    handlers.model_call_started({}, { sessionKey: "nf2" });
-    await vi.advanceTimersByTimeAsync(900);
-    handlers.model_call_started({}, { sessionKey: "nf2" }); // 连续思考(去重)
-    await vi.advanceTimersByTimeAsync(900);
-    expect(calls.length).toBe(0);
-    await finalizeCard("nf2", { success: true });
-    expect(calls.some((c) => c.url.includes("/message/edit"))).toBe(false);
-  });
-
-  it("懒发契约:真实工具后思考步照常更新已存在的卡", async () => {
-    const { fn, calls } = mockFetch();
-    global.fetch = fn as unknown as typeof fetch;
-    const { handlers } = makeApi();
-    setCardContext("nf3", { apiUrl: "https://nf3.test", botToken: "bf", channelId: "g", channelType: ChannelType.Group });
-    handlers.model_call_started({}, { sessionKey: "nf3" });               // 纯思考:不发
-    handlers.before_tool_call({ toolName: "read", toolCallId: "r1" }, { sessionKey: "nf3" }); // 真实工具:发首帧
-    await vi.advanceTimersByTimeAsync(900);
-    expect(calls.some((c) => c.url.includes("/sendMessage"))).toBe(true);
-    calls.length = 0;
-    handlers.after_tool_call({ toolName: "read", toolCallId: "r1", durationMs: 20 }, { sessionKey: "nf3" });
-    handlers.model_call_started({}, { sessionKey: "nf3" });               // 卡已存在 → 思考步刷新
-    await vi.advanceTimersByTimeAsync(900);
-    expect(calls.some((c) => c.url.includes("/message/edit"))).toBe(true);
-  });
-
-  it("NEW-3: display-card 前的 running thinking 被收尾(思考耗时不吞掉发卡时长)", async () => {
-    const { fn, calls } = mockFetch();
-    global.fetch = fn as unknown as typeof fetch;
-    const { handlers } = makeApi();
-    setCardContext("nf4", { apiUrl: "https://nf4.test", botToken: "bf", channelId: "g", channelType: ChannelType.Group });
-    handlers.before_tool_call({ toolName: "read", toolCallId: "r1" }, { sessionKey: "nf4" }); // 让卡存在
-    handlers.after_tool_call({ toolName: "read", toolCallId: "r1", durationMs: 10 }, { sessionKey: "nf4" });
-    handlers.model_call_started({}, { sessionKey: "nf4" });               // 起一个思考步
-    handlers.before_tool_call({ toolName: "octo_send_display_card", toolCallId: "d1" }, { sessionKey: "nf4" }); // 应收尾思考步
-    handlers.before_tool_call({ toolName: "read", params: { path: "/b" }, toolCallId: "r2" }, { sessionKey: "nf4" });
-    await vi.advanceTimersByTimeAsync(900);
-    const send = calls.find((c) => c.url.includes("/sendMessage")) ?? calls.find((c) => c.url.includes("/message/edit"));
-    // 思考步已 done(有 💭 且带耗时),不再是 running（⏳）
-    expect(send).toBeTruthy();
-  });
-
-  it("runId 在 before_agent_run 预绑定:旧 run 迟到 hook 先到也不能抢占新 entry", async () => {
-    const { fn, calls } = mockFetch();
-    global.fetch = fn as unknown as typeof fetch;
-    const { handlers } = makeApi();
-    const target = { apiUrl: "https://rg.test", botToken: "bf", channelId: "g", channelType: ChannelType.Group };
-
-    // run A 在任何 model/tool 事件前由 before_agent_run 绑定,随后跑一步并超时收尾。
-    setCardContext("rg1", target);
-    expect(handlers.before_agent_run({}, { sessionKey: "rg1", runId: "A" })).toEqual({ outcome: "pass" });
-    handlers.before_tool_call({ toolName: "read", params: { path: "/a" }, toolCallId: "a1" }, { sessionKey: "rg1", runId: "A" });
-    await vi.advanceTimersByTimeAsync(900);
-    await finalizeCard("rg1", { success: false });
-
-    // 同 sessionKey 的 run B 登记 fresh entry。A 的迟到 hook 在 B 的首个工具事件之前到达，
-    // 但 entry 尚未由 before_agent_run 绑定时不得 first-hook-wins。
-    setCardContext("rg1", target);
-    handlers.before_tool_call({ toolName: "exec", params: { command: "echo x" }, toolCallId: "a2" }, { sessionKey: "rg1", runId: "A" });
-    handlers.after_tool_call({ toolName: "exec", toolCallId: "a2", durationMs: 9 }, { sessionKey: "rg1", runId: "A" });
-    expect(handlers.before_agent_run({}, { sessionKey: "rg1", runId: "B" })).toEqual({ outcome: "pass" });
-    handlers.before_tool_call({ toolName: "write", params: { path: "/b" }, toolCallId: "b1" }, { sessionKey: "rg1", runId: "B" });
-    await vi.advanceTimersByTimeAsync(900);
-
-    // 聚合所有发出去的帧(send payload + edit content_edit)的卡片文本
-    const allText = calls
-      .filter((c) => c.url.includes("/sendMessage") || c.url.includes("/message/edit"))
-      .map((c) => {
-        const card = c.url.includes("/message/edit")
-          ? JSON.parse(c.body!.content_edit as string).card
-          : (c.body!.payload as { card: { body: Array<Record<string, unknown>> } }).card;
-        return progressCardText(card);
-      })
-      .join(" || ");
-    expect(allText).toContain("write"); // B 自己的步骤渲染出来了
-    expect(allText).not.toContain("exec"); // A 迟到的 exec 步骤从未进入任何帧
-  });
-
-  it("bindCardRun 缺标识/无 entry/skip 时 no-op,且既有 owner 不可被覆盖", async () => {
-    const { fn, calls } = mockFetch();
-    global.fetch = fn as unknown as typeof fetch;
-    const { handlers } = makeApi();
-
-    bindCardRun(undefined, "run-a");
-    bindCardRun("missing", undefined);
-    bindCardRun("missing", "run-a");
-    setCardContext("skipped", {
-      apiUrl: "https://owner.test",
-      botToken: "bf",
-      channelId: "g",
-      channelType: ChannelType.Group,
-      onBehalfOf: "grantor",
-    });
-    bindCardRun("skipped", "run-a");
-
-    setCardContext("owned", {
-      apiUrl: "https://owner.test",
-      botToken: "bf",
-      channelId: "g",
-      channelType: ChannelType.Group,
-    });
-    bindCardRun("owned", "run-a");
-    bindCardRun("owned", "run-b");
-    handlers.before_tool_call({ toolName: "exec", toolCallId: "b1" }, { sessionKey: "owned", runId: "run-b" });
-    handlers.before_tool_call({ toolName: "read", toolCallId: "a1" }, { sessionKey: "owned", runId: "run-a" });
-    await vi.advanceTimersByTimeAsync(900);
-
-    const send = calls.find((c) => c.url.includes("/sendMessage"));
-    expect(send).toBeTruthy();
-    const rendered = progressCardText((send!.body!.payload as {
-      card: { body: Array<Record<string, unknown>> };
-    }).card);
-    expect(rendered).toContain("read");
-    expect(rendered).not.toContain("exec");
-  });
-
-  it("entry 等待 profile 时被新身份替换,恢复后不得向旧频道发送占位卡", async () => {
-    const profileReached = makeDeferred();
-    const releaseProfile = makeDeferred();
-    const calls: Array<{ url: string; body?: Record<string, unknown> }> = [];
-    let profileSignal: AbortSignal | undefined;
-    global.fetch = vi.fn().mockImplementation(async (url: string, init?: { body?: string; signal?: AbortSignal }) => {
-      calls.push({ url: String(url), body: init?.body ? JSON.parse(init.body) : undefined });
-      if (String(url).includes("/card/profile")) {
-        profileSignal = init?.signal;
-        profileReached.resolve();
-        await releaseProfile.promise;
-        return { ok: true, status: 200, json: async () => ({ enabled: true, profiles: ["octo/v1"] }) };
-      }
-      if (String(url).includes("/sendMessage")) {
-        return { ok: true, status: 200, text: async () => JSON.stringify({ message_id: "stale" }) };
-      }
-      return { ok: true, status: 200, text: async () => "" };
-    }) as unknown as typeof fetch;
-    const { handlers } = makeApi();
-
-    setCardContext("collision", { apiUrl: "https://race.test", botToken: "token-a", channelId: "group-a", channelType: ChannelType.Group });
-    handlers.before_tool_call({ toolName: "read", toolCallId: "a1" }, { sessionKey: "collision" });
-    await vi.advanceTimersByTimeAsync(900);
-    await profileReached.promise;
-
-    setCardContext("collision", { apiUrl: "https://race.test", botToken: "token-b", channelId: "group-b", channelType: ChannelType.Group });
-    expect(profileSignal?.aborted).toBe(true);
-    releaseProfile.resolve();
-    await vi.runAllTimersAsync();
-    await Promise.resolve();
-
-    expect(calls.some((c) => c.url.includes("/sendMessage"))).toBe(false);
+    expect(wire.calls.filter((call) => call.url.includes("/sendMessage"))).toHaveLength(1);
+  });
+
+  it("does not create a reasoning card for a display-card-only turn", async () => {
+    const wire = mockFetch();
+    global.fetch = wire.fetch as typeof fetch;
+    const handlers = makeApi();
+    setCardContext("display-only", context());
+    const hookContext = { sessionKey: "display-only", runId: "run-1" };
+    handlers.before_agent_run?.({}, hookContext);
+    handlers.model_call_started?.({ callId: "model-1" }, hookContext);
+    handlers.before_tool_call?.({ toolName: DISPLAY_CARD_TOOL_NAME, toolCallId: "display-1" }, hookContext);
+    handlers.after_tool_call?.({ toolName: DISPLAY_CARD_TOOL_NAME, toolCallId: "display-1" }, hookContext);
+    await vi.advanceTimersByTimeAsync(900);
+    await finalizeCard("display-only", { success: true });
+
+    expect(wire.calls).toEqual([]);
+  });
+
+  it("captures visible reasoning but never captures it when visibility is off", async () => {
+    const wire = mockFetch();
+    global.fetch = wire.fetch as typeof fetch;
+    const handlers = makeApi();
+    setCardContext("reasoning-on", context({ reasoningVisibility: "on" }));
+    const onContext = { sessionKey: "reasoning-on", runId: "run-1" };
+    handlers.before_agent_run?.({}, onContext);
+    handlers.model_call_started?.({ callId: "model-1" }, onContext);
+    recordCardReasoning("reasoning-on", "visible thought", { snapshot: true });
+    handlers.before_tool_call?.({ toolName: "read", toolCallId: "tool-1" }, onContext);
+    await vi.advanceTimersByTimeAsync(900);
+    expect(JSON.stringify(wire.calls.find((call) => call.url.includes("/sendMessage"))?.body))
+      .toContain("visible thought");
+
+    clearCard("reasoning-on");
+    wire.calls.length = 0;
+    setCardContext("reasoning-off", context({ reasoningVisibility: "off" }));
+    const offContext = { sessionKey: "reasoning-off", runId: "run-2" };
+    handlers.before_agent_run?.({}, offContext);
+    handlers.model_call_started?.({ callId: "model-2" }, offContext);
+    recordCardReasoning("reasoning-off", "private thought", { snapshot: true });
+    handlers.before_tool_call?.({ toolName: "read", toolCallId: "tool-2" }, offContext);
+    await vi.advanceTimersByTimeAsync(900);
+    expect(JSON.stringify(wire.calls.find((call) => call.url.includes("/sendMessage"))?.body))
+      .not.toContain("private thought");
   });
 });

--- a/src/card-progress.test.ts
+++ b/src/card-progress.test.ts
@@ -105,6 +105,13 @@ function registryProfile(version = "0.2.0"): Record<string, unknown> {
   return {
     enabled: true,
     profiles: ["octo/v1", "octo/v2"],
+    config: {
+      card_enabled: true,
+      display_enabled: true,
+      interaction_enabled: true,
+      reasoning_enabled: true,
+      reasoning_template_ref: { id: "ai.reasoning-process", version },
+    },
     templating: {
       supported: true,
       wire: "template-ref/v1",
@@ -469,6 +476,105 @@ describe("card-progress 状态机 + hook + 节流", () => {
     expect(payload).not.toHaveProperty("card");
   });
 
+  it("服务端 reasoning_enabled=false 时不发送任何推理进度卡", async () => {
+    const profile = registryProfile("0.3.0");
+    profile.config = {
+      card_enabled: true,
+      display_enabled: true,
+      interaction_enabled: true,
+      reasoning_enabled: false,
+      reasoning_template_ref: null,
+    };
+    const { fn, calls } = mockFetch({ profile });
+    global.fetch = fn as unknown as typeof fetch;
+    const { handlers } = makeApi();
+    const hookCtx = { sessionKey: "server-reasoning-disabled", runId: "run-1" };
+
+    setCardContext(hookCtx.sessionKey, {
+      apiUrl: "https://server-reasoning-disabled.test",
+      botToken: "bot-a",
+      channelId: "g",
+      channelType: ChannelType.Group,
+      reasoningVisibility: "stream",
+    });
+    handlers.before_agent_run({}, hookCtx);
+    handlers.model_call_started({ callId: "call-1" }, hookCtx);
+    recordCardReasoning(hookCtx.sessionKey, "先核对服务端配置。", { snapshot: true });
+    handlers.before_tool_call({ toolName: "read", toolCallId: "tool-1" }, hookCtx);
+    await vi.advanceTimersByTimeAsync(900);
+
+    expect(calls.some((call) => call.url.includes("/card/profile"))).toBe(true);
+    expect(calls.some((call) => call.url.includes("/sendMessage"))).toBe(false);
+  });
+
+  it("reasoning ref 缺失或不在 catalog 时 fail closed，不发送 Model B", async () => {
+    for (const profile of [
+      {
+        ...registryProfile("0.3.0"),
+        config: {
+          card_enabled: true,
+          display_enabled: true,
+          interaction_enabled: true,
+          reasoning_enabled: true,
+          reasoning_template_ref: null,
+        },
+      },
+      {
+        ...registryProfile("0.3.0"),
+        config: {
+          card_enabled: true,
+          display_enabled: true,
+          interaction_enabled: true,
+          reasoning_enabled: true,
+          reasoning_template_ref: { id: "ai.reasoning-process", version: "9.9.9" },
+        },
+      },
+    ]) {
+      _resetCardProgressForTests();
+      const { fn, calls } = mockFetch({ profile });
+      global.fetch = fn as unknown as typeof fetch;
+      const { handlers } = makeApi();
+      const sessionKey = `invalid-server-ref-${String((profile.config as { reasoning_template_ref: unknown }).reasoning_template_ref)}`;
+      setCardContext(sessionKey, {
+        apiUrl: `https://${sessionKey}.test`,
+        botToken: "bot-a",
+        channelId: "g",
+        channelType: ChannelType.Group,
+      });
+      handlers.before_tool_call({ toolName: "read", toolCallId: "tool-1" }, { sessionKey });
+      await vi.advanceTimersByTimeAsync(900);
+
+      expect(calls.some((call) => call.url.includes("/sendMessage"))).toBe(false);
+    }
+  });
+
+  it("忽略本地 cardProgress/reasoningCardTemplateMode，按服务端有效配置发送 Registry 模板", async () => {
+    const { fn, calls } = mockFetch({ profile: registryProfile("0.3.0") });
+    global.fetch = fn as unknown as typeof fetch;
+    const { handlers } = makeApi();
+    const hookCtx = { sessionKey: "server-policy-over-local", runId: "run-1" };
+
+    setCardContext(hookCtx.sessionKey, {
+      apiUrl: "https://server-policy-over-local.test",
+      botToken: "bot-a",
+      channelId: "g",
+      channelType: ChannelType.Group,
+      cardProgress: false,
+      reasoningCardTemplateMode: "off",
+      reasoningVisibility: "stream",
+    });
+    handlers.before_agent_run({}, hookCtx);
+    handlers.model_call_started({ callId: "call-1" }, hookCtx);
+    recordCardReasoning(hookCtx.sessionKey, "服务端配置是唯一策略来源。", { snapshot: true });
+    handlers.before_tool_call({ toolName: "read", toolCallId: "tool-1" }, hookCtx);
+    await vi.advanceTimersByTimeAsync(900);
+
+    const sends = calls.filter((call) => call.url.includes("/sendMessage"));
+    expect(sends).toHaveLength(1);
+    expect(sends[0]?.body?.payload).toHaveProperty("template_ref.version", "0.3.0");
+    expect(sends[0]?.body?.payload).not.toHaveProperty("card");
+  });
+
   it("shadow 模式只验证 manifest，仍发送 Model B 完整卡", async () => {
     const { fn, calls } = mockFetch({
       profile: {
@@ -674,7 +780,7 @@ describe("card-progress 状态机 + hook + 节流", () => {
     expect(appliedSeqs).toEqual([...appliedSeqs].sort((a, b) => a - b));
   });
 
-  it("Model A 首帧被确定性拒绝时，在同一 flush 内仅回退一次兼容的 Model B", async () => {
+  it("Registry 首帧被确定性拒绝时也绝不回退本地 Model B", async () => {
     const calls: Array<{ url: string; body: Record<string, unknown> | undefined }> = [];
     global.fetch = vi.fn().mockImplementation(async (url: string, init?: { body?: string }) => {
       const target = String(url);
@@ -693,7 +799,7 @@ describe("card-progress 状态机 + hook + 节流", () => {
             text: async () => '{"code":"card_invalid"}',
           };
         }
-        return { ok: true, status: 200, text: async () => JSON.stringify({ message_id: "fallback-card" }) };
+        return { ok: true, status: 200, text: async () => JSON.stringify({ message_id: "must-not-send-model-b" }) };
       }
       return { ok: true, status: 200, text: async () => "" };
     }) as unknown as typeof fetch;
@@ -711,16 +817,13 @@ describe("card-progress 状态机 + hook + 节流", () => {
     await vi.advanceTimersByTimeAsync(900);
 
     const sends = calls.filter((call) => call.url.includes("/sendMessage"));
-    expect(sends).toHaveLength(2);
+    expect(sends).toHaveLength(1);
     expect(sends[0]?.body?.payload).toHaveProperty("template_ref.version", "0.3.0");
-    expect(sends[1]?.body?.payload).toHaveProperty("card");
-    expect(sends[1]?.body?.payload).not.toHaveProperty("template_ref");
+    expect(sends.some((send) => Object.hasOwn(send.body?.payload ?? {}, "card"))).toBe(false);
 
     markCardAnswering(sessionKey);
     await vi.advanceTimersByTimeAsync(900);
-    const edit = calls.find((call) => call.url.includes("/message/edit"))?.body;
-    expect(edit).toHaveProperty("content_edit");
-    expect(edit).not.toHaveProperty("template_ref");
+    expect(calls.some((call) => call.url.includes("/message/edit"))).toBe(false);
   });
 
   it.each([

--- a/src/card-progress.ts
+++ b/src/card-progress.ts
@@ -1,54 +1,56 @@
 /**
- * 波 B —— InteractiveCard(=17) 进度卡状态机 + hook 驱动 + 节流。
+ * Registry reasoning InteractiveCard(=17) 进度状态机 + hook 驱动 + 节流。
  *
  * 架构(见 .context 计划):
  *   - dispatch(`inbound.ts`)在 run 开始 `setCardContext(sessionKey, ctx)` 存发送上下文
  *     (apiUrl/botToken/channel/onBehalfOf),`finally` 里 `finalizeCard(sessionKey, success)`。
  *   - 本模块订阅 hook(before/after_tool_call、model_call_started),用 `ctx.sessionKey`
- *     查 Map:首个工具事件懒发占位卡 → 后续就地 `editCardMessage`,节流合帧。
+ *     查 Map:首个工具事件懒发占位卡 → 后续就地 `editTemplateCardMessage`,节流合帧。
  *   - sessions_yield 将已发出的卡移入 pausedCards；后续 lifecycle run 继续编辑同一张卡。
  *   - `sessionKey` 桥接 dispatch 与 hook(H1 实证一致)。Map 只含 octo dispatch 登记的
  *     session → hook 查不到即 return,**天然过滤**非 octo run,无需 messageProvider 判断。
  *
- * 决策:关联键 sessionKey;单写者(dispatch per-group 串行)→ 不传 card_seq;卡仅进度/
- * 状态(C2,答案走文本);OBO(persona-clone)场景跳过(服务端拒 type-17 OBO,Decision 2b)。
+ * 决策:关联键 sessionKey;Registry 编辑用单调 card_seq 串行提交;卡仅承载进度/状态
+ * (C2,答案走文本);OBO(persona-clone)场景跳过(服务端拒 type-17 OBO,Decision 2b)。
  */
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
-import { ChannelType, CARD_PROFILE, CARD_VERSION } from "./types.js";
+import { ChannelType } from "./types.js";
 import {
-  editCardMessage,
   editTemplateCardMessage,
-  getCardProfile,
   httpStatusFromApiFetchError,
-  sendCardMessage,
   sendTemplateCardMessage,
   type CardProfileManifest,
   type CardTemplateRef,
 } from "./api-fetch.js";
-import { deriveCardCaps } from "./card-caps.js";
-import { renderProgressCard, renderProgressResponseCard, summarizeToolParams, SUBAGENT_WAIT_STEP_TOOL, type CardStep, type CardProgressState, type CardCaps } from "./card-render.js";
+import {
+  _resetBotCardProfileCacheForTests,
+  getBotCardProfile,
+  peekBotCardProfile,
+} from "./card-profile-cache.js";
+import { summarizeToolParams, SUBAGENT_WAIT_STEP_TOOL, type CardStep, type CardProgressState } from "./card-render.js";
 import {
   buildReasoningProcessId,
   buildReasoningProcessWireData,
-  renderReasoningProcessCard,
   selectReasoningProcessTemplate,
   summarizeToolResult,
 } from "./reasoning-process.js";
 import { DISPLAY_CARD_TOOL_NAME, INTERACTIVE_CARD_TOOL_NAME } from "./constants.js";
 import { collapseParentScope, parentGroupOf, resolveOutboundTarget } from "./target.js";
 import { getKnownGroupIds } from "./group-md.js";
-import type { ReasoningCardTemplateMode } from "./config-schema.js";
+import { requestCardEventPolling } from "./events-poll.js";
 
 /** dispatch 侧登记的发送上下文。 */
 export interface CardContext {
+  /** Account owning this Bot credential; used only to lazily start its config-event poller. */
+  accountId?: string;
   apiUrl: string;
   botToken: string;
   channelId: string;
   channelType: ChannelType;
-  /** false force-disables automatic progress cards for this account/session. */
+  /** @deprecated Ignored. Server config.reasoning_enabled is authoritative. */
   cardProgress?: boolean;
-  /** Explicit Registry migration gate. Defaults to experimental with Model B fallback. */
-  reasoningCardTemplateMode?: ReasoningCardTemplateMode;
+  /** @deprecated Ignored. Server config.reasoning_template_ref is authoritative. */
+  reasoningCardTemplateMode?: "off" | "shadow" | "experimental";
   /** persona-clone 身份;存在则跳过卡片(服务端拒 type-17 OBO)。 */
   onBehalfOf?: string;
   /** OpenClaw reasoning visibility resolved for this turn/session. */
@@ -88,17 +90,15 @@ interface CardEntry {
   /** paused/resuming/done 跨-run edit 的串行尾指针。 */
   stateEditPromise?: Promise<void>;
   stateEditAbort?: AbortController;
-  /** All Model A edits share this tail so card_seq reservation order equals wire order. */
-  modelAEditPromise?: Promise<boolean>;
+  /** All Registry edits share this tail so card_seq reservation order equals wire order. */
+  templateEditPromise?: Promise<boolean>;
   /** paused 卡的有界回收定时器。 */
   pausedExpiryTimer?: ReturnType<typeof setTimeout>;
   /** replacement/clear 时主动取消 profile/send/edit,缩小 stale side-effect 窗口。 */
   flushAbort?: AbortController;
-  /** Pinned once before the first send; one message must never switch wire modes. */
-  deliveryMode?: "model-a" | "model-b";
-  /** Manifest-selected ref, pinned for every frame of a Model A message. */
+  /** Server-selected ref, pinned for every frame of a Registry-authored message. */
   templateRef?: CardTemplateRef;
-  /** Next positive CAS value for a Model A edit. */
+  /** Next positive CAS value for a Registry edit. */
   nextCardSeq: number;
   /** Stable for every frame, including paused continuation runs. */
   reasoningId?: string;
@@ -114,16 +114,9 @@ interface CardEntry {
   deliveredByTool?: boolean;
 }
 
-type CachedCardProfile = {
-  manifest: CardProfileManifest;
-  expiresAt: number;
-};
-
 type CardProgressSharedState = {
   cards: Map<string, CardEntry>;
   pausedCards: Map<string, CardEntry>;
-  profileCache: Map<string, CachedCardProfile>;
-  capsCache: Map<string, CardCaps>;
 };
 
 /**
@@ -140,8 +133,6 @@ function getCardProgressSharedState(): CardProgressSharedState {
   const created: CardProgressSharedState = {
     cards: new Map(),
     pausedCards: new Map(),
-    profileCache: new Map(),
-    capsCache: new Map(),
   };
   root[CARD_PROGRESS_STATE_KEY] = created;
   return created;
@@ -158,19 +149,8 @@ const cards = sharedState.cards;
  */
 const pausedCards = sharedState.pausedCards;
 
-/** Short-lived bot-scoped profile cache; expiry lets new messages observe catalog rollouts. */
-const profileCache = sharedState.profileCache;
-
-/**
- * D12 能力(elements/limits 派生的渲染 caps)缓存,key = apiUrl(部署级,同 gate)。gateEnabled
- * 探测 manifest 时一并填充;渲染时按元素以及节点/深度/字节上限裁剪。旧部署无这些字段 → caps 为空 → 渲染
- * 走保守默认(等同今天行为)。
- */
-const capsCache = sharedState.capsCache;
-
 const FLUSH_DEBOUNCE_MS = 800;
 const EDIT_TIMEOUT_MS = 10_000;
-const PROFILE_CACHE_TTL_MS = 60_000;
 const REGISTRY_EDIT_RETRY_DELAYS_MS = [100, 250] as const;
 /** Registry 契约里必须进修订历史的终态帧。 */
 const TERMINAL_TEMPLATE_STATES = new Set(["completed", "stopped", "error"]);
@@ -194,11 +174,6 @@ const dbg: (msg: string) => void = process.env.OCTO_CARD_DEBUG
  */
 function contextIdentity(ctx: CardContext): string {
   return JSON.stringify([ctx.apiUrl, ctx.channelId, ctx.channelType, ctx.onBehalfOf ?? "", ctx.botToken]);
-}
-
-/** Profile enabled/catalog facts are authorized by botToken, not shared by an apiUrl deployment. */
-function profileCacheKey(ctx: CardContext): string {
-  return JSON.stringify([ctx.apiUrl, ctx.botToken]);
 }
 
 /**
@@ -237,33 +212,22 @@ export function setCardContext(sessionKey: string, ctx: CardContext): void {
     dirty: false,
     inFlight: false,
     nextCardSeq: 1,
-    // Account config is a per-session narrowing decision. Keep it out of the
-    // bot-scoped profile cache and apiUrl-keyed deployment render-caps cache.
-    skip: collision || !!ctx.onBehalfOf || ctx.cardProgress === false,
+    skip: collision || !!ctx.onBehalfOf,
   });
   dbg(`context set session=${sessionKey} channel=${ctx.channelId} obo=${!!ctx.onBehalfOf} collision=${collision}`);
 }
 
 /**
- * 是否允许发卡:D12 manifest 优先,端点未部署(available:false)则回退 env 开关。
+ * 是否允许发卡：只接受 profile 中服务端已计算好的 per-Bot reasoning policy 与精确模板 ref。
  * 返回值三态:`true`=启用,`false`=**明确禁用**(可永久 skip 本 session),
  * `null`=**瞬时探测失败**(5xx/网络,不缓存、不 skip,下次 flush 重探)。
  */
 async function gateEnabled(ctx: CardContext, signal?: AbortSignal): Promise<boolean | null> {
-  const cacheKey = profileCacheKey(ctx);
-  const cached = profileCache.get(cacheKey);
-  if (cached && cached.expiresAt > Date.now()) return profileEnabledForContext(ctx, cached.manifest);
-  if (cached) profileCache.delete(cacheKey);
   try {
-    const m = await getCardProfile({ apiUrl: ctx.apiUrl, botToken: ctx.botToken, signal });
-    // 能力清单是部署级事实(与 enabled 无关),探到就缓存供渲染裁剪。
-    capsCache.set(ctx.apiUrl, deriveCardCaps(m));
-    // Profile 来自带 botToken 的请求，其中 enabled/templating 都是 Bot 级事实。
-    profileCache.set(cacheKey, {
-      manifest: m,
-      expiresAt: Date.now() + PROFILE_CACHE_TTL_MS,
-    });
-    return profileEnabledForContext(ctx, m);
+    if (ctx.accountId) requestCardEventPolling(ctx.accountId);
+    const m = await getBotCardProfile({ apiUrl: ctx.apiUrl, botToken: ctx.botToken });
+    if (signal?.aborted) throw signal.reason;
+    return !!reasoningTemplateForProfile(m);
   } catch (err: unknown) {
     // 瞬时失败(5xx/网络抖动)不缓存、不 skip —— 否则一次抖动会让该 apiUrl(缓存)或
     // 该 session(skip)的卡片进度永久关闭。返回 null,下次 flush(仍在 !messageId 期间)重探。
@@ -272,50 +236,13 @@ async function gateEnabled(ctx: CardContext, signal?: AbortSignal): Promise<bool
   }
 }
 
-function baseProfileEnabled(manifest: CardProfileManifest): boolean {
-  return manifest.available
-    ? manifest.enabled
-    : process.env.OCTO_CARD_MESSAGE_ENABLED === "1";
+function reasoningTemplateForProfile(manifest: CardProfileManifest): CardTemplateRef | null {
+  if (!manifest.available || manifest.config?.reasoning_enabled !== true) return null;
+  return selectReasoningProcessTemplate(
+    manifest.templating,
+    manifest.config.reasoning_template_ref,
+  );
 }
-
-function modelBProfileCompatible(manifest: CardProfileManifest): boolean {
-  if (!manifest.available) return true;
-  if (Array.isArray(manifest.profiles) && manifest.profiles.length > 0 &&
-      !manifest.profiles.includes(CARD_PROFILE)) {
-    dbg(`gate: profile ${CARD_PROFILE} not advertised (${manifest.profiles.join(",")}) → disabled`);
-    return false;
-  }
-  if (typeof manifest.card_version === "string" && manifest.card_version !== CARD_VERSION) {
-    dbg(`gate: card_version ${manifest.card_version} != ${CARD_VERSION} → disabled`);
-    return false;
-  }
-  if (Array.isArray(manifest.elements) && !manifest.elements.includes("TextBlock")) {
-    // Model B 的所有安全降级最终都依赖 TextBlock。显式空数组或缺 TextBlock 是权威不支持。
-    dbg("gate: TextBlock not advertised → disabled");
-    return false;
-  }
-  return true;
-}
-
-function modelBEnabledForContext(manifest: CardProfileManifest): boolean {
-  return baseProfileEnabled(manifest) && modelBProfileCompatible(manifest);
-}
-
-function profileEnabledForContext(ctx: CardContext, manifest: CardProfileManifest): boolean {
-  const enabled = baseProfileEnabled(manifest);
-  if (!enabled) return false;
-  const registryCompatible = (ctx.reasoningCardTemplateMode ?? "experimental") === "experimental" &&
-    !!selectReasoningProcessTemplate(manifest.templating);
-  // Model A 由 Registry 模板自己的 wire/views 契约协商，不依赖 Model B 的 Adaptive Card
-  // profile/card_version/elements。仅在实际走 Model B 时应用下面的渲染兼容 gate。
-  return registryCompatible || modelBProfileCompatible(manifest);
-}
-
-const TEMPLATE_FRAME_REJECTION_STATUSES = new Set([400, 404, 422]);
-const CARD_INVALID_ERROR_CODES = new Set([
-  "card_invalid",
-  "err.server.bot_api.card_invalid",
-]);
 
 function apiErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
@@ -330,35 +257,16 @@ function errorCodeFromApiError(error: unknown): string | undefined {
   return apiErrorMessage(error).match(/"code"\s*:\s*"([^"]+)"/)?.[1];
 }
 
-function canFallbackFirstFrameToModelB(entry: CardEntry, error: unknown): boolean {
-  const transportStatus = httpStatusFromApiFetchError(error);
-  const semanticStatus = semanticHttpStatusFromApiError(error);
-  const errorCode = errorCodeFromApiError(error);
-  // 第二次 send 只能发生在服务端明确拒绝模板帧时。408/冲突/限流/5xx 都可能是
-  // 已提交或瞬时失败，不能因为外层 transport 400 就切到 Model B 造成孤儿卡。
-  if (transportStatus === undefined || !TEMPLATE_FRAME_REJECTION_STATUSES.has(transportStatus)) return false;
-  if (semanticStatus !== undefined && !TEMPLATE_FRAME_REJECTION_STATUSES.has(semanticStatus)) return false;
-  if (errorCode !== undefined && !CARD_INVALID_ERROR_CODES.has(errorCode)) return false;
-  const manifest = profileCache.get(profileCacheKey(entry.ctx))?.manifest;
-  return !!manifest && modelBEnabledForContext(manifest);
-}
-
 function resolveEntryDeliveryMode(entry: CardEntry): void {
-  if (entry.deliveryMode) return;
-  const requested = entry.ctx.reasoningCardTemplateMode ?? "experimental";
-  const templateRef = selectReasoningProcessTemplate(
-    profileCache.get(profileCacheKey(entry.ctx))?.manifest.templating,
-  );
-  if (requested === "shadow") {
-    dbg(`Registry shadow discovery compatible=${!!templateRef}`);
-  }
-  if (requested === "experimental" && templateRef) {
-    entry.deliveryMode = "model-a";
+  if (entry.templateRef) return;
+  const profile = peekBotCardProfile(entry.ctx);
+  const templateRef = profile ? reasoningTemplateForProfile(profile) : null;
+  if (templateRef) {
     entry.templateRef = templateRef;
     dbg(`selected Registry reasoning template ${templateRef.id}@${templateRef.version}`);
     return;
   }
-  entry.deliveryMode = "model-b";
+  entry.skip = true;
 }
 
 function scheduleFlush(sessionKey: string, entry: CardEntry): void {
@@ -385,23 +293,6 @@ function entryProgressState(
     ...(opts.elapsedMs !== undefined ? { elapsedMs: opts.elapsedMs } : {}),
     ...(opts.errorText ? { errorText: opts.errorText } : {}),
   };
-}
-
-function usesReasoningProcessContract(entry: CardEntry): boolean {
-  const reasoningVisible = entry.ctx.reasoningVisibility === "on" ||
-    entry.ctx.reasoningVisibility === "stream";
-  return reasoningVisible && entry.steps.some((step) => !!step.thought?.trim());
-}
-
-function renderEntryProgress(
-  sessionKey: string,
-  entry: CardEntry,
-  state: CardProgressState,
-): { card: Record<string, unknown>; plain: string } {
-  const caps = capsCache.get(entry.ctx.apiUrl);
-  return usesReasoningProcessContract(entry)
-    ? renderReasoningProcessCard(state, caps)
-    : renderProgressCard(state, caps);
 }
 
 function isRetryableRegistryEditError(error: unknown): boolean {
@@ -457,12 +348,11 @@ async function editEntryProgress(params: {
   const { entry, state } = params;
   const messageId = entry.messageId;
   if (!messageId) return false;
-  if (entry.deliveryMode === "model-a") {
-    const data = buildReasoningProcessWireData(state);
-    const templateRef = entry.templateRef;
-    if (!data || !templateRef) return false;
-    const previous = entry.modelAEditPromise;
-    const work = (async (): Promise<boolean> => {
+  const data = buildReasoningProcessWireData(state);
+  const templateRef = entry.templateRef;
+  if (!data || !templateRef) return false;
+  const previous = entry.templateEditPromise;
+  const work = (async (): Promise<boolean> => {
       // Match the two sibling serialisation tails in this file (`:641` state transitions,
       // `:735` finalize): a queue is for ordering, so a predecessor's failure must not take
       // the edit behind it down with it before that edit has even reserved a card_seq.
@@ -471,7 +361,7 @@ async function editEntryProgress(params: {
       }
       if (entry.skip) return false;
       if (params.signal.aborted) throw params.signal.reason;
-      // Reserve inside the single Model A queue: reservation order now equals request order, so
+      // Reserve inside the single Registry queue: reservation order now equals request order, so
       // a later CAS value cannot commit before an earlier one and make it stale on arrival.
       const cardSeq = entry.nextCardSeq++;
       await editTemplateCardWithRetry({
@@ -493,30 +383,13 @@ async function editEntryProgress(params: {
         signal: params.signal,
       });
       return true;
-    })();
-    entry.modelAEditPromise = work;
-    try {
-      return await work;
-    } finally {
-      if (entry.modelAEditPromise === work) entry.modelAEditPromise = undefined;
-    }
+  })();
+  entry.templateEditPromise = work;
+  try {
+    return await work;
+  } finally {
+    if (entry.templateEditPromise === work) entry.templateEditPromise = undefined;
   }
-
-  const { card, plain } = renderEntryProgress(params.sessionKey, entry, state);
-  if (!Array.isArray(card.body) || card.body.length === 0) return false;
-  await editCardMessage({
-    apiUrl: entry.ctx.apiUrl,
-    botToken: entry.ctx.botToken,
-    messageId,
-    channelId: entry.ctx.channelId,
-    channelType: entry.ctx.channelType,
-    card,
-    plain,
-    ...(params.transient ? { transient: true } : {}),
-    ...(entry.ctx.onBehalfOf ? { onBehalfOf: entry.ctx.onBehalfOf } : {}),
-    signal: params.signal,
-  });
-  return true;
 }
 
 async function flush(sessionKey: string): Promise<void> {
@@ -569,53 +442,22 @@ async function runFlush(sessionKey: string, entry: CardEntry): Promise<void> {
     const state = entryProgressState(sessionKey, entry);
     if (!entry.messageId) {
       if (!isCurrentEntry(sessionKey, entry)) return;
-      let res;
-      if (entry.deliveryMode === "model-a") {
-        const data = buildReasoningProcessWireData(state);
-        if (!data) {
-          dbg("model-a first frame deferred: no phases with actions yet");
-          return;
-        }
-        if (!entry.templateRef) return;
-        try {
-          res = await sendTemplateCardMessage({
-            apiUrl: entry.ctx.apiUrl,
-            botToken: entry.ctx.botToken,
-            channelId: entry.ctx.channelId,
-            channelType: entry.ctx.channelType,
-            templateRef: entry.templateRef,
-            state: data.state,
-            data,
-            signal,
-          });
-        } catch (error) {
-          if (!canFallbackFirstFrameToModelB(entry, error) || !isCurrentEntry(sessionKey, entry)) {
-            throw error;
-          }
-          warn(`model-a first frame rejected; retrying once with model-b: ${apiErrorMessage(error)}`);
-          entry.deliveryMode = "model-b";
-          entry.templateRef = undefined;
-        }
+      const data = buildReasoningProcessWireData(state);
+      if (!data) {
+        dbg("Registry first frame deferred: no phases with actions yet");
+        return;
       }
-
-      if (entry.deliveryMode === "model-b") {
-        const { card, plain } = renderEntryProgress(sessionKey, entry, state);
-        if (!Array.isArray(card.body) || card.body.length === 0) {
-          warn("rendered card cannot fit negotiated capabilities/limits; disabling for session");
-          entry.skip = true;
-          return;
-        }
-        res = await sendCardMessage({
-          apiUrl: entry.ctx.apiUrl,
-          botToken: entry.ctx.botToken,
-          channelId: entry.ctx.channelId,
-          channelType: entry.ctx.channelType,
-          card,
-          plain,
-          ...(entry.ctx.onBehalfOf ? { onBehalfOf: entry.ctx.onBehalfOf } : {}),
-          signal,
-        });
-      }
+      if (!entry.templateRef) return;
+      const res = await sendTemplateCardMessage({
+        apiUrl: entry.ctx.apiUrl,
+        botToken: entry.ctx.botToken,
+        channelId: entry.ctx.channelId,
+        channelType: entry.ctx.channelType,
+        templateRef: entry.templateRef,
+        state: data.state,
+        data,
+        signal,
+      });
       entry.messageId = res?.message_id;
       if (!isCurrentEntry(sessionKey, entry)) return;
       if (!entry.messageId) {
@@ -743,15 +585,12 @@ async function editTrackedCardState(
       });
       dbg(`transitioned session=${sessionKey} phase=${phase}`);
     } catch (err: unknown) {
-      // Same policy as runFlush (`:569`): only a deterministic 4xx is worth giving up on. A 5xx
+      // Same policy as runFlush: only a deterministic 4xx is worth giving up on. A 5xx
       // or timeout that merely outlasted REGISTRY_EDIT_RETRY_DELAYS_MS must not be terminal —
       // the next edit takes a fresh nextCardSeq, still strictly greater than the server's last
-      // commit, so retrying stays CAS-safe. Model B never set skip here and recovers on the next
-      // transition; Model A giving up made it the only mode a transient blip could freeze.
-      if (entry.deliveryMode === "model-a") {
-        const status = httpStatusFromApiFetchError(err);
-        if (status !== undefined && status >= 400 && status < 500 && status !== 429) entry.skip = true;
-      }
+      // commit, so retrying stays CAS-safe.
+      const status = httpStatusFromApiFetchError(err);
+      if (status !== undefined && status >= 400 && status < 500 && status !== 429) entry.skip = true;
       if (!abort.signal.aborted) {
         warn(`state transition failed: ${err instanceof Error ? err.message : String(err)}`);
       }
@@ -974,39 +813,9 @@ export async function finalizeCardWithResponse(
   endRunningThinking(entry, Date.now());
   if (entry.skip || !entry.messageId || cards.get(sessionKey) !== entry) return false;
   // Registry-authored messages can only be updated with template_ref + state + data.
-  // The final answer remains on the normal text path for Model A.
-  if (entry.deliveryMode === "model-a") return false;
-
-  const rendered = renderProgressResponseCard({
-    phase: "done",
-    steps: entry.steps,
-    elapsedMs: Date.now() - entry.startedAt,
-  }, responseText, capsCache.get(entry.ctx.apiUrl));
-  if (!rendered) return false;
-
-  // Freeze late hook/debounce activity while the terminal edit is in flight so
-  // no stale transient frame can overwrite the merged response afterward.
-  entry.skip = true;
-  try {
-    await editCardMessage({
-      apiUrl: entry.ctx.apiUrl,
-      botToken: entry.ctx.botToken,
-      messageId: entry.messageId,
-      channelId: entry.ctx.channelId,
-      channelType: entry.ctx.channelType,
-      card: rendered.card,
-      plain: rendered.plain,
-      ...(entry.ctx.onBehalfOf ? { onBehalfOf: entry.ctx.onBehalfOf } : {}),
-      signal: AbortSignal.timeout(EDIT_TIMEOUT_MS),
-    });
-    if (cards.get(sessionKey) === entry) cards.delete(sessionKey);
-    dbg(`merged final response session=${sessionKey} steps=${entry.steps.length}`);
-    return true;
-  } catch (err: unknown) {
-    if (cards.get(sessionKey) === entry) entry.skip = false;
-    warn(`final response merge failed: ${err instanceof Error ? err.message : String(err)}`);
-    return false;
-  }
+  // The final answer remains on the normal text path.
+  void responseText;
+  return false;
 }
 
 /** 硬清理(不发收尾帧),用于异常兜底。 */
@@ -1035,8 +844,7 @@ export function _resetCardProgressForTests(): void {
   }
   cards.clear();
   pausedCards.clear();
-  profileCache.clear();
-  capsCache.clear();
+  _resetBotCardProfileCacheForTests();
 }
 
 /**

--- a/src/card-progress.ts
+++ b/src/card-progress.ts
@@ -222,10 +222,38 @@ export function setCardContext(sessionKey: string, ctx: CardContext): void {
  * 返回值三态:`true`=启用,`false`=**明确禁用**(可永久 skip 本 session),
  * `null`=**瞬时探测失败**(5xx/网络,不缓存、不 skip,下次 flush 重探)。
  */
+function getBotCardProfileForCaller(
+  ctx: CardContext,
+  signal?: AbortSignal,
+): Promise<CardProfileManifest> {
+  if (signal?.aborted) return Promise.reject(signal.reason);
+  const sharedRead = getBotCardProfile({ apiUrl: ctx.apiUrl, botToken: ctx.botToken });
+  if (!signal) return sharedRead;
+
+  return new Promise<CardProfileManifest>((resolve, reject) => {
+    const cleanup = (): void => signal.removeEventListener("abort", onAbort);
+    const onAbort = (): void => {
+      cleanup();
+      reject(signal.reason);
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+    sharedRead.then(
+      (manifest) => {
+        cleanup();
+        resolve(manifest);
+      },
+      (error) => {
+        cleanup();
+        reject(error);
+      },
+    );
+  });
+}
+
 async function gateEnabled(ctx: CardContext, signal?: AbortSignal): Promise<boolean | null> {
   try {
     if (ctx.accountId) requestCardEventPolling(ctx.accountId);
-    const m = await getBotCardProfile({ apiUrl: ctx.apiUrl, botToken: ctx.botToken });
+    const m = await getBotCardProfileForCaller(ctx, signal);
     if (signal?.aborted) throw signal.reason;
     return !!reasoningTemplateForProfile(m);
   } catch (err: unknown) {

--- a/src/card-tool.test.ts
+++ b/src/card-tool.test.ts
@@ -41,6 +41,13 @@ function setup(): void {
     inputs: ["Input.Text"],
     actions: ["Action.OpenUrl", "Action.ToggleVisibility", "Action.CopyToClipboard"],
     limits: { max_nodes: 20, max_depth: 8, max_payload_bytes: 16384 },
+    config: {
+      card_enabled: true,
+      display_enabled: true,
+      interaction_enabled: true,
+      reasoning_enabled: false,
+      reasoning_template_ref: null,
+    },
   });
   vi.mocked(sendCardMessage).mockResolvedValue({ message_id: "m1" } as never);
   vi.mocked(sendMessage).mockResolvedValue({ message_id: "fallback" } as never);
@@ -65,7 +72,7 @@ describe("octo_send_card", () => {
     setup();
   });
 
-  it("cardInteraction:false 时 discovery 不暴露工具", () => {
+  it("本地 cardInteraction:false 已弃用，discovery 不再读取它", () => {
     vi.mocked(resolveOctoAccount).mockReturnValue({
       accountId: "default",
       enabled: true,
@@ -78,7 +85,8 @@ describe("octo_send_card", () => {
         cardInteraction: false,
       },
     } as never);
-    expect(createInteractiveCardTool({ cfg, agentAccountId: "default", deliveryContext } as never)).toEqual([]);
+    expect(createInteractiveCardTool({ cfg, agentAccountId: "default", deliveryContext } as never))
+      .toHaveLength(1);
   });
 
   it("cfg 缺失、非 Octo 会话、无可用账号时不暴露工具", () => {
@@ -106,7 +114,7 @@ describe("octo_send_card", () => {
     vi.mocked(resolveOctoAccount).mockImplementation(({ accountId }: { accountId: string }) => ({
       accountId, enabled: true, configured: true, config: { botToken: "tok", cardInteraction: false },
     } as never));
-    expect(createInteractiveCardTool({ cfg } as never)).toEqual([]);
+    expect(createInteractiveCardTool({ cfg } as never)).toHaveLength(1);
 
     vi.mocked(listOctoAccountIds).mockImplementation(() => { throw new Error("bad config"); });
     expect(createInteractiveCardTool({ cfg } as never)).toEqual([]);
@@ -399,7 +407,7 @@ describe("octo_send_card", () => {
     }));
   });
 
-  it("execute 热更新 cardInteraction:false 或账号失效时拒绝副作用", async () => {
+  it("execute 忽略本地 cardInteraction:false，仍以服务端配置为准", async () => {
     const current = tool();
     vi.mocked(resolveOctoAccount).mockReturnValue({
       accountId: "default",
@@ -415,7 +423,36 @@ describe("octo_send_card", () => {
     } as never);
     expect((await current.execute("disabled", {
       title: "确认", buttons: [{ id: "ok", label: "确定" }],
-    })).content[0].text).toMatch(/disabled/i);
+    })).details).toEqual(expect.objectContaining({ sent: true, message_id: "m1" }));
+    expect(sendCardMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it("服务端 interaction_enabled=false 时拒绝副作用，不降级发送文本", async () => {
+    vi.mocked(getCardProfile).mockResolvedValue({
+      available: true,
+      enabled: true,
+      profiles: ["octo/v1", "octo/v2"],
+      card_version: "1.5",
+      config: {
+        card_enabled: true,
+        display_enabled: true,
+        interaction_enabled: false,
+        reasoning_enabled: false,
+        reasoning_template_ref: null,
+      },
+    });
+
+    const result = await tool().execute("server-disabled", {
+      title: "确认", buttons: [{ id: "ok", label: "确定" }],
+    });
+
+    expect(result.content[0].text).toMatch(/disabled|plain text/i);
+    expect(sendCardMessage).not.toHaveBeenCalled();
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("execute 仍拒绝已失效账号", async () => {
+    const current = tool();
 
     vi.mocked(resolveOctoAccount).mockReturnValue({
       accountId: "default", enabled: false, configured: false, config: {},

--- a/src/card-tool.test.ts
+++ b/src/card-tool.test.ts
@@ -5,19 +5,30 @@ vi.mock("./accounts.js", () => ({
   resolveOctoAccount: vi.fn(),
 }));
 vi.mock("./api-fetch.js", () => ({
-  getCardProfile: vi.fn(),
   sendCardMessage: vi.fn(),
   sendMessage: vi.fn(),
+}));
+vi.mock("./card-profile-cache.js", () => ({
+  getBotCardProfile: vi.fn(),
+  peekBotCardProfile: vi.fn(),
 }));
 vi.mock("./card-session.js", () => ({ registerCardSession: vi.fn() }));
 
 import { createInteractiveCardTool } from "./card-tool.js";
 import { listOctoAccountIds, resolveOctoAccount } from "./accounts.js";
-import { getCardProfile, sendCardMessage, sendMessage } from "./api-fetch.js";
+import { sendCardMessage, sendMessage } from "./api-fetch.js";
+import { getBotCardProfile, peekBotCardProfile } from "./card-profile-cache.js";
 import { registerCardSession } from "./card-session.js";
 
 const cfg = { channels: { octo: { botToken: "tok" } } } as never;
 const deliveryContext = { channel: "octo", to: "group:g1", accountId: "default" };
+const INTERACTION_ENABLED_CONFIG = {
+  card_enabled: true,
+  display_enabled: true,
+  interaction_enabled: true,
+  reasoning_enabled: false,
+  reasoning_template_ref: null,
+} as const;
 
 function setup(): void {
   vi.mocked(listOctoAccountIds).mockReturnValue(["default"]);
@@ -32,7 +43,8 @@ function setup(): void {
       heartbeatIntervalMs: 30000,
     },
   } as never);
-  vi.mocked(getCardProfile).mockResolvedValue({
+  vi.mocked(peekBotCardProfile).mockReturnValue(undefined);
+  vi.mocked(getBotCardProfile).mockResolvedValue({
     available: true,
     enabled: true,
     profiles: ["octo/v1", "octo/v2"],
@@ -120,6 +132,41 @@ describe("octo_send_card", () => {
     expect(createInteractiveCardTool({ cfg } as never)).toEqual([]);
   });
 
+  it("cached interaction_enabled 只隐藏匹配 Bot 的交互卡工具", () => {
+    vi.mocked(listOctoAccountIds).mockReturnValue(["account-a", "account-b"]);
+    vi.mocked(resolveOctoAccount).mockImplementation(({ accountId }: { accountId?: string }) => ({
+      accountId: accountId ?? "account-a",
+      enabled: true,
+      configured: true,
+      config: {
+        botToken: `tok-${accountId}`,
+        apiUrl: "https://api.test",
+        pollIntervalMs: 2000,
+        heartbeatIntervalMs: 30000,
+      },
+    }) as never);
+    vi.mocked(peekBotCardProfile).mockImplementation(({ botToken }) => ({
+      available: true,
+      enabled: true,
+      config: {
+        card_enabled: true,
+        display_enabled: true,
+        interaction_enabled: botToken !== "tok-account-a",
+        reasoning_enabled: false,
+        reasoning_template_ref: null,
+      },
+    }));
+
+    expect(createInteractiveCardTool({
+      cfg,
+      deliveryContext: { ...deliveryContext, accountId: "account-a" },
+    } as never)).toEqual([]);
+    expect(createInteractiveCardTool({
+      cfg,
+      deliveryContext: { ...deliveryContext, accountId: "account-b" },
+    } as never)).toHaveLength(1);
+  });
+
   it("schema 不暴露 channelId/accountId，成功发送 v2 后登记 session", async () => {
     const current = tool();
     const schema = current.parameters as { properties: Record<string, unknown> };
@@ -148,7 +195,7 @@ describe("octo_send_card", () => {
   });
 
   it("octo/v2 profile 即表示 Submit 可用，不要求本地 actions 列出 Action.Submit", async () => {
-    vi.mocked(getCardProfile).mockResolvedValue({
+    vi.mocked(getBotCardProfile).mockResolvedValue({
       available: true,
       enabled: true,
       profiles: ["octo/v1", "octo/v2"],
@@ -156,6 +203,7 @@ describe("octo_send_card", () => {
       elements: ["TextBlock"],
       inputs: ["Input.Text"],
       actions: ["Action.OpenUrl", "Action.ToggleVisibility", "Action.CopyToClipboard"],
+      config: INTERACTION_ENABLED_CONFIG,
     });
 
     const result = await tool().execute("live-d12-shape", {
@@ -169,7 +217,7 @@ describe("octo_send_card", () => {
   });
 
   it("把 tool 的 section/options blocks 传给受控构建器并登记原卡快照", async () => {
-    vi.mocked(getCardProfile).mockResolvedValue({
+    vi.mocked(getBotCardProfile).mockResolvedValue({
       available: true,
       enabled: true,
       profiles: ["octo/v2"],
@@ -177,6 +225,7 @@ describe("octo_send_card", () => {
       elements: ["TextBlock", "Container", "FactSet"],
       inputs: ["Input.ChoiceSet"],
       actions: ["Action.OpenUrl"],
+      config: INTERACTION_ENABLED_CONFIG,
     });
 
     await tool().execute("structured", {
@@ -204,11 +253,12 @@ describe("octo_send_card", () => {
   });
 
   it("服务端不支持 octo/v2 时降级为当前会话纯文本，不登记 session", async () => {
-    vi.mocked(getCardProfile).mockResolvedValue({
+    vi.mocked(getBotCardProfile).mockResolvedValue({
       available: true,
       enabled: true,
       profiles: ["octo/v1"],
       card_version: "1.5",
+      config: INTERACTION_ENABLED_CONFIG,
     });
     const result = await tool().execute("call-2", {
       title: "选择环境",
@@ -222,7 +272,7 @@ describe("octo_send_card", () => {
   });
 
   it("octo/v2 不依赖 actions 列表，但请求未支持 Input 时仍降级文本", async () => {
-    vi.mocked(getCardProfile).mockResolvedValue({
+    vi.mocked(getBotCardProfile).mockResolvedValue({
       available: true,
       enabled: true,
       profiles: ["octo/v2"],
@@ -230,6 +280,7 @@ describe("octo_send_card", () => {
       elements: ["TextBlock"],
       inputs: ["Input.Text"],
       actions: [],
+      config: INTERACTION_ENABLED_CONFIG,
     });
     await tool().execute("missing-action", {
       title: "确认",
@@ -238,7 +289,7 @@ describe("octo_send_card", () => {
     expect(sendCardMessage).toHaveBeenCalledTimes(1);
     expect(sendMessage).not.toHaveBeenCalled();
 
-    vi.mocked(getCardProfile).mockResolvedValue({
+    vi.mocked(getBotCardProfile).mockResolvedValue({
       available: true,
       enabled: true,
       profiles: ["octo/v2"],
@@ -246,6 +297,7 @@ describe("octo_send_card", () => {
       elements: ["TextBlock"],
       inputs: [],
       actions: ["Action.OpenUrl"],
+      config: INTERACTION_ENABLED_CONFIG,
     });
     await tool().execute("missing-input", {
       title: "确认",
@@ -255,15 +307,13 @@ describe("octo_send_card", () => {
     expect(sendMessage).toHaveBeenCalledTimes(1);
   });
 
-  it("manifest 不可用、服务端禁用或版本不匹配时均降级", async () => {
+  it("服务端允许交互但 capability 版本不匹配时降级", async () => {
     const manifests = [
-      { available: false, enabled: true, profiles: ["octo/v2"], card_version: "1.5" },
-      { available: true, enabled: false, profiles: ["octo/v2"], card_version: "1.5" },
-      { available: true, enabled: true, profiles: ["octo/v2"], card_version: "1.4" },
-      { available: true, enabled: true, profiles: ["octo/v2"] },
+      { available: true, enabled: true, profiles: ["octo/v2"], card_version: "1.4", config: INTERACTION_ENABLED_CONFIG },
+      { available: true, enabled: true, profiles: ["octo/v2"], config: INTERACTION_ENABLED_CONFIG },
     ];
     for (const manifest of manifests) {
-      vi.mocked(getCardProfile).mockResolvedValueOnce(manifest);
+      vi.mocked(getBotCardProfile).mockResolvedValueOnce(manifest);
       const result = await tool().execute("gate", {
         title: "确认", buttons: [{ id: "ok", label: "确定" }],
       });
@@ -273,7 +323,7 @@ describe("octo_send_card", () => {
   });
 
   it("规范化按钮/choice、协商 limits，且不伪造缺失的 sessionKey", async () => {
-    vi.mocked(getCardProfile).mockResolvedValue({
+    vi.mocked(getBotCardProfile).mockResolvedValue({
       available: true,
       enabled: true,
       profiles: ["octo/v2"],
@@ -288,6 +338,7 @@ describe("octo_send_card", () => {
         max_input_text_bytes: 4096,
         max_inputs_bytes: 8192,
       },
+      config: INTERACTION_ENABLED_CONFIG,
     });
     const current = createInteractiveCardTool({
       cfg,
@@ -335,7 +386,7 @@ describe("octo_send_card", () => {
     ]) {
       expect((await current.execute("invalid", args)).details).toBeNull();
     }
-    expect(getCardProfile).not.toHaveBeenCalled();
+    expect(getBotCardProfile).not.toHaveBeenCalled();
 
     expect((await current.execute("invalid-inputs", {
       title: "确认", buttons: [{ id: "ok", label: "确定" }], inputs: "bad",
@@ -343,7 +394,7 @@ describe("octo_send_card", () => {
   });
 
   it("manifest 探测失败时降级文本；fallback 失败返回错误", async () => {
-    vi.mocked(getCardProfile).mockRejectedValue(new Error("profile down"));
+    vi.mocked(getBotCardProfile).mockRejectedValue(new Error("profile down"));
     const degraded = await tool().execute("probe-down", {
       title: "确认",
       buttons: [{ id: "ok", label: "确定" }],
@@ -359,12 +410,12 @@ describe("octo_send_card", () => {
   });
 
   it("非 Error 异常也会生成稳定错误信息", async () => {
-    vi.mocked(getCardProfile).mockRejectedValueOnce("profile down");
+    vi.mocked(getBotCardProfile).mockRejectedValueOnce("profile down");
     expect((await tool().execute("probe-string", {
       title: "确认", buttons: [{ id: "ok", label: "确定" }],
     })).details).toEqual(expect.objectContaining({ degraded: true }));
 
-    vi.mocked(getCardProfile).mockRejectedValueOnce("profile down");
+    vi.mocked(getBotCardProfile).mockRejectedValueOnce("profile down");
     vi.mocked(sendMessage).mockRejectedValueOnce("fallback down");
     expect((await tool().execute("fallback-string", {
       title: "确认", buttons: [{ id: "ok", label: "确定" }],
@@ -428,7 +479,7 @@ describe("octo_send_card", () => {
   });
 
   it("服务端 interaction_enabled=false 时拒绝副作用，不降级发送文本", async () => {
-    vi.mocked(getCardProfile).mockResolvedValue({
+    vi.mocked(getBotCardProfile).mockResolvedValue({
       available: true,
       enabled: true,
       profiles: ["octo/v1", "octo/v2"],
@@ -466,7 +517,7 @@ describe("octo_send_card", () => {
   it("结构非法时在探测和发送前返回错误", async () => {
     const result = await tool().execute("invalid", { title: "确认", buttons: [] });
     expect(result.content[0].text).toMatch(/at least one button/i);
-    expect(getCardProfile).not.toHaveBeenCalled();
+    expect(getBotCardProfile).not.toHaveBeenCalled();
     expect(sendCardMessage).not.toHaveBeenCalled();
     expect(sendMessage).not.toHaveBeenCalled();
   });

--- a/src/card-tool.ts
+++ b/src/card-tool.ts
@@ -1,7 +1,8 @@
 import type { OpenClawConfig } from "openclaw/plugin-sdk";
 import type { OpenClawPluginToolContext } from "openclaw/plugin-sdk/plugin-entry";
 import { listOctoAccountIds, resolveOctoAccount } from "./accounts.js";
-import { getCardProfile, sendCardMessage, sendMessage, type CardProfileManifest } from "./api-fetch.js";
+import { sendCardMessage, sendMessage, type CardProfileManifest } from "./api-fetch.js";
+import { getBotCardProfile, peekBotCardProfile } from "./card-profile-cache.js";
 import {
   buildInteractiveCard,
   type CardButtonSpec,
@@ -15,6 +16,7 @@ import { INTERACTIVE_CARD_TOOL_NAME, CHANNEL_ID } from "./constants.js";
 import { resolveOutboundOctoTarget } from "./actions.js";
 import { CARD_INTERACTIVE_PROFILE, CARD_VERSION, type ChannelType } from "./types.js";
 import type { CardCaps } from "./card-render.js";
+import { requestCardEventPolling } from "./events-poll.js";
 
 const SEND_TIMEOUT_MS = 15_000;
 
@@ -114,8 +116,9 @@ function normalizeBlocks(value: unknown): InteractiveCardBlockSpec[] | undefined
 }
 
 function interactiveGateReason(manifest: CardProfileManifest): string | null {
-  if (!manifest.available) return "interactive card manifest is unavailable";
-  if (!manifest.enabled) return "card sending is disabled by the server";
+  if (!manifest.available || manifest.config?.interaction_enabled !== true) {
+    return "interactive cards are disabled by the server Bot policy";
+  }
   if (!manifest.profiles?.includes(CARD_INTERACTIVE_PROFILE)) return "octo/v2 is not advertised";
   if (manifest.card_version !== CARD_VERSION) return `card_version ${manifest.card_version ?? "missing"} is unsupported`;
   return null;
@@ -146,8 +149,16 @@ export function createInteractiveCardTool(params: Params): any[] {
       ?? agentAccountId
       ?? (ids.length === 1 ? ids[0] : undefined);
     if (discoveryAccountId) {
-      if (resolveOctoAccount({ cfg, accountId: discoveryAccountId }).config.cardInteraction === false) return [];
-    } else if (configured.every((account) => account.config.cardInteraction === false)) {
+      const account = resolveOctoAccount({ cfg, accountId: discoveryAccountId });
+      if (account.config.botToken && peekBotCardProfile({
+        apiUrl: account.config.apiUrl,
+        botToken: account.config.botToken,
+      })?.config?.interaction_enabled === false) return [];
+    } else if (configured.every((account) =>
+      !!account.config.botToken && peekBotCardProfile({
+        apiUrl: account.config.apiUrl,
+        botToken: account.config.botToken,
+      })?.config?.interaction_enabled === false)) {
       return [];
     }
   } catch {
@@ -257,10 +268,6 @@ export function createInteractiveCardTool(params: Params): any[] {
       if (!account.enabled || !account.configured || !account.config.botToken) {
         return error("Octo account is not fully configured");
       }
-      if (account.config.cardInteraction === false) {
-        return error("interactive cards are disabled for this account; use plain text");
-      }
-
       const target = resolveOutboundOctoTarget(deliveryContext.to, deliveryContext.threadId);
       const spec: InteractiveCardSpec = {
         title: typeof args.title === "string" ? args.title : "",
@@ -276,10 +283,14 @@ export function createInteractiveCardTool(params: Params): any[] {
       let negotiatedCaps: CardCaps | undefined;
       let unsupportedReason = "card profile probe failed";
       try {
-        manifest = await getCardProfile({
+        requestCardEventPolling(account.accountId);
+        manifest = await getBotCardProfile({
           apiUrl: account.config.apiUrl,
           botToken: account.config.botToken,
         });
+        if (!manifest.available || manifest.config?.interaction_enabled !== true) {
+          return error("interactive cards are disabled by the server Bot policy; use plain text");
+        }
         unsupportedReason = interactiveGateReason(manifest) ?? "";
       } catch (probeError) {
         unsupportedReason = `card profile probe failed: ${probeError instanceof Error ? probeError.message : String(probeError)}`;

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1544,10 +1544,11 @@ export const octoPlugin: ChannelPlugin<ResolvedOctoAccount> = {
         });
         log?.info?.(`octo: [${account.accountId}] card_action poller started`);
       };
-      if (account.config.cardInteraction !== false) {
-        setCardEventPollStarter(account.accountId, startCardEventPoller);
-        if (process.env.OCTO_CARD_POLL_FORCE === "1") startCardEventPoller();
-      }
+      // The poller remains lazy, but every card-profile consumer may now start it so
+      // bot_setting_updated can invalidate that Bot's cached policy even when interactions are
+      // currently disabled. Local cardInteraction is deprecated and no longer gates events.
+      setCardEventPollStarter(account.accountId, startCardEventPoller);
+      if (process.env.OCTO_CARD_POLL_FORCE === "1") startCardEventPoller();
 
       // 6. Connect WebSocket — pure real-time
       const socket = new WKSocket({

--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -7,6 +7,7 @@
  * not fail validation today.
  */
 export type ForkCommandScope = "owner-mentioned" | "any-mentioned" | "owner-only" | "any";
+/** @deprecated Kept only so older openclaw.json files still type-check; runtime ignores it. */
 export type ReasoningCardTemplateMode = "off" | "shadow" | "experimental";
 
 /** Per-command configuration (top-level only; not per-account in v1). */
@@ -30,10 +31,14 @@ export interface OctoAccountConfig {
   botUid?: string;
   historyLimit?: number;  // 群聊历史消息条数限制（默认20）
   historyPromptTemplate?: string;  // Template for group history context injection
-  cardProgress?: boolean;  // false force-disables automatic progress cards; true/unset follows server capabilities
-  reasoningCardTemplateMode?: ReasoningCardTemplateMode;  // off=Model B, shadow=discover only, experimental=Model A when compatible
-  cardDisplay?: boolean;  // false force-disables the display-card tool; true/unset follows server capabilities
-  cardInteraction?: boolean;  // false force-disables interactive cards; true/unset follows server capabilities
+  /** @deprecated Ignored; the server's per-Bot card config is authoritative. */
+  cardProgress?: boolean;
+  /** @deprecated Ignored; the server's reasoning_enabled/template_ref is authoritative. */
+  reasoningCardTemplateMode?: ReasoningCardTemplateMode;
+  /** @deprecated Ignored; the server's per-Bot display_enabled is authoritative. */
+  cardDisplay?: boolean;
+  /** @deprecated Ignored; the server's per-Bot interaction_enabled is authoritative. */
+  cardInteraction?: boolean;
   onBehalfOf?: string;  // Persona clone: grantor uid — bot acts on behalf of this human
   secretsFileRoot?: string;  // Jail root for write-secret: secret files may only be written under this path. When unset, defaults to the agent's workspace (agents.list[].workspace matched to the agent, else agents.defaults.workspace); if neither resolves, write-secret fails closed (no process.cwd() fallback).
   dispatchTimeoutMs?: number;  // Explicit per-inbound dispatch timeout override (ms). Unset = derived from agents.defaults.timeoutSeconds + 60s buffer (issue #113).
@@ -53,10 +58,14 @@ export interface OctoConfig {
   botUid?: string;
   historyLimit?: number;  // 群聊历史消息条数限制（默认20）
   historyPromptTemplate?: string;  // Template for group history context injection
-  cardProgress?: boolean;  // Top-level default for automatic progress cards
-  reasoningCardTemplateMode?: ReasoningCardTemplateMode;  // Top-level Registry migration mode for reasoning cards
-  cardDisplay?: boolean;  // Top-level default for the display-card tool
-  cardInteraction?: boolean;  // Top-level default for interactive cards
+  /** @deprecated Ignored; the server's per-Bot card config is authoritative. */
+  cardProgress?: boolean;
+  /** @deprecated Ignored; the server's reasoning_enabled/template_ref is authoritative. */
+  reasoningCardTemplateMode?: ReasoningCardTemplateMode;
+  /** @deprecated Ignored; the server's per-Bot display_enabled is authoritative. */
+  cardDisplay?: boolean;
+  /** @deprecated Ignored; the server's per-Bot interaction_enabled is authoritative. */
+  cardInteraction?: boolean;
   onBehalfOf?: string;  // Persona clone: grantor uid — bot acts on behalf of this human
   secretsFileRoot?: string;  // Jail root for write-secret (see OctoAccountConfig)
   dispatchTimeoutMs?: number;  // Explicit per-inbound dispatch timeout override (ms); see OctoAccountConfig
@@ -82,25 +91,6 @@ export const SECRETS_FILE_ROOT_DESCRIPTION =
 // fires strictly after OpenClaw core's own agent-run timeout.
 export const DISPATCH_TIMEOUT_MS_DESCRIPTION =
   "Per-inbound dispatch timeout in milliseconds (infrastructure backstop that releases the per-group queue when an upstream dispatch hangs). When unset, derived from agents.defaults.timeoutSeconds (default 600) as timeoutSeconds*1000 + 60000, so it always fires after the agent-run timeout. Set explicitly only when you need to decouple it from the agent timeout.";
-
-export const CARD_PROGRESS_DESCRIPTION =
-  "When omitted or true, follow the server card capability gate; false force-disables automatic progress cards. Per-account values override the top-level value.";
-
-export const REASONING_CARD_TEMPLATE_MODE_DESCRIPTION =
-  "Registry migration mode for automatic reasoning progress cards. off keeps local Model B rendering, shadow validates discovery while still sending Model B, and experimental sends Model A when exactly one compatible Bot-catalog template is advertised, using its manifest version unchanged; zero or multiple compatible entries fall back to Model B because catalog order is not a preference signal. A rejected experimental first frame retries once as Model B only for a deterministic card-invalid response; timeouts, conflicts, and transient/server errors do not trigger that fallback. Defaults to experimental; per-account values override the top-level value.";
-
-const REASONING_CARD_TEMPLATE_MODE_SCHEMA = {
-  type: "string" as const,
-  enum: ["off", "shadow", "experimental"] as const,
-  default: "experimental" as const,
-  description: REASONING_CARD_TEMPLATE_MODE_DESCRIPTION,
-};
-
-export const CARD_DISPLAY_DESCRIPTION =
-  "When omitted or true, follow the server card capability gate; false force-disables the octo_send_display_card tool. Per-account values override the top-level value.";
-
-export const CARD_INTERACTION_DESCRIPTION =
-  "When omitted or true, follow the server octo/v2 card capability gate; false force-disables the octo_send_card tool and new interactive callback polling. Per-account values override the top-level value.";
 
 export const EVENT_WAIT_SECONDS_DESCRIPTION =
   "Seconds to let the server hold an empty /v1/bot/events queue open (its `wait` parameter), so a card action reaches the bot as soon as it happens instead of on the next poll tick. Omitted or 0 keeps plain short polling at pollIntervalMs; a non-zero value below 5 is raised to 5, because shorter holds issue more requests than the short polling they replace. Requires a server that supports the long poll; older servers ignore the field and answer immediately, which is safe but gives no benefit. The client request timeout is derived from this value, and the server clamps it to 30s. Per-account values override the top-level value.";
@@ -146,10 +136,6 @@ export const OctoConfigJsonSchema = {
       botUid: { type: "string" },
       historyLimit: { type: "number", minimum: 1, maximum: 100 },
       historyPromptTemplate: { type: "string" },
-      cardProgress: { type: "boolean", description: CARD_PROGRESS_DESCRIPTION },
-      reasoningCardTemplateMode: REASONING_CARD_TEMPLATE_MODE_SCHEMA,
-      cardDisplay: { type: "boolean", description: CARD_DISPLAY_DESCRIPTION },
-      cardInteraction: { type: "boolean", description: CARD_INTERACTION_DESCRIPTION },
       onBehalfOf: { type: "string" },
       secretsFileRoot: { type: "string", description: SECRETS_FILE_ROOT_DESCRIPTION },
       dispatchTimeoutMs: { type: "number", minimum: 1000, description: DISPATCH_TIMEOUT_MS_DESCRIPTION },
@@ -172,10 +158,6 @@ export const OctoConfigJsonSchema = {
             botUid: { type: "string" },
             historyLimit: { type: "number", minimum: 1, maximum: 100 },
             historyPromptTemplate: { type: "string" },
-            cardProgress: { type: "boolean", description: CARD_PROGRESS_DESCRIPTION },
-            reasoningCardTemplateMode: REASONING_CARD_TEMPLATE_MODE_SCHEMA,
-            cardDisplay: { type: "boolean", description: CARD_DISPLAY_DESCRIPTION },
-            cardInteraction: { type: "boolean", description: CARD_INTERACTION_DESCRIPTION },
             onBehalfOf: { type: "string" },
             secretsFileRoot: { type: "string", description: SECRETS_FILE_ROOT_DESCRIPTION },
             dispatchTimeoutMs: { type: "number", minimum: 1000, description: DISPATCH_TIMEOUT_MS_DESCRIPTION },

--- a/src/events-poll.test.ts
+++ b/src/events-poll.test.ts
@@ -348,6 +348,20 @@ describe("event poller", () => {
     requestCardEventPolling("bot-a");
     expect(starter).toHaveBeenCalledOnce();
   });
+
+  it("channel 与 agent runtime 的独立模块实例共享懒启动器", async () => {
+    vi.resetModules();
+    const channelRuntime = await import("./events-poll.js");
+    const starter = vi.fn();
+    channelRuntime.setCardEventPollStarter("Cross-Loader-Bot", starter);
+
+    vi.resetModules();
+    const agentRuntime = await import("./events-poll.js");
+    agentRuntime.requestCardEventPolling("cross-loader-bot");
+
+    expect(starter).toHaveBeenCalledOnce();
+    agentRuntime.setCardEventPollStarter("cross-loader-bot", undefined);
+  });
 });
 
 describe("file event cursor store", () => {

--- a/src/events-poll.test.ts
+++ b/src/events-poll.test.ts
@@ -10,6 +10,11 @@ import {
   type EventCursorStore,
 } from "./events-poll.js";
 import type { CardAction } from "./card-action.js";
+import {
+  _resetBotCardProfileCacheForTests,
+  getBotCardProfile,
+  peekBotCardProfile,
+} from "./card-profile-cache.js";
 
 const actionEvent = (eventId: number) => ({
   event_id: eventId,
@@ -37,8 +42,12 @@ function memoryCursor(initial = 0): EventCursorStore & { saved: number[] } {
 }
 
 describe("event poller", () => {
-  beforeEach(() => vi.useFakeTimers());
+  beforeEach(() => {
+    vi.useFakeTimers();
+    _resetBotCardProfileCacheForTests();
+  });
   afterEach(() => {
+    _resetBotCardProfileCacheForTests();
     vi.useRealTimers();
     vi.restoreAllMocks();
   });
@@ -125,6 +134,54 @@ describe("event poller", () => {
 
     expect(onCardAction).not.toHaveBeenCalled();
     expect(cursor.saved).toEqual([31]);
+    poller.stop();
+  });
+
+  it("bot_setting_updated 只清理当前 Bot 的 profile cache，并正常推进 cursor", async () => {
+    const profile = (displayEnabled: boolean) => ({
+      enabled: true,
+      profiles: ["octo/v1"],
+      card_version: "1.5",
+      config: {
+        card_enabled: true,
+        display_enabled: displayEnabled,
+        interaction_enabled: true,
+        reasoning_enabled: false,
+        reasoning_template_ref: null,
+      },
+    });
+    global.fetch = vi.fn().mockImplementation(async (_url: string, init?: RequestInit) => {
+      const token = String((init?.headers as Record<string, string> | undefined)?.Authorization ?? "");
+      return Response.json(profile(token.includes("bot-b")));
+    }) as typeof fetch;
+    const botA = { apiUrl: "https://api.test", botToken: "bot-a" };
+    const botB = { apiUrl: "https://api.test", botToken: "bot-b" };
+    await getBotCardProfile(botA);
+    await getBotCardProfile(botB);
+
+    global.fetch = vi.fn().mockResolvedValue(Response.json({
+      results: [{
+        event_id: 32,
+        event_type: "bot_setting_updated",
+        event_data: { scope: "bot_setting" },
+      }],
+    })) as typeof fetch;
+    const cursor = memoryCursor(31);
+    const onCardAction = vi.fn();
+    const poller = startEventPoller({
+      ...botA,
+      intervalMs: 1000,
+      cursorStore: cursor,
+      onCardAction,
+    });
+
+    await poller.ready;
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(peekBotCardProfile(botA)).toBeUndefined();
+    expect(peekBotCardProfile(botB)?.config?.display_enabled).toBe(true);
+    expect(onCardAction).not.toHaveBeenCalled();
+    expect(cursor.saved).toEqual([32]);
     poller.stop();
   });
 

--- a/src/events-poll.ts
+++ b/src/events-poll.ts
@@ -12,6 +12,7 @@ import {
 } from "./api-fetch.js";
 import { CHANNEL_ID } from "./constants.js";
 import { parseCardAction, type CardAction } from "./card-action.js";
+import { invalidateBotCardProfile } from "./card-profile-cache.js";
 
 const DEFAULT_INTERVAL_MS = 2_000;
 const DEFAULT_LIMIT = 50;
@@ -85,7 +86,20 @@ export interface EventPoller {
   cursor(): number;
 }
 
-const pollStarters = new Map<string, () => void>();
+const POLL_STARTERS_STATE_KEY = Symbol.for("openclaw.octo.card-event-poll-starters.v1");
+
+function getPollStarters(): Map<string, () => void> {
+  const root = process as unknown as Record<PropertyKey, unknown>;
+  const existing = root[POLL_STARTERS_STATE_KEY] as Map<string, () => void> | undefined;
+  if (existing) return existing;
+  const created = new Map<string, () => void>();
+  root[POLL_STARTERS_STATE_KEY] = created;
+  return created;
+}
+
+// Channel and embedded agent runtimes may load separate module instances. Keep the lazy starters
+// process-shared so any profile consumer can activate the owning account's event poller.
+const pollStarters = getPollStarters();
 
 export function setCardEventPollStarter(accountId: string, starter: (() => void) | undefined): void {
   const id = normalizeAccountId(accountId);
@@ -207,6 +221,10 @@ export function startEventPoller(options: EventPollerOptions): EventPoller {
         if (action) {
           cardActions += 1;
           await options.onCardAction(action);
+        }
+        if (event.event_type === "bot_setting_updated" &&
+            event.event_data?.scope === "bot_setting") {
+          invalidateBotCardProfile({ apiUrl: options.apiUrl, botToken: options.botToken });
         }
 
         await options.cursorStore.save(event.event_id);

--- a/src/inbound-card-failure-precedence.test.ts
+++ b/src/inbound-card-failure-precedence.test.ts
@@ -86,9 +86,29 @@ function installFetchStub(opts: { failPlainSend?: boolean } = {}) {
     if (url.includes("/card/profile")) {
       return json({
         enabled: true,
-        profiles: ["octo/v1"],
+        profiles: ["octo/v1", "octo/v2"],
         card_version: "1.5",
         elements: ["TextBlock", "RichTextBlock", "Container", "ColumnSet"],
+        config: {
+          card_enabled: true,
+          display_enabled: true,
+          interaction_enabled: true,
+          reasoning_enabled: true,
+          reasoning_template_ref: { id: "ai.reasoning-process", version: "0.3.0" },
+        },
+        templating: {
+          supported: true,
+          wire: "template-ref/v1",
+          templates: [{
+            id: "ai.reasoning-process",
+            version: "0.3.0",
+            views: [
+              { name: "active", states: ["reasoning", "answering"], wire_profile: "octo/v2", submit_actions: ["reasoning_stop"] },
+              { name: "error", states: ["error"], wire_profile: "octo/v2", submit_actions: ["reasoning_retry"] },
+              { name: "result", states: ["completed", "stopped"], wire_profile: "octo/v1", submit_actions: [] },
+            ],
+          }],
+        },
       });
     }
     if (url.includes("/members")) {
@@ -204,13 +224,12 @@ describe("inbound progress-card failure precedence", () => {
     // …so the card must not claim success on the strength of the tool delivery.
     const terminal = edits.at(-1);
     expect(terminal).toBeTruthy();
-    const card = JSON.parse(terminal!.content_edit as string).card as {
-      body: Array<Record<string, unknown>>;
-    };
-    const header = String((card.body[0] as { text?: string }).text
-      ?? JSON.stringify(card.body[0]));
-    expect(header).toContain("Interrupted");
-    expect(header).not.toContain("Done");
+    expect(terminal).toMatchObject({
+      template_ref: { id: "ai.reasoning-process", version: "0.3.0" },
+      state: "error",
+      data: { state: "error" },
+    });
+    expect(terminal).not.toHaveProperty("content_edit");
   });
   it("keeps the card in the error state when the buffered final send failed silently", async () => {
     const { edits, texts } = installFetchStub({ failPlainSend: true });
@@ -232,12 +251,11 @@ describe("inbound progress-card failure precedence", () => {
     expect(texts).toHaveLength(0);
     const terminal = edits.at(-1);
     expect(terminal).toBeTruthy();
-    const card = JSON.parse(terminal!.content_edit as string).card as {
-      body: Array<Record<string, unknown>>;
-    };
-    const header = String((card.body[0] as { text?: string }).text
-      ?? JSON.stringify(card.body[0]));
-    expect(header).toContain("Interrupted");
-    expect(header).not.toContain("Done");
+    expect(terminal).toMatchObject({
+      template_ref: { id: "ai.reasoning-process", version: "0.3.0" },
+      state: "error",
+      data: { state: "error" },
+    });
+    expect(terminal).not.toHaveProperty("content_edit");
   });
 });

--- a/src/inbound-card-response-merge.test.ts
+++ b/src/inbound-card-response-merge.test.ts
@@ -77,10 +77,30 @@ function installFetchStub() {
     if (url.includes("/card/profile")) {
       return json({
         enabled: true,
-        profiles: ["octo/v1"],
+        profiles: ["octo/v1", "octo/v2"],
         card_version: "1.5",
         elements: ["TextBlock", "RichTextBlock", "Container", "ColumnSet", "ActionSet"],
         actions: ["Action.ToggleVisibility"],
+        config: {
+          card_enabled: true,
+          display_enabled: true,
+          interaction_enabled: true,
+          reasoning_enabled: true,
+          reasoning_template_ref: { id: "ai.reasoning-process", version: "0.3.0" },
+        },
+        templating: {
+          supported: true,
+          wire: "template-ref/v1",
+          templates: [{
+            id: "ai.reasoning-process",
+            version: "0.3.0",
+            views: [
+              { name: "active", states: ["reasoning", "answering"], wire_profile: "octo/v2", submit_actions: ["reasoning_stop"] },
+              { name: "error", states: ["error"], wire_profile: "octo/v2", submit_actions: ["reasoning_retry"] },
+              { name: "result", states: ["completed", "stopped"], wire_profile: "octo/v1", submit_actions: [] },
+            ],
+          }],
+        },
       });
     }
     if (url.includes("/members")) {
@@ -218,7 +238,7 @@ describe("inbound final response progress-card merge", () => {
     else process.env.OCTO_CARD_MERGE_FINAL = originalMergeFlag;
   });
 
-  it("edits the visible progress card with the final text instead of sending a second text message", async () => {
+  it("keeps the Registry progress card separate and sends the final answer on the text path", async () => {
     const { sends, edits } = installFetchStub();
     const hooks = collectCardHooks();
     const finalText = "结论\n\n渠道 B 的下降主要来自权益认知不足。";
@@ -228,12 +248,16 @@ describe("inbound final response progress-card merge", () => {
     const cardSends = sends.filter((body) => (body.payload as { type?: number } | undefined)?.type === 17);
     const textSends = sends.filter((body) => (body.payload as { type?: number } | undefined)?.type === 1);
     expect(cardSends).toHaveLength(1);
-    expect(textSends).toHaveLength(0);
+    expect(textSends).toHaveLength(1);
+    expect((textSends[0].payload as { content?: string }).content).toContain("渠道 B 的下降主要来自权益认知不足");
     expect(edits).toHaveLength(1);
     expect(edits[0].message_id).toBe("progress-message");
-    const contentEdit = JSON.parse(edits[0].content_edit as string);
-    expect(contentEdit.transient).toBeUndefined();
-    expect(JSON.stringify(contentEdit.card)).toContain("渠道 B 的下降主要来自权益认知不足");
+    expect(edits[0]).toMatchObject({
+      template_ref: { id: "ai.reasoning-process", version: "0.3.0" },
+      state: "completed",
+      card_seq: 1,
+    });
+    expect(edits[0]).not.toHaveProperty("content_edit");
   });
 
   it("captures reasoning snapshots in the progress card without sending a reasoning text message", async () => {
@@ -249,10 +273,11 @@ describe("inbound final response progress-card merge", () => {
     const cardSends = sends.filter((body) => (body.payload as { type?: number } | undefined)?.type === 17);
     const textSends = sends.filter((body) => (body.payload as { type?: number } | undefined)?.type === 1);
     expect(cardSends).toHaveLength(1);
-    expect(textSends).toHaveLength(0);
-    const card = (cardSends[0]?.payload as { card: Record<string, unknown> }).card;
-    expect(JSON.stringify(card)).toContain("先核对渠道数据，再给出结论。");
-    expect(JSON.stringify(card)).toContain("read");
+    expect(textSends).toHaveLength(1);
+    const payload = cardSends[0]?.payload;
+    expect(JSON.stringify(payload)).toContain("先核对渠道数据，再给出结论。");
+    expect(JSON.stringify(payload)).toContain("read");
+    expect(payload).not.toHaveProperty("card");
   });
 
   it.each(["stream", "dispatcher"] as const)(
@@ -274,7 +299,7 @@ describe("inbound final response progress-card merge", () => {
       expect(JSON.stringify(cardSend?.payload)).not.toContain("MUST STAY HIDDEN");
       const textSends = sends.filter((body) =>
         (body.payload as { type?: number } | undefined)?.type === 1);
-      expect(textSends).toHaveLength(0);
+      expect(textSends).toHaveLength(1);
     },
   );
 

--- a/src/inbound.ts
+++ b/src/inbound.ts
@@ -2682,12 +2682,11 @@ export async function handleInboundMessage(params: {
   // 波 B:登记进度卡发送上下文(hook 侧懒发/更新时用)。route.sessionKey 桥接
   // dispatch↔hook(H1 实证一致)。OBO(persona-clone)场景由 setCardContext 内部标记跳过。
   setCardContext(route.sessionKey, {
+    accountId: account.accountId,
     apiUrl,
     botToken,
     channelId: replyChannelId,
     channelType: replyChannelType,
-    cardProgress: account.config.cardProgress,
-    reasoningCardTemplateMode: account.config.reasoningCardTemplateMode,
     reasoningVisibility,
     ...(effectiveOnBehalfOf ? { onBehalfOf: effectiveOnBehalfOf } : {}),
   });

--- a/src/manifest-schema-sync.test.ts
+++ b/src/manifest-schema-sync.test.ts
@@ -34,36 +34,17 @@ describe("openclaw.plugin.json channelConfigs", () => {
     );
   });
 
-  it.each(["cardProgress", "cardDisplay", "cardInteraction"])(
-    "%s description matches at top-level and per-account",
-    (key) => {
-      const manifestProps = manifest.channelConfigs.octo.schema.properties;
-      const manifestAccountProps = manifestProps.accounts.additionalProperties.properties;
-      const tsProps = OctoConfigJsonSchema.schema.properties as Record<string, any>;
-      const tsAccountProps = (tsProps.accounts as any).additionalProperties.properties;
-      const description = tsProps[key]?.description as string | undefined;
-
-      expect(description).toBeDefined();
-      expect(manifestProps[key]?.description).toBe(description);
-      expect(tsAccountProps[key]?.description).toBe(description);
-      expect(manifestAccountProps[key]?.description).toBe(description);
-      expect(description).toMatch(/omitted|true/i);
-      expect(description).toMatch(/false/i);
-      expect(description).toMatch(/server/i);
-    },
-  );
-
-  it("reasoningCardTemplateMode is synced at top-level and per-account", () => {
+  it("does not advertise the deprecated local card policy fields", () => {
     const manifestProps = manifest.channelConfigs.octo.schema.properties;
     const manifestAccountProps = manifestProps.accounts.additionalProperties.properties;
     const tsProps = OctoConfigJsonSchema.schema.properties as Record<string, any>;
     const tsAccountProps = (tsProps.accounts as any).additionalProperties.properties;
-
-    expect(tsProps.reasoningCardTemplateMode.enum).toEqual(["off", "shadow", "experimental"]);
-    expect(tsProps.reasoningCardTemplateMode.default).toBe("experimental");
-    expect(tsAccountProps.reasoningCardTemplateMode).toEqual(tsProps.reasoningCardTemplateMode);
-    expect(manifestProps.reasoningCardTemplateMode).toEqual(tsProps.reasoningCardTemplateMode);
-    expect(manifestAccountProps.reasoningCardTemplateMode).toEqual(tsProps.reasoningCardTemplateMode);
+    for (const key of ["cardProgress", "reasoningCardTemplateMode", "cardDisplay", "cardInteraction"]) {
+      expect(tsProps[key]).toBeUndefined();
+      expect(tsAccountProps[key]).toBeUndefined();
+      expect(manifestProps[key]).toBeUndefined();
+      expect(manifestAccountProps[key]).toBeUndefined();
+    }
   });
 
   // Description drift guard: secretsFileRoot carries operator-facing semantics

--- a/src/reasoning-process.test.ts
+++ b/src/reasoning-process.test.ts
@@ -226,6 +226,32 @@ describe("reasoning process template discovery", () => {
     }
   });
 
+  it("selects the exact server-configured ref when the catalog advertises multiple compatible versions", () => {
+    expect(selectReasoningProcessTemplate({
+      supported: true,
+      wire: "template-ref/v1",
+      templates: [template("0.2.0"), template("0.3.0")],
+    }, { id: "ai.reasoning-process", version: "0.3.0" })).toEqual({
+      id: "ai.reasoning-process",
+      version: "0.3.0",
+    });
+  });
+
+  it("fails closed when the configured ref is absent, malformed, or points at an incompatible entry", () => {
+    const incompatible = { ...template("0.3.0"), views: template("0.3.0").views.slice(0, 2) };
+    const templating = {
+      supported: true,
+      wire: "template-ref/v1",
+      templates: [template("0.2.0"), incompatible],
+    };
+
+    expect(selectReasoningProcessTemplate(templating, null)).toBeNull();
+    expect(selectReasoningProcessTemplate(templating, { id: "ai.reasoning-process", version: "0.4.0" }))
+      .toBeNull();
+    expect(selectReasoningProcessTemplate(templating, { id: "ai.reasoning-process", version: "0.3.0" }))
+      .toBeNull();
+  });
+
   it("selects the sole compatible version when another advertised version has incompatible views", () => {
     const incompatible = { ...template("0.2.0"), views: template("0.2.0").views.slice(0, 2) };
     expect(selectReasoningProcessTemplate({

--- a/src/reasoning-process.ts
+++ b/src/reasoning-process.ts
@@ -100,15 +100,21 @@ const REQUIRED_VIEWS = [
  * `.octospec/tasks/cardtmpl-runtime-catalog-overlay/brief.md` D13/E1d and
  * `.octospec/tasks/cardtmpl-reasoning-schema-successor/brief.md` D5: the catalog advertises one
  * new-send version, and multiple compatible entries without an explicit preference capability
- * fail closed to Model B rather than reintroducing a local semver policy.
+ * fail closed rather than reintroducing a local semver policy.
  * A duplicated id/version also remains ambiguous even if only one copy has compatible views:
  * `template_ref` cannot identify which copy the server would resolve.
  */
 export function selectReasoningProcessTemplate(
   templating: CardTemplatingCapability | undefined,
+  configuredRef?: CardTemplateRef | null,
 ): CardTemplateRef | null {
-  if (!templating?.supported || templating.wire !== TEMPLATE_WIRE) return null;
-  const claimed = templating.templates.filter((template) => template.id === REASONING_TEMPLATE_ID);
+  if (!templating?.supported || templating.wire !== TEMPLATE_WIRE || configuredRef === null) return null;
+  if (configuredRef !== undefined &&
+      (configuredRef.id !== REASONING_TEMPLATE_ID || !configuredRef.version ||
+       configuredRef.version.trim() !== configuredRef.version)) return null;
+  const claimed = templating.templates.filter((template) =>
+    template.id === REASONING_TEMPLATE_ID &&
+    (configuredRef === undefined || template.version === configuredRef.version));
   const compatible = claimed.filter((template) => {
     if (!template.version || template.version.trim() !== template.version) return false;
     return REQUIRED_VIEWS.every((required) => {


### PR DESCRIPTION
## Summary

- Treat `GET /v1/bot/card/profile` top-level `config` as the sole authority for reasoning, display, and interactive cards.
- Remove automatic local Model B progress-card fallback and ignore the legacy local card switches.
- Use the exact server-selected Registry template ref for reasoning progress cards while keeping final answers on the normal text path.
- Add a process-shared per-Bot profile cache with TTL, in-flight deduplication, generation-safe invalidation, and `bot_setting_updated` event handling.
- Preserve caller-local abort budgets without cancelling the shared profile fetch.

## Behavior and compatibility

- Missing, malformed, or internally inconsistent profile config fails closed at execution time.
- Tool discovery only hides a tool from a cached authoritative deny; unknown state remains discoverable and is checked before execution.
- Existing reasoning cards may still receive terminal edits after new sends are disabled.
- `cardProgress`, `reasoningCardTemplateMode`, `cardDisplay`, and `cardInteraction` remain deprecated compatibility types but are ignored at runtime and no longer advertised in public schemas.

## Rollout

Server counterpart: octo-server PR #706 (`7929bf7`). Deploy this plugin before setting `reasoning_enabled=false`; older plugin versions can still emit raw Model B cards that the server intentionally does not classify as reasoning cards.

Static built-in template hard-block support remains out of scope.

## Verification

- `npm run type-check`
- `npm test` — 61 files passed, 1739 tests passed, 10 skipped
- `npm run build`
- `npm run pack:check`
- `git diff --check`
