### PR TITLE
fix(cards): count successful card tools as answer delivery

### DIFF
--- a/e2e/openclaw-host-plugin/index.mjs
+++ b/e2e/openclaw-host-plugin/index.mjs
@@ -79,6 +79,7 @@ function scriptedReply(body) {
   const marker = allText.match(/(?:CHILD|PARENT)_E2E_OK:([0-9a-f-]{36})/i)?.[1] ??
     allText.match(/FILES_E2E_WORKFLOW:([0-9a-f-]{36})/i)?.[1] ??
     allText.match(/TOOL_DELIVERY_E2E:([0-9a-f-]{36})/i)?.[1] ??
+    allText.match(/DISPLAY_DELIVERY_E2E:([0-9a-f-]{36})/i)?.[1] ??
     allText.match(/OpenClaw host E2E marker: ([0-9a-f-]{36})/i)?.[1] ??
     allText.match(/Ordinary user follow-up for ([0-9a-f-]{36})/i)?.[1];
   if (!marker) return { text: "E2E_SCRIPT_ERROR: missing marker" };
@@ -119,6 +120,35 @@ function scriptedReply(body) {
     }
     // Terminal turn with no assistant text at all.
     return { text: "", reasoning: "The answer is already delivered." };
+  }
+
+  // Same terminal shape as the production report, but through the Octo-owned
+  // display-card tool: the side effect succeeds and the model returns NO_REPLY.
+  if (allText.includes(`DISPLAY_DELIVERY_E2E:${marker}`)) {
+    if (toolMessages.length === 0) {
+      return {
+        tool: "exec",
+        arguments: {
+          command: "sleep 2 && printf DISPLAY_DELIVERY_PREFLIGHT_OK",
+          yieldMs: 5_000,
+          timeout: 15,
+          background: false,
+        },
+        reasoning: "Check the current time source before rendering the card.",
+        delayMs: 1_200,
+      };
+    }
+    if (toolMessages.length === 1) {
+      return {
+        tool: "octo_send_display_card",
+        arguments: {
+          title: `DISPLAY_DELIVERY_E2E:${marker}`,
+          blocks: [{ type: "text", text: "The requested display card was delivered." }],
+        },
+        reasoning: "Deliver the requested answer as an Octo display card.",
+      };
+    }
+    return { text: "NO_REPLY", reasoning: "The display card already contains the answer." };
   }
 
   if (allText.includes(`FILES_E2E_WORKFLOW:${marker}`)) {
@@ -356,6 +386,14 @@ function buildPrompt(kind, marker, childDelaySeconds, targetUid) {
       "The message tool already delivered the answer, so end the turn with no final text at all.",
     ].join(" ");
   }
+  if (kind === "display-card-delivery") {
+    return [
+      `DISPLAY_DELIVERY_E2E:${marker}.`,
+      "First call exec exactly once to verify the source.",
+      "After exec succeeds, call octo_send_display_card exactly once with the marker in its title.",
+      "The display card is the answer, so finish with NO_REPLY and no user-visible final text.",
+    ].join(" ");
+  }
   if (kind === "followup") {
     return `Ordinary user follow-up for ${marker}. Do not call tools. Reply exactly FOLLOWUP_E2E_OK:${marker}`;
   }
