### PR TITLE
feat(agent-mail): bridge trusted owner draft delivery

### DIFF
--- a/src/agent-mail-owner-draft.test.ts
+++ b/src/agent-mail-owner-draft.test.ts
@@ -1,0 +1,497 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  clearOwnerDraftConfirmations,
+  createOwnerDraftDeliveryCapability,
+  recordOwnerDraftConfirmation,
+} from "./agent-mail-owner-draft.js";
+import { ChannelType, MessageType, type BotMessage } from "./types.js";
+
+afterEach(() => {
+  clearOwnerDraftConfirmations();
+  vi.restoreAllMocks();
+});
+
+function message(overrides: Partial<BotMessage> = {}): BotMessage {
+  return {
+    message_id: "msg-1",
+    message_seq: 1,
+    from_uid: "owner-1",
+    channel_id: "sspace-1_owner-1@sspace-1_bot-1",
+    channel_type: ChannelType.DM,
+    timestamp: Math.floor(Date.now() / 1_000),
+    payload: { type: MessageType.Text, content: "确认发送" },
+    ...overrides,
+  };
+}
+
+describe("OCTO Agent Mail owner Draft capability", () => {
+  it("consumes one exact Owner DM and sends only through the Bot gateway", async () => {
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+      expect(init?.headers).toMatchObject({
+        Authorization: "Bearer bf_secret",
+        "X-Space-ID": "space-1",
+      });
+      expect(JSON.parse(String(init?.body))).toEqual({ mailboxId: "42", draftVersion: 3 });
+      return new Response(JSON.stringify({
+        outcome: "accepted",
+        messageId: "mail-1",
+        submissionIds: [7],
+        senderAddress: "bot@mail.imocto.cn",
+      }), { status: 200 });
+    });
+    const capability = createCapability(fetchMock);
+    const request = {
+      sessionKey: "agent:a:octo:direct:space-1:owner-1",
+      mailboxId: "42",
+      draftId: "E17",
+      draftVersion: 3,
+    };
+    capability.prepareOwnerDraft(request);
+    expect(recordOwnerDraftConfirmation({
+      accountId: "Bot-1",
+      sessionKey: request.sessionKey,
+      spaceId: "space-1",
+      ownerUid: "owner-1",
+      message: message(),
+    })).toBe(true);
+    await expect(capability.sendOwnerDraft(request)).resolves.toEqual({
+      outcome: "accepted",
+      messageId: "mail-1",
+      submissionIds: ["7"],
+      senderAddress: "bot@mail.imocto.cn",
+    });
+    await expect(capability.sendOwnerDraft(request)).rejects.toThrow("No matching exact");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not grant a replay of a confirmation rejected before preparation", () => {
+    const capability = createCapability(vi.fn());
+    const confirmation = {
+      accountId: "bot-1",
+      sessionKey: "agent:a:octo:direct:space-1:owner-1",
+      spaceId: "space-1",
+      ownerUid: "owner-1",
+      message: message(),
+    };
+    const request = {
+      sessionKey: confirmation.sessionKey,
+      mailboxId: "42",
+      draftId: "E17",
+      draftVersion: 3,
+    };
+
+    expect(recordOwnerDraftConfirmation(confirmation)).toBe(false);
+    capability.prepareOwnerDraft(request);
+    expect(recordOwnerDraftConfirmation(confirmation)).toBe(false);
+    expect(recordOwnerDraftConfirmation({
+      ...confirmation,
+      message: message({ message_id: "msg-new-after-prepare" }),
+    })).toBe(true);
+  });
+
+  it("rejects replacing a prepared Draft and preserves the original confirmation binding", async () => {
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      expect(url).toContain("/drafts/E17/send");
+      expect(JSON.parse(String(init?.body))).toEqual({ mailboxId: "42", draftVersion: 3 });
+      return new Response(JSON.stringify({
+        outcome: "accepted",
+        messageId: "mail-original",
+        submissionIds: ["submission-original"],
+      }), { status: 200 });
+    });
+    const capability = createCapability(fetchMock);
+    const original = {
+      sessionKey: "agent:a:octo:direct:space-1:owner-1",
+      mailboxId: "42",
+      draftId: "E17",
+      draftVersion: 3,
+    };
+    const replacement = {
+      ...original,
+      draftId: "E99",
+      draftVersion: 4,
+    };
+
+    capability.prepareOwnerDraft(original);
+    expect(() => capability.prepareOwnerDraft(replacement)).toThrow("different mail Draft");
+    expect(recordOwnerDraftConfirmation({
+      accountId: "bot-1",
+      sessionKey: original.sessionKey,
+      spaceId: "space-1",
+      ownerUid: "owner-1",
+      message: message({ message_id: "msg-original-draft" }),
+    })).toBe(true);
+
+    await expect(capability.sendOwnerDraft(original)).resolves.toMatchObject({
+      outcome: "accepted",
+      messageId: "mail-original",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    expect(() => capability.prepareOwnerDraft(replacement)).not.toThrow();
+  });
+
+  it("treats preparing the same Draft tuple as idempotent", () => {
+    const capability = createCapability(vi.fn());
+    const request = {
+      sessionKey: "agent:a:octo:direct:space-1:owner-1",
+      mailboxId: "42",
+      draftId: "E17",
+      draftVersion: 3,
+    };
+
+    capability.prepareOwnerDraft(request);
+    expect(() => capability.prepareOwnerDraft(request)).not.toThrow();
+  });
+
+  it("expires an abandoned prepared Draft before accepting a fresh binding", async () => {
+    const now = 1_000_000;
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(now);
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      expect(url).toContain("/drafts/E99/send");
+      expect(JSON.parse(String(init?.body))).toEqual({ mailboxId: "42", draftVersion: 4 });
+      return new Response(JSON.stringify({
+        outcome: "accepted",
+        messageId: "mail-replacement",
+        submissionIds: ["submission-replacement"],
+      }), { status: 200 });
+    });
+    const capability = createCapability(fetchMock);
+    const abandoned = {
+      sessionKey: "agent:a:octo:direct:space-1:owner-1",
+      mailboxId: "42",
+      draftId: "E17",
+      draftVersion: 3,
+    };
+    const replacement = {
+      ...abandoned,
+      draftId: "E99",
+      draftVersion: 4,
+    };
+    const staleConfirmation = {
+      accountId: "bot-1",
+      sessionKey: abandoned.sessionKey,
+      spaceId: "space-1",
+      ownerUid: "owner-1",
+      message: message({ message_id: "msg-abandoned-draft" }),
+    };
+
+    capability.prepareOwnerDraft(abandoned);
+    expect(() => capability.prepareOwnerDraft(replacement)).toThrow("different mail Draft");
+
+    nowSpy.mockReturnValue(now + 2 * 60_000);
+    expect(recordOwnerDraftConfirmation({ ...staleConfirmation, nowMs: Date.now() })).toBe(false);
+    expect(() => capability.prepareOwnerDraft(replacement)).not.toThrow();
+    expect(recordOwnerDraftConfirmation({ ...staleConfirmation, nowMs: Date.now() })).toBe(false);
+    expect(recordOwnerDraftConfirmation({
+      ...staleConfirmation,
+      message: message({ message_id: "msg-replacement-draft" }),
+      nowMs: Date.now(),
+    })).toBe(true);
+
+    await expect(capability.sendOwnerDraft(replacement)).resolves.toMatchObject({
+      outcome: "accepted",
+      messageId: "mail-replacement",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    ["mailbox", { mailboxId: "43" }],
+    ["Draft id", { draftId: "E18" }],
+    ["Draft version", { draftVersion: 4 }],
+  ])("consumes and rejects a confirmation for a mismatched %s", async (_name, mismatch) => {
+    const fetchMock = vi.fn();
+    const capability = createCapability(fetchMock);
+    const request = {
+      sessionKey: "agent:a:octo:direct:space-1:owner-1",
+      mailboxId: "42",
+      draftId: "E17",
+      draftVersion: 3,
+    };
+    capability.prepareOwnerDraft(request);
+    expect(recordOwnerDraftConfirmation({
+      accountId: "bot-1",
+      sessionKey: request.sessionKey,
+      spaceId: "space-1",
+      ownerUid: "owner-1",
+      message: message({ message_id: `msg-mismatch-${_name}` }),
+    })).toBe(true);
+
+    await expect(capability.sendOwnerDraft({ ...request, ...mismatch }))
+      .rejects.toThrow("No matching exact");
+    await expect(capability.sendOwnerDraft(request)).rejects.toThrow("No matching exact");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("does not recreate a consumed confirmation when the same inbound message is replayed", async () => {
+    const confirmation = {
+      accountId: "bot-1",
+      sessionKey: "agent:a:octo:direct:space-1:owner-1",
+      spaceId: "space-1",
+      ownerUid: "owner-1",
+      message: message({ message_id: "msg-replayed" }),
+    };
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({
+      outcome: "accepted",
+      messageId: "mail-1",
+      submissionIds: [7],
+    }), { status: 200 }));
+    const capability = createCapability(fetchMock);
+    const firstDraft = {
+      sessionKey: confirmation.sessionKey,
+      mailboxId: "42",
+      draftId: "E17",
+      draftVersion: 3,
+    };
+    capability.prepareOwnerDraft(firstDraft);
+    expect(recordOwnerDraftConfirmation(confirmation)).toBe(true);
+    await expect(capability.sendOwnerDraft(firstDraft)).resolves.toMatchObject({
+      outcome: "accepted",
+      messageId: "mail-1",
+    });
+
+    const secondDraft = {
+      ...firstDraft,
+      draftId: "E18",
+      draftVersion: 4,
+    };
+    capability.prepareOwnerDraft(secondDraft);
+    expect(recordOwnerDraftConfirmation(confirmation)).toBe(false);
+    await expect(capability.sendOwnerDraft(firstDraft)).rejects.toThrow("No matching exact");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    capability.prepareOwnerDraft(secondDraft);
+    expect(recordOwnerDraftConfirmation({
+      ...confirmation,
+      message: message({ message_id: "msg-new-confirmation" }),
+    })).toBe(true);
+    await expect(capability.sendOwnerDraft(secondDraft))
+      .resolves.toMatchObject({ outcome: "accepted" });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects a consumed confirmation replayed after an account restart", async () => {
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(1_000_000);
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({
+      outcome: "accepted",
+      messageId: "mail-1",
+      submissionIds: ["submission-1"],
+    }), { status: 200 }));
+    const capability = createCapability(fetchMock);
+    const firstDraft = {
+      sessionKey: "agent:a:octo:direct:space-1:owner-1",
+      mailboxId: "42",
+      draftId: "E17",
+      draftVersion: 3,
+    };
+    const consumedMessage = message({ message_id: "msg-before-restart" });
+
+    capability.prepareOwnerDraft(firstDraft);
+    expect(recordOwnerDraftConfirmation({
+      accountId: "bot-1",
+      sessionKey: firstDraft.sessionKey,
+      spaceId: "space-1",
+      ownerUid: "owner-1",
+      message: consumedMessage,
+    })).toBe(true);
+    await expect(capability.sendOwnerDraft(firstDraft)).resolves.toMatchObject({
+      outcome: "accepted",
+    });
+
+    clearOwnerDraftConfirmations("bot-1");
+    nowSpy.mockReturnValue(1_120_000);
+    const nextDraft = {
+      ...firstDraft,
+      draftId: "E18",
+      draftVersion: 4,
+    };
+    capability.prepareOwnerDraft(nextDraft);
+
+    expect(recordOwnerDraftConfirmation({
+      accountId: "bot-1",
+      sessionKey: nextDraft.sessionKey,
+      spaceId: "space-1",
+      ownerUid: "owner-1",
+      message: consumedMessage,
+      nowMs: Date.now(),
+    })).toBe(false);
+    expect(recordOwnerDraftConfirmation({
+      accountId: "bot-1",
+      sessionKey: nextDraft.sessionKey,
+      spaceId: "space-1",
+      ownerUid: "owner-1",
+      message: message({ message_id: "msg-after-restart" }),
+      nowMs: Date.now(),
+    })).toBe(true);
+    await expect(capability.sendOwnerDraft(nextDraft)).resolves.toMatchObject({
+      outcome: "accepted",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("preserves preparation when delivery is attempted before confirmation", async () => {
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({
+      outcome: "accepted",
+      messageId: "mail-1",
+      submissionIds: ["submission-1"],
+    }), { status: 200 }));
+    const capability = createCapability(fetchMock);
+    const request = {
+      sessionKey: "agent:a:octo:direct:space-1:owner-1",
+      mailboxId: "42",
+      draftId: "E17",
+      draftVersion: 3,
+    };
+    capability.prepareOwnerDraft(request);
+
+    await expect(capability.sendOwnerDraft(request)).rejects.toThrow("No matching exact");
+    expect(recordOwnerDraftConfirmation({
+      accountId: "bot-1",
+      sessionKey: request.sessionKey,
+      spaceId: "space-1",
+      ownerUid: "owner-1",
+      message: message({ message_id: "msg-after-premature-send" }),
+    })).toBe(true);
+    await expect(capability.sendOwnerDraft(request)).resolves.toMatchObject({
+      outcome: "accepted",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not evict an earlier replay tombstone after many later confirmations", async () => {
+    const capability = createCapability(vi.fn(async () => new Response(JSON.stringify({
+      outcome: "accepted",
+      messageId: "mail-1",
+      submissionIds: [],
+    }), { status: 200 })));
+    const first = {
+      sessionKey: "agent:a:octo:direct:space-1:owner-1",
+      mailboxId: "42",
+      draftId: "E17",
+      draftVersion: 1,
+    };
+    const firstConfirmation = {
+      accountId: "bot-1",
+      sessionKey: first.sessionKey,
+      spaceId: "space-1",
+      ownerUid: "owner-1",
+      message: message({ message_id: "msg-oldest" }),
+    };
+    capability.prepareOwnerDraft(first);
+    expect(recordOwnerDraftConfirmation(firstConfirmation)).toBe(true);
+    await capability.sendOwnerDraft(first);
+    capability.prepareOwnerDraft(first);
+
+    for (let index = 0; index < 4_096; index += 1) {
+      const sessionKey = `agent:a:octo:direct:space-1:owner-${index + 2}`;
+      capability.prepareOwnerDraft({ ...first, sessionKey });
+      expect(recordOwnerDraftConfirmation({
+        ...firstConfirmation,
+        sessionKey,
+        message: message({ message_id: `msg-later-${index}` }),
+      })).toBe(true);
+    }
+
+    expect(recordOwnerDraftConfirmation(firstConfirmation)).toBe(false);
+  });
+
+  it.each([
+    ["revoked", undefined],
+    ["changed", "owner-2"],
+  ])("rejects a confirmation after the registered Owner is %s", async (name, nextOwner) => {
+    let currentOwnerUid: string | undefined = "owner-1";
+    const fetchMock = vi.fn();
+    const capability = createOwnerDraftDeliveryCapability({
+      accountId: "bot-1",
+      apiUrl: "https://octo.example/api",
+      botToken: "bf_secret",
+      getCurrentOwnerUid: () => currentOwnerUid,
+      fetchImpl: fetchMock as typeof fetch,
+    });
+    const request = {
+      sessionKey: "agent:a:octo:direct:space-1:owner-1",
+      mailboxId: "42",
+      draftId: "E17",
+      draftVersion: 3,
+    };
+    capability.prepareOwnerDraft(request);
+    expect(recordOwnerDraftConfirmation({
+      accountId: "bot-1",
+      sessionKey: request.sessionKey,
+      spaceId: "space-1",
+      ownerUid: "owner-1",
+      message: message({ message_id: `msg-owner-${name}` }),
+    })).toBe(true);
+
+    currentOwnerUid = nextOwner;
+
+    await expect(capability.sendOwnerDraft(request)).rejects.toThrow("No matching exact");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("scopes replay tombstones to the OCTO account", () => {
+    const sharedMessage = message({ message_id: "msg-shared-id" });
+    const first = createCapability(vi.fn(), "bot-1");
+    const second = createCapability(vi.fn(), "bot-2");
+    first.prepareOwnerDraft({
+      sessionKey: "agent:a:octo:direct:space-1:owner-1",
+      mailboxId: "42",
+      draftId: "E17",
+      draftVersion: 3,
+    });
+    second.prepareOwnerDraft({
+      sessionKey: "agent:b:octo:direct:space-1:owner-1",
+      mailboxId: "43",
+      draftId: "E18",
+      draftVersion: 1,
+    });
+    expect(recordOwnerDraftConfirmation({
+      accountId: "bot-1",
+      sessionKey: "agent:a:octo:direct:space-1:owner-1",
+      spaceId: "space-1",
+      ownerUid: "owner-1",
+      message: sharedMessage,
+    })).toBe(true);
+    expect(recordOwnerDraftConfirmation({
+      accountId: "bot-2",
+      sessionKey: "agent:b:octo:direct:space-1:owner-1",
+      spaceId: "space-1",
+      ownerUid: "owner-1",
+      message: sharedMessage,
+    })).toBe(true);
+  });
+
+  it.each([
+    ["non-owner", { from_uid: "attacker" }],
+    ["group", { channel_type: ChannelType.Group }],
+    ["non-text", { payload: { type: MessageType.Image, content: "确认发送" } }],
+    ["fuzzy", { payload: { type: MessageType.Text, content: "我确认发送" } }],
+  ])("does not grant for %s input", (_name, overrides) => {
+    const capability = createCapability(vi.fn());
+    capability.prepareOwnerDraft({
+      sessionKey: "agent:a:octo:direct:space-1:owner-1",
+      mailboxId: "42",
+      draftId: "E17",
+      draftVersion: 3,
+    });
+    expect(recordOwnerDraftConfirmation({
+      accountId: "bot-1",
+      sessionKey: "agent:a:octo:direct:space-1:owner-1",
+      spaceId: "space-1",
+      ownerUid: "owner-1",
+      message: message(overrides as Partial<BotMessage>),
+    })).toBe(false);
+  });
+});
+
+function createCapability(fetchImpl: ReturnType<typeof vi.fn>, accountId = "bot-1") {
+  return createOwnerDraftDeliveryCapability({
+    accountId,
+    apiUrl: "https://octo.example/api/",
+    botToken: "bf_secret",
+    getCurrentOwnerUid: () => "owner-1",
+    fetchImpl: fetchImpl as typeof fetch,
+  });
+}

--- a/src/agent-mail-owner-draft.ts
+++ b/src/agent-mail-owner-draft.ts
@@ -1,0 +1,312 @@
+import { normalizeAccountId } from "./account-id.js";
+import { ChannelType, MessageType, type BotMessage } from "./types.js";
+
+export const OCTO_AGENT_MAIL_OWNER_DRAFT_CAPABILITY =
+  "octo.agent-mail.owner-draft.v1";
+
+const CONFIRMATION_TTL_MS = 2 * 60_000;
+const REQUEST_TIMEOUT_MS = 30_000;
+const DRAFT_ID_PATTERN = /^E[1-9][0-9]*$/;
+
+type PreparedOwnerDraft = {
+  accountId: string;
+  sessionKey: string;
+  mailboxId: string;
+  draftId: string;
+  draftVersion: number;
+  status: "prepared";
+  preparedAtTimestamp: number;
+  expiresAtMs: number;
+};
+
+type OwnerDraftConfirmation = Omit<PreparedOwnerDraft, "status" | "expiresAtMs"> & {
+  status: "confirmed";
+  spaceId: string;
+  ownerUid: string;
+  messageId: string;
+  expiresAtMs: number;
+};
+
+type OwnerDraftState = PreparedOwnerDraft | OwnerDraftConfirmation;
+
+export type OwnerDraftDeliveryInput = {
+  sessionKey: string;
+  mailboxId: string;
+  draftId: string;
+  draftVersion: number;
+  signal?: AbortSignal;
+};
+
+export type OwnerDraftDeliveryResult = {
+  outcome: "accepted";
+  messageId: string;
+  submissionIds: string[];
+  senderAddress?: string;
+};
+
+export interface OwnerDraftDeliveryCapability {
+  prepareOwnerDraft(input: OwnerDraftDeliveryInput): void;
+  sendOwnerDraft(input: OwnerDraftDeliveryInput): Promise<OwnerDraftDeliveryResult>;
+}
+
+const ownerDraftStates = new Map<string, OwnerDraftState>();
+// Keep a process-local tombstone for authoritative inbound messages.
+// WKSocket acknowledges before dispatch, but a reconnect or event replay may
+// still redeliver the same message. One OCTO message may grant at most once,
+// even after its active account/session confirmation has been consumed.
+// Only an authenticated Owner's exact confirmation can enter this set, and all
+// entries are cleared when the account or process state is cleared.
+const recordedConfirmationMessages = new Set<string>();
+
+function confirmationKey(accountId: string, sessionKey: string): string {
+  return `${normalizeAccountId(accountId)}\0${sessionKey}`;
+}
+
+function confirmationMessageKey(accountId: string, messageId: string): string {
+  return `${normalizeAccountId(accountId)}\0${messageId}`;
+}
+
+/** Record only an exact, server-identified Owner DM confirmation. */
+export function recordOwnerDraftConfirmation(input: {
+  accountId: string;
+  sessionKey: string;
+  spaceId: string;
+  ownerUid: string | undefined;
+  message: BotMessage;
+  nowMs?: number;
+}): boolean {
+  pruneExpired(input.nowMs);
+  const content = input.message.payload?.content;
+  if (
+    !input.ownerUid ||
+    input.message.from_uid !== input.ownerUid ||
+    input.message.channel_type !== ChannelType.DM ||
+    input.message.payload?.type !== MessageType.Text ||
+    typeof content !== "string" ||
+    content.trim() !== "确认发送" ||
+    input.sessionKey.trim() === "" ||
+    input.spaceId.trim() === "" ||
+    input.message.message_id.trim() === ""
+  ) {
+    return false;
+  }
+
+  const accountId = normalizeAccountId(input.accountId);
+  const messageId = input.message.message_id.trim();
+  const messageKey = confirmationMessageKey(accountId, messageId);
+  if (recordedConfirmationMessages.has(messageKey)) return false;
+  recordedConfirmationMessages.add(messageKey);
+
+  const key = confirmationKey(accountId, input.sessionKey);
+  const prepared = ownerDraftStates.get(key);
+  if (prepared?.status !== "prepared") return false;
+  if (
+    !Number.isSafeInteger(input.message.timestamp) ||
+    input.message.timestamp < prepared.preparedAtTimestamp
+  ) {
+    return false;
+  }
+
+  const now = input.nowMs ?? Date.now();
+  const value: OwnerDraftConfirmation = {
+    ...prepared,
+    status: "confirmed",
+    spaceId: input.spaceId,
+    ownerUid: input.ownerUid,
+    messageId,
+    expiresAtMs: now + CONFIRMATION_TTL_MS,
+  };
+  ownerDraftStates.set(key, value);
+  return true;
+}
+
+export function createOwnerDraftDeliveryCapability(input: {
+  accountId: string;
+  apiUrl: string;
+  botToken: string;
+  getCurrentOwnerUid: () => string | undefined;
+  fetchImpl?: typeof fetch;
+}): OwnerDraftDeliveryCapability {
+  const accountId = normalizeAccountId(input.accountId);
+  const apiUrl = input.apiUrl.replace(/\/+$/, "");
+  const botToken = input.botToken.trim();
+  const fetchImpl = input.fetchImpl ?? fetch;
+  if (!apiUrl || !botToken) {
+    throw new Error("OCTO Agent Mail owner Draft capability is not configured");
+  }
+
+  return {
+    prepareOwnerDraft(request) {
+      validateDeliveryInput(request);
+      pruneExpired();
+      const key = confirmationKey(accountId, request.sessionKey);
+      const current = ownerDraftStates.get(key);
+      if (current?.status === "confirmed") {
+        throw new Error(
+          "An Owner-confirmed mail Draft is already pending delivery for this OCTO account and session.",
+        );
+      }
+      const mailboxId = request.mailboxId.trim();
+      if (current?.status === "prepared") {
+        if (
+          current.mailboxId === mailboxId &&
+          current.draftId === request.draftId &&
+          current.draftVersion === request.draftVersion
+        ) {
+          return;
+        }
+        throw new Error(
+          "A different mail Draft is already awaiting Owner confirmation for this OCTO account and session.",
+        );
+      }
+      const now = Date.now();
+      ownerDraftStates.set(key, {
+        accountId,
+        sessionKey: request.sessionKey,
+        mailboxId,
+        draftId: request.draftId,
+        draftVersion: request.draftVersion,
+        status: "prepared",
+        preparedAtTimestamp: Math.floor(now / 1_000),
+        expiresAtMs: now + CONFIRMATION_TTL_MS,
+      });
+    },
+    async sendOwnerDraft(request) {
+      validateDeliveryInput(request);
+      const key = confirmationKey(accountId, request.sessionKey);
+      const confirmation = ownerDraftStates.get(key);
+      // Consume confirmed authorization before validation or the network. A
+      // timeout may hide a successful submission, so the same confirmation
+      // must never be replayable. A premature call must not erase preparation.
+      if (confirmation?.status === "confirmed") ownerDraftStates.delete(key);
+      const currentOwnerUid = input.getCurrentOwnerUid()?.trim();
+      if (
+        confirmation?.status !== "confirmed" ||
+        confirmation.expiresAtMs <= Date.now() ||
+        currentOwnerUid === undefined ||
+        confirmation.ownerUid !== currentOwnerUid ||
+        confirmation.mailboxId !== request.mailboxId.trim() ||
+        confirmation.draftId !== request.draftId ||
+        confirmation.draftVersion !== request.draftVersion
+      ) {
+        throw new Error(
+          "No matching exact trusted-owner mail confirmation exists for this OCTO account, session, and Draft.",
+        );
+      }
+
+      const signal = request.signal
+        ? AbortSignal.any([request.signal, AbortSignal.timeout(REQUEST_TIMEOUT_MS)])
+        : AbortSignal.timeout(REQUEST_TIMEOUT_MS);
+      const response = await fetchImpl(
+        `${apiUrl}/v1/bot/agent-mail/drafts/${encodeURIComponent(confirmation.draftId)}/send`,
+        {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${botToken}`,
+            "Content-Type": "application/json",
+            "X-Space-ID": confirmation.spaceId,
+          },
+          body: JSON.stringify({
+            mailboxId: confirmation.mailboxId,
+            draftVersion: confirmation.draftVersion,
+          }),
+          signal,
+        },
+      );
+      const body = await response.text();
+      if (!response.ok) {
+        const code = readErrorCode(body);
+        throw new Error(
+          code
+            ? `OCTO Agent Mail owner Draft delivery failed: ${code}`
+            : `OCTO Agent Mail owner Draft delivery failed (${response.status})`,
+        );
+      }
+      return parseDeliveryResult(body);
+    },
+  };
+}
+
+export function clearOwnerDraftConfirmations(accountId?: string): void {
+  if (accountId === undefined) {
+    ownerDraftStates.clear();
+    recordedConfirmationMessages.clear();
+    return;
+  }
+  const prefix = `${normalizeAccountId(accountId)}\0`;
+  for (const key of ownerDraftStates.keys()) {
+    if (key.startsWith(prefix)) ownerDraftStates.delete(key);
+  }
+  for (const key of recordedConfirmationMessages) {
+    if (key.startsWith(prefix)) recordedConfirmationMessages.delete(key);
+  }
+}
+
+function validateDeliveryInput(input: OwnerDraftDeliveryInput): void {
+  if (
+    input.sessionKey.trim() === "" ||
+    input.sessionKey.length > 512 ||
+    input.mailboxId.trim() === "" ||
+    input.mailboxId.length > 64 ||
+    !DRAFT_ID_PATTERN.test(input.draftId) ||
+    !Number.isSafeInteger(input.draftVersion) ||
+    input.draftVersion <= 0
+  ) {
+    throw new Error("Invalid OCTO Agent Mail owner Draft delivery request");
+  }
+}
+
+function parseDeliveryResult(body: string): OwnerDraftDeliveryResult {
+  let value: unknown;
+  try {
+    value = JSON.parse(body);
+  } catch {
+    throw new Error("OCTO Agent Mail owner Draft delivery returned invalid JSON");
+  }
+  if (!isRecord(value) || value["outcome"] !== "accepted") {
+    throw new Error("OCTO Agent Mail owner Draft delivery returned an invalid result");
+  }
+  const messageId = value["messageId"];
+  const submissionIds = value["submissionIds"];
+  const senderAddress = value["senderAddress"];
+  if (
+    typeof messageId !== "string" ||
+    messageId.trim() === "" ||
+    !Array.isArray(submissionIds) ||
+    !submissionIds.every((item) => typeof item === "string" || typeof item === "number") ||
+    (senderAddress !== undefined && typeof senderAddress !== "string")
+  ) {
+    throw new Error("OCTO Agent Mail owner Draft delivery returned an invalid result");
+  }
+  return {
+    outcome: "accepted",
+    messageId,
+    submissionIds: submissionIds.map(String),
+    ...(typeof senderAddress === "string" && senderAddress.trim() !== ""
+      ? { senderAddress }
+      : {}),
+  };
+}
+
+function readErrorCode(body: string): string | undefined {
+  try {
+    const value: unknown = JSON.parse(body);
+    if (!isRecord(value) || !isRecord(value["error"])) return undefined;
+    const code = value["error"]["code"];
+    return typeof code === "string" && code.trim() !== "" ? code : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function pruneExpired(nowMs = Date.now()): void {
+  for (const [key, value] of ownerDraftStates) {
+    if (value.expiresAtMs <= nowMs) {
+      ownerDraftStates.delete(key);
+    }
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/src/channel.test.ts
+++ b/src/channel.test.ts
@@ -36,6 +36,19 @@ vi.mock("./api-fetch.js", async () => {
   };
 });
 
+vi.mock("./socket.js", () => ({
+  WKSocket: class {
+    connect() {}
+    disconnect() {}
+    async disconnectAndWait() {}
+    updateCredentials() {}
+    stopReconnectTimer() {}
+    isConnected() { return false; }
+    isConnectingOrConnected() { return false; }
+    hasPendingReconnect() { return false; }
+  },
+}));
+
 // ─── Token refresh cooldown tests ───────────────────────────────────────────
 // These test the time-based cooldown pattern used in channel.ts onError handler
 // to prevent token refresh storms.
@@ -161,6 +174,136 @@ describe("octoPlugin structure", () => {
 
     expect(octoPlugin.capabilities?.chatTypes).toContain("direct");
     expect(octoPlugin.capabilities?.chatTypes).toContain("group");
+  });
+});
+
+describe("gateway owner registration", () => {
+  it("clears a stale owner when account startup returns no owner_uid", async () => {
+    const { registerBot } = await import("./api-fetch.js");
+    const {
+      _clearOwnerRegistry,
+      getOwnerUid,
+      registerOwnerUid,
+    } = await import("./owner-registry.js");
+    const { octoPlugin } = await import("./channel.js");
+
+    _clearOwnerRegistry();
+    registerOwnerUid("acct1", "revoked-owner");
+    vi.mocked(registerBot).mockResolvedValueOnce({
+      robot_id: "acct1_bot",
+      im_token: "im-token",
+      ws_url: "ws://127.0.0.1:1",
+      api_url: "http://127.0.0.1:1",
+      owner_uid: "",
+      owner_channel_id: "",
+    });
+
+    const abortController = new AbortController();
+    abortController.abort();
+    await octoPlugin.gateway!.startAccount!({
+      account: {
+        accountId: "acct1",
+        name: "acct1",
+        enabled: true,
+        configured: true,
+        config: {
+          apiUrl: "http://127.0.0.1:1",
+          botToken: "bot-token",
+          wsUrl: "ws://127.0.0.1:1",
+          heartbeatIntervalMs: 60_000,
+          pollIntervalMs: 1_000,
+          eventWaitSeconds: 1,
+        },
+      },
+      cfg: {
+        channels: {
+          octo: {
+            accounts: {
+              acct1: {
+                botToken: "bot-token",
+                apiUrl: "http://127.0.0.1:1",
+              },
+            },
+          },
+        },
+      },
+      log: {},
+      setStatus: vi.fn(),
+      abortSignal: abortController.signal,
+    } as any);
+
+    expect(getOwnerUid("acct1")).toBeUndefined();
+    _clearOwnerRegistry();
+  });
+
+  it("registers the Agent Mail runtime capability with a normalized account ID", async () => {
+    const { registerBot } = await import("./api-fetch.js");
+    const { octoPlugin } = await import("./channel.js");
+    const {
+      _resetOctoRuntimeForTests,
+      setOctoRuntime,
+    } = await import("./runtime.js");
+    const registerContext = vi.fn(() => ({ dispose: vi.fn() }));
+    setOctoRuntime({
+      version: "test",
+      channel: { runtimeContexts: { register: registerContext } },
+    } as any);
+    vi.mocked(registerBot).mockResolvedValueOnce({
+      robot_id: "mixed_bot",
+      im_token: "im-token",
+      ws_url: "ws://127.0.0.1:1",
+      api_url: "http://127.0.0.1:1",
+      owner_uid: "owner-1",
+      owner_channel_id: "",
+    });
+
+    try {
+      const abortController = new AbortController();
+      abortController.abort();
+      await octoPlugin.gateway!.startAccount!({
+        account: {
+          accountId: "Mixed_Bot",
+          name: "Mixed_Bot",
+          enabled: true,
+          configured: true,
+          config: {
+            apiUrl: "http://127.0.0.1:1",
+            botToken: "bot-token",
+            wsUrl: "ws://127.0.0.1:1",
+            heartbeatIntervalMs: 60_000,
+            pollIntervalMs: 1_000,
+            eventWaitSeconds: 1,
+          },
+        },
+        cfg: {
+          channels: {
+            octo: {
+              accounts: {
+                Mixed_Bot: {
+                  botToken: "bot-token",
+                  apiUrl: "http://127.0.0.1:1",
+                },
+              },
+            },
+          },
+        },
+        log: {},
+        setStatus: vi.fn(),
+        abortSignal: abortController.signal,
+      } as any);
+
+      expect(registerContext).toHaveBeenCalledWith(expect.objectContaining({
+        channelId: "octo",
+        accountId: "mixed_bot",
+        capability: "octo.agent-mail.owner-draft.v1",
+        context: expect.objectContaining({
+          prepareOwnerDraft: expect.any(Function),
+          sendOwnerDraft: expect.any(Function),
+        }),
+      }));
+    } finally {
+      _resetOctoRuntimeForTests();
+    }
   });
 });
 

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -40,7 +40,7 @@ import { WKSocket } from "./socket.js";
 import { handleInboundMessage, type OctoStatusSink, sanitizeFilename } from "./inbound.js";
 import { runWithSessionInitRetry, isSessionInitConflict } from "./session-retry.js";
 import { notifyInboundConflictDropped } from "./inbound-conflict-notice.js";
-import { enqueueInbound, getInboundQueueKey } from "./inbound-queue.js";
+import { dispatchInboundWithQueue } from "./inbound-queue.js";
 import {
   createFileEventCursorStore,
   setCardEventPollStarter,
@@ -68,7 +68,12 @@ import { buildEntitiesFromFallback, parseStructuredMentions, convertStructuredMe
 import type { MentionEntity } from "./types.js";
 import { handleOctoMessageAction, parseTarget, resolveOutboundOctoTarget, normalizeOutboundChannelPrefix, extractInlineMentionUids, type MessageActionResult } from "./actions.js";
 import { getOrCreateGroupMdCache, registerBotGroupIds, getKnownGroupIds, writeGroupMdToDisk, extractParentGroupNo } from "./group-md.js";
-import { registerOwnerUid } from "./owner-registry.js";
+import { getOwnerUid, registerOwnerUid } from "./owner-registry.js";
+import {
+  clearOwnerDraftConfirmations,
+  createOwnerDraftDeliveryCapability,
+  OCTO_AGENT_MAIL_OWNER_DRAFT_CAPABILITY,
+} from "./agent-mail-owner-draft.js";
 import { registerKnownBot, isKnownBot } from "./bot-registry.js";
 import { preloadGroupMemberCache, getGroupMembersFromCache } from "./member-cache.js";
 import { preloadMentionPrefs } from "./mention-prefs.js";
@@ -1294,9 +1299,35 @@ export const octoPlugin: ChannelPlugin<ResolvedOctoAccount> = {
       // Track this bot's uid for bot-to-bot loop prevention
       _knownBotUids.add(credentials.robot_id);
 
-      // Register owner_uid for permission checks
-      if (credentials.owner_uid) {
-        registerOwnerUid(account.accountId, credentials.owner_uid);
+      // Synchronize owner_uid for permission checks. An empty value is
+      // authoritative too: it revokes any owner cached by an earlier account
+      // start in this process.
+      registerOwnerUid(account.accountId, credentials.owner_uid);
+
+      // Expose a narrow account-scoped capability to the independent OCTO
+      // Mail plugin. The capability retains the Bot credential internally and
+      // requires a prepared exact Draft tuple plus a one-time exact Owner DM
+      // recorded by inbound.ts. The consumer must finish the Draft-preparation
+      // turn before waiting for `确认发送`; this confirmation is recorded only
+      // when that new Owner message enters the normal inbound path.
+      let ownerDraftContext: { dispose: () => void } | undefined;
+      try {
+        ownerDraftContext = getOctoRuntime().channel.runtimeContexts.register({
+          channelId: CHANNEL_ID,
+          accountId: normalizeAccountId(account.accountId),
+          capability: OCTO_AGENT_MAIL_OWNER_DRAFT_CAPABILITY,
+          context: createOwnerDraftDeliveryCapability({
+            accountId: account.accountId,
+            apiUrl: account.config.apiUrl,
+            botToken: account.config.botToken,
+            getCurrentOwnerUid: () => getOwnerUid(account.accountId),
+          }),
+          abortSignal: ctx.abortSignal,
+        });
+      } catch (err) {
+        log?.warn?.(
+          `octo: [${account.accountId}] Agent Mail owner Draft capability unavailable: ${String(err)}`,
+        );
       }
 
       log?.info?.(
@@ -1456,8 +1487,10 @@ export const octoPlugin: ChannelPlugin<ResolvedOctoAccount> = {
       const dispatchInboundMessage = (
         msg: BotMessage,
         routeOverride?: { sessionKey: string; agentId?: string },
-      ): Promise<"completed" | "dropped"> =>
-        enqueueInbound(getInboundQueueKey(account.accountId, msg), async () => {
+      ): Promise<"completed" | "dropped"> => {
+        const run = async (
+          dispatchMode: "standard" | "approval-bypass" = "standard",
+        ): Promise<"completed" | "dropped"> => {
           try {
             await runWithSessionInitRetry(
               () =>
@@ -1476,6 +1509,7 @@ export const octoPlugin: ChannelPlugin<ResolvedOctoAccount> = {
                   log,
                   statusSink,
                   routeOverride,
+                  dispatchMode,
                 }),
               { ...SESSION_INIT_RETRY, log },
             );
@@ -1494,7 +1528,23 @@ export const octoPlugin: ChannelPlugin<ResolvedOctoAccount> = {
             throw err;
           }
           return "completed" as const;
+        };
+
+        const ownerUid = getOwnerUid(account.accountId);
+        return dispatchInboundWithQueue({
+          accountId: account.accountId,
+          message: msg,
+          ownerUid,
+          run: async (dispatchMode) => {
+            if (dispatchMode === "approval-bypass") {
+              log?.info?.(
+                `octo: [${account.accountId}] dispatching approval command outside the conversation queue`,
+              );
+            }
+            return run(dispatchMode);
+          },
         });
+      };
 
       let cardEventPoller: EventPoller | undefined;
       const startCardEventPoller = (): void => {
@@ -1632,6 +1682,7 @@ export const octoPlugin: ChannelPlugin<ResolvedOctoAccount> = {
                   });
                   if (stopped) return;
                   credentials = fresh;
+                  registerOwnerUid(account.accountId, fresh.owner_uid);
                   log?.info?.(`octo: [${account.accountId}] got fresh IM token, reconnecting WS...`);
                   socket.updateCredentials(fresh.robot_id, fresh.im_token);
                   // Stagger reconnect to avoid thundering herd when multiple bots
@@ -1732,6 +1783,8 @@ export const octoPlugin: ChannelPlugin<ResolvedOctoAccount> = {
           watchdog.stop();
           deferredReconnect.cancel();
           stopPersonaPromptCache(account.accountId);
+          ownerDraftContext?.dispose();
+          clearOwnerDraftConfirmations(account.accountId);
           ctx.setStatus({
             accountId: account.accountId,
             running: false,

--- a/src/inbound-card-response-merge.test.ts
+++ b/src/inbound-card-response-merge.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { handleInboundMessage } from "./inbound.js";
+import { handleInboundMessage, pendingInboundContext } from "./inbound.js";
 import {
   registerCardProgress,
   setCardContext,
@@ -8,6 +8,10 @@ import {
 import { setOctoRuntime } from "./runtime.js";
 import { _clearKnownBots } from "./bot-registry.js";
 import { _clearOwnerRegistry, registerOwnerUid } from "./owner-registry.js";
+import {
+  clearOwnerDraftConfirmations,
+  createOwnerDraftDeliveryCapability,
+} from "./agent-mail-owner-draft.js";
 import { ChannelType, MessageType } from "./types.js";
 import type { ResolvedOctoAccount } from "./accounts.js";
 
@@ -204,10 +208,13 @@ function installRuntime(
 async function runInbound(opts: {
   log?: { warn?: (message: string) => void };
   messageContent?: string;
+  message?: ReturnType<typeof makeMessage>;
+  dispatchMode?: "standard" | "approval-bypass";
+  account?: ResolvedOctoAccount;
 } = {}) {
   await handleInboundMessage({
-    account: makeAccount(),
-    message: makeMessage(opts.messageContent) as any,
+    account: opts.account ?? makeAccount(),
+    message: (opts.message ?? makeMessage(opts.messageContent)) as any,
     botUid: BOT_UID,
     groupHistories: new Map(),
     lastBotReplySeqMap: new Map(),
@@ -215,6 +222,7 @@ async function runInbound(opts: {
     uidToNameMap: new Map(),
     groupCacheTimestamps: new Map(),
     log: opts.log,
+    dispatchMode: opts.dispatchMode,
   });
 }
 
@@ -224,15 +232,19 @@ describe("inbound final response progress-card merge", () => {
     sessionStoreMocks.getSessionEntry.mockReturnValue(undefined);
     _clearKnownBots();
     _clearOwnerRegistry();
+    clearOwnerDraftConfirmations();
     registerOwnerUid("acct1", HUMAN_UID);
     _resetCardProgressForTests();
+    pendingInboundContext.clear();
     process.env.OCTO_CARD_MERGE_FINAL = "1";
   });
 
   afterEach(() => {
     globalThis.fetch = originalFetch;
     _clearOwnerRegistry();
+    clearOwnerDraftConfirmations();
     _resetCardProgressForTests();
+    pendingInboundContext.clear();
     vi.restoreAllMocks();
     if (originalMergeFlag === undefined) delete process.env.OCTO_CARD_MERGE_FINAL;
     else process.env.OCTO_CARD_MERGE_FINAL = originalMergeFlag;
@@ -371,6 +383,129 @@ describe("inbound final response progress-card merge", () => {
       (body.payload as { type?: number } | undefined)?.type === 17);
     expect(cardSend).toBeTruthy();
     expect(JSON.stringify(cardSend?.payload)).not.toContain("STALE TURN MUST NOT LEAK");
+  });
+
+  it("approval bypass preserves the waiting run's progress card and pending context", async () => {
+    const { sends } = installFetchStub();
+    const hooks = collectCardHooks();
+    installRuntime(hooks, "", {
+      captureReasoningCallback: () => {},
+    });
+
+    setCardContext("sk-merge", {
+      apiUrl: API,
+      botToken: "tok",
+      channelId: GROUP_ID,
+      channelType: ChannelType.DM,
+    });
+    const waitingRun = { sessionKey: "sk-merge", runId: "run-waiting-for-approval" };
+    hooks.before_agent_run({}, waitingRun);
+    pendingInboundContext.set("sk-merge", {
+      historyPrefix: "waiting-run-history",
+      memberListPrefix: "",
+    });
+
+    await runInbound({ dispatchMode: "approval-bypass" });
+
+    expect(pendingInboundContext.get("sk-merge")?.historyPrefix)
+      .toBe("waiting-run-history");
+    hooks.before_tool_call(
+      { toolName: "read", toolCallId: "read-after-approval" },
+      waitingRun,
+    );
+    await new Promise((resolve) => setTimeout(resolve, 850));
+
+    const cardSends = sends.filter((body) =>
+      (body.payload as { type?: number } | undefined)?.type === 17);
+    expect(cardSends).toHaveLength(1);
+  });
+
+  it("confirms the prepared Draft with the inbound route session and parsed Space", async () => {
+    installFetchStub();
+    installRuntime(collectCardHooks(), "");
+    const deliveryFetch = vi.fn(async () => new Response(JSON.stringify({
+      outcome: "accepted",
+      messageId: "mail-1",
+      submissionIds: ["submission-1"],
+    }), { status: 200 }));
+    const capability = createOwnerDraftDeliveryCapability({
+      accountId: "acct1",
+      apiUrl: API,
+      botToken: "tok",
+      getCurrentOwnerUid: () => HUMAN_UID,
+      fetchImpl: deliveryFetch as typeof fetch,
+    });
+    const request = {
+      sessionKey: "sk-merge",
+      mailboxId: "42",
+      draftId: "E17",
+      draftVersion: 3,
+    };
+    capability.prepareOwnerDraft(request);
+
+    await runInbound({
+      message: {
+        ...makeMessage("确认发送"),
+        message_id: "owner-confirmation-1",
+        channel_id: `sspace-42_${HUMAN_UID}@sspace-42_${BOT_UID}`,
+        channel_type: ChannelType.DM,
+        payload: { type: MessageType.Text, content: "确认发送" },
+      },
+    });
+
+    await expect(capability.sendOwnerDraft(request)).resolves.toMatchObject({
+      outcome: "accepted",
+      messageId: "mail-1",
+    });
+    expect(deliveryFetch).toHaveBeenCalledWith(
+      `${API}/v1/bot/agent-mail/drafts/E17/send`,
+      expect.objectContaining({
+        headers: expect.objectContaining({ "X-Space-ID": "space-42" }),
+      }),
+    );
+  });
+
+  it("does not confirm a prepared Draft from an OBO message rejected as irrelevant", async () => {
+    installFetchStub();
+    installRuntime(collectCardHooks(), "");
+    const deliveryFetch = vi.fn();
+    const capability = createOwnerDraftDeliveryCapability({
+      accountId: "acct1",
+      apiUrl: API,
+      botToken: "tok",
+      getCurrentOwnerUid: () => HUMAN_UID,
+      fetchImpl: deliveryFetch as typeof fetch,
+    });
+    const request = {
+      sessionKey: "sk-merge",
+      mailboxId: "42",
+      draftId: "E17",
+      draftVersion: 3,
+    };
+    capability.prepareOwnerDraft(request);
+    const account = makeAccount();
+    account.config.onBehalfOf = HUMAN_UID;
+
+    await runInbound({
+      account,
+      message: {
+        ...makeMessage("确认发送"),
+        message_id: "irrelevant-obo-confirmation",
+        channel_id: `sspace-42_${HUMAN_UID}@sspace-42_${BOT_UID}`,
+        channel_type: ChannelType.DM,
+        payload: {
+          type: MessageType.Text,
+          content: "确认发送",
+          obo_origin_channel_id: GROUP_ID,
+          obo_origin_channel_type: ChannelType.Group,
+          obo_respond_as: HUMAN_UID,
+          mention: { ais: 1 },
+        },
+      } as ReturnType<typeof makeMessage>,
+    });
+
+    await expect(capability.sendOwnerDraft(request)).rejects.toThrow("No matching exact");
+    expect(deliveryFetch).not.toHaveBeenCalled();
   });
 
   it("keeps mention-bearing final text on the normal message path", async () => {

--- a/src/inbound-queue.test.ts
+++ b/src/inbound-queue.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { enqueueInbound, getInboundQueueKey } from "./inbound-queue.js";
+import {
+  dispatchInboundWithQueue,
+  enqueueInbound,
+  getInboundQueueKey,
+  shouldBypassInboundQueue,
+} from "./inbound-queue.js";
 import { ChannelType, MessageType, type BotMessage } from "./types.js";
 
 function message(channelId: string, channelType: ChannelType): BotMessage {
@@ -24,6 +29,14 @@ describe("shared inbound queue", () => {
       .toBe("bot-b:group:g1");
     expect(getInboundQueueKey("Bot-A", message("s123_u1@bot", ChannelType.DM)))
       .toBe("bot-a:dm:123:u1");
+    expect(getInboundQueueKey("Bot-A", {
+      ...message("sspace-42_human_user@sspace-42_bot_user", ChannelType.DM),
+      from_uid: "human_user",
+    })).toBe("bot-a:dm:space-42:human_user");
+    expect(getInboundQueueKey("Bot-A", {
+      ...message("s123_other_user@s123_user", ChannelType.DM),
+      from_uid: "user",
+    })).toBe("bot-a:dm:123:user");
     expect(getInboundQueueKey("Bot-A", { ...message("u1", ChannelType.DM), channel_id: undefined }))
       .toBe("bot-a:dm:u1");
   });
@@ -68,5 +81,174 @@ describe("shared inbound queue", () => {
   it("向调用方返回当前任务的实际结果", async () => {
     await expect(enqueueInbound("a:dm:u1", async () => "completed" as const))
       .resolves.toBe("completed");
+  });
+
+  it("仅让可信 Owner 在明确私聊中发送的审批命令绕过会话队列", () => {
+    const direct = message("u1", ChannelType.DM);
+    expect(
+      shouldBypassInboundQueue({
+        ...direct,
+        payload: {
+          type: MessageType.Text,
+          content: "/approve plugin:request-1 allow-once",
+        },
+      }, "u1"),
+    ).toBe(true);
+    expect(
+      shouldBypassInboundQueue({
+        ...direct,
+        payload: {
+          type: MessageType.Text,
+          content: "/approve plugin:request-1 deny",
+        },
+      }, "u1"),
+    ).toBe(true);
+    expect(
+      shouldBypassInboundQueue({
+        ...direct,
+        payload: { type: MessageType.Text, content: "/approve request-1" },
+      }, "u1"),
+    ).toBe(false);
+    expect(
+      shouldBypassInboundQueue({
+        ...message("g1", ChannelType.Group),
+        payload: {
+          type: MessageType.Text,
+          content: "/approve plugin:request-1 allow-once",
+        },
+      }, "u1"),
+    ).toBe(false);
+  });
+
+  it("兼容 OpenClaw 的决策别名和两种参数顺序", () => {
+    const direct = message("u1", ChannelType.DM);
+    const accepted = [
+      "/approve request-1 allow",
+      "/approve request-1 once",
+      "/approve request-1 allowonce",
+      "/approve request-1 always",
+      "/approve request-1 allow-always",
+      "/approve request-1 allowalways",
+      "/approve request-1 deny",
+      "/approve request-1 reject",
+      "/approve request-1 block",
+      "/approve deny request-1",
+      "/approve allow request id with spaces",
+      "approve request-1 allow-once",
+      "approve deny request-1",
+    ];
+
+    for (const content of accepted) {
+      expect(
+        shouldBypassInboundQueue({
+          ...direct,
+          payload: { type: MessageType.Text, content },
+        }, "u1"),
+        content,
+      ).toBe(true);
+    }
+
+  });
+
+  it.each([
+    "/approve request-1 allow-once",
+    "approve request-1 allow-once",
+  ])("dispatcher 仅让可信 Owner 的审批命令跳过同一会话队列: %s", async (approvalCommand) => {
+    const direct = message("u1", ChannelType.DM);
+    const order: string[] = [];
+    let releaseFirst!: () => void;
+    const firstGate = new Promise<void>((resolve) => { releaseFirst = resolve; });
+    let markFirstStarted!: () => void;
+    const firstStarted = new Promise<void>((resolve) => { markFirstStarted = resolve; });
+
+    const dispatch = (content: string, run: (mode: "standard" | "approval-bypass") => Promise<void>) =>
+      dispatchInboundWithQueue({
+        accountId: "acct1",
+        message: {
+          ...direct,
+          payload: { type: MessageType.Text, content },
+        },
+        ownerUid: "u1",
+        run,
+      });
+
+    const first = dispatch("first ordinary message", async (mode) => {
+      order.push(`first:${mode}`);
+      markFirstStarted();
+      await firstGate;
+    });
+    await firstStarted;
+    const queued = dispatch("second ordinary message", async (mode) => {
+      order.push(`second:${mode}`);
+    });
+    const approval = dispatch(approvalCommand, async (mode) => {
+      order.push(`approval:${mode}`);
+    });
+
+    await approval;
+    expect(order).toEqual([
+      "first:standard",
+      "approval:approval-bypass",
+    ]);
+
+    releaseFirst();
+    await Promise.all([first, queued]);
+    expect(order).toEqual([
+      "first:standard",
+      "approval:approval-bypass",
+      "second:standard",
+    ]);
+  });
+
+  it("非 Owner、未登记 Owner 和不完整审批命令不能绕过", () => {
+    const direct = message("u1", ChannelType.DM);
+    const approval = {
+      ...direct,
+      payload: {
+        type: MessageType.Text,
+        content: "/approve request-1 allow-once",
+      },
+    };
+
+    expect(shouldBypassInboundQueue(approval, "u2")).toBe(false);
+    expect(shouldBypassInboundQueue(approval, undefined)).toBe(false);
+    expect(shouldBypassInboundQueue({
+      ...direct,
+      payload: { type: MessageType.Text, content: "/approve request-1" },
+    }, "u1")).toBe(false);
+    expect(shouldBypassInboundQueue({
+      ...direct,
+      payload: { type: MessageType.Text, content: "/approve request-1 unknown" },
+    }, "u1")).toBe(false);
+  });
+
+  it("字段缺失、群聊、Topic 和非文本载荷均 fail closed", () => {
+    const approvalPayload = {
+      type: MessageType.Text,
+      content: "/approve request-1 allow-once",
+    };
+    const direct = message("u1", ChannelType.DM);
+
+    expect(shouldBypassInboundQueue({
+      ...direct,
+      channel_type: undefined,
+      payload: approvalPayload,
+    }, "u1")).toBe(false);
+    expect(shouldBypassInboundQueue({
+      ...message("g1", ChannelType.Group),
+      channel_id: undefined,
+      payload: approvalPayload,
+    }, "u1")).toBe(false);
+    expect(shouldBypassInboundQueue({
+      ...message("g1____t1", ChannelType.CommunityTopic),
+      payload: approvalPayload,
+    }, "u1")).toBe(false);
+    expect(shouldBypassInboundQueue({
+      ...direct,
+      payload: {
+        type: MessageType.File,
+        content: "/approve request-1 allow-once",
+      },
+    }, "u1")).toBe(false);
   });
 });

--- a/src/inbound-queue.ts
+++ b/src/inbound-queue.ts
@@ -1,7 +1,47 @@
 import { normalizeAccountId } from "./account-id.js";
-import { ChannelType, type BotMessage } from "./types.js";
+import { ChannelType, MessageType, type BotMessage } from "./types.js";
 
 const inboundQueues = new Map<string, Promise<void>>();
+const APPROVAL_DECISIONS = new Set([
+  "allow",
+  "once",
+  "allow-once",
+  "allowonce",
+  "always",
+  "allow-always",
+  "allowalways",
+  "deny",
+  "reject",
+  "block",
+]);
+
+/**
+ * Match the approval forms accepted by the minimum supported OpenClaw host.
+ * This deliberately remains a local predicate: importing a hashed private
+ * host bundle would make the plugin depend on an unstable implementation file.
+ * The host still parses, authorizes, and resolves the command authoritatively.
+ */
+function isAcceptedApprovalCommand(content: string): boolean {
+  // OpenClaw 2026.6.9's approval parser accepts both `/approve ...` and
+  // slashless `approve ...`; mirror that public host behavior here.
+  const commandMatch = content.trim().match(/^\/?approve(?:\s|$)/i);
+  if (!commandMatch) return false;
+
+  const tokens = content
+    .trim()
+    .slice(commandMatch[0].length)
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean);
+  if (tokens.length < 2) return false;
+
+  const first = tokens[0].toLowerCase();
+  const second = tokens[1].toLowerCase();
+  if (APPROVAL_DECISIONS.has(first)) {
+    return tokens.slice(1).join(" ").trim().length > 0;
+  }
+  return APPROVAL_DECISIONS.has(second);
+}
 
 export function getInboundQueueKey(accountId: string, message: BotMessage): string {
   const id = normalizeAccountId(accountId);
@@ -12,14 +52,69 @@ export function getInboundQueueKey(accountId: string, message: BotMessage): stri
       message.channel_type === ChannelType.CommunityTopic);
   if (isGroup) return `${id}:group:${message.channel_id}`;
 
-  let spaceId = "";
-  if (message.channel_id?.startsWith("s")) {
-    const firstPart = message.channel_id.split("@", 1)[0];
-    const lastUnderscore = firstPart.lastIndexOf("_");
-    if (lastUnderscore > 0) spaceId = firstPart.slice(1, lastUnderscore);
-  }
+  const spaceId = extractDmSpaceId(message);
   const sessionId = spaceId ? `${spaceId}:${message.from_uid}` : message.from_uid;
   return `${id}:dm:${sessionId}`;
+}
+
+/** Extract Space from s{spaceId}_{uid}@s{spaceId}_{uid} without splitting UID underscores. */
+export function extractDmSpaceId(
+  message: Pick<BotMessage, "channel_id" | "from_uid">,
+): string {
+  if (!message.channel_id?.startsWith("s")) return "";
+  const senderSuffix = `_${message.from_uid}`;
+  let spaceId = "";
+  for (const participant of message.channel_id.split("@")) {
+    if (participant.startsWith("s") && participant.endsWith(senderSuffix)) {
+      const candidate = participant.slice(1, -senderSuffix.length);
+      // Another participant UID may itself end in `_${from_uid}`. Its derived
+      // candidate includes that UID prefix, so prefer the shortest match.
+      if (candidate !== "" && (spaceId === "" || candidate.length < spaceId.length)) {
+        spaceId = candidate;
+      }
+    }
+  }
+  return spaceId;
+}
+
+/**
+ * Approval replies must not wait behind the Agent run that is itself blocked
+ * on that approval. Only a server-verified owner sending an OpenClaw-supported
+ * plain-text approval command in an explicit DM may bypass serialization.
+ * OpenClaw still performs authoritative authorization and approval-id checks.
+ */
+export function shouldBypassInboundQueue(
+  message: BotMessage,
+  ownerUid: string | undefined,
+): boolean {
+  if (
+    ownerUid === undefined ||
+    message.from_uid !== ownerUid ||
+    message.channel_type !== ChannelType.DM ||
+    message.payload?.type !== MessageType.Text ||
+    typeof message.payload.content !== "string"
+  ) {
+    return false;
+  }
+  return isAcceptedApprovalCommand(message.payload.content);
+}
+
+export type InboundDispatchMode = "standard" | "approval-bypass";
+
+/** Keep the queue/bypass decision and the dispatch mode passed to inbound handling in one place. */
+export function dispatchInboundWithQueue<T>(params: {
+  accountId: string;
+  message: BotMessage;
+  ownerUid: string | undefined;
+  run: (mode: InboundDispatchMode) => Promise<T>;
+}): Promise<T> {
+  if (shouldBypassInboundQueue(params.message, params.ownerUid)) {
+    return params.run("approval-bypass");
+  }
+  return enqueueInbound(
+    getInboundQueueKey(params.accountId, params.message),
+    () => params.run("standard"),
+  );
 }
 
 /** Serialize work per account/conversation while still returning this task's real outcome. */

--- a/src/inbound-reply-delivery-mode.test.ts
+++ b/src/inbound-reply-delivery-mode.test.ts
@@ -3,7 +3,9 @@ import { ChannelType, MessageType } from "./types.js";
 import { handleInboundMessage } from "./inbound.js";
 import { setOctoRuntime } from "./runtime.js";
 import { _clearKnownBots } from "./bot-registry.js";
+import { _clearOwnerRegistry, registerOwnerUid } from "./owner-registry.js";
 import type { ResolvedOctoAccount } from "./accounts.js";
+import { resolveCommandAuthorization } from "openclaw/plugin-sdk/command-auth";
 
 /**
  * Regression tests for #172 — DM no-reply.
@@ -149,6 +151,7 @@ const replyOptionsOf = (dispatch: ReturnType<typeof vi.fn>) => dispatch.mock.cal
 
 beforeEach(() => {
   _clearKnownBots();
+  _clearOwnerRegistry();
 });
 
 afterEach(() => {
@@ -157,6 +160,63 @@ afterEach(() => {
 });
 
 describe("#172 DM reply delivery mode", () => {
+  it("passes the server-verified OCTO owner through OpenClaw's standard owner allowlist", async () => {
+    installFetchStub();
+    registerOwnerUid("acct1", HUMAN_UID);
+    const { dispatch } = installRuntime({});
+
+    await runDm();
+
+    const ctx = dispatch.mock.calls[0][0].ctx;
+    expect(ctx.OwnerAllowFrom).toEqual([HUMAN_UID]);
+    expect(ctx.SenderId).toBe(HUMAN_UID);
+    expect(
+      resolveCommandAuthorization({ ctx, cfg: {}, commandAuthorized: true })
+        .senderIsOwner,
+    ).toBe(true);
+  });
+
+  it("does not grant OCTO owner status to a different sender", async () => {
+    installFetchStub();
+    registerOwnerUid("acct1", "different-owner");
+    const { dispatch } = installRuntime({});
+
+    await runDm();
+
+    const ctx = dispatch.mock.calls[0][0].ctx;
+    expect(ctx.OwnerAllowFrom).toEqual(["different-owner"]);
+    expect(ctx.SenderId).toBe(HUMAN_UID);
+    expect(
+      resolveCommandAuthorization({ ctx, cfg: {}, commandAuthorized: true })
+        .senderIsOwner,
+    ).toBe(false);
+  });
+
+  it("does not synthesize an owner allowlist before OCTO registration establishes ownership", async () => {
+    installFetchStub();
+    const { dispatch } = installRuntime({});
+
+    await runDm();
+
+    expect(dispatch.mock.calls[0][0].ctx.OwnerAllowFrom).toBeUndefined();
+  });
+
+  it("keeps an explicit OpenClaw owner allowlist authoritative", async () => {
+    installFetchStub();
+    registerOwnerUid("acct1", "different-server-owner");
+    const config = { commands: { ownerAllowFrom: [HUMAN_UID] } };
+    const { dispatch } = installRuntime(config);
+
+    await runDm();
+
+    const ctx = dispatch.mock.calls[0][0].ctx;
+    expect(ctx.OwnerAllowFrom).toEqual(["different-server-owner"]);
+    expect(
+      resolveCommandAuthorization({ ctx, cfg: config, commandAuthorized: true })
+        .senderIsOwner,
+    ).toBe(true);
+  });
+
   it("DM without configured visibleReplies → injects sourceReplyDeliveryMode=automatic", async () => {
     installFetchStub();
     const { dispatch } = installRuntime({});

--- a/src/inbound.ts
+++ b/src/inbound.ts
@@ -54,7 +54,9 @@ import type { MentionPayload, MentionEntity, SendMessageResult } from "./types.j
 import { registerGroupAccount, ensureGroupMd, handleGroupMdEvent, broadcastGroupMdUpdate, extractParentGroupNo, extractThreadShortId, ensureThreadMd, handleThreadMdEvent } from "./group-md.js";
 import { handleForkCommandIfMatched } from "./commands/fork-inbound.js";
 import { isForkCommandHistoryMessage } from "./commands/fork-history-filter.js";
-import { isOwner } from "./owner-registry.js";
+import { getOwnerUid } from "./owner-registry.js";
+import { recordOwnerDraftConfirmation } from "./agent-mail-owner-draft.js";
+import { extractDmSpaceId } from "./inbound-queue.js";
 import { isKnownBot } from "./bot-registry.js";
 import { getPersonaPromptForSession } from "./persona-prompt.js";
 import { createWriteStream } from "node:fs";
@@ -1526,6 +1528,11 @@ export async function handleInboundMessage(params: {
   statusSink?: OctoStatusSink;
   /** Trusted adapter-side route captured when an interactive card was authored. */
   routeOverride?: { sessionKey: string; agentId?: string };
+  /**
+   * A trusted owner approval must use the same session while an older run is
+   * waiting, but must not replace or clean up that run's adapter-owned state.
+   */
+  dispatchMode?: "standard" | "approval-bypass";
 }) {
   const { account, message, botUid, groupHistories, lastBotReplySeqMap, memberMap, uidToNameMap, groupCacheTimestamps, groupMdCache, log, statusSink } = params;
   // Server-authoritative robot map. Default to a throwaway Map when the caller
@@ -1535,6 +1542,7 @@ export async function handleInboundMessage(params: {
   // Current-group roster cache (per-account, keyed by parent groupNo). Same
   // fallback pattern as memberRobotMap so omitting it is harmless.
   const currentGroupMembersMap = params.currentGroupMembersMap ?? new Map<string, GroupMember[]>();
+  const ownsRunScopedState = params.dispatchMode !== "approval-bypass";
 
   // Detect GROUP.md update/delete notification — refresh both memory + disk cache, do NOT pass to LLM
   const earlyEventType = (message.payload as any)?.event?.type;
@@ -1665,29 +1673,18 @@ export async function handleInboundMessage(params: {
     // and never reach here because early handler returns.
   }
 
-  // Parse space_id from channel_id (format: s{spaceId}_{peerId})
-  // For DM, channel_id is a fake channel: s{spaceId}_{uid1}@s{spaceId}_{uid2}
-  // Use LastIndex approach: spaceId is everything between 's' and the last '_' before peerId
+  // Parse space_id from channel_id. A DM channel contains full participant
+  // UIDs, which may themselves contain underscores, so match the authoritative
+  // sender suffix instead of splitting on the last underscore.
   let spaceId = "";
-  const effectiveChannelId = isGroup ? message.channel_id! : message.from_uid;
-  if (effectiveChannelId.startsWith("s")) {
+  const effectiveChannelId = isGroup ? message.channel_id! : "";
+  if (isGroup && effectiveChannelId.startsWith("s")) {
     const lastUnderscore = effectiveChannelId.lastIndexOf("_");
     if (lastUnderscore > 0) {
       spaceId = effectiveChannelId.substring(1, lastUnderscore);
     }
   }
-  // Also try to extract spaceId from the WS channel_id (compound DM format)
-  if (!spaceId && message.channel_id && message.channel_id.startsWith("s")) {
-    // DM compound: s{spaceId}_{uid1}@s{spaceId}_{uid2}
-    const atIdx = message.channel_id.indexOf("@");
-    const firstPart = atIdx > 0 ? message.channel_id.substring(0, atIdx) : message.channel_id;
-    if (firstPart.startsWith("s")) {
-      const lastUnderscore = firstPart.lastIndexOf("_");
-      if (lastUnderscore > 0) {
-        spaceId = firstPart.substring(1, lastUnderscore);
-      }
-    }
-  }
+  if (!isGroup) spaceId = extractDmSpaceId(message);
 
   // Session ID: include spaceId for Space isolation (same user in different Spaces = different sessions)
   const sessionId = isGroup
@@ -2315,7 +2312,7 @@ export async function handleInboundMessage(params: {
     ? (currentGroupMembersMap.get(memberCacheGroupNo) ?? [])
     : [];
   const memberListPrefix = isGroup ? buildMemberListPrefix(currentGroupMembers) : "";
-  if (historyPrefix || memberListPrefix) {
+  if (ownsRunScopedState && (historyPrefix || memberListPrefix)) {
     pendingInboundContext.set(route.sessionKey, { historyPrefix, memberListPrefix });
   }
 
@@ -2366,7 +2363,12 @@ export async function handleInboundMessage(params: {
   }
 
   const commandBody = resolveCommandBody(rawBody, isGroup, isExplicitBotMention);
-  const commandAuthorized = resolveCommandAuthorized(isGroup, isOwner(account.accountId, message.from_uid), isExplicitBotMention);
+  const ownerUid = getOwnerUid(account.accountId);
+  const commandAuthorized = resolveCommandAuthorized(
+    isGroup,
+    message.from_uid === ownerUid,
+    isExplicitBotMention,
+  );
 
   // `/fork` command split (spec §3). Runs BEFORE OBO detection /
   // finalizeInboundContext / recordInboundSession / the dispatch main path: a
@@ -2397,7 +2399,7 @@ export async function handleInboundMessage(params: {
     // before_prompt_build hook's get/delete (index.ts) — neither runs for a
     // fork. Drop the entry set above (pendingInboundContext.set) so a fork does
     // not leak a Map entry / inject a stale historyPrefix later.
-    pendingInboundContext.delete(route.sessionKey);
+    if (ownsRunScopedState) pendingInboundContext.delete(route.sessionKey);
     return;
   }
 
@@ -2467,6 +2469,20 @@ export async function handleInboundMessage(params: {
       return;
     }
   }
+
+  // Mail confirmation is recorded from the authoritative inbound Channel
+  // event, not from model-visible prompt text. It confirms only the exact
+  // mailbox/Draft/version tuple prepared earlier for this account/session;
+  // that bound tuple is later consumed once by the runtime capability. Keep
+  // this after the OBO relevance filter so a message intentionally discarded
+  // by the Channel cannot grant delivery authorization as a side effect.
+  recordOwnerDraftConfirmation({
+    accountId: account.accountId,
+    sessionKey: route.sessionKey,
+    spaceId,
+    ownerUid: getOwnerUid(account.accountId),
+    message,
+  });
 
   // Compute GroupSystemPrompt for two distinct persona-clone scenarios:
   //
@@ -2567,6 +2583,12 @@ export async function handleInboundMessage(params: {
     AccountId: route.accountId,
     ChatType: isGroup ? "group" : "direct",
     ConversationLabel: fromLabel,
+    // ownerUid comes from the authenticated OCTO registerBot response and is
+    // registered per account during startAccount. Supplying that trusted list
+    // lets OpenClaw derive senderIsOwner from SenderId using its standard
+    // command-authorization path. Never derive this list directly from the
+    // inbound sender, otherwise any sender could self-assert owner status.
+    OwnerAllowFrom: ownerUid ? [ownerUid] : undefined,
     SenderId: message.from_uid,
     SenderName: senderName,
     SenderUsername: message.from_uid,
@@ -2681,16 +2703,20 @@ export async function handleInboundMessage(params: {
 
   // 波 B:登记进度卡发送上下文(hook 侧懒发/更新时用)。route.sessionKey 桥接
   // dispatch↔hook(H1 实证一致)。OBO(persona-clone)场景由 setCardContext 内部标记跳过。
-  setCardContext(route.sessionKey, {
-    accountId: account.accountId,
-    apiUrl,
-    botToken,
-    channelId: replyChannelId,
-    channelType: replyChannelType,
-    reasoningVisibility,
-    ...(effectiveOnBehalfOf ? { onBehalfOf: effectiveOnBehalfOf } : {}),
-  });
-  const recordReasoningForGeneration = createCardReasoningRecorder(route.sessionKey);
+  if (ownsRunScopedState) {
+    setCardContext(route.sessionKey, {
+      accountId: account.accountId,
+      apiUrl,
+      botToken,
+      channelId: replyChannelId,
+      channelType: replyChannelType,
+      reasoningVisibility,
+      ...(effectiveOnBehalfOf ? { onBehalfOf: effectiveOnBehalfOf } : {}),
+    });
+  }
+  const recordReasoningForGeneration = ownsRunScopedState
+    ? createCardReasoningRecorder(route.sessionKey)
+    : () => {};
 
   // 已读回执 + 正在输入 — fire-and-forget
   if (isOBOv2) {
@@ -2866,7 +2892,9 @@ export async function handleInboundMessage(params: {
       && sentMediaUrls.size === 0
       && !hasPotentialMention
     ) {
-      const merged = await finalizeCardWithResponse(route.sessionKey, content);
+      const merged = ownsRunScopedState
+        ? await finalizeCardWithResponse(route.sessionKey, content)
+        : false;
       if (merged) {
         statusSink?.({ lastOutboundAt: Date.now(), lastError: null });
         return { merged: true };
@@ -2983,7 +3011,9 @@ export async function handleInboundMessage(params: {
 
           // OpenClaw has no exact "answer generation started" hook. The first
           // non-reasoning, non-tool text is the documented best-effort boundary.
-          if (kind !== "tool") markCardAnswering(route.sessionKey);
+          if (ownsRunScopedState && kind !== "tool") {
+            markCardAnswering(route.sessionKey);
+          }
 
           if (kind === "tool") {
             // Verbose tool call output: send immediately
@@ -3188,12 +3218,14 @@ export async function handleInboundMessage(params: {
     clearInterval(typingInterval);
     // 波 B:收尾进度卡(终态帧 + 清理);fire-and-forget，不阻塞 dispatch 结束/会话释放。
     // finalizeCard 内部同步删 Map(立即释放关联),终态 edit 后台异步发送。
-    void finalizeCard(route.sessionKey, {
-      success: replySucceeded,
-      ...(!replySucceeded && dispatchFailed ? { failed: true } : {}),
-    });
+    if (ownsRunScopedState) {
+      void finalizeCard(route.sessionKey, {
+        success: replySucceeded,
+        ...(!replySucceeded && dispatchFailed ? { failed: true } : {}),
+      });
+    }
     // Safety net: clean up pending inbound context in case the hook didn't fire
-    pendingInboundContext.delete(route.sessionKey);
+    if (ownsRunScopedState) pendingInboundContext.delete(route.sessionKey);
 
     // Record last answered inbound message_seq for history segmentation (don't clear history).
     // We use the inbound @mention message's message_seq (from WebSocket frame) rather than

--- a/src/owner-registry.test.ts
+++ b/src/owner-registry.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import {
   registerOwnerUid,
+  getOwnerUid,
   isOwner,
   _clearOwnerRegistry,
 } from "./owner-registry.js";
@@ -28,6 +29,7 @@ describe("owner-registry case-insensitive accountId (issue #33)", () => {
 
   it("registered mixed-case A, queried mixed-case B (different case form) → hit", () => {
     registerOwnerUid("AbCd_bot", "owner-uid");
+    expect(getOwnerUid("aBcD_bot")).toBe("owner-uid");
     expect(isOwner("aBcD_bot", "owner-uid")).toBe(true);
     expect(isOwner("ABCD_bot", "owner-uid")).toBe(true);
   });
@@ -38,6 +40,7 @@ describe("owner-registry case-insensitive accountId (issue #33)", () => {
   });
 
   it("unregistered account returns false regardless of case", () => {
+    expect(getOwnerUid("never_registered_bot")).toBeUndefined();
     expect(isOwner("never_registered_bot", "anyuid")).toBe(false);
     expect(isOwner("NEVER_REGISTERED_BOT", "anyuid")).toBe(false);
   });
@@ -47,5 +50,13 @@ describe("owner-registry case-insensitive accountId (issue #33)", () => {
     registerOwnerUid("BOT_bot", "owner-two"); // same canonical id
     expect(isOwner("bot_bot", "owner-one")).toBe(false);
     expect(isOwner("bot_bot", "owner-two")).toBe(true);
+  });
+
+  it("clears a stale owner when refresh no longer returns an owner uid", () => {
+    registerOwnerUid("Bot_bot", "owner-one");
+    registerOwnerUid("BOT_bot", undefined);
+
+    expect(getOwnerUid("bot_bot")).toBeUndefined();
+    expect(isOwner("bot_bot", "owner-one")).toBe(false);
   });
 });

--- a/src/owner-registry.ts
+++ b/src/owner-registry.ts
@@ -14,12 +14,26 @@ import { normalizeAccountId } from "./account-id.js";
 
 const _ownerUidMap = new Map<string, string>(); // normalized accountId → owner_uid
 
-export function registerOwnerUid(accountId: string, ownerUid: string): void {
-  _ownerUidMap.set(normalizeAccountId(accountId), ownerUid);
+export function registerOwnerUid(
+  accountId: string,
+  ownerUid: string | null | undefined,
+): void {
+  const normalizedAccountId = normalizeAccountId(accountId);
+  const normalizedOwnerUid = ownerUid?.trim();
+  if (!normalizedOwnerUid) {
+    _ownerUidMap.delete(normalizedAccountId);
+    return;
+  }
+  _ownerUidMap.set(normalizedAccountId, normalizedOwnerUid);
+}
+
+/** Return the server-verified owner UID for an account, if registered. */
+export function getOwnerUid(accountId: string): string | undefined {
+  return _ownerUidMap.get(normalizeAccountId(accountId));
 }
 
 export function isOwner(accountId: string, uid: string): boolean {
-  return _ownerUidMap.get(normalizeAccountId(accountId)) === uid;
+  return getOwnerUid(accountId) === uid;
 }
 
 /** Visible for testing — clears all owner registrations. */


### PR DESCRIPTION
## Summary

Bridges trusted OCTO Owner confirmation to exact Agent Mail Draft delivery while preserving the existing OpenClaw approval-command path.

## Linked Issue

Closes #210
Closes #215

Refs Mininglamp-OSS/octo-server#735

## Changes

- Pass the server-verified account Owner through `OwnerAllowFrom` while retaining the actual inbound sender identity.
- Allow OpenClaw-supported trusted-Owner DM `/approve` and slashless `approve` commands to bypass the conversation queue; ordinary, group, non-text, and non-matching messages keep the existing queue behavior.
- Clear stale Owner state during registration and credential refresh.
- Expose the account-scoped `octo.agent-mail.owner-draft.v1` Runtime Context capability using the normalized account ID expected by OpenClaw consumers.
- Require the Mail Plugin to prepare the exact session, mailbox, Draft ID, and Draft version before a trusted-Owner DM `确认发送` can confirm it.
- Reject replayed confirmation messages, including account-restart redeliveries that predate the current prepared binding; expire abandoned bindings after the existing two-minute confirmation window and revalidate the registered Owner before delivery.
- Require the prepared and delivered Draft tuple to match exactly, then keep the Bot token inside the Channel and call the existing octo-server Owner Draft endpoint unchanged.
- Consume confirmed authorization before validation or the network call without erasing an unconfirmed prepared binding; ignore OBO messages rejected by the relevance filter, parse DM Space IDs without splitting underscore-bearing UIDs, and isolate the confirmation path from shared Run state.
- Add focused Owner authorization, account normalization, queue, startup, Runtime Context, replay, revocation, and Run-state regression tests.

## How verified

- `npm run type-check`
- `npm test` — 2013 passed, 11 skipped
- `npm run build`
- `npx vitest run src/agent-mail-owner-draft.test.ts src/inbound-queue.test.ts src/inbound-card-response-merge.test.ts src/channel.test.ts` — 108 passed


