### PR TITLE
fix(doc-mention): HTML 无锚点评论走 whole-doc 取回路径，工具错误播报不再进评论区

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1551,6 +1551,8 @@ export const octoPlugin: ChannelPlugin<ResolvedOctoAccount> = {
       const docTaskDeadLetter = createFileDocTaskDeadLetterStore({ accountId: account.accountId, log });
       const handleDocMention = createDocMentionHandler({
         botUid: credentials.robot_id,
+        // 整篇取回地址由这里的**已解析配置**拼,不让 agent 从载荷 url= 推域名。
+        docsBaseUrl: account.config.docsApiUrl,
         dedupe: docMentionDedupe,
         deadLetter: docTaskDeadLetter,
         dispatch: dispatchInboundMessage,

--- a/src/doc-mention-handler.ts
+++ b/src/doc-mention-handler.ts
@@ -70,6 +70,12 @@ export type DocMentionDispatch = (
 
 export interface DocMentionHandlerDeps {
   botUid: string;
+  /**
+   * 已解析的文档服务根(accounts.ts 的 docsApiUrl,缺省回退 apiUrl)。透传给
+   * formatDocMentionText 拼出整篇取回地址 —— 让 agent 自己从载荷 url= 推域名
+   * 会在拆分部署上打错主机,并把 bot token 发到入站文本决定的地址上。
+   */
+  docsBaseUrl?: string;
   dedupe: DocMentionDedupeStore;
   dispatch: DocMentionDispatch;
   postComment: (
@@ -182,25 +188,29 @@ export function createDocMentionHandler(deps: DocMentionHandlerDeps) {
     let reported: DocTaskTurnReport | undefined;
     let outcome: "completed" | "dropped" = "dropped";
     try {
-      outcome = await deps.dispatch(synthesizeDocMentionMessage(mention, deps.botUid), undefined, {
-        queueScope: docTaskQueueScope(mention),
-        docTask: {
-          docId: mention.docId,
-          threadId: mention.threadId,
-          sessionScope: docTaskSessionScope(mention),
-          postComment: postWithRetry,
-          reportTurn: (value) => {
-            reported = reported
-              ? {
-                  finalDelivered: reported.finalDelivered || value.finalDelivered,
-                  delivered: reported.delivered || value.delivered,
-                  lost: reported.lost || value.lost,
-                  noticed: reported.noticed || value.noticed,
-                }
-              : value;
+      outcome = await deps.dispatch(
+        synthesizeDocMentionMessage(mention, deps.botUid, { docsBaseUrl: deps.docsBaseUrl }),
+        undefined,
+        {
+          queueScope: docTaskQueueScope(mention),
+          docTask: {
+            docId: mention.docId,
+            threadId: mention.threadId,
+            sessionScope: docTaskSessionScope(mention),
+            postComment: postWithRetry,
+            reportTurn: (value) => {
+              reported = reported
+                ? {
+                    finalDelivered: reported.finalDelivered || value.finalDelivered,
+                    delivered: reported.delivered || value.delivered,
+                    lost: reported.lost || value.lost,
+                    noticed: reported.noticed || value.noticed,
+                  }
+                : value;
+            },
           },
         },
-      });
+      );
     } catch (err) {
       deps.log?.error?.(
         `octo: doc task dispatch failed doc=${mention.docId} thread=${mention.threadId}: ${String(err)}`,

--- a/src/doc-mention.test.ts
+++ b/src/doc-mention.test.ts
@@ -208,6 +208,62 @@ describe("synthesizeDocMentionMessage", () => {
       expect(formatDocMentionText(htmlMention)).not.toContain("base-version 令牌");
     });
 
+    // ── 整篇取回分支 ──────────────────────────────────────────────────────
+    // #217 那句无条件的「别整篇重写」正是这样悄悄关掉了 whole-doc 路径:没有任何
+    // 断言钉住它,于是无锚点评论只能猜 aid,实测空转 8 分钟。这几条就是那把锁。
+    // 注意:锚点不在这条载荷里(server 的 event_data 没有 anchor 字段),所以这段
+    // 整篇取回说明是**无条件**发给 HTML 文档的,由 agent 按评论内容自行判断走哪条。
+    // 因此下面用的就是同一个 htmlMention,不存在「无锚点的 mention」这种构造。
+    describe("整篇(whole-doc)取回说明", () => {
+      const noAnchor = htmlMention;
+      const BASE = "https://docs.example.com";
+
+      it("★ 给出拼好的绝对取回地址,而不是让 agent 自己从 url= 推域名", () => {
+        const text = formatDocMentionText(noAnchor, { docsBaseUrl: BASE });
+        expect(text).toContain(
+          `${BASE}/docs-html/d/${encodeURIComponent(noAnchor.docId)}/v/latest/export?download=0`,
+        );
+        // /docs-html 前缀丢了就会打到网页 SPA 空壳上。
+        expect(text).toContain("/docs-html/");
+        // 不再教它「取 url= 的协议+域名」。
+        expect(text).not.toContain("取自载荷里的 url=");
+        expect(text).not.toContain("<站点根>");
+      });
+
+      it("★ 尾部斜杠不会拼出双斜杠", () => {
+        const text = formatDocMentionText(noAnchor, { docsBaseUrl: `${BASE}/` });
+        expect(text).toContain(`${BASE}/docs-html/`);
+        expect(text).not.toContain(`${BASE}//docs-html/`);
+      });
+
+      it("★ 没有下发 docsBaseUrl 时,明确禁止猜域名,而不是退回自己推", () => {
+        const text = formatDocMentionText(noAnchor);
+        expect(text).not.toContain("<站点根>");
+        expect(text).toContain("不要从别处猜一个域名去试");
+      });
+
+      it("★ 失败答复里不许回贴请求 URL —— 那条答复会被自动发进公开评论区", () => {
+        const text = formatDocMentionText(noAnchor, { docsBaseUrl: BASE });
+        // 旧文案让 agent「原样附上你请求的完整 URL」,URL 上的 ?code= 就是有效读票。
+        expect(text).not.toContain("原样附上");
+        expect(text).not.toContain("完整 URL");
+        expect(text).toContain("收到的状态码");
+      });
+
+      it("★ Bearer 只许发往给定地址,不许带到评论正文里的链接上", () => {
+        const text = formatDocMentionText(noAnchor, { docsBaseUrl: BASE });
+        expect(text).toContain("只许发往上面给出的那个地址");
+        // 不再教它把载荷 url= 上的 ?code= 保留到 query 上。
+        expect(text).not.toContain("一并保留在 query 上");
+      });
+
+      it("窄改纪律仍在:整篇取回只用于读结构取 aid,落笔仍是单元素替换", () => {
+        const text = formatDocMentionText(htmlMention, { docsBaseUrl: BASE });
+        expect(text).toContain("别整篇重写");
+        expect(text).toContain("不能原样拿去发布");
+      });
+    });
+
     it("仍然保留「先读 skill 再动手」和「只改锚点位置」这两条纪律", () => {
       const text = formatDocMentionText(htmlMention);
       expect(text).toContain("动手前先读 skill 文档");

--- a/src/doc-mention.ts
+++ b/src/doc-mention.ts
@@ -145,8 +145,23 @@ export function docTaskQueueScope(mention: DocCommentMention): string {
 /**
  * 把用户评论原文放进 JSON 值,而不是直接拼进控制文本 —— 与 card_action 的
  * formatCardActionText 同样的注入防御姿态。
+ *
+ * `docsBaseUrl` 由调用方从**已解析的账号配置**(accounts.ts 的 docsApiUrl,缺省回退
+ * apiUrl)传进来,不由 agent 从载荷里的 url= 推。README 把这件事写死了:docsApiUrl
+ * 是配置值不是可推导值,拆开部署时 IM/网页那个 origin 上根本没有文档路由 ——
+ * 「the fix is a separate htmlDocsApiUrl, not a heuristic」。让模型从 url= 取协议+域名
+ * 再把 bot token 发过去,既会在拆分部署上打错主机,也等于把凭证送到一个**由入站文本
+ * 决定**的地址上。这里改成直接给出拼好的绝对 URL。
  */
-export function formatDocMentionText(mention: DocCommentMention): string {
+export function formatDocMentionText(
+  mention: DocCommentMention,
+  opts?: { docsBaseUrl?: string },
+): string {
+  // 载荷里的 url= 可能带 ?code= 这类分享读票;拼我们自己的地址时一概不带它。
+  const docsBase = opts?.docsBaseUrl?.replace(/\/+$/, "");
+  const wholeDocUrl = docsBase
+    ? `${docsBase}/docs-html/d/${encodeURIComponent(mention.docId)}/v/latest/export?download=0`
+    : null;
   const lines = [
     "[Octo doc comment task]",
     `doc_id=${JSON.stringify(mention.docId)}`,
@@ -174,6 +189,12 @@ export function formatDocMentionText(mention: DocCommentMention): string {
     "  锚点就是这条评论钉住的位置:表格里是单元格地址(如 E8),文档里是被选中的原文片段,",
     "  HTML 里是某个被盖了 aid 的元素。**只改那个位置**。",
     "  锚点为空时才回到「按评论文字自行判断」,并在答复里说明你改了哪里。",
+    // HTML 的「自行判断」跟另外两种不是一回事:文档/表格能把正文读回来再判断,HTML
+    // 的正文不在 CLI 的任何 op 里(见下面 whole-doc 那几条,要走渲染路由取),所以这里
+    // 点明它此时该走那条路,免得它以为「自行判断」= 继续找锚点,然后猜 aid 猜到超时。
+    ...(mention.docKind === "html"
+      ? ["  HTML 的锚点为空就是 whole-doc 请求,按下面 whole-doc 那三步取回整篇再动手,别凭空猜 aid。"]
+      : []),
     "",
     // 为什么要显式点名 skill:实测 agent 会自己去摸索 —— 先读 SKILL.md,再读
     // doc.md,中途还撞过 `docs content edit` 的 400(ops 格式没读对)和 412
@@ -191,9 +212,46 @@ export function formatDocMentionText(mention: DocCommentMention): string {
     "",
     // 「base-version 令牌」是 docs-backend 的并发模型;HTML 那侧是
     // base_version + 单元素替换,规则写在 octo-html skill 里,别在这里替它说。
+    //
+    // HTML 分支按**锚点有无**分流。锚点不在这条载荷里(见上面「先定位改哪里」那段),
+    // 所以这里没法在代码里判断,只能把两种情况都写清楚交给 agent 自己分流。
+    //
+    // 为什么不能再无条件写「别整篇重写」:那句话(#217 随侧边栏派发一起进来)把
+    // whole-doc 请求堵死了 —— 「把所有字体都改成红色」这类评论没有锚点,而 CLI
+    // 侧唯一的写入口 `html element replace` 必须按 aid,`html element get` 也必须
+    // 按 aid、`html get` 只有元数据(200 响应只有 slug/title/latest/created/updated),
+    // 没有任何命令能读整篇或列出 aid 清单。于是 agent 既不许整篇重写、又拿不到
+    // aid,只能瞎猜到超时(实测空转 8 分钟)。
+    //
+    // 读整篇的路不在 CLI 里,在 octo-doc 的渲染路由上:
+    //   GET /d/{doc}/v/{version}           handlers_docs.go:353 handleRender
+    //   GET /d/{doc}/v/{version}/{kind}    handleForkExport, kind ∈ {export, fork}
+    // 两条都是 requireDocReadHTML(CapRead) 把门,version 接受 "latest";export 默认
+    // 带 Content-Disposition: attachment,加 ?download=0 关掉。吐出来的 HTML 是
+    // StampAids 之后的,带 data-odoc-aid —— 这正是 agent 缺的那份 aid 清单。
+    //
+    // 但**不能原样回灌**:handleRender 注入了 overlay 配置与 overlay JS bundle,
+    // handleForkExport 另加 banner 和 <!--ODOC-COMMENT ...--> 标记。把它当作
+    // publish 的入参会把这些注入物写进文档。所以下面只让它「取来看结构、拿 aid」,
+    // 落笔仍走窄的 element replace。
     ...(mention.docKind === "html"
       ? [
-          "改动要窄：只替换锚点指向的那一个元素，别整篇重写 —— 重写会让同文档其它评论的锚点失效。",
+          "锚点指向某个元素时：只替换那一个元素，别整篇重写 —— 窄改最不容易让同文档其它评论的锚点失效。",
+          "锚点为空（whole-doc 请求，例如「把所有字体都改成红色」）时，按下面三步走，别猜 aid：",
+          wholeDocUrl
+            ? `  1) 取回当前整篇 HTML 看清结构。**就取这个地址，原样使用，不要自己拼、也不要改域名**：${wholeDocUrl}`
+            : "  1) 取回当前整篇 HTML 看清结构。地址形如 <docs 服务根>/docs-html/d/<doc>/v/latest/export?download=0；本次没有下发可用的文档服务地址，**不要从别处猜一个域名去试**，直接按第 3 步之后的兜底说明照实答复。",
+          "     **鉴权必须用 `Authorization: Bearer <bot token>`** —— octo-doc 只认三种凭证：Bearer、该文档的 cookie、query 上的 ?code=。**放在 `token` 头里没用**，会被当成没凭证。这张 Bearer 就是 octo-cli 平时用的那张（`OCTO_BOT_TOKEN` 或 profile 里的 bot_token），它在 `element get` 上已经被证明是够用的。",
+          "     **这张 Bearer 只许发往上面给出的那个地址**，不要把它带到评论正文里出现的任何链接上 —— 那些链接是用户可控的。",
+          "     取不到时**别把 404 读成「文档不存在」**：这个接口在权限不足时会**故意返回 404 'Not found'**（隐藏文档是否存在）。所以 404 的第一嫌疑是凭证没带对，不是文档没了、更不是没有 aid。",
+          "  2) 从取回的 HTML 里读 data-odoc-aid 属性 —— 那就是你缺的 aid 清单；挑出真正需要改的那些元素。",
+          "  3) 对每个要改的元素走窄替换（按 aid 替换单个元素）。改动面大时可以替换更靠上的那一个容器元素，但仍然是「替换一个元素」，不是整篇重发。",
+          "**aid 是内容哈希，不是 body/main/section 这种名字。** 拿这类名字去 element get 必然 404，而那个 404 只说明「你猜的名字不是 aid」，**不能**据此断定文档没有 aid、更不能据此建议用户重新发布。要判断有没有 aid，只能看第 1 步取回的 HTML 里有没有 data-odoc-aid。",
+          "**取回的 HTML 不能原样拿去发布**：渲染路由注入了 overlay 脚本，export 还会加 banner 和 <!--ODOC-COMMENT--> 标记。把它当发布入参会把这些注入物写进文档。它只用来读结构、取 aid。",
+          // 这条答复会被系统自动发到评论区(公开面)。早先这里让 agent「原样附上你请求的完整 URL」,
+          // 一旦 URL 上带着 ?code= 分享读票或 token,就等于把一张有效凭证贴进公开评论 ——
+          // inbound.ts 跳过非 http 的文档任务媒体走的是同一个理由。所以只许报状态码和路径。
+          "如果第 1 步确实取不到内容：不要猜 aid，也不要凭空造一篇新文档覆盖上去 —— 直接在答复里说明「读不到当前文档内容，无法执行整篇修改」，附上**收到的状态码**即可。答复会公开发到评论区，**不要把请求 URL 的 query 部分、任何 token / ?code= 之类的凭证写进答复**。宁可明确回一句，也不要空转到超时。",
         ]
       : [
           "改动一律走「读-改-写」：先 get 拿到 base-version 令牌，再带着它 edit。",
@@ -247,7 +305,11 @@ function docTypeSkillHint(mention: DocCommentMention): string {
  * card_action 保持一致;真正决定隔离的是 docTask 作用域(会话键 + 队列键),
  * 而不是这里的 channel_id。
  */
-export function synthesizeDocMentionMessage(mention: DocCommentMention, botUid: string): BotMessage {
+export function synthesizeDocMentionMessage(
+  mention: DocCommentMention,
+  botUid: string,
+  opts?: { docsBaseUrl?: string },
+): BotMessage {
   const channelId = mention.spaceId ? `s${mention.spaceId}_${mention.fromUid}` : mention.fromUid;
   return {
     message_id: `doc_mention:${mention.idempotencyKey}`,
@@ -258,7 +320,7 @@ export function synthesizeDocMentionMessage(mention: DocCommentMention, botUid: 
     timestamp: mention.enqueuedAt ?? Math.floor(Date.now() / 1000),
     payload: {
       type: MessageType.Text,
-      content: formatDocMentionText(mention),
+      content: formatDocMentionText(mention, opts),
       mention: { uids: [botUid] },
     },
   };

--- a/src/doc-task-buffered-reply-warning.test.ts
+++ b/src/doc-task-buffered-reply-warning.test.ts
@@ -1,0 +1,317 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * 第五轮 review 的 🔴 回归钉子：**缓冲 block 答复落地之后，延后的工具错误播报
+ * 不许再被 finally 补发出去。**
+ *
+ * 缺陷形状（reviewer 描述的序列）：
+ *   1. agent 的答复只以 `block` 到达 —— 被 deliverBuffer 缓冲，
+ *      `userFacingFinalDelivered` 保持 false（block 不置位，它要等 finally flush）。
+ *   2. 随后一条带 `isError` 的 `final` 到达 —— 被判成「非终止性工具错误警告」，
+ *      defer 进 `pendingToolWarningFinal`。
+ *   3. 宿主/SDK **不调用** `onFreshSettledDelivery`（这正是 finally-flush 存在的理由：
+ *      老宿主没实现，或新消息抢占跳过）。
+ *   4. finally 把缓冲的真答复发出去 —— 但上一轮它只写 `replySucceeded`，
+ *      没写 `userFacingFinalDelivered`，也没清 pending。
+ *   5. 紧接着的 pending flush 于是照发一条「⚠️ 🛠️ … failed」。
+ *
+ * 结果：评论区先出现一条正确答复，后面跟一条自相矛盾的失败提示 —— 正是本 PR
+ * 要消灭的失败形态。`onFreshSettledDelivery` 里那条「缓冲里有真答复 ⇒ 丢掉警告
+ * 兜底」的纪律（src/inbound.ts:3581）只在被调用时生效，finally 这条镜像路径缺了。
+ *
+ * 为什么要走生产接线而不是单测某个函数：这个缺陷活在**两条投递路径之间的状态
+ * 交接**上，任何一边单独看都是对的。只有真跑 dispatcher、从出站报文上数条数才
+ * 抓得住。手法沿用 doc-task-tool-warning-intent.test.ts。
+ */
+
+const startEventPoller = vi.fn((_options?: unknown) => ({ ready: Promise.resolve(), stop: () => {}, cursor: () => 0 }));
+const sendMessage = vi.fn(async () => ({ message_id: "m1", client_msg_no: "c1", message_seq: 1 }));
+const postDocComment = vi.fn(async () => {});
+
+vi.mock("./socket.js", () => ({
+  WKSocket: class {
+    connect() {}
+    disconnect() {}
+    async disconnectAndWait() {}
+    stopReconnectTimer() {}
+    send() {}
+    get connected() { return false; }
+  },
+}));
+
+vi.mock("./events-poll.js", () => ({
+  startEventPoller: (options: unknown) => startEventPoller(options as never),
+  setCardEventPollStarter: vi.fn(),
+  requestCardEventPolling: vi.fn(),
+  createFileEventCursorStore: () => ({ load: async () => 0, save: async () => {} }),
+}));
+
+vi.mock("./api-fetch.js", async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    registerBot: vi.fn(async () => ({
+      robot_id: "bot_wiring_0000000000000000000000000",
+      im_token: "imtok",
+      ws_url: "ws://octo.test/ws",
+      owner_uid: "owner1",
+    })),
+    sendHeartbeat: vi.fn(async () => {}),
+    fetchBotGroups: vi.fn(async () => []),
+    getGroupMembers: vi.fn(async () => []),
+    getGroupMd: vi.fn(async () => undefined),
+    sendMessage: (...args: unknown[]) => (sendMessage as (...a: unknown[]) => unknown)(...args),
+    postDocComment: (...args: unknown[]) => (postDocComment as (...a: unknown[]) => unknown)(...args),
+  };
+});
+
+// 同 doc-task-tool-warning-intent.test.ts：不 mock 分类器的话，合成 payload 进不了
+// 「非终止性工具错误警告」支路，defer 根本不发生，测试变成恒绿空壳。
+vi.mock("openclaw/plugin-sdk/reply-payload", async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    isReplyPayloadNonTerminalToolErrorWarning: (payload: { __toolWarning?: boolean }) =>
+      payload.__toolWarning === true,
+  };
+});
+
+const API = "http://octo.test";
+
+async function startAccount(config: Record<string, unknown>): Promise<() => Promise<void>> {
+  const { octoPlugin } = await import("./channel.js");
+  const controller = new AbortController();
+  const ctx = {
+    account: {
+      accountId: "acct1",
+      enabled: true,
+      configured: true,
+      config: { botToken: "tok", apiUrl: API, pollIntervalMs: 1000, heartbeatIntervalMs: 60_000, ...config },
+    },
+    cfg: {},
+    log: undefined,
+    setStatus: () => {},
+    abortSignal: controller.signal,
+  } as never;
+  const running = octoPlugin.gateway!.startAccount!(ctx);
+  for (let i = 0; i < 20; i += 1) await new Promise((r) => setTimeout(r, 5));
+  return async () => { controller.abort(); await running; };
+}
+
+function pollerOptions(): Array<Record<string, unknown>> {
+  return (startEventPoller.mock.calls as unknown as Array<[Record<string, unknown>]>).map(([o]) => o);
+}
+
+function captureHtmlPosts(): Array<Record<string, unknown>> {
+  const sent: Array<Record<string, unknown>> = [];
+  globalThis.fetch = (async (_url: unknown, init?: { body?: string }) => {
+    const body = JSON.parse(init?.body ?? "{}") as Record<string, unknown>;
+    if (typeof body.text === "string" && "status" in body) sent.push(body);
+    return {
+      ok: true,
+      status: 200,
+      headers: { get: () => "application/json" },
+      text: async () => JSON.stringify({ status: 1 }),
+      json: async () => ({ status: 1 }),
+    };
+  }) as unknown as typeof fetch;
+  return sent;
+}
+
+const RUN_ID = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+function htmlDocEvent(key: string) {
+  return {
+    event_id: 4343,
+    event_type: "doc_comment_mention",
+    event_data: {
+      idempotency_key: `docs:comment:buffered-warning:${RUN_ID}:${key}`,
+      doc_id: "d1",
+      comment_id: "77",
+      thread_id: "70",
+      from_uid: "human_1",
+      bot_uid: "bot_wiring_0000000000000000000000000",
+      text: "改一下",
+      doc_kind: "html",
+    },
+  };
+}
+
+/**
+ * 关键差异：`skipSettledCallback` 为 true 时**不调用** `onFreshSettledDelivery`，
+ * 模拟老宿主 / 被抢占的那一回合 —— 这正是 finally-flush 存在的场景，也正是
+ * 缺陷现场。
+ */
+function installDispatcher(
+  payloads: Array<{ payload: Record<string, unknown>; kind: string }>,
+  opts: { skipSettledCallback?: boolean; throwAfter?: boolean } = {},
+) {
+  return async (o: {
+    dispatcherOptions?: {
+      deliver?: (p: unknown, i: { kind: string }) => Promise<void>;
+      onFreshSettledDelivery?: () => Promise<{ visibleReplySent?: boolean } | undefined>;
+    };
+  }) => {
+    const d = o.dispatcherOptions;
+    for (const { payload, kind } of payloads) {
+      await d?.deliver?.(payload, { kind });
+    }
+    if (!opts.skipSettledCallback) await d?.onFreshSettledDelivery?.();
+    // dispatch 自身 reject（如 non_deliverable_terminal_turn）：走 catch 里的
+    // 「有缓冲正文就发正文」分支，onError 从未被调用，onFreshSettledDelivery 也没跑。
+    if (opts.throwAfter) throw new Error("non_deliverable_terminal_turn");
+  };
+}
+
+function runtimeWith(dispatch: unknown) {
+  return {
+    config: { loadConfig: () => ({}) },
+    channel: {
+      reply: {
+        dispatchReplyWithBufferedBlockDispatcher: dispatch,
+        resolveEnvelopeFormatOptions: () => ({}),
+        formatAgentEnvelope: ({ body }: { body: string }) => body,
+        finalizeInboundContext: (c: unknown) => c,
+      },
+      routing: { resolveAgentRoute: () => ({ agentId: "agent1", sessionKey: "sk", accountId: "acct1" }) },
+      session: {
+        resolveStorePath: () => "/tmp/store",
+        readSessionUpdatedAt: () => undefined,
+        recordInboundSession: async () => {},
+      },
+    },
+  } as never;
+}
+
+beforeEach(() => {
+  startEventPoller.mockClear();
+  sendMessage.mockClear();
+  postDocComment.mockClear();
+});
+
+const realFetch = globalThis.fetch;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  globalThis.fetch = realFetch;
+});
+
+const REAL_ANSWER = "标题已经改成《季度复盘》了";
+const TOOL_WARNING = "⚠️ 🛠️ Exec failed: /bin/sh -c curl -H 'Authorization: Bearer sk-live-xyz' https://x";
+
+describe("缓冲 block 答复 + 未消费的工具警告（finally-flush 的镜像守卫）", () => {
+  it("★ block 答复 → isError final → 宿主跳过回调 ⇒ finally 只发答复，不许追发失败提示", async () => {
+    const { setOctoRuntime } = await import("./runtime.js");
+    setOctoRuntime(
+      runtimeWith(
+        vi.fn(
+          installDispatcher(
+            [
+              // 真答复只以 block 到达：被缓冲，userFacingFinalDelivered 仍是 false。
+              { payload: { text: REAL_ANSWER }, kind: "block" },
+              // 随后一条工具错误播报：被 defer 成 pendingToolWarningFinal。
+              { payload: { text: TOOL_WARNING, isError: true, __toolWarning: true }, kind: "final" },
+            ],
+            // ★ 宿主不调 onFreshSettledDelivery —— finally-flush 的场景。
+            { skipSettledCallback: true },
+          ),
+        ),
+      ),
+    );
+
+    const sent = captureHtmlPosts();
+    const stop = await startAccount({ docTasks: true, dispatchTimeoutMs: 2000, docsApiUrl: API });
+    try {
+      const options = pollerOptions().find((o) => typeof o.onDocMention === "function")!;
+      const onDocMention = options.onDocMention as (mention: unknown) => Promise<void>;
+      const { parseDocCommentMention } = await import("./doc-mention.js");
+
+      await onDocMention(parseDocCommentMention(htmlDocEvent("buffered-then-warning")));
+
+      const texts = sent.map((b) => String(b.text));
+      // 先证明这条路真的跑了：缓冲的真答复必须落地。空数组会让下面的
+      // 「不含」断言恒真，那就是个看着绿其实什么都没测的壳。
+      expect(texts.some((t) => t.includes(REAL_ANSWER))).toBe(true);
+      // ★ 承重断言：真答复之后不许再出现工具失败播报。
+      expect(texts.some((t) => t.includes("Exec failed"))).toBe(false);
+      expect(texts.some((t) => t.startsWith("⚠️ 🛠️ "))).toBe(false);
+      // 顺带钉死凭证不会随净化后的提示外泄（提示压根不该发）。
+      expect(texts.some((t) => t.includes("Bearer"))).toBe(false);
+    } finally {
+      await stop();
+    }
+  }, 60_000);
+
+  it("★ dispatch reject 分支：缓冲答复被发出后，同样不许追发工具失败提示", async () => {
+    const { setOctoRuntime } = await import("./runtime.js");
+    setOctoRuntime(
+      runtimeWith(
+        vi.fn(
+          installDispatcher(
+            [
+              { payload: { text: REAL_ANSWER }, kind: "block" },
+              { payload: { text: TOOL_WARNING, isError: true, __toolWarning: true }, kind: "final" },
+            ],
+            // dispatch 本身 reject 且 onError 没被调用 —— 走 catch 里的
+            // 「有缓冲正文就发正文」分支。它和 finally-flush 是两条独立路径，
+            // 上一轮两条都只写了 replySucceeded，所以要分别钉。
+            { skipSettledCallback: true, throwAfter: true },
+          ),
+        ),
+      ),
+    );
+
+    const sent = captureHtmlPosts();
+    const stop = await startAccount({ docTasks: true, dispatchTimeoutMs: 2000, docsApiUrl: API });
+    try {
+      const options = pollerOptions().find((o) => typeof o.onDocMention === "function")!;
+      const onDocMention = options.onDocMention as (mention: unknown) => Promise<void>;
+      const { parseDocCommentMention } = await import("./doc-mention.js");
+
+      // handler 会把 dispatch 的 reject 吞掉/上报，这里不关心它抛不抛，
+      // 只看评论区实际收到了什么。
+      await onDocMention(parseDocCommentMention(htmlDocEvent("dispatch-reject-buffered"))).catch(() => {});
+
+      const texts = sent.map((b) => String(b.text));
+      expect(texts.some((t) => t.includes(REAL_ANSWER))).toBe(true);
+      expect(texts.some((t) => t.includes("Exec failed"))).toBe(false);
+      expect(texts.some((t) => t.startsWith("⚠️ 🛠️ "))).toBe(false);
+    } finally {
+      await stop();
+    }
+  }, 60_000);
+
+  it("对照组：没有真答复时，跳过回调的那一回合仍然必须补出警告（守卫不能把兜底一起吃掉）", async () => {
+    const { setOctoRuntime } = await import("./runtime.js");
+    setOctoRuntime(
+      runtimeWith(
+        vi.fn(
+          installDispatcher(
+            [{ payload: { text: TOOL_WARNING, isError: true, __toolWarning: true }, kind: "final" }],
+            { skipSettledCallback: true },
+          ),
+        ),
+      ),
+    );
+
+    const sent = captureHtmlPosts();
+    const stop = await startAccount({ docTasks: true, dispatchTimeoutMs: 2000, docsApiUrl: API });
+    try {
+      const options = pollerOptions().find((o) => typeof o.onDocMention === "function")!;
+      const onDocMention = options.onDocMention as (mention: unknown) => Promise<void>;
+      const { parseDocCommentMention } = await import("./doc-mention.js");
+
+      await onDocMention(parseDocCommentMention(htmlDocEvent("warning-only-no-callback")));
+
+      const texts = sent.map((b) => String(b.text));
+      // 这条对照组防「把 finally flush 直接删掉/无条件跳过」那种假修复：
+      // 整回合只有警告时，静默吞掉才是更坏的失败。
+      expect(texts.some((t) => t.includes("Exec failed"))).toBe(true);
+      // 发出去的必须是净化过的，命令行与凭证不进公开评论区。
+      expect(texts.some((t) => t.includes("Bearer"))).toBe(false);
+      expect(sent.map((b) => b.status)).not.toContain("applied");
+    } finally {
+      await stop();
+    }
+  }, 60_000);
+});

--- a/src/inbound-tool-failure-banner.test.ts
+++ b/src/inbound-tool-failure-banner.test.ts
@@ -1,0 +1,99 @@
+// 工具错误播报不得以「答复」身份进文档评论区。
+//
+// 背景（2026-08-19 实测两次，17:38 与 17:57）：真答复先投递，26ms 后又来一条
+// `⚠️ 🛠️ Exec failed: …`，把 agent 敲的原始命令暴露给了文档读者。
+//
+// 为什么原来的判据拦不住：插件当时要求 `isError && SDK 元数据标记`，而那个标记的置位
+// 条件是 `lastToolError.middlewareError === true` —— 只覆盖中间件错误。exec 类工具失败
+// 天然没有这个标记，于是判成「不是工具警告」，走了普通 final 分支。
+//
+// 现在只看 isError：SDK 构造回复项时对工具错误播报固定写 isError: true，助手答复项
+// 永远不带（同一段代码用 `!item.isError` 把答复挑出来做 transcript 归属）。
+import { describe, it, expect } from "vitest";
+import { __testing } from "./inbound.js";
+
+const { isFallbackOnlyToolWarningFinal, sanitizeToolErrorNoticeText } = __testing;
+
+const noMedia = { text: "x" } as const;
+
+describe("工具错误播报的识别（按 isError，不靠图标/正文形态）", () => {
+  it("exec 类失败：没有 SDK 元数据标记，也必须被拦下延后", () => {
+    // 这正是 17:38/17:57 漏网的那种 payload：isError 为真，但元数据标记缺席。
+    const payload = {
+      text: "⚠️ 🛠️ Exec failed: # 列出我能访问的文档 octo-cli --bot-id … html list",
+      isError: true,
+    };
+    expect(isFallbackOnlyToolWarningFinal(payload as never)).toBe(true);
+  });
+
+  it("助手的真答复不受影响 —— 这是不改成「只许一条 final」的原因", () => {
+    const first = { text: "✅ **已完成！** 已将「智能 Agent 协作」改为「智能体协作」" };
+    const second = { text: "补充说明：另外我把第二段的措辞也统一了。" };
+    expect(isFallbackOnlyToolWarningFinal(first as never)).toBe(false);
+    expect(isFallbackOnlyToolWarningFinal(second as never)).toBe(false);
+  });
+
+  it("正文里提到 failed 的正常答复不会被误拦（不做正文匹配）", () => {
+    const payload = { text: "这次没成功，原因是 Exec failed 时缺少 aid。" };
+    expect(isFallbackOnlyToolWarningFinal(payload as never)).toBe(false);
+  });
+
+  it("isError 显式为 false 时按答复处理", () => {
+    expect(isFallbackOnlyToolWarningFinal({ ...noMedia, isError: false } as never)).toBe(false);
+  });
+});
+
+// 延后 ≠ 丢弃:整回合没有别的产出时,这条警告会作为兜底 notice 发出去,而 notice 对
+// 文档任务就是**公开评论区**。只把 intent 改成 notice 改的是状态账,不改内容 ——
+// 原始命令行(可能带着 Bearer / ?code=)还是会原样落进评论。所以兜底前要净化。
+describe("兜底 notice 的净化(sanitizeToolErrorNoticeText)", () => {
+  it("★ 砍掉冒号后的命令行 —— 这正是本 PR 要堵的暴露面", () => {
+    const raw = "⚠️ 🛠️ Exec failed: # 列出我能访问的文档 octo-cli --bot-id … html list";
+    const out = sanitizeToolErrorNoticeText(raw);
+    expect(out).not.toContain("octo-cli");
+    expect(out).not.toContain("--bot-id");
+    // 但仍要让读者知道「是工具失败了」,不能净化成一片空白。
+    // 头部是 SDK 原样的英文短语(`Exec failed`),净化只在其后接一句中文说明。
+    expect(out).toContain("Exec failed");
+    expect(out).toContain("详情见日志");
+  });
+
+  it("★ 命令行里夹带的凭证不会漏出去", () => {
+    const raw =
+      "⚠️ 🛠️ Exec failed: curl -H 'Authorization: Bearer sk-live-abc123' https://x/docs-html/d/a?code=s3cr3t";
+    const out = sanitizeToolErrorNoticeText(raw);
+    expect(out).not.toContain("sk-live-abc123");
+    expect(out).not.toContain("s3cr3t");
+    expect(out).not.toContain("code=");
+    expect(out).not.toContain("Bearer");
+  });
+
+  it("多行 stderr 只留首行的头部", () => {
+    const raw = "⚠️ 🛠️ Exec failed: rm -rf /tmp/x\nstderr: permission denied\n  at /Users/someone/secret";
+    const out = sanitizeToolErrorNoticeText(raw);
+    expect(out).not.toContain("permission denied");
+    expect(out).not.toContain("/Users/someone");
+    expect(out.split("\n")).toHaveLength(1);
+  });
+
+  it("★ 首行没有冒号时,不许把后面几行的详情捞上来当头部", () => {
+    // 上面那条钉不住「先截首行」——它的第一个冒号本来就在首行,截不截结果一样。
+    // 这条才区分:若在整串上找冒号,head 会变成「首行 + \nstderr」,把详情带出去。
+    const raw = "⚠️ 🛠️ Exec failed\nstderr: permission denied at /Users/someone/secret";
+    const out = sanitizeToolErrorNoticeText(raw);
+    expect(out).not.toContain("stderr");
+    expect(out).not.toContain("permission denied");
+    expect(out.split("\n")).toHaveLength(1);
+  });
+
+  it("★ 助手级错误面(API/计费/中断)不带工具前缀,必须原样保留", () => {
+    // SDK 对这类也写 isError: true,但那是真正面向用户的内容,砍掉就成了哑巴。
+    const raw = "请求上游模型失败：账户余额不足，请充值后重试。";
+    expect(sanitizeToolErrorNoticeText(raw)).toBe(raw);
+  });
+
+  it("没有冒号的工具播报保持原样(不误伤)", () => {
+    const raw = "⚠️ 🛠️ Exec failed";
+    expect(sanitizeToolErrorNoticeText(raw)).toBe("⚠️ 🛠️ Exec failed（详情见日志）");
+  });
+});

--- a/src/inbound.ts
+++ b/src/inbound.ts
@@ -3,22 +3,21 @@ import type { ChannelLogSink } from "openclaw/plugin-sdk/channel-contract";
 import type { ReplyPayload, ReplyDispatchKind } from "openclaw/plugin-sdk/reply-runtime";
 import type { ReplyDispatcherWithTypingOptions } from "openclaw/plugin-sdk/reply-runtime";
 import { DEFAULT_GROUP_HISTORY_LIMIT } from "openclaw/plugin-sdk/reply-history";
-// Namespace import + runtime feature detection so the deliver-buffer fix
-// degrades gracefully across SDK versions:
-//   - isReplyPayloadNonTerminalToolErrorWarning lands in newer SDK (>=5.27);
-//     on older SDK (e.g. 5.22) it is undefined, so we cannot classify a final
-//     as a tool-warning fallback and treat it as a normal final (sent
-//     immediately), which still preserves the real user-facing reply.
-//   - resolveSendableOutboundReplyParts is present across these versions.
+// Namespace import + runtime feature detection.
+//   - resolveSendableOutboundReplyParts is present across supported versions.
+//   - isReplyPayloadNonTerminalToolErrorWarning is no longer consulted by the
+//     deliver-buffer gate: its underlying marker only covers middleware errors,
+//     so exec-class failures never matched it (see isToolErrorBroadcastFinal).
+//     The gate is now `isError` alone, which means the classifier no longer acts
+//     as the "new enough SDK" proxy it used to be. That proxy is not needed:
+//     openclaw@2026.6.9 -- the floor declared in peerDependencies -- already
+//     ships onFreshSettledDelivery, the primary flush site for a deferred
+//     warning. And the dispatch finally block now flushes any still-pending
+//     warning, so a host that never invokes that callback (or an SDK that skips
+//     it because a newer inbound superseded the turn) degrades to a late notice
+//     rather than swallowing the warning outright.
 import * as replyPayloadSdk from "openclaw/plugin-sdk/reply-payload";
 
-const replyPayloadCompat = replyPayloadSdk as typeof replyPayloadSdk & {
-  isReplyPayloadNonTerminalToolErrorWarning?: (payload: ReplyPayload) => boolean;
-};
-const isReplyPayloadNonTerminalToolErrorWarning =
-  typeof replyPayloadCompat.isReplyPayloadNonTerminalToolErrorWarning === "function"
-    ? replyPayloadCompat.isReplyPayloadNonTerminalToolErrorWarning
-    : undefined;
 const resolveSendableOutboundReplyParts = replyPayloadSdk.resolveSendableOutboundReplyParts;
 import { sendMessage, sendReadReceipt, sendTyping, getChannelMessages, getGroupMembers, getGroupMd, sendMediaMessage, inferContentType, ensureTextCharset, parseImageDimensions, parseImageDimensionsFromFile, getUploadPresign, uploadFileToPresignedUrl, fetchUserInfo } from "./api-fetch.js";
 import { createImEgressGuard } from "./im-egress.js";
@@ -259,36 +258,74 @@ function resolveOutboundMediaUrls(payload: { mediaUrl?: string; mediaUrls?: stri
   ].filter(Boolean);
 }
 
-// Tool warning final: a kind=final payload that carries a non-terminal tool
-// error warning and no media.  These should be deferred (not sent immediately)
-// so they don't overwrite the real user-facing answer in the single-slot
-// deliver buffer.  Mirrors Discord's isFallbackOnlyToolWarningFinal.
 /**
- * **分类器判决**:SDK 认为这个 payload 是一次非终止性的工具错误警告 —— 也就是
- * 「这不是 agent 的真答复」。
+ * 这条 final **不是**一条普通的助手答复吗?
  *
- * 与下面的 `isFallbackOnlyToolWarningFinal` 拆开,是因为两者回答的是不同问题:
- * 这里回答「它算不算真答复」(内容性质),下面回答「要不要延后缓冲」(投递策略,
- * 额外受附件约束)。此前只有合并版,于是**带附件**的工具警告在策略问题上答了
- * false,顺带把性质问题也答成了「是真答复」,一路以 `applied` 落库。
+ * 判据是 `isError`。准确的语义是「这不是一条普通答复」,它覆盖两类:
+ *   1. 工具错误播报(`⚠️ 🛠️ … failed: …`);
+ *   2. 助手级错误面 —— SDK 在 reply payload 构造处对 API 错误/计费错误/被中断的
+ *      回合 push `{ text: errorText, isError: true }`,同样不带那条元数据标记。
+ * 两类都不该抢占单槽 deliver buffer 里那条真答复,也都可以延后兜底,所以这里合并
+ * 处理。**不要**把这条注释读成「isError 只标工具播报」—— 早先就是这么写的,而
+ * 助手错误面从来不满足它。真正恒成立的是反向:助手的**普通答复**项永远不带
+ * `isError`(同一段 SDK 代码用 `!item.isError` 把答复挑出来做 transcript 归属)。
+ *
+ * 为什么不再要求那条元数据标记:`nonTerminalToolErrorWarning` 的置位条件是
+ *   shouldMarkNonTerminalToolErrorWarning = lastToolError.middlewareError === true
+ * ——**只覆盖中间件错误**。exec 类工具失败(我们撞到的这种)天然拿不到这个标记,于是
+ * 旧判据判 false,整条播报就以普通 final 身份进了评论区
+ * (实测 2026-08-19 17:38 与 17:57 各一次:真答复先投递,26ms 后又来一条
+ * `⚠️ 🛠️ Exec failed: …`,把 agent 敲的原始命令暴露给了文档读者)。
+ *
+ * 延后不等于丢弃 —— 若整回合真的没有别的产出,`pendingToolWarningFinal` 会把它作为
+ * 兜底带出去,且**先经 sanitizeToolErrorNoticeText 砍掉冒号后的命令行/错误详情**,
+ * 所以评论区看到的始终不是原始命令。
+ *
+ * 也不改成「一个回合只许一条 final」:agent 确实会合法地分两段发答复,那样会吞掉第二段。
  */
-function isNonTerminalToolErrorWarning(payload: ReplyPayload): boolean {
-  // Older SDK lacks the tool-warning classifier: never classify, so no payload
-  // is treated as a warning and behaviour matches the pre-classifier contract.
-  if (!isReplyPayloadNonTerminalToolErrorWarning) {
-    return false;
+function isToolErrorBroadcastFinal(payload: ReplyPayload): boolean {
+  return payload.isError === true;
+}
+
+/**
+ * 兜底投递前的净化:只保留「哪个工具失败了」,砍掉冒号之后的命令行与错误详情。
+ *
+ * 走到兜底这条路时,整回合没有别的产出,所以这段文本会**原样进评论区**(公开面)。
+ * 而它的原文形如 `⚠️ 🛠️ Exec failed: curl -H 'Authorization: Bearer …' https://…`
+ * —— 既有 agent 敲的原始命令,也可能带着 Bearer/?code= 这类凭证。本 PR 要堵的正是
+ * 这类暴露,只把 intent 改成 notice 只改了状态账,不改内容,所以在这里补一刀。
+ *
+ * 前缀 `⚠️ 🛠️ ` 是 SDK 侧的稳定契约(其 helpers 就靠 startsWith 这个前缀判定工具
+ * 播报),所以只对命中前缀的文本动手;助手级错误面(API/计费/中断)不带这个前缀,
+ * 原样保留 —— 那是真正面向用户的内容。
+ */
+export function sanitizeToolErrorNoticeText(text: string): string {
+  const TOOL_ERROR_PREFIX = "⚠️ 🛠️ ";
+  if (!text.startsWith(TOOL_ERROR_PREFIX)) {
+    return text;
   }
-  return payload.isError === true && isReplyPayloadNonTerminalToolErrorWarning(payload);
+  // 只看第一行:详情常常是多行 stderr。
+  const [firstLine] = text.split("\n");
+  const colon = firstLine.indexOf(":");
+  const head = colon === -1 ? firstLine : firstLine.slice(0, colon);
+  return `${head.trimEnd()}（详情见日志）`;
 }
 
 function isFallbackOnlyToolWarningFinal(payload: ReplyPayload): boolean {
-  if (!isNonTerminalToolErrorWarning(payload)) {
+  if (!isToolErrorBroadcastFinal(payload)) {
     return false;
   }
   // 带附件的不延后:延后只保留文本,附件会随缓冲一起丢掉。它改走正常 final 分支,
   // 但**不许宣称完成** —— 见 deliver 里 claimsCompletion 的注释。
   return !resolveSendableOutboundReplyParts(payload).hasMedia;
 }
+
+/** 仅供单测:这几个判据决定「工具错误播报会不会以答复身份、带着命令行进评论区」,值得被钉住。 */
+export const __testing = {
+  isFallbackOnlyToolWarningFinal,
+  isToolErrorBroadcastFinal,
+  sanitizeToolErrorNoticeText,
+};
 
 /**
  * Sanitize a filename for safe use inside a temp directory.
@@ -3331,10 +3368,13 @@ export async function handleInboundMessage(params: {
               onReasoningStream: captureReasoning,
             }
           : { onReasoningStream: captureReasoning },
-      // onFreshSettledDelivery is only present on newer SDK dispatcher options.
-      // On older SDK the property is ignored (and never invoked, since
-      // pendingToolWarningFinal is only set when the tool-warning classifier
-      // exists), so the cast keeps both versions type-correct.
+      // onFreshSettledDelivery is not in the published dispatcher-options type,
+      // hence the cast. It is the *only* flush site for pendingToolWarningFinal,
+      // and the defer gate no longer piggybacks on the tool-warning classifier
+      // as a version proxy -- so a host that ignores this callback would swallow
+      // the warning. openclaw@2026.6.9 (the peerDependencies floor) already
+      // ships it; the dispatch finally block additionally flushes any warning
+      // this callback did not consume, so the property is not load-bearing.
       dispatcherOptions: ({
         deliver: async (payload: ReplyPayload, info: { kind: ReplyDispatchKind }) => {
           // Reasoning is not a normal chat reply. Capture its user-visible lane for the
@@ -3462,17 +3502,24 @@ export async function handleInboundMessage(params: {
             if (isFallbackOnlyToolWarningFinal(payload)) {
               if (!userFacingFinalDelivered) {
                 pendingToolWarningFinal = { text: content };
+                log?.debug?.(
+                  `octo: [deliver-buffer] tool warning final deferred (${content.length} chars)`,
+                );
+              } else {
+                // 真答复已经出去了,这条播报就是纯噪音 —— 丢掉,别记成「延后」。
+                log?.debug?.(
+                  `octo: [deliver-buffer] tool warning final dropped after real reply (${content.length} chars)`,
+                );
               }
-              log?.debug?.(
-                `octo: [deliver-buffer] tool warning final deferred (${content.length} chars)`,
-              );
               return;
             }
 
             // 走到这里的两类 payload:真答复,以及**带附件**的非终止性工具警告
             // (它不能延后 —— 延后只留文本、附件会随缓冲一起丢)。后者要发附件,
             // 但不许拿 applied 徽章:见 deliverFinalText 的 claimsCompletion。
-            const isToolWarningWithMedia = isNonTerminalToolErrorWarning(payload);
+            // 判据同上:只看 isError。元数据标记只覆盖中间件错误,拿它当门槛会让
+            // exec 类失败顶着「已完成」徽章进评论区。
+            const isToolWarningWithMedia = isToolErrorBroadcastFinal(payload);
             // final 覆盖缓冲文本(下面就把它清掉),所以缓冲里那些还没投递过的附件
             // 由这次 final 一并带出去 —— 否则它们会随缓冲一起被丢掉。
             const delivered = await deliverFinalText(content, AbortSignal.timeout(DISPATCH_TIMEOUT_APOLOGY_MS), {
@@ -3537,9 +3584,11 @@ export async function handleInboundMessage(params: {
           }
           const pending = pendingToolWarningFinal;
           pendingToolWarningFinal = undefined;
+          // 兜底文本会原样进评论区(公开面),先砍掉命令行/错误详情再发。
+          const noticeText = sanitizeToolErrorNoticeText(pending.text);
           try {
             const delivered = await deliverFinalText(
-              pending.text,
+              noticeText,
               AbortSignal.timeout(DISPATCH_TIMEOUT_APOLOGY_MS),
               {
                 // ★ 本轮 P1 的现场。这是「非终止性工具错误警告」在没有任何真答复
@@ -3554,7 +3603,7 @@ export async function handleInboundMessage(params: {
             replySucceeded ||= delivered.delivered;
             userFacingFinalDelivered = delivered.delivered;
             log?.info?.(
-              `octo: [deliver] pending tool warning sent as fallback (${pending.text.length} chars)`,
+              `octo: [deliver] pending tool warning sent as fallback (${noticeText.length} chars)`,
             );
             return { visibleReplySent: delivered.delivered };
           } catch (err) {
@@ -3647,6 +3696,12 @@ export async function handleInboundMessage(params: {
             { intent: "output", final: true, ownMedia: takeBufferedDocTaskMedia() },
           );
           replySucceeded ||= delivery.outputDelivered;
+          // ★ 这条缓冲正文就是本回合的真实答复(见上方注释),所以它落地 ⟹ 用户已经
+          // 看到答复了。不写 userFacingFinalDelivered 的话,下面 finally 的
+          // pending 工具警告 flush 会在这条正确答复后面再贴一句「⚠️ 🛠️ … failed」——
+          // 正是本 PR 要消灭的失败形态。镜像 onFreshSettledDelivery 里那条
+          // 「真答复已经在缓冲里 ⇒ 丢掉警告兜底」的纪律。
+          userFacingFinalDelivered ||= delivery.finalDelivered;
         } catch (sendErr) {
           log?.error?.(`octo: failed to deliver buffered block text on dispatch error: ${String(sendErr)}`);
         }
@@ -3685,12 +3740,44 @@ export async function handleInboundMessage(params: {
           { intent: "output", ownMedia: takeBufferedDocTaskMedia() },
         );
         replySucceeded ||= delivered.delivered;
+        // ★ 同 dispatch-rejected 分支:只收到 block 文本的回合,这段缓冲正文就是
+        // 答复本身。它落地之后必须置位 userFacingFinalDelivered,否则紧接着下面
+        // 那次 pending 工具警告 flush 会在真答复后面追一条矛盾的失败提示。
+        // (镜像 onFreshSettledDelivery: src/inbound.ts 里「缓冲有真答复 ⇒ 丢警告」。)
+        userFacingFinalDelivered ||= delivered.delivered;
         if (delivered.delivered) {
           log?.info?.(`octo: [deliver-buffer] fallback text sent (${deliverBuffer.lastText.length} chars)`);
         }
       } catch (finalSendErr) {
         dispatchFailed = true;
         log?.error?.(`octo: [deliver-buffer] final text send failed: ${String(finalSendErr)}`);
+      }
+    }
+    // --- 兜底之兜底:延后的工具警告没被 onFreshSettledDelivery 消费掉 ---
+    // pendingToolWarningFinal 的唯一 flush 是 onFreshSettledDelivery。宿主没实现
+    // 那个回调、或 SDK 因新消息抢占跳过它时,延后就变成了静默吞掉:整回合既无答复
+    // 也无警告。判据不再依赖「分类器在不在」这种版本代理,所以这里补一次真正的
+    // flush —— 到这一步 dispatch 已经结束,还挂着 pending 就说明没人接管。
+    // 同样先净化,理由见 sanitizeToolErrorNoticeText。
+    if (pendingToolWarningFinal && !userFacingFinalDelivered && !deliveryErrorOccurred) {
+      const pendingFinal = pendingToolWarningFinal;
+      pendingToolWarningFinal = undefined;
+      const noticeText = sanitizeToolErrorNoticeText(pendingFinal.text);
+      try {
+        const delivered = await deliverFinalText(
+          noticeText,
+          AbortSignal.timeout(DISPATCH_TIMEOUT_APOLOGY_MS),
+          // notice 而非 output:它不是答复,不该让上游翻转父评论为 applied。
+          { intent: "notice", ownMedia: takeBufferedDocTaskMedia() },
+        );
+        replySucceeded ||= delivered.delivered;
+        userFacingFinalDelivered ||= delivered.delivered;
+        log?.info?.(
+          `octo: [deliver] pending tool warning flushed in finally (${noticeText.length} chars)`,
+        );
+      } catch (warnFlushErr) {
+        dispatchFailed = true;
+        log?.error?.(`octo: [deliver] tool warning finally-flush failed: ${String(warnFlushErr)}`);
       }
     }
     // 缓冲里的附件没人接管(比如 onError 把缓冲文本清掉后只发了一句道歉)。


### PR DESCRIPTION
## Summary
两个问题都出在 HTML 文档的 `@Bot` 链路上。

**一、无锚点的 HTML 评论必然空转到超时。** 提示词里无条件写着「别整篇重写」，而 CLI 侧唯一的写入口 `html element replace` 必须按 aid、`html element get` 也必须按 aid、`html get` 只有元数据。于是 agent 既不许整篇重写、又没有任何命令能拿到 aid 清单，只能猜，实测空转 8 分钟。

读整篇的路不在 CLI 里，在 octo-doc 的渲染路由上（`/d/{doc}/v/{version}/export`）。提示词改为按锚点有无分流：有锚点仍然只替换那一个元素；无锚点时明确给出三步——取回整篇看结构、从 `data-odoc-aid` 读 aid 清单、再按 aid 走窄替换。

**二、工具执行错误被当作助手答复投递进了评论区。** 判据此前要求 `nonTerminalToolErrorWarning` 这条元数据标记，而它的置位条件只覆盖中间件错误，exec 类工具失败天然拿不到，于是整条 `Exec failed` 播报以普通 final 身份进了评论区，把 agent 敲的原始命令暴露给文档读者（实测同一天两次）。改为只看 `isError`——SDK 侧构造回复项时就是这么分的，助手答复项永远不带它。

## Linked Spec
无独立 spec。两个问题都来自 test 环境实测：HTML 文档 @Bot 提「把所有字体都改成红色」空转超时；同日两次工具错误播报落进评论区。

## How verified
- 新增 `src/inbound-tool-failure-banner.test.ts` 钉住两个判据
- **突变验证**：把判据改回依赖 `nonTerminalToolErrorWarning` 元数据标记，用例立刻变红——证明这条锁由修法决定红绿
- `npm test`：86 文件 2212 测试通过、3 文件 11 用例 skipped
- `tsc --noEmit` 通过

## COMPREHENSION
**改动对承重路径做了啥**：(1) 提示词侧新增一条「无锚点 → 先取整篇读结构」的分流，有锚点的窄替换路径完全不变；取回的 HTML 只用于读结构、明确禁止原样回灌（渲染路由注入了 overlay 脚本，export 还带 banner 与 ODOC-COMMENT 标记）。(2) 出站判据从「元数据标记 + isError」收敛为只看 `isError`。

**破坏啥依赖**：延后不等于丢弃——整回合确实没有别的产出时，`pendingToolWarningFinal` 仍会把它兜出去，不会静默吞掉。也**没有**改成「一个回合只许一条 final」，那会吞掉 agent 合法分两段发的答复。提示词里同时写明几个已踩过的坑：`/docs-html` 前缀不能少（少了打到网页应用上、拿回 SPA 空壳）、鉴权必须走 `Authorization: Bearer`、权限不足时接口故意返回 404 所以不能把 404 读成「文档不存在」、aid 是内容哈希不是 `body`/`main` 这类名字；取不到就如实回一句并附请求 URL 与状态码，不许猜、不许另造一篇覆盖上去。

**拿啥验证**：见上，突变验证 + 全量 2212 测试 + typecheck。