### PR TITLE
[已关闭] card-render: 剥离 URL 查询串

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,47 @@ to paste a secret in plaintext. Whether to adjust the configuration is up to you
 7. Sends display and submit-interactive cards with negotiated fallback
 8. Polls durable `card_action` events only after an interactive card is sent
 
+### Query strings are stripped from host-shaped values
+
+Anything this plugin renders into a card goes through one URL-reduction step, and
+that step strips the query string off anything it can identify as a host: a
+dotted hostname, a single-label host such as `localhost`, or an IPv4 literal. A
+query string is where callback codes, signed URLs, session ids and one-time
+tokens live, and cards are visible to every member of the channel, so the rule
+applies at every sink rather than only to progress cards.
+
+It is *host-shaped* rather than unconditional, because two shapes are left alone
+on purpose:
+
+- **A bare numeric label** — `8080?code=abc`. Indistinguishable from ordinary
+  prose such as `10/20?ok=yes` or `2026-08-06?ok=yes`, and a `grep` pattern has
+  no program name to fall back to, so withholding renders a blank card that reads
+  as a bug.
+- **A fragment** — `localhost/cb#code=abc` renders in full. Implicit-flow OAuth
+  does return tokens in the fragment, so this is a real gap; closing it would
+  also hit `file.ts#L10` and markdown anchors, so it is left for its own change.
+
+Where the query cannot be terminated cleanly — a quote inside it — the summary is
+withheld rather than half-rewritten. A partially rewritten command looks
+sanitized while still carrying its tail. Shell operators (`;`, `&&`, `|`, `>`)
+*do* terminate it cleanly and are left untouched: `curl localhost/a?b=1;echo done`
+becomes `curl localhost/a;echo done`, not a different command.
+
+Three consequences are worth knowing, because they are not just cosmetic:
+
+- Rich-text blocks may collapse. When more of a string counts as reducible, a
+  display card can fall back to a single text block and lose its formatting.
+- **A value you submitted may be echoed back without its query string.** The
+  status card that records an interactive submission runs the same reduction over
+  the submitted value, so `docs/parser?mode=fast` is frozen into the card as
+  `docs/parser`. The card is no longer a verbatim record of what was submitted.
+- **`?` is read as a query delimiter even where it was a quantifier.** A `grep`
+  pattern of `colou?r=red` renders as `colou`. The rewrite is silent — there is
+  no ellipsis or marker.
+
+The last two are content-fidelity costs, not styling ones. They are the reason
+this lives in its own change rather than riding along with a defect fix.
+
 ### A scheme-less `user:pass@host` is only reduced when the host carries a dot
 
 `postgres://user:pw@host/db` and `user:pw@db.example.com` lose their userinfo, but

--- a/src/card-render.corpus.ts
+++ b/src/card-render.corpus.ts
@@ -76,6 +76,21 @@ export const LEAK_CORPUS: CorpusRow[] = [
     note: "R4:横跨切口的密钥。切在空白上后 token 不会被切开 —— 密钥整个落在保留段之外、被丢掉,而不是留下一个守卫认不出的片段。盲切时它渲染成 `…AKIAIOSFO`",
   },
   {
+    input: "internal/v1/pay?signature=dead",
+    expect: { grep: "internal/v1/pay", read: "internal/v1/pay" },
+    note: "R4:单标签主机的 query 段。main 原样渲染",
+  },
+  {
+    input: "192.168.0.1?code=abc",
+    expect: { grep: "192.168.0.1", read: "192.168.0.1" },
+    note: "R4b:IPv4 是内网最常见的无字母主机。OAuth code 等价于 bearer",
+  },
+  {
+    input: `'localhost:8080/s?f={"a":1}&code=hunter2'`,
+    expect: { grep: "" },
+    note: "R4:query 里嵌引号 → 收尾判定不成立,归约不改写、兜底整串不渲染",
+  },
+  {
     input: "https://hooks.slack.com/services/T00/B00/abcdEFGH1234abcdEFGH1234",
     expect: { grep: "https://slack.com", fetch: "https://slack.com" },
     note: "既有:webhook path 即凭据,只暴露注册域",
@@ -124,6 +139,38 @@ export const BENIGN_CORPUS: CorpusRow[] = [
     expect: { grep: "user:.*@example" },
     note: "R4c:同上",
   },
+  // R5-P1:前导。归约曾用「分隔符白名单」而兜底无前导要求,于是白名单外的每个前导字符上
+  // 归约不动、兜底却拦,摘要整个消失。这些在 main 上全部渲染。
+  {
+    input: "^auth/callback?code=abc",
+    expect: { grep: "^auth/callback" },
+    note: "R5-P1:`^` 锚定是 grep 模式的默认形状,不是冷僻输入",
+  },
+  {
+    input: "[a-z]+/x?y=1",
+    expect: { grep: "[a-z]+/x" },
+    note: "R5-P1:字符类开头",
+  },
+  {
+    input: "/api/v1/items?sort=name",
+    expect: { read: "/api/v1/items" },
+    note: "R5-P1:绝对路径",
+  },
+  {
+    input: "./build/out?v=1",
+    expect: { read: "./build/out" },
+    note: "R5-P1:相对路径",
+  },
+  {
+    input: "~/notes/todo?done=1",
+    expect: { read: "~/notes/todo" },
+    note: "R5-P1:`~` 展开前的路径",
+  },
+  {
+    input: "查询localhost/a?b=1",
+    expect: { grep: "查询localhost/a" },
+    note: "R5-P1:任何非 ASCII 前导。白名单形式列不全「不是主机的一部分」,故改用负向后顾",
+  },
   {
     input: "sed 's:a:b@c:g'",
     expect: { exec: "sed" },
@@ -152,6 +199,43 @@ export const BENIGN_CORPUS: CorpusRow[] = [
  * `https://sha256abcd`,`3:4@2/x` 曾被 new URL() 规范化成 `https://0.0.0.2`。
  */
 export const REWRITE_CORPUS: CorpusRow[] = [
+  // R5-P2:query 段曾把 shell 算子吃掉,**把命令改写成另一条命令** ——
+  // `localhost/a?b=1;rm -rf /tmp` → `localhost/a -rf /tmp`。算子现在算合法收尾,原样保留。
+  {
+    input: "localhost/a?b=1;rm -rf /tmp",
+    expect: { grep: "localhost/a;rm -rf /tmp" },
+    note: "R5-P2:`;` 之后的部分必须原样留下,不能被当成 query 吃掉",
+  },
+  {
+    input: "localhost/a?b=1&&curl evil.com",
+    expect: { grep: "localhost/a&&curl evil.com" },
+    note: "R5-P2:`&&` 是算子;单个 `&` 仍是 query 分隔符(见下一行)",
+  },
+  {
+    input: "localhost/a?b=1&c=2",
+    expect: { grep: "localhost/a" },
+    note: "R5-P2:多参数 query 靠单个 `&` 连接,整段剥掉",
+  },
+  {
+    input: "'localhost/reset?code=abc'",
+    expect: { read: "'localhost/reset'" },
+    note: "R4:命令行上给 URL 加引号是常态",
+  },
+  {
+    input: "--url=localhost/reset?code=abc",
+    expect: { read: "--url=localhost/reset" },
+    note: "R4:query 前面粘的是 `=`",
+  },
+  {
+    input: "localhost?code=abc",
+    expect: { read: "localhost" },
+    note: "R4:query 直接挂在裸主机上,路径段两边都必须可选",
+  },
+  {
+    input: "colou?r=red",
+    expect: { grep: "colou" },
+    note: "R4:grep 模式里 `?` 是量词的概率远大于 query 分隔符。静默改写,README 写明",
+  },
   {
     input: "user:pw@db.example.com:5432/prod",
     expect: { grep: "https://example.com" },

--- a/src/card-render.ts
+++ b/src/card-render.ts
@@ -358,6 +358,84 @@ const SCHEMELESS_HOST_PATH_RE =
   /(^|[^A-Za-z0-9@._/:+-])([A-Za-z0-9-]+(?:\.[A-Za-z0-9-]+)*\.[A-Za-z]{2,}(?::\d+)?\/[^\s]+)/g;
 
 /**
+ * 无 scheme、**单标签主机或 IPv4 字面量**的 `host/path?query`。前面几趟都要求主机带点,这类串
+ * 一趟都不匹配,query 会原样渲染(`curl localhost/reset?code=…`)。
+ *
+ * 不放宽主机形状去匹配整串 —— 那样 `src/index.ts` 会被当成 host/path,把普通相对路径毁掉。
+ * 只针对**含 `=` 的 query 段**下手:shell glob(`src/file?.ts`)里不含 `=`,不会被误伤。
+ */
+// 前导用**负向后顾**,不是前导字符白名单。
+//
+// 上一版是 `(^|[白名单])`,而兜底没有任何前导要求 —— 于是每个白名单外的前导字符上,归约不动、
+// 兜底却拦,摘要整个消失。`^`、`[`、`\`、`.`、`~`、`/` 和所有非 ASCII 都在白名单外,也就是说
+// `^` 锚定的 grep 模式、字符类、相对路径、绝对路径全都丢了参数摘要:
+//
+//     ^auth/callback?code=abc   /api/v1/items?sort=name   ./build/out?v=1
+//     [a-z]+/x?y=1              /tmp/session?sid=abc      查询localhost/a?b=1
+//
+// 根因不是兜底缺锚点,而是「分隔符白名单」这个形式本身列不全「不是主机的一部分」。换成对主机
+// 字符类取负向后顾,归约与兜底就在这条轴上**由构造一致**,不再是两张要同步的表。
+const QUERY_LEAD = `(?<![A-Za-z0-9._-])`;
+
+/**
+ * 主机形状前瞻。归约与兜底**共用这一个常量**。
+ *
+ * 含字母,**或**点分四段 IPv4。只要求字母的话,内网/开发环境里最常见的无字母主机 —— IPv4 字面量
+ * —— 既过不了这里、也过不了第 4 趟(那趟要求字母 TLD),于是 query 原样渲染。按本模块自己的论据
+ * (OAuth 授权码等价于 bearer),那正是这一趟要挡的。
+ *
+ * 裸数字单标签(`8080?code=abc`)仍然不碰:它与 `10/20?ok=yes`、`2026-08-06?ok=yes` 这种日期/
+ * 比值散文形状完全一致,而 query 策略没有程序名可退,拦下来就是一张空白卡。
+ */
+const QUERY_HOST_LEAD = `(?:(?=[A-Za-z0-9._-]*[A-Za-z])|(?=\\d{1,3}(?:\\.\\d{1,3}){3}(?:[:/?]|$)))`;
+
+/**
+ * query 段:`key=value`,可由**单个** `&` 连接多段。
+ *
+ * 段内排除 shell 算子。上一版只排除空白和引号,于是 `;`、`&&`、`|`、`>` 被当成 query 的一部分
+ * 吃掉,**把命令改写成了另一条命令**:
+ *
+ *     localhost/a?b=1;rm -rf /tmp     →   localhost/a -rf /tmp
+ *     localhost/a?b=1&&curl evil.com  →   localhost/a evil.com
+ *
+ * 本文件把「改写成另一条命令」列为不可接受的失败模式,并以此为由把引号排除在外 —— 同一条理由
+ * 同样排除这几个算子。`&` 不能整个排掉(多参数 query 靠它),所以写成「段之间只允许单个 `&`」:
+ * `&&` 匹配不上第二段的 `=`,自然落到收尾判定上。
+ */
+const QUERY_ATOM = `[^\\s'";|<>&\`)]*`;
+const QUERY_BODY = `${QUERY_ATOM}=${QUERY_ATOM}(?:&${QUERY_ATOM}=${QUERY_ATOM})*`;
+
+/**
+ * 收尾判定:query 必须**干净收尾** —— 停在串尾、空白、shell 算子,或一个「后面就是 SHELL_BREAK
+ * 或串尾」的闭合引号上(即那个引号确实是词的结尾,而不是 query 内部的引号)。
+ *
+ * 少了它,query 里只要出现一个引号,匹配就在那里断掉、只删前半段,后半段原样渲染 —— 半改写的
+ * 输出看起来像脱敏过的,却留着尾巴。确认不了就不改写,交给 RESIDUAL_QUERY_RE 整串不渲染。
+ *
+ * 算子算合法收尾(而不是交给兜底):`curl localhost/a?b=1;echo done` 的 query 确实在 `;` 处结束,
+ * 剥掉 query、保留 `;echo done` 才是对的;整串不渲染反而丢信息。
+ */
+const QUERY_END = `(?=$|[\\s;|<>&)]|['"](?:[${SHELL_BREAK}]|$))`;
+
+const SCHEMELESS_QUERY_RE = new RegExp(
+  `${QUERY_LEAD}(${QUERY_HOST_LEAD}[A-Za-z0-9._-]+(?::\\d+)?(?:\\/[^\\s?]*)?)\\?${QUERY_BODY}${QUERY_END}`,
+  "g",
+);
+
+/**
+ * 归约后**仍然残留**的 `host/path?…=…` → 摘要整串不渲染。
+ *
+ * 路径段可选:归约要求 `?` 前有 `/` 的话,`host?query` 两边都不匹配 —— 归约不处理、兜底也不拦,
+ * 原样渲染。共享的不是字符类而是**结构要求**,失效方式一样。
+ *
+ * 前导与主机前瞻都与归约**共用常量**。第一版这里没有前导要求而归约有,那条不对称就是上面
+ * QUERY_LEAD 注释里那一整类过度隐藏的来源。
+ */
+const RESIDUAL_QUERY_RE = new RegExp(
+  `${QUERY_LEAD}${QUERY_HOST_LEAD}[A-Za-z0-9._-]+(?::\\d+)?(?:\\/[^\\s?]*)?\\?[^\\s]*=`,
+);
+
+/**
  * 超长输入的截断:**切口只能落在空白上**,切不到就整串不渲染。
  *
  * 上一版是 `s.slice(0, REDUCE_INPUT_MAX)` —— 盲切。它自己就是一条泄漏路径:下面几趟归约靠
@@ -410,6 +488,12 @@ export function reduceUrlsInText(input: string): string {
   out = out.replace(SCHEMELESS_HOST_PATH_RE, (_m, prefix: string, hostAndPath: string) => (
     prefix + (originDomain(`https://${hostAndPath}`) ?? "")
   ));
+  // 5. 单标签主机 / IPv4 的 `host/path?query`:上面几趟都要求主机带点,漏掉这一类。
+  //
+  // 这一趟落在 reduceUrlsInText 里,所以它的其它调用方(display card 文本、action label、
+  // reasoning 文本、card-author、card-display-tool、card-action-status)一并生效。
+  // 「query 段不渲染」是全局判据,只在进度卡里补上等于把另一半留着。代价见 README。
+  out = out.replace(SCHEMELESS_QUERY_RE, "$1");
   return out;
 }
 
@@ -444,6 +528,8 @@ export function summarizeToolParams(toolName: string | undefined, params: unknow
   // query/url 是「裸 token」易出没处 → 额外套用通用高熵/长 hex 检测;path/shell 只走关键词
   // + 明确前缀,避免把 git SHA / docker digest / 缓存哈希等正常路径误伤成空。
   const generic = strategy === "query" || strategy === "url";
+  // 归约处理不掉的 query 形状 → 整串不渲染,而不是半改写。
+  if (RESIDUAL_QUERY_RE.test(s)) return "";
   if (!s || isSensitive(s, generic)) return "";
   return s.length > SUMMARY_MAX ? s.slice(0, SUMMARY_MAX) + "…" : s;
 }


### PR DESCRIPTION
**已关闭,不合并。** 分支 `octo/card-query-strip` 保留,便于后续取用。

## 关闭原因

这一趟正则想解决的是「`?a=1&code=hunter2` 这类查询串里的凭据被原样渲染」。目标成立,但**这个实现方式**在一轮评审里就打出三条自造缺陷,而且都出在归约管线这条攻击者可达的路径上:

1. **三次方 ReDoS(P0)。** `QUERY_ATOM = [^\s'";|<>&\`)]*` 同时放行 `?` 和 `=`,于是 `QUERY_BODY` 里两个不定长原子加上 `(?:&…)*` 的重复,分隔符位置有 O(n²) 种切法。在 `ff6d219` 上实测(同一形状,只差一个 `?`):

   | 输入长度 | 带 `?` | 对照(无 `?`) |
   |---|---|---|
   | 502 | 23.7 ms | — |
   | 1002 | 165.9 ms | — |
   | 2002 | 1309.6 ms | — |
   | 3902 | **9707 ms** | 0.2 ms |

   4000 字符的入参上限正好把它顶在最贵的一档。这条路径从成员提交的 `Input.Text` 就能进,不需要任何权限。

2. **半改写反而拆掉了兜底(P1-b)。** 终止符集合把 `;` `|` `&` 这些算作结束,于是 `localhost/cb?a=1;code=hunter2` 只剥掉 `?a=1`,渲染成 `localhost/cb;code=hunter2` —— 凭据还在,而且 `?` 被删掉了。`RESIDUAL_QUERY_RE` 正是靠 `?` 定位的,这一剥把「兜底本来会整块扣下的串」变成了「兜底看不见的串」。净效果是负的。

3. **半剥与模块核心规则相反(P1-a)。** `QUERY_HOST_LEAD` 只要求含一个字母,所以带点主机名也被这一趟接手;它剥掉查询串就收工,不再走 pass 4 的 `originDomain`。`presigned-bucket-xy9.s3.amazonaws.com?sig=abc` 渲染成完整桶名 —— 而这个模块的规则是主机名只留 eTLD+1。

三条都不是 main 上的既有缺陷,是这趟正则自己造的。

## 后续

查询串泄漏在 main 上是既有问题,应当单独修,但**不该再用正则**。合适的做法是在归约管线里对 URL 做 `new URL()` 解析,解析成功就重建(只留 eTLD+1 + 路径,丢弃 query/fragment),解析失败就整块扣下 —— 解析器天然没有回溯歧义,也不会出现「剥了一半、锚点没了」的中间态。这条留给新的独立改动。

`#203` 保持独立,不受本 PR 影响。
