### PR TITLE
chore(ci): allowlist the redaction corpora in the secret scan

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -18,6 +18,12 @@ paths = [
   # Unit tests seed bots/accounts with fabricated tokens
   # (e.g. "tok-…_bot", "bf_secret", "app_EXAMPLE_dummy_app_bot_token").
   '''.*\.test\.ts''',
+  # Redaction corpora: these files exist precisely to hold secret-shaped
+  # strings (high-entropy tokens next to "api_key" / "db_pass" keywords) so the
+  # masking pipeline can be tested against them. A generic-api-key hit here is
+  # the corpus doing its job, not a leak — the strings are fabricated.
+  '''.*\.corpus\.ts''',
+  '''src/__tests__/fixtures/.*''',
   # API skill docs demonstrate curl calls with placeholder Authorization headers.
   '''skills/.*\.md''',
 ]


### PR DESCRIPTION
## 问题

`secret-scan (gitleaks)` 在 **main 的 push 扫描** 和 **release PR #200** 上都是红的，2 处 finding：

| 文件 | 行 | 规则 |
|---|---|---|
| `src/card-render.corpus.ts` | 802 | `generic-api-key` |
| `src/__tests__/fixtures/parity-space.ts` | 174 | `generic-api-key` |

两处都是**脱敏逻辑的测试语料**——这些文件的存在意义就是携带"长得像 secret"的字符串（高熵 token 紧邻 `api_key` / `db_pass` 关键词），好让 masking pipeline 有真实形状的输入可测。gitleaks 命中它们恰恰说明语料有效，里面每个字符串都是编造的。

`.gitleaks.toml` 的 allowlist 已经覆盖了 `*.test.ts`，但没覆盖承载语料本身的这两个文件，所以自它们落地起扫描就一直失败。

## 改动

allowlist 加 `*.corpus.ts` 和 `src/__tests__/fixtures/`，而不是把这两个路径写死——后续新增的语料 / fixture 自动覆盖。production 源码仍然全量扫描。

## 验证

用 reusable workflow 固定的同一版本 gitleaks 8.30.1 本地跑：

```
# 改前（main 的 config）
WRN leaks found: 2
# 改后
INF no leaks found
```

这是 1.3.0 发版的前置阻塞项（#200 需要 secret-scan 绿才能合）。

Closes #213