@@ -408,7 +446,8 @@ export default {
     const runRequest = async (params) => {
       try {
         const kind = params.kind === "followup" || params.kind === "configure-reasoning" ||
-          params.kind === "file-tools" || params.kind === "tool-delivery"
+          params.kind === "file-tools" || params.kind === "tool-delivery" ||
+          params.kind === "display-card-delivery"
           ? params.kind
           : "spawn";
         const marker = requiredString(params, "marker");

--- a/e2e/openclaw-host-plugin/index.mjs
+++ b/e2e/openclaw-host-plugin/index.mjs
@@ -142,7 +142,10 @@ function scriptedReply(body) {
       return {
         tool: "octo_send_display_card",
         arguments: {
-          title: `DISPLAY_DELIVERY_E2E:${marker}`,
+          // A full UUID intentionally looks secret-like to the display-card
+          // sanitizer. Keep the run marker unique without testing against a
+          // value that production is expected to remove.
+          title: `DISPLAY_DELIVERY_E2E_RUN:${marker.slice(0, 8)}`,
           blocks: [{ type: "text", text: "The requested display card was delivered." }],
         },
         reasoning: "Deliver the requested answer as an Octo display card.",
@@ -390,7 +393,7 @@ function buildPrompt(kind, marker, childDelaySeconds, targetUid) {
     return [
       `DISPLAY_DELIVERY_E2E:${marker}.`,
       "First call exec exactly once to verify the source.",
-      "After exec succeeds, call octo_send_display_card exactly once with the marker in its title.",
+      "After exec succeeds, call octo_send_display_card exactly once with a short run marker in its title.",
       "The display card is the answer, so finish with NO_REPLY and no user-visible final text.",
     ].join(" ");
   }

--- a/e2e/openclaw-host-plugin/inspect.mjs
+++ b/e2e/openclaw-host-plugin/inspect.mjs
@@ -68,7 +68,7 @@ function findParentTranscript() {
     const serialized = JSON.stringify(rows);
     if (serialized.includes(marker) &&
         (serialized.includes("sessions_yield") || serialized.includes("FILES_E2E_WORKFLOW") ||
-          serialized.includes("TOOL_DELIVERY_E2E"))) {
+          serialized.includes("TOOL_DELIVERY_E2E") || serialized.includes("DISPLAY_DELIVERY_E2E"))) {
       return { file, rows };
     }
   }

--- a/src/card-openclaw-e2e.test.ts
+++ b/src/card-openclaw-e2e.test.ts
@@ -430,3 +430,46 @@ suite("OpenClaw messaging-tool delivery E2E", () => {
     expect(card?.state).toBe("completed");
   }, 150_000);
 });
+
+suite("OpenClaw display-card delivery E2E", () => {
+  it("does not mark reasoning failed after the display card delivered the answer", async () => {
+    expect(targetUid, "OCTO_E2E_TARGET_UID is required").not.toBe("");
+    const marker = randomUUID();
+    const sessionKey = `agent:main:octo-host-e2e:${marker}`;
+
+    await callBridge({ kind: "configure-reasoning", marker, targetUid, sessionKey });
+    const startedAtMs = Date.now();
+    const accepted = await callBridge({
+      kind: "display-card-delivery",
+      marker,
+      targetUid,
+      sessionKey,
+    });
+    expect(accepted.kind).toBe("display-card-delivery");
+
+    const completed = await waitForEvidence(
+      marker,
+      sessionKey,
+      startedAtMs,
+      (evidence) => evidence.toolCalls.some((call) => call.name === "octo_send_display_card") &&
+        evidence.cards.some((card) => card.templateRef?.id === "ai.reasoning-process" &&
+          (card.state === "completed" || card.state === "error")),
+      90_000,
+    );
+
+    expect(completed.toolCalls.map((call) => call.name)).toEqual([
+      "exec",
+      "octo_send_display_card",
+    ]);
+    const displayCard = completed.cards.find((card) =>
+      card.templateRef?.id !== "ai.reasoning-process" && cardText(card).includes(marker));
+    expect(displayCard, "the requested display card should be delivered").toBeDefined();
+
+    const reasoningCard = completed.cards.find((card) =>
+      card.templateRef?.id === "ai.reasoning-process");
+    const text = cardText(reasoningCard);
+    expect(text).not.toContain("Generation failed");
+    expect(text).not.toContain("Reasoning was interrupted");
+    expect(reasoningCard?.state).toBe("completed");
+  }, 150_000);
+});

--- a/src/card-openclaw-e2e.test.ts
+++ b/src/card-openclaw-e2e.test.ts
@@ -461,8 +461,9 @@ suite("OpenClaw display-card delivery E2E", () => {
       "exec",
       "octo_send_display_card",
     ]);
+    const displayMarker = `DISPLAY_DELIVERY_E2E_RUN:${marker.slice(0, 8)}`;
     const displayCard = completed.cards.find((card) =>
-      card.templateRef?.id !== "ai.reasoning-process" && cardText(card).includes(marker));
+      card.templateRef?.id !== "ai.reasoning-process" && cardText(card).includes(displayMarker));
     expect(displayCard, "the requested display card should be delivered").toBeDefined();
 
     const reasoningCard = completed.cards.find((card) =>

--- a/src/card-progress.test.ts
+++ b/src/card-progress.test.ts
@@ -10,7 +10,7 @@ import {
   registerCardProgress,
   setCardContext,
 } from "./card-progress.js";
-import { DISPLAY_CARD_TOOL_NAME } from "./constants.js";
+import { DISPLAY_CARD_TOOL_NAME, INTERACTIVE_CARD_TOOL_NAME } from "./constants.js";
 
 type Hook = (event: Record<string, unknown>, ctx: { sessionKey: string; runId?: string }) => unknown;
 
@@ -601,6 +601,77 @@ describe("server-driven Registry reasoning progress", () => {
     await finalizeCard("display-only", { success: true });
 
     expect(wire.calls).toEqual([]);
+  });
+
+  it.each([
+    ["display", DISPLAY_CARD_TOOL_NAME],
+    ["interactive", INTERACTIVE_CARD_TOOL_NAME],
+  ])("treats a successful %s card tool as delivery for an existing reasoning card", async (_label, toolName) => {
+    const wire = mockFetch();
+    global.fetch = wire.fetch as typeof fetch;
+    const handlers = makeApi();
+    const sessionKey = `card-tool-delivery-${toolName}`;
+    const hookContext = { sessionKey, runId: "run-1" };
+    setCardContext(sessionKey, context());
+
+    await triggerFirstFrame(handlers, sessionKey);
+    handlers.after_tool_call?.({ toolName: "read", toolCallId: "tool-1", result: {} }, hookContext);
+    handlers.before_tool_call?.({ toolName, toolCallId: "card-tool-1" }, hookContext);
+    handlers.after_tool_call?.({ toolName, toolCallId: "card-tool-1", result: {} }, hookContext);
+    await finalizeCard(sessionKey, { success: false });
+
+    const terminalEdit = wire.calls.filter((call) => call.url.includes("/message/edit")).at(-1)?.body;
+    expect(terminalEdit).toMatchObject({ state: "completed" });
+  });
+
+  it("does not count a failed display-card tool as delivery", async () => {
+    const wire = mockFetch();
+    global.fetch = wire.fetch as typeof fetch;
+    const handlers = makeApi();
+    const sessionKey = "failed-display-card-tool";
+    const hookContext = { sessionKey, runId: "run-1" };
+    setCardContext(sessionKey, context());
+
+    await triggerFirstFrame(handlers, sessionKey);
+    handlers.after_tool_call?.({ toolName: "read", toolCallId: "tool-1", result: {} }, hookContext);
+    handlers.before_tool_call?.({
+      toolName: DISPLAY_CARD_TOOL_NAME,
+      toolCallId: "display-1",
+    }, hookContext);
+    handlers.after_tool_call?.({
+      toolName: DISPLAY_CARD_TOOL_NAME,
+      toolCallId: "display-1",
+      error: "send rejected",
+    }, hookContext);
+    await finalizeCard(sessionKey, { success: false });
+
+    const terminalEdit = wire.calls.filter((call) => call.url.includes("/message/edit")).at(-1)?.body;
+    expect(terminalEdit).toMatchObject({ state: "error" });
+  });
+
+  it("keeps a real dispatch failure ahead of successful card-tool delivery evidence", async () => {
+    const wire = mockFetch();
+    global.fetch = wire.fetch as typeof fetch;
+    const handlers = makeApi();
+    const sessionKey = "display-card-dispatch-failed";
+    const hookContext = { sessionKey, runId: "run-1" };
+    setCardContext(sessionKey, context());
+
+    await triggerFirstFrame(handlers, sessionKey);
+    handlers.after_tool_call?.({ toolName: "read", toolCallId: "tool-1", result: {} }, hookContext);
+    handlers.before_tool_call?.({
+      toolName: DISPLAY_CARD_TOOL_NAME,
+      toolCallId: "display-1",
+    }, hookContext);
+    handlers.after_tool_call?.({
+      toolName: DISPLAY_CARD_TOOL_NAME,
+      toolCallId: "display-1",
+      result: {},
+    }, hookContext);
+    await finalizeCard(sessionKey, { success: false, failed: true });
+
+    const terminalEdit = wire.calls.filter((call) => call.url.includes("/message/edit")).at(-1)?.body;
+    expect(terminalEdit).toMatchObject({ state: "error" });
   });
 
   it("captures visible reasoning but never captures it when visibility is off", async () => {

--- a/src/card-progress.test.ts
+++ b/src/card-progress.test.ts
@@ -617,7 +617,23 @@ describe("server-driven Registry reasoning progress", () => {
     await triggerFirstFrame(handlers, sessionKey);
     handlers.after_tool_call?.({ toolName: "read", toolCallId: "tool-1", result: {} }, hookContext);
     handlers.before_tool_call?.({ toolName, toolCallId: "card-tool-1" }, hookContext);
-    handlers.after_tool_call?.({ toolName, toolCallId: "card-tool-1", result: {} }, hookContext);
+    handlers.after_tool_call?.({
+      toolName,
+      toolCallId: "card-tool-1",
+      result: toolName === DISPLAY_CARD_TOOL_NAME
+        ? {
+            content: [{ type: "text", text: "sent display card" }],
+            details: {
+              message_id: "display-card-1",
+              channel_id: "group-1",
+              client_msg_no: "display-client-1",
+            },
+          }
+        : {
+            content: [{ type: "text", text: "sent interactive card" }],
+            details: { sent: true, message_id: "interactive-card-1", channel_id: "group-1" },
+          },
+    }, hookContext);
     await finalizeCard(sessionKey, { success: false });
 
     const terminalEdit = wire.calls.filter((call) => call.url.includes("/message/edit")).at(-1)?.body;
@@ -641,7 +657,10 @@ describe("server-driven Registry reasoning progress", () => {
     handlers.after_tool_call?.({
       toolName: DISPLAY_CARD_TOOL_NAME,
       toolCallId: "display-1",
-      error: "send rejected",
+      result: {
+        content: [{ type: "text", text: "Error: send rejected" }],
+        details: null,
+      },
     }, hookContext);
     await finalizeCard(sessionKey, { success: false });
 
@@ -666,7 +685,14 @@ describe("server-driven Registry reasoning progress", () => {
     handlers.after_tool_call?.({
       toolName: DISPLAY_CARD_TOOL_NAME,
       toolCallId: "display-1",
-      result: {},
+      result: {
+        content: [{ type: "text", text: "sent display card" }],
+        details: {
+          message_id: "display-card-1",
+          channel_id: "group-1",
+          client_msg_no: "display-client-1",
+        },
+      },
     }, hookContext);
     await finalizeCard(sessionKey, { success: false, failed: true });
 

--- a/src/card-progress.ts
+++ b/src/card-progress.ts
@@ -115,8 +115,8 @@ interface CardEntry {
    */
   pendingMessageToolCallIds?: Set<string>;
   /**
-   * 本 run 已通过 `message` 工具向本卡频道成功投递过内容。等价于 OpenClaw core 的
-   * messaging delivery evidence,`finalizeCard` 据此不把这类 turn 误判为失败。
+   * 本 run 已通过 `message` 或 Octo 自有卡片工具向本卡频道成功投递过内容。
+   * `finalizeCard` 据此不把这类 turn 误判为失败。
    */
   deliveredByTool?: boolean;
 }
@@ -1236,6 +1236,25 @@ export function markCardAnswering(sessionKey: string): void {
 /** OpenClaw core 的 messaging 工具规范名(`normalizeCliMessagingToolName`)。 */
 const MESSAGING_TOOL_NAME = "message";
 
+function isOutputCardTool(
+  toolName: string | undefined,
+): toolName is typeof DISPLAY_CARD_TOOL_NAME | typeof INTERACTIVE_CARD_TOOL_NAME {
+  return toolName === DISPLAY_CARD_TOOL_NAME || toolName === INTERACTIVE_CARD_TOOL_NAME;
+}
+
+/**
+ * Octo 卡片工具把失败编码在 `details: null` 的普通 ToolResult 中，host 不一定会填
+ * after_tool_call.error。因此只认两个工具各自的成功 envelope，不能单看 `error` 缺失。
+ */
+function outputCardToolDelivered(toolName: string, result: unknown): boolean {
+  const details = asRecord(asRecord(result)?.details);
+  if (!details || typeof details.channel_id !== "string" || !details.channel_id.trim()) return false;
+  if (toolName === DISPLAY_CARD_TOOL_NAME) {
+    return typeof details.message_id === "string" && typeof details.client_msg_no === "string";
+  }
+  return toolName === INTERACTIVE_CARD_TOOL_NAME && details.sent === true;
+}
+
 /**
  * 判断一次 `message` 工具调用是否**就是**向本卡频道投递可见内容。
  *
@@ -1404,7 +1423,7 @@ export function registerCardProgress(api: OpenClawPluginApi): void {
     if (!claimRun(entry, ctx)) return; // 超时 run 的迟到 hook 落到新 run 的卡 → 丢弃
     // P1-h:agent 展示卡工具的产出**就是那张卡本身**,不该再有旁边的"正在处理/已中断"进度卡噪音。
     // 该工具不计入进度、不触发发卡。混合 turn 里其它真实工具照常显示,仅不含这步。
-    if (e.toolName === DISPLAY_CARD_TOOL_NAME || e.toolName === INTERACTIVE_CARD_TOOL_NAME) {
+    if (isOutputCardTool(e.toolName)) {
       // 仍要收尾上一轮 running thinking —— 否则思考步 duration 会把 display-card 的执行时长吞进去。
       endRunningThinking(entry, Date.now());
       return;
@@ -1496,7 +1515,13 @@ export function registerCardProgress(api: OpenClawPluginApi): void {
     if (!entry || entry.skip) return;
     if (!claimRun(entry, ctx)) return; // 同 §before_tool_call:外来 run 的迟到 after 事件 → 丢弃
     // P1-h:与 before_tool_call 对称,避免 display-card 触发 scheduleFlush 而误发进度卡。
-    if (e.toolName === DISPLAY_CARD_TOOL_NAME || e.toolName === INTERACTIVE_CARD_TOOL_NAME) return;
+    if (isOutputCardTool(e.toolName)) {
+      if (!e.error && outputCardToolDelivered(e.toolName, e.result)) {
+        entry.deliveredByTool = true;
+        dbg(`${e.toolName} delivered to this card session=${sk}`);
+      }
+      return;
+    }
     // 回填终态。优先按 toolCallId 精确匹配 running 步骤;若 toolCallId 存在但没命中
     // running(过期/重复投递的 after 事件),直接丢弃,**不**回退按名匹配 —— 否则会把仍
     // 在跑的并发同名步骤误标为终态。仅当 toolCallId 缺失(旧 host)才回退「最后一个同名 running」。


### PR DESCRIPTION
## Summary

- treat successful `octo_send_display_card` and `octo_send_card` results as answer-delivery evidence
- accept only each tool’s explicit success envelope; `details: null` and hook errors remain failures
- preserve dispatch-failure precedence so delivery evidence cannot mask a real failed turn
- add unit coverage for success, failure, and precedence, plus a real OpenClaw container E2E for the display-card + `NO_REPLY` flow

## Root cause

The delivery accounting added in #198 recognized only the core `message` tool. Octo-owned card tools are intentionally skipped by progress-step rendering, so their successful results never set delivery evidence. When the model then returned `NO_REPLY`, the reasoning card finalized as `Failed / Interrupted` even though the requested card had already been sent.

## Validation

- focused tests: 46 passed
- full test suite: 68 files passed, 1922 tests passed; 3 files / 11 tests skipped
- `npm run type-check`
- `npm run build`
- `npm run pack:check`
- real OpenClaw + Octo container E2E: 5/5 passed, including display-card delivery followed by `NO_REPLY`
- E2E cleanup verified: companion removed, config restored, Gateway restarted